### PR TITLE
3784 - Handle roundabouts correctly in Attribute Conflation

### DIFF
--- a/docs/user/CommandLineExamples.asciidoc
+++ b/docs/user/CommandLineExamples.asciidoc
@@ -565,7 +565,7 @@ See the User Guide for more details on command usage.
 
 -----
     hoot convert -D convert.ops="hoot::RemoveTagsVisitor" \
-      -D remove.tags.visitor.element.criterion="hoot::WayCriterion" \
+      -D tag.filter.element.criterion="hoot::WayCriterion" \
       -D tag.filter.keys="source;error:circular" input.osm output.osm
 -----
 
@@ -580,7 +580,7 @@ See the User Guide for more details on command usage.
 
 -----
     hoot convert -D convert.ops=hoot::RemoveTagsVisitor -D tag.filter.keys="REF1;REF2" \
-      -D remove.tags.visitor.element.criterion=hoot::TagCriterion \
+      -D tag.filter.element.criterion=hoot::TagCriterion \
       -D tag.criterion.kvps="power=line" -D element.criterion.negate=true input.osm output.osm
 -----
 
@@ -589,7 +589,7 @@ See the User Guide for more details on command usage.
 -----
     hoot convert -D convert.ops=hoot::SetTagValueVisitor -D set.tag.value.visitor.keys=power \
       -D set.tag.value.visitor.values=minor_line \
-      -D set.tag.value.visitor.element.criterion=hoot::TagValueNumericRangeCriterion \
+      -D set.tag.value.visitor.element.criteria="hoot::TagValueNumericRangeCriterion" \
       -D tag.value.numeric.range.criterion.keys=voltage \
       -D tag.value.numeric.range.criterion.min=1 -D tag.value.numeric.range.criterion.max=45000 \
       input.osm output.osm

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.h
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.h
@@ -68,7 +68,7 @@ private:
   int _numTotalTasks;
 
   void _updateConfigOptionsForAttributeConflation();
-  void _updateConfigOptionsForDifferentialConflation();
+  void _disableRoundaboutRemoval();
   void _checkForTagValueTruncationOverride();
 
   float _getJobPercentComplete(const int currentTaskNum) const;

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.h
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef CONFLATECMD_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.cpp
@@ -80,9 +80,7 @@ void MatchFactory::createMatches(const ConstOsmMapPtr& map, std::vector<ConstMat
   for (size_t i = 0; i < _creators.size(); ++i)
   { 
     std::shared_ptr<MatchCreator> matchCreator = _creators[i];
-    LOG_STATUS(
-      "Looking for matches with: " << matchCreator->getName() << " (" << i + 1 << " / " <<
-      _creators.size() << "): ...");
+    LOG_STATUS("Launching matcher: " << i + 1 << " / " << _creators.size() << "...");
     _checkMatchCreatorBoundable(matchCreator, bounds);
     if (threshold.get())
     {

--- a/hoot-core/src/main/cpp/hoot/core/ops/RemoveRoundabouts.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/RemoveRoundabouts.cpp
@@ -109,7 +109,7 @@ void RemoveRoundabouts::removeRoundabouts(std::vector<RoundaboutPtr>& removed)
 
     // This could be very expensive...enable for debugging only.
     //OsmMapWriterFactory::writeDebugMap(
-      //_pMap, "after-handline-crossing-ways-" + QString::number(i + 1));
+      //_pMap, "after-RemoveRoundabouts-handling-crossing-ways-" + QString::number(i + 1));
   }
 
   //  Mangle the last way if it doesn't have a sibling
@@ -119,7 +119,7 @@ void RemoveRoundabouts::removeRoundabouts(std::vector<RoundaboutPtr>& removed)
     removed[removed.size() - 1]->overrideRoundabout();
   }
 
-  OsmMapWriterFactory::writeDebugMap(_pMap, "after-handline-crossing-ways");
+  OsmMapWriterFactory::writeDebugMap(_pMap, "after-RemoveRoundabouts-handling-crossing-ways");
 
   // Now remove roundabouts
   for (size_t i = 0; i < removed.size(); i++)

--- a/hoot-core/src/main/cpp/hoot/core/ops/RemoveRoundabouts.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/RemoveRoundabouts.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "RemoveRoundabouts.h"

--- a/test-files/cases/attribute/network/highway-3784-roundabouts-1/Expected.osm
+++ b/test-files/cases/attribute/network/highway-3784-roundabouts-1/Expected.osm
@@ -1,0 +1,2201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="2.7766" minlon="32.2948" maxlat="2.7807" maxlon="32.2997"/>
+    <node visible="true" id="-387" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775182790145094" lon="32.2987437336142023">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-387"/>
+    </node>
+    <node visible="true" id="-386" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775194490855006" lon="32.2987622993437995">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-386"/>
+    </node>
+    <node visible="true" id="-385" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775212699682599" lon="32.2987808131540035">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-385"/>
+    </node>
+    <node visible="true" id="-384" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775237394443395" lon="32.2987992524884007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-384"/>
+    </node>
+    <node visible="true" id="-383" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775268545050698" lon="32.2988175948816973">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-383"/>
+    </node>
+    <node visible="true" id="-382" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775306113552500" lon="32.2988358179865003">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-382"/>
+    </node>
+    <node visible="true" id="-381" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775350054177395" lon="32.2988538996008003">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-381"/>
+    </node>
+    <node visible="true" id="-380" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775400313390599" lon="32.2988718176950016">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-380"/>
+    </node>
+    <node visible="true" id="-379" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775439510922300" lon="32.2988843398693959">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-379"/>
+    </node>
+    <node visible="true" id="-378" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775476247119597" lon="32.2988923819512976">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-378"/>
+    </node>
+    <node visible="true" id="-377" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775520964563594" lon="32.2989000138261986">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-377"/>
+    </node>
+    <node visible="true" id="-376" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775573205735005" lon="32.2989071574099000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-376"/>
+    </node>
+    <node visible="true" id="-375" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775632436136997" lon="32.2989137396141004">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-375"/>
+    </node>
+    <node visible="true" id="-374" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775698049763502" lon="32.2989196930938007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-374"/>
+    </node>
+    <node visible="true" id="-373" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775769375299397" lon="32.2989249569370998">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-373"/>
+    </node>
+    <node visible="true" id="-372" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775845682989302" lon="32.2989294772878992">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-372"/>
+    </node>
+    <node visible="true" id="-371" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775926192103602" lon="32.2989332078967024">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-371"/>
+    </node>
+    <node visible="true" id="-370" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776010078926401" lon="32.2989361105947026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-370"/>
+    </node>
+    <node visible="true" id="-369" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776096485183497" lon="32.2989381556830963">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-369"/>
+    </node>
+    <node visible="true" id="-368" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776184526823298" lon="32.2989393222380983">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-368"/>
+    </node>
+    <node visible="true" id="-367" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776273303062093" lon="32.2989395983240968">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-367"/>
+    </node>
+    <node visible="true" id="-366" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776361905600395" lon="32.2989389811164926">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-366"/>
+    </node>
+    <node visible="true" id="-365" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776449427915590" lon="32.2989374769300994">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-365"/>
+    </node>
+    <node visible="true" id="-364" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776534974537297" lon="32.2989351011545978">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-364"/>
+    </node>
+    <node visible="true" id="-363" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776610795133205" lon="32.2989326301865987">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-363"/>
+    </node>
+    <node visible="true" id="-362" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776687436674705" lon="32.2989304238757029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-362"/>
+    </node>
+    <node visible="true" id="-361" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776764805786005" lon="32.2989284849100997">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-361"/>
+    </node>
+    <node visible="true" id="-360" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776842808204694" lon="32.2989268156520026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-360"/>
+    </node>
+    <node visible="true" id="-359" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776921348896901" lon="32.2989254181351910">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-359"/>
+    </node>
+    <node visible="true" id="-358" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777000332172896" lon="32.2989242940624024">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-358"/>
+    </node>
+    <node visible="true" id="-357" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777079661803796" lon="32.2989234448031013">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-357"/>
+    </node>
+    <node visible="true" id="-356" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777159241138700" lon="32.2989228713919019">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-356"/>
+    </node>
+    <node visible="true" id="-355" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777238973222400" lon="32.2989225745275945">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-355"/>
+    </node>
+    <node visible="true" id="-354" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777318760913592" lon="32.2989225545717034">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-354"/>
+    </node>
+    <node visible="true" id="-353" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777398507003501" lon="32.2989228115486995">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-353"/>
+    </node>
+    <node visible="true" id="-352" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777478114333496" lon="32.2989233451452975">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-352"/>
+    </node>
+    <node visible="true" id="-351" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777557059444296" lon="32.2989241496163970">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-351"/>
+    </node>
+    <node visible="true" id="-350" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777603712000198" lon="32.2989264652775034">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-350"/>
+    </node>
+    <node visible="true" id="-349" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777647256661595" lon="32.2989293174193008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-349"/>
+    </node>
+    <node visible="true" id="-348" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777687072609001" lon="32.2989326653786009">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-348"/>
+    </node>
+    <node visible="true" id="-347" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777722592183198" lon="32.2989364614232031">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-347"/>
+    </node>
+    <node visible="true" id="-346" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777753308978701" lon="32.2989406514326021">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-346"/>
+    </node>
+    <node visible="true" id="-345" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777778785063898" lon="32.2989451756697008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-345"/>
+    </node>
+    <node visible="true" id="-344" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777798657224202" lon="32.2989499696318987">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-344"/>
+    </node>
+    <node visible="true" id="-343" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777812642140494" lon="32.2989549649713013">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-343"/>
+    </node>
+    <node visible="true" id="-342" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777820540428904" lon="32.2989600904691017">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-342"/>
+    </node>
+    <node visible="true" id="-341" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777822239482695" lon="32.2989652730505981">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-341"/>
+    </node>
+    <node visible="true" id="-340" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777817715078297" lon="32.2989704388271974">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-340"/>
+    </node>
+    <node visible="true" id="-339" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777807031720601" lon="32.2989755141502002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-339"/>
+    </node>
+    <node visible="true" id="-338" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777790341722994" lon="32.2989804266602007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-338"/>
+    </node>
+    <node visible="true" id="-337" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777767883036200" lon="32.2989851063192006">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-337"/>
+    </node>
+    <node visible="true" id="-336" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777739975855296" lon="32.2989894864088996">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-336"/>
+    </node>
+    <node visible="true" id="-335" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777646275009094" lon="32.2990438123054986">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-335"/>
+    </node>
+    <node visible="true" id="-334" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777501802418496" lon="32.2991014182805998">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-334"/>
+    </node>
+    <node visible="true" id="-333" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777327403677594" lon="32.2991581991857970">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-333"/>
+    </node>
+    <node visible="true" id="-332" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777123550695801" lon="32.2992140013760007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-332"/>
+    </node>
+    <node visible="true" id="-331" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776890795083506" lon="32.2992686738545984">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-331"/>
+    </node>
+    <node visible="true" id="-330" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776844812841599" lon="32.2992782909542981">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-330"/>
+    </node>
+    <node visible="true" id="-329" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7793072792240094" lon="32.2965970744986990">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-329"/>
+    </node>
+    <node visible="true" id="-328" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792919414114792" lon="32.2965958598485017">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-328"/>
+    </node>
+    <node visible="true" id="-327" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792765651822093" lon="32.2965953045047982">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-327"/>
+    </node>
+    <node visible="true" id="-326" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792611791784196" lon="32.2965954095024017">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-326"/>
+    </node>
+    <node visible="true" id="-325" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792458120605494" lon="32.2965961746454013">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-325"/>
+    </node>
+    <node visible="true" id="-324" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792304924538493" lon="32.2965975985086970">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-324"/>
+    </node>
+    <node visible="true" id="-323" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792152488950594" lon="32.2965996784397973">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-323"/>
+    </node>
+    <node visible="true" id="-322" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792001097792700" lon="32.2966024105643896">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-322"/>
+    </node>
+    <node visible="true" id="-321" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791851033070194" lon="32.2966057897930980">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-321"/>
+    </node>
+    <node visible="true" id="-320" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791702574317498" lon="32.2966098098312031">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-320"/>
+    </node>
+    <node visible="true" id="-319" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791555998077695" lon="32.2966144631904015">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-319"/>
+    </node>
+    <node visible="true" id="-318" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791411577387000" lon="32.2966197412023988">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-318"/>
+    </node>
+    <node visible="true" id="-317" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791269581266493" lon="32.2966256340356992">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-317"/>
+    </node>
+    <node visible="true" id="-316" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791130274220595" lon="32.2966321307132986">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-316"/>
+    </node>
+    <node visible="true" id="-315" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7790993915745092" lon="32.2966392191333966">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-315"/>
+    </node>
+    <node visible="true" id="-314" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7790860759842801" lon="32.2966468860918994">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-314"/>
+    </node>
+    <node visible="true" id="-313" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7805279610607099" lon="32.2964359705758994">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-313"/>
+    </node>
+    <node visible="true" id="-312" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7804773080670695" lon="32.2964345295478026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-312"/>
+    </node>
+    <node visible="true" id="-311" timestamp="2020-02-07T17:57:36Z" version="1" lat="2.7770631254490197" lon="32.2953548897616969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-311"/>
+    </node>
+    <node visible="true" id="-310" timestamp="2020-02-07T17:57:36Z" version="1" lat="2.7770279992641798" lon="32.2952081316341975">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-310"/>
+    </node>
+    <node visible="true" id="-309" timestamp="2020-02-07T17:57:36Z" version="1" lat="2.7770137855736001" lon="32.2951331858424950">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-309"/>
+    </node>
+    <node visible="true" id="-308" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799148692709994" lon="32.2958915832183990">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-308"/>
+    </node>
+    <node visible="true" id="-307" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799286005237192" lon="32.2960484939745029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-307"/>
+    </node>
+    <node visible="true" id="-306" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799515256394494" lon="32.2963401706744975">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-306"/>
+    </node>
+    <node visible="true" id="-305" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799565540837596" lon="32.2964673701593981">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-305"/>
+    </node>
+    <node visible="true" id="-304" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799190543354095" lon="32.2964677480541980">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-304"/>
+    </node>
+    <node visible="true" id="-303" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7798659443090497" lon="32.2964713657132023">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-303"/>
+    </node>
+    <node visible="true" id="-302" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7798251073870599" lon="32.2964721617457968">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-302"/>
+    </node>
+    <node visible="true" id="-301" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7797573833053395" lon="32.2964819104586027">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-301"/>
+    </node>
+    <node visible="true" id="-300" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7795905576110393" lon="32.2965205264260007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-300"/>
+    </node>
+    <node visible="true" id="-299" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7794444617889198" lon="32.2965452244570983">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-299"/>
+    </node>
+    <node visible="true" id="-298" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7794303706162595" lon="32.2965450561986032">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-298"/>
+    </node>
+    <node visible="true" id="-297" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7793869065920895" lon="32.2965579304608923">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-297"/>
+    </node>
+    <node visible="true" id="-296" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7793714551548900" lon="32.2965687687937972">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-296"/>
+    </node>
+    <node visible="true" id="-295" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7793061826668599" lon="32.2965840227614933">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-295"/>
+    </node>
+    <node visible="true" id="-294" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7806791852046904" lon="32.2964508188340034">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-294"/>
+    </node>
+    <node visible="true" id="-293" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7806289611560095" lon="32.2964441201832955">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-293"/>
+    </node>
+    <node visible="true" id="-292" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7805785326282191" lon="32.2964391687532029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-292"/>
+    </node>
+    <node visible="true" id="-291" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7790944263331601" lon="32.2966168197570980">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-291"/>
+    </node>
+    <node visible="true" id="-290" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7791040579579995" lon="32.2965528088653997">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-290"/>
+    </node>
+    <node visible="true" id="-289" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7791028556961495" lon="32.2964862556405947">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-289"/>
+    </node>
+    <node visible="true" id="-288" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7790934061625991" lon="32.2963965733989014">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-288"/>
+    </node>
+    <node visible="true" id="-287" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7790862553409301" lon="32.2963451450642012">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-287"/>
+    </node>
+    <node visible="true" id="-286" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7773390139459297" lon="32.2983055209448011">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-286"/>
+    </node>
+    <node visible="true" id="-285" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7772860569032298" lon="32.2983210906537010">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-285"/>
+    </node>
+    <node visible="true" id="-284" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7772376015852398" lon="32.2983333262564969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-284"/>
+    </node>
+    <node visible="true" id="-283" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7771899450191602" lon="32.2983419583239950">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-283"/>
+    </node>
+    <node visible="true" id="-282" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7771433411058797" lon="32.2983478908695005">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-282"/>
+    </node>
+    <node visible="true" id="-281" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7769725299953301" lon="32.2983627060958014">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-281"/>
+    </node>
+    <node visible="true" id="-280" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7769349978565998" lon="32.2983687012281990">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-280"/>
+    </node>
+    <node visible="true" id="-279" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7769000417745797" lon="32.2983774209166015">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-279"/>
+    </node>
+    <node visible="true" id="-278" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7768679156497500" lon="32.2983897691734967">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-278"/>
+    </node>
+    <node visible="true" id="-277" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7767952554397999" lon="32.2984237017090976">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-277"/>
+    </node>
+    <node visible="true" id="-276" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7767329872946691" lon="32.2984500192949966">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-276"/>
+    </node>
+    <node visible="true" id="-275" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7767138166833489" lon="32.2984640915333969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-275"/>
+    </node>
+    <node visible="true" id="-274" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766939753116495" lon="32.2984772120453982">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-274"/>
+    </node>
+    <node visible="true" id="-273" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766735109103799" lon="32.2984893492679035">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-273"/>
+    </node>
+    <node visible="true" id="-272" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766524727091100" lon="32.2985004740034967">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-272"/>
+    </node>
+    <node visible="true" id="-271" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766309113177696" lon="32.2985105594903033">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-271"/>
+    </node>
+    <node visible="true" id="-270" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766088786048702" lon="32.2985195814665005">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-270"/>
+    </node>
+    <node visible="true" id="-269" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787270390095595" lon="32.2970533533747997">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-269"/>
+    </node>
+    <node visible="true" id="-268" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787309531035702" lon="32.2970335158837969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-268"/>
+    </node>
+    <node visible="true" id="-267" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787364401982191" lon="32.2970180036822967">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-267"/>
+    </node>
+    <node visible="true" id="-266" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787435002936896" lon="32.2970068167703985">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-266"/>
+    </node>
+    <node visible="true" id="-265" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787511992954097" lon="32.2970004466722997">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-265"/>
+    </node>
+    <node visible="true" id="-264" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7788087425187094" lon="32.2969717156124005">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-264"/>
+    </node>
+    <node visible="true" id="-263" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7788506285021701" lon="32.2969477435619012">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-263"/>
+    </node>
+    <node visible="true" id="-262" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7788937732080199" lon="32.2969168513654026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-262"/>
+    </node>
+    <node visible="true" id="-261" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7789893211751795" lon="32.2962968428053969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-261"/>
+    </node>
+    <node visible="true" id="-260" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7789614889881196" lon="32.2963137532252986">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-260"/>
+    </node>
+    <node visible="true" id="-259" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7789053292336101" lon="32.2963209158563984">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-259"/>
+    </node>
+    <node visible="true" id="-258" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7788489621043695" lon="32.2963262285276969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-258"/>
+    </node>
+    <node visible="true" id="-257" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7787924491999996" lon="32.2963296854335979">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-257"/>
+    </node>
+    <node visible="true" id="-256" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7787358522793997" lon="32.2963312827966007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-256"/>
+    </node>
+    <node visible="true" id="-255" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7786210910917495" lon="32.2963291251494979">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-255"/>
+    </node>
+    <node visible="true" id="-254" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7785335638757296" lon="32.2963240213678020">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-254"/>
+    </node>
+    <node visible="true" id="-253" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7784549540499190" lon="32.2963174243649007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-253"/>
+    </node>
+    <node visible="true" id="-252" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7783756213934598" lon="32.2963076869760002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-252"/>
+    </node>
+    <node visible="true" id="-251" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7783644627528590" lon="32.2963051594362014">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-251"/>
+    </node>
+    <node visible="true" id="-250" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7783277573913798" lon="32.2962925453375007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-250"/>
+    </node>
+    <node visible="true" id="-249" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7790762995339198" lon="32.2951529783225979">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-249"/>
+    </node>
+    <node visible="true" id="-248" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7791011265381602" lon="32.2951495912118034">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-248"/>
+    </node>
+    <node visible="true" id="-247" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7791259086498701" lon="32.2951458998063998">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-247"/>
+    </node>
+    <node visible="true" id="-246" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7791456877739402" lon="32.2951427593902025">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-246"/>
+    </node>
+    <node visible="true" id="-245" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7791753777756396" lon="32.2951378700906986">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-245"/>
+    </node>
+    <node visible="true" id="-244" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7792494921451198" lon="32.2951252056762996">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-244"/>
+    </node>
+    <node visible="true" id="-243" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7792989576203095" lon="32.2951171252784022">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-243"/>
+    </node>
+    <node visible="true" id="-242" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7793237368115795" lon="32.2951133933273979">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-242"/>
+    </node>
+    <node visible="true" id="-241" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7801431587327694" lon="32.2949945766952027">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-241"/>
+    </node>
+    <node visible="true" id="-240" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773145289795398" lon="32.2973382157608029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-240"/>
+    </node>
+    <node visible="true" id="-239" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773336814374101" lon="32.2974426710620008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-239"/>
+    </node>
+    <node visible="true" id="-238" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773727898948297" lon="32.2977247211759035">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-238"/>
+    </node>
+    <node visible="true" id="-237" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773906753164899" lon="32.2978988167995027">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-237"/>
+    </node>
+    <node visible="true" id="-236" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7774030133222793" lon="32.2980314393681027">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-236"/>
+    </node>
+    <node visible="true" id="-235" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7774179126540690" lon="32.2981668106442967">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-235"/>
+    </node>
+    <node visible="true" id="-234" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7774251529098195" lon="32.2982169092732008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-234"/>
+    </node>
+    <node visible="true" id="-233" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7774156763440994" lon="32.2995995663855027">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-233"/>
+    </node>
+    <node visible="true" id="-232" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773915670919997" lon="32.2996018872200992">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-232"/>
+    </node>
+    <node visible="true" id="-231" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773724616824595" lon="32.2996009689238903">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-231"/>
+    </node>
+    <node visible="true" id="-230" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7772893357687201" lon="32.2995909546071971">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-230"/>
+    </node>
+    <node visible="true" id="-229" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7772671674411900" lon="32.2995912485744014">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-229"/>
+    </node>
+    <node visible="true" id="-228" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7772090356714805" lon="32.2995961566197991">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-228"/>
+    </node>
+    <node visible="true" id="-227" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7770877203034496" lon="32.2996131343109028">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-227"/>
+    </node>
+    <node visible="true" id="-226" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7767254579384497" lon="32.2996735266724002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-226"/>
+    </node>
+    <node visible="true" id="-225" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7789366650597493" lon="32.2968795862481031">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-225"/>
+    </node>
+    <node visible="true" id="-224" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7789777924808599" lon="32.2968364954355920">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-224"/>
+    </node>
+    <node visible="true" id="-223" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7790156438949696" lon="32.2967881261537002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-223"/>
+    </node>
+    <node visible="true" id="-222" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7790487077257802" lon="32.2967350256286991">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-222"/>
+    </node>
+    <node visible="true" id="-221" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7790754723971696" lon="32.2966777410874002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-221"/>
+    </node>
+    <node visible="true" id="-220" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7790849044578998" lon="32.2966474247637976">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-220"/>
+    </node>
+    <node visible="true" id="-219" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7774369596119795" lon="32.2982820972044991">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-219"/>
+    </node>
+    <node visible="true" id="-218" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7774626380325098" lon="32.2982815648464978">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-218"/>
+    </node>
+    <node visible="true" id="-217" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7774882821284392" lon="32.2982801415870000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-217"/>
+    </node>
+    <node visible="true" id="-216" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7775138606563705" lon="32.2982778291599999">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-216"/>
+    </node>
+    <node visible="true" id="-215" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7775393424527901" lon="32.2982746303827000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-215"/>
+    </node>
+    <node visible="true" id="-214" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7775646964720195" lon="32.2982705491522992">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-214"/>
+    </node>
+    <node visible="true" id="-213" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7775898918240998" lon="32.2982655904410905">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-213"/>
+    </node>
+    <node visible="true" id="-212" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7776148978123198" lon="32.2982597602904917">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-212"/>
+    </node>
+    <node visible="true" id="-211" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7776396839707300" lon="32.2982530658035927">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-211"/>
+    </node>
+    <node visible="true" id="-210" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7776642201011699" lon="32.2982455151365002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-210"/>
+    </node>
+    <node visible="true" id="-209" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7776884763101295" lon="32.2982371174884975">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-209"/>
+    </node>
+    <node visible="true" id="-208" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7777124230451200" lon="32.2982278830908029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-208"/>
+    </node>
+    <node visible="true" id="-207" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7777360311307002" lon="32.2982178231942001">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-207"/>
+    </node>
+    <node visible="true" id="-206" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7777592718040296" lon="32.2982069500548903">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-206"/>
+    </node>
+    <node visible="true" id="-205" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7777625781590793" lon="32.2982053222500980">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-205"/>
+    </node>
+    <node visible="true" id="-204" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7787963648221194" lon="32.2971009015447024">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-204"/>
+    </node>
+    <node visible="true" id="-203" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7788284031442996" lon="32.2971081970185026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-203"/>
+    </node>
+    <node visible="true" id="-202" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7788772095488996" lon="32.2971150417172979">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-202"/>
+    </node>
+    <node visible="true" id="-201" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7789264630866199" lon="32.2971169087592997">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-201"/>
+    </node>
+    <node visible="true" id="-200" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7789756518014195" lon="32.2971137787374971">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-200"/>
+    </node>
+    <node visible="true" id="-199" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7802648640015990" lon="32.2949085176392998">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-199"/>
+    </node>
+    <node visible="true" id="-198" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7774859531654603" lon="32.2971798678577002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-198"/>
+    </node>
+    <node visible="true" id="-197" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7780744641452095" lon="32.2971089943925023">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-197"/>
+    </node>
+    <node visible="true" id="-196" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7782770375765700" lon="32.2970885723319938">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-196"/>
+    </node>
+    <node visible="true" id="-195" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7785026490386202" lon="32.2970730894105031">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-195"/>
+    </node>
+    <node visible="true" id="-194" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7786476470914194" lon="32.2970604072306955">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-194"/>
+    </node>
+    <node visible="true" id="-193" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7786626640867493" lon="32.2970611807515979">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-193"/>
+    </node>
+    <node visible="true" id="-192" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7786797299840194" lon="32.2970641285152027">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-192"/>
+    </node>
+    <node visible="true" id="-191" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7787246979159801" lon="32.2970775161554968">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-191"/>
+    </node>
+    <node visible="true" id="-190" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7804898163031706" lon="32.2949240333992975">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-190"/>
+    </node>
+    <node visible="true" id="-189" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7803884947554898" lon="32.2949496516802981">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-189"/>
+    </node>
+    <node visible="true" id="-188" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7802820953679195" lon="32.2949715954966976">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-188"/>
+    </node>
+    <node visible="true" id="-187" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7772836575038697" lon="32.2972018287101008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-187"/>
+    </node>
+    <node visible="true" id="-186" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7772501254376700" lon="32.2970529479139969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-186"/>
+    </node>
+    <node visible="true" id="-185" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7772307442505402" lon="32.2969431351758018">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-185"/>
+    </node>
+    <node visible="true" id="-184" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7771294554076396" lon="32.2962343203032987">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-184"/>
+    </node>
+    <node visible="true" id="-183" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7771202173468099" lon="32.2961424051902029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-183"/>
+    </node>
+    <node visible="true" id="-182" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7771116826744997" lon="32.2960116855251016">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-182"/>
+    </node>
+    <node visible="true" id="-181" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7771043240371598" lon="32.2959079210252966">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-181"/>
+    </node>
+    <node visible="true" id="-180" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770881015616595" lon="32.2957475602725026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-180"/>
+    </node>
+    <node visible="true" id="-179" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770817892336996" lon="32.2956705918687987">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-179"/>
+    </node>
+    <node visible="true" id="-178" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770782669788097" lon="32.2955808140050991">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-178"/>
+    </node>
+    <node visible="true" id="-177" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770807222976890" lon="32.2954718424969016">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-177"/>
+    </node>
+    <node visible="true" id="-176" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770787292631693" lon="32.2954424312888904">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-176"/>
+    </node>
+    <node visible="true" id="-175" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7774541148099803" lon="32.2995857555437951">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-175"/>
+    </node>
+    <node visible="true" id="-174" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7774710615923790" lon="32.2995745703018926">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-174"/>
+    </node>
+    <node visible="true" id="-173" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7775318157337399" lon="32.2995200418195978">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-173"/>
+    </node>
+    <node visible="true" id="-172" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7775801075251696" lon="32.2994571221653999">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-172"/>
+    </node>
+    <node visible="true" id="-171" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7776133843055297" lon="32.2994078301435010">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-171"/>
+    </node>
+    <node visible="true" id="-170" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7776440386302998" lon="32.2993568839232026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-170"/>
+    </node>
+    <node visible="true" id="-169" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7776719875511797" lon="32.2993044213613985">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-169"/>
+    </node>
+    <node visible="true" id="-168" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7776826474353000" lon="32.2992821264148020">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-168"/>
+    </node>
+    <node visible="true" id="-167" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790242644109999" lon="32.2971056841855031">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-167"/>
+    </node>
+    <node visible="true" id="-166" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790315514972499" lon="32.2971038268491029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-166"/>
+    </node>
+    <node visible="true" id="-165" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790405653388497" lon="32.2971003506071028">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-165"/>
+    </node>
+    <node visible="true" id="-164" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790492309758594" lon="32.2970960876630926">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-164"/>
+    </node>
+    <node visible="true" id="-163" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790574791499600" lon="32.2970910720879019">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-163"/>
+    </node>
+    <node visible="true" id="-162" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790652439393195" lon="32.2970853439671970">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-162"/>
+    </node>
+    <node visible="true" id="-161" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790724632854906" lon="32.2970789490819996">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-161"/>
+    </node>
+    <node visible="true" id="-160" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790790794893199" lon="32.2970719385419969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-160"/>
+    </node>
+    <node visible="true" id="-159" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790850396722004" lon="32.2970643683775975">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-159"/>
+    </node>
+    <node visible="true" id="-158" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790902961985697" lon="32.2970562990916008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-158"/>
+    </node>
+    <node visible="true" id="-157" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790948070567598" lon="32.2970477951761978">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-157"/>
+    </node>
+    <node visible="true" id="-156" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790985361946494" lon="32.2970389245972029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-156"/>
+    </node>
+    <node visible="true" id="-155" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791014538078898" lon="32.2970297582508010">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-155"/>
+    </node>
+    <node visible="true" id="-154" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791035365780692" lon="32.2970203693972024">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-154"/>
+    </node>
+    <node visible="true" id="-153" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791047678590695" lon="32.2970108330748005">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-153"/>
+    </node>
+    <node visible="true" id="-152" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791051378101401" lon="32.2970012255008001">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-152"/>
+    </node>
+    <node visible="true" id="-151" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791046434745397" lon="32.2969916234616008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-151"/>
+    </node>
+    <node visible="true" id="-150" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791029517280301" lon="32.2969824146832920">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-150"/>
+    </node>
+    <node visible="true" id="-149" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791005899865300" lon="32.2969733529161971">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-149"/>
+    </node>
+    <node visible="true" id="-148" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790975707975401" lon="32.2969644863038923">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-148"/>
+    </node>
+    <node visible="true" id="-147" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790939102014489" lon="32.2969558619530019">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-147"/>
+    </node>
+    <node visible="true" id="-146" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790896276463202" lon="32.2969475256830023">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-146"/>
+    </node>
+    <node visible="true" id="-145" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790847458845800" lon="32.2969395217829955">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-145"/>
+    </node>
+    <node visible="true" id="-144" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790792908520991" lon="32.2969318927762004">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-144"/>
+    </node>
+    <node visible="true" id="-143" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790732915304490" lon="32.2969246791940989">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-143"/>
+    </node>
+    <node visible="true" id="-142" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790667797929096" lon="32.2969179193610003">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-142"/>
+    </node>
+    <node visible="true" id="-141" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790597902351197" lon="32.2969116491907968">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-141"/>
+    </node>
+    <node visible="true" id="-140" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790523599912897" lon="32.2969059019956006">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-140"/>
+    </node>
+    <node visible="true" id="-139" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790445285368999" lon="32.2969007083091029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-139"/>
+    </node>
+    <node visible="true" id="-138" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790363374789999" lon="32.2968960957244988">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-138"/>
+    </node>
+    <node visible="true" id="-137" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790278303351501" lon="32.2968920887473985">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-137"/>
+    </node>
+    <node visible="true" id="-136" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790190523021798" lon="32.2968887086663017">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-136"/>
+    </node>
+    <node visible="true" id="-135" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790109489176200" lon="32.2968877484774026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-135"/>
+    </node>
+    <node visible="true" id="-134" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790028167736796" lon="32.2968870701194035">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-134"/>
+    </node>
+    <node visible="true" id="-133" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789946657781202" lon="32.2968866744188006">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-133"/>
+    </node>
+    <node visible="true" id="-132" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789865058616696" lon="32.2968865618576970">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-132"/>
+    </node>
+    <node visible="true" id="-131" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789783469659306" lon="32.2968867325731992">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-131"/>
+    </node>
+    <node visible="true" id="-130" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789701990312596" lon="32.2968871863574023">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-130"/>
+    </node>
+    <node visible="true" id="-129" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789620719846595" lon="32.2968879226572980">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-129"/>
+    </node>
+    <node visible="true" id="-128" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789539757276800" lon="32.2968889405758972">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-128"/>
+    </node>
+    <node visible="true" id="-127" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789459201243600" lon="32.2968902388730967">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-127"/>
+    </node>
+    <node visible="true" id="-126" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789379149892097" lon="32.2968918159670011">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-126"/>
+    </node>
+    <node visible="true" id="-125" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789299700752599" lon="32.2968936699360967">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-125"/>
+    </node>
+    <node visible="true" id="-124" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789220950621401" lon="32.2968957985218026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-124"/>
+    </node>
+    <node visible="true" id="-123" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789158003601693" lon="32.2968977138286988">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-123"/>
+    </node>
+    <node visible="true" id="-122" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789969358401998" lon="32.2971102347032968">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-122"/>
+    </node>
+    <node visible="true" id="-121" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790025505555400" lon="32.2971191375876998">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-121"/>
+    </node>
+    <node visible="true" id="-120" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790156767274601" lon="32.2971388297540969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-120"/>
+    </node>
+    <node visible="true" id="-119" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790294859569196" lon="32.2971580543520034">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-119"/>
+    </node>
+    <node visible="true" id="-118" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790439614195095" lon="32.2971767879592022">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-118"/>
+    </node>
+    <node visible="true" id="-117" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790590854791493" lon="32.2971950077516965">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-117"/>
+    </node>
+    <node visible="true" id="-116" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792366533190895" lon="32.2973305133172985">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-116"/>
+    </node>
+    <node visible="true" id="-115" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794372986508997" lon="32.2974413865974981">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-115"/>
+    </node>
+    <node visible="true" id="-114" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794472236061289" lon="32.2974626635860034">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-114"/>
+    </node>
+    <node visible="true" id="-113" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794552230133291" lon="32.2974880624872966">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-113"/>
+    </node>
+    <node visible="true" id="-112" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794605108359001" lon="32.2975141534396002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-112"/>
+    </node>
+    <node visible="true" id="-111" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794632400624395" lon="32.2975539616876972">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-111"/>
+    </node>
+    <node visible="true" id="-110" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794609369698202" lon="32.2975806660790994">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-110"/>
+    </node>
+    <node visible="true" id="-109" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794570386275002" lon="32.2975972691074986">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-109"/>
+    </node>
+    <node visible="true" id="-108" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794433005530799" lon="32.2976400568823010">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-108"/>
+    </node>
+    <node visible="true" id="-107" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794221618565693" lon="32.2976955792871010">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-107"/>
+    </node>
+    <node visible="true" id="-106" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792911885029801" lon="32.2980073079898986">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-106"/>
+    </node>
+    <node visible="true" id="-105" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792771932894604" lon="32.2980400495640012">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-105"/>
+    </node>
+    <node visible="true" id="-104" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792340225389993" lon="32.2981379062442002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-104"/>
+    </node>
+    <node visible="true" id="-103" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792194809194601" lon="32.2981713309427008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-103"/>
+    </node>
+    <node visible="true" id="-102" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792059237228997" lon="32.2982034031176966">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-102"/>
+    </node>
+    <node visible="true" id="-101" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791925796028298" lon="32.2982363990170995">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-101"/>
+    </node>
+    <node visible="true" id="-100" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791799282448499" lon="32.2982696353302998">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-100"/>
+    </node>
+    <node visible="true" id="-99" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791681365765095" lon="32.2983031686358970">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-99"/>
+    </node>
+    <node visible="true" id="-98" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791573715253901" lon="32.2983370555132012">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-98"/>
+    </node>
+    <node visible="true" id="-97" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791482647869201" lon="32.2983674966233991">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-97"/>
+    </node>
+    <node visible="true" id="-96" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791362574831098" lon="32.2984225754577992">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-96"/>
+    </node>
+    <node visible="true" id="-95" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791282559892796" lon="32.2984823032193944">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-95"/>
+    </node>
+    <node visible="true" id="-94" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791239709769004" lon="32.2985348622788990">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-94"/>
+    </node>
+    <node visible="true" id="-93" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791230486703595" lon="32.2985744034322977">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-93"/>
+    </node>
+    <node visible="true" id="-92" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791246982731694" lon="32.2986553633340989">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-92"/>
+    </node>
+    <node visible="true" id="-91" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791315907305294" lon="32.2987766773950966">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-91"/>
+    </node>
+    <node visible="true" id="-90" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791479205242298" lon="32.2989834577483990">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-90"/>
+    </node>
+    <node visible="true" id="-89" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791902029950202" lon="32.2995085121716983">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-89"/>
+    </node>
+    <node visible="true" id="-88" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792022892283490" lon="32.2996321148190901">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-88"/>
+    </node>
+    <node visible="true" id="-87" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7806931403000497" lon="32.2969913941988978">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-87"/>
+    </node>
+    <node visible="true" id="-86" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7806583129355396" lon="32.2969763882787007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-86"/>
+    </node>
+    <node visible="true" id="-85" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7806240333863697" lon="32.2969601827373936">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-85"/>
+    </node>
+    <node visible="true" id="-84" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7806086750433101" lon="32.2969524411589006">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-84"/>
+    </node>
+    <node visible="true" id="-83" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805968276526696" lon="32.2969416271105985">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-83"/>
+    </node>
+    <node visible="true" id="-82" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805857259420201" lon="32.2969300569622035">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-82"/>
+    </node>
+    <node visible="true" id="-81" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805754185966896" lon="32.2969177814534021">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-81"/>
+    </node>
+    <node visible="true" id="-80" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805659508184002" lon="32.2969048544170008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-80"/>
+    </node>
+    <node visible="true" id="-79" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805573641270294" lon="32.2968913325430975">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-79"/>
+    </node>
+    <node visible="true" id="-78" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805496961785692" lon="32.2968772751304982">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-78"/>
+    </node>
+    <node visible="true" id="-77" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805429805999298" lon="32.2968627438264022">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-77"/>
+    </node>
+    <node visible="true" id="-76" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805372468415497" lon="32.2968478023561971">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-76"/>
+    </node>
+    <node visible="true" id="-75" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805325200481597" lon="32.2968325162440948">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-75"/>
+    </node>
+    <node visible="true" id="-74" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805288209485899" lon="32.2968169525255959">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-74"/>
+    </node>
+    <node visible="true" id="-73" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805261657648095" lon="32.2968011794536949">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-73"/>
+    </node>
+    <node visible="true" id="-72" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805245661408300" lon="32.2967852661994996">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-72"/>
+    </node>
+    <node visible="true" id="-71" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805240290916098" lon="32.2967692825488015">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-71"/>
+    </node>
+    <node visible="true" id="-70" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805245569723094" lon="32.2967532985960020">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-70"/>
+    </node>
+    <node visible="true" id="-69" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805261474679601" lon="32.2967373844371011">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-69"/>
+    </node>
+    <node visible="true" id="-68" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805209559507098" lon="32.2967175128437987">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-68"/>
+    </node>
+    <node visible="true" id="-67" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805167552768602" lon="32.2966974109988030">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-67"/>
+    </node>
+    <node visible="true" id="-66" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805135556507095" lon="32.2966771277339006">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-66"/>
+    </node>
+    <node visible="true" id="-65" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805113648448301" lon="32.2966567123213011">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-65"/>
+    </node>
+    <node visible="true" id="-64" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805101881811396" lon="32.2966362143545993">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-64"/>
+    </node>
+    <node visible="true" id="-63" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805100285179902" lon="32.2966156836275999">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-63"/>
+    </node>
+    <node visible="true" id="-62" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805108862432300" lon="32.2965951700138021">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-62"/>
+    </node>
+    <node visible="true" id="-61" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805127592732499" lon="32.2965747233452021">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-61"/>
+    </node>
+    <node visible="true" id="-60" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805156430580400" lon="32.2965543932911032">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-60"/>
+    </node>
+    <node visible="true" id="-59" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805195305922603" lon="32.2965342292375013">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-59"/>
+    </node>
+    <node visible="true" id="-58" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805244124322495" lon="32.2965142801673011">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-58"/>
+    </node>
+    <node visible="true" id="-57" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805302767189599" lon="32.2964945945410022">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-57"/>
+    </node>
+    <node visible="true" id="-56" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805371092067896" lon="32.2964752201790901">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-56"/>
+    </node>
+    <node visible="true" id="-55" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805448932981300" lon="32.2964562041460965">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-55"/>
+    </node>
+    <node visible="true" id="-54" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805536100837798" lon="32.2964375926361029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-54"/>
+    </node>
+    <node visible="true" id="-53" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7803760046767496" lon="32.2964369238177937">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-53"/>
+    </node>
+    <node visible="true" id="-52" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7803254777025197" lon="32.2964407561984004">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-52"/>
+    </node>
+    <node visible="true" id="-51" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7802751159966999" lon="32.2964463398967965">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-51"/>
+    </node>
+    <node visible="true" id="-50" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7802249809171897" lon="32.2964536681096988">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-50"/>
+    </node>
+    <node visible="true" id="-49" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7801906146286002" lon="32.2964597252812027">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-49"/>
+    </node>
+    <node visible="true" id="-48" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7781376019073698" lon="32.2952631078974974">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-48"/>
+    </node>
+    <node visible="true" id="-47" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7777085094541092" lon="32.2953098296460013">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-47"/>
+    </node>
+    <node visible="true" id="-46" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7775371941190001" lon="32.2953307884130965">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-46"/>
+    </node>
+    <node visible="true" id="-45" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7773665222192294" lon="32.2953558664478990">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-45"/>
+    </node>
+    <node visible="true" id="-44" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7770739994837497" lon="32.2954084708673008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-44"/>
+    </node>
+    <node visible="true" id="-43" timestamp="2020-02-07T17:57:23Z" version="1" lat="2.7774371355780696" lon="32.2995936087139910">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-43"/>
+    </node>
+    <node visible="true" id="-42" timestamp="2020-02-07T17:57:23Z" version="1" lat="2.7806846759986197" lon="32.2962260576761011">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-42"/>
+    </node>
+    <node visible="true" id="-41" timestamp="2020-02-07T17:57:23Z" version="1" lat="2.7805079593334501" lon="32.2963666091931927">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-41"/>
+    </node>
+    <node visible="true" id="-40" timestamp="2020-02-07T17:57:23Z" version="1" lat="2.7804266353601501" lon="32.2964348474243010">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-40"/>
+    </node>
+    <node visible="true" id="-39" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789724255123094" lon="32.2951664064648014">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-39"/>
+    </node>
+    <node visible="true" id="-38" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789689964763595" lon="32.2952618810179999">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-38"/>
+    </node>
+    <node visible="true" id="-37" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789699294789494" lon="32.2953520215660035">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-37"/>
+    </node>
+    <node visible="true" id="-36" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789740140146200" lon="32.2954423091296974">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-36"/>
+    </node>
+    <node visible="true" id="-35" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789809746809002" lon="32.2955324225370006">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-35"/>
+    </node>
+    <node visible="true" id="-34" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789901570095994" lon="32.2956182804691991">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-34"/>
+    </node>
+    <node visible="true" id="-33" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7790278750120700" lon="32.2959181961172987">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-33"/>
+    </node>
+    <node visible="true" id="-32" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7790489272173700" lon="32.2961377013033015">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-32"/>
+    </node>
+    <node visible="true" id="-31" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7790576488356300" lon="32.2961947257553987">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-31"/>
+    </node>
+    <node visible="true" id="-30" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7790747222463801" lon="32.2962826583055929">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-30"/>
+    </node>
+    <node visible="true" id="-29" timestamp="2020-02-07T17:57:40Z" version="1" lat="2.7771899749620195" lon="32.2972141754823951">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-29"/>
+    </node>
+    <node visible="true" id="-28" timestamp="2020-02-07T17:57:40Z" version="1" lat="2.7769523387945796" lon="32.2972517846122997">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-28"/>
+    </node>
+    <node visible="true" id="-27" timestamp="2020-02-07T17:57:40Z" version="1" lat="2.7766812980759195" lon="32.2972883666062032">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-27"/>
+    </node>
+    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7776847598532020" lon="32.2997000000000014">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-26"/>
+    </node>
+    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7765999999999997" lon="32.2973002854333870">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-25"/>
+    </node>
+    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2962170523098280">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-24"/>
+    </node>
+    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7774845037998643" lon="32.2997000000000014">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-23"/>
+    </node>
+    <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7807000000000004" lon="32.2969940710825796">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-22"/>
+    </node>
+    <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7792108274089626" lon="32.2997000000000014">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-21"/>
+    </node>
+    <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999995" lon="32.2948615871501872">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-20"/>
+    </node>
+    <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7802302174146551" lon="32.2948000000000022">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-19"/>
+    </node>
+    <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7765999999999997" lon="32.2996925211341050">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-18"/>
+    </node>
+    <node visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7789980366231744" lon="32.2948000000000022">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-17"/>
+    </node>
+    <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7765999999999997" lon="32.2985227201807987">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-16"/>
+    </node>
+    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2964543343445740">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-15"/>
+    </node>
+    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7769704322783269" lon="32.2948000000000022">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-14"/>
+    </node>
+    <way visible="true" id="-44" timestamp="2020-02-07T17:57:47Z" version="1">
+        <nd ref="-54"/>
+        <nd ref="-313"/>
+        <nd ref="-312"/>
+        <nd ref="-40"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.845Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-44"/>
+        <tag k="source:datetime" v="2019-01-22T08:12:42Z;2020-02-07T17:57:47Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-42" timestamp="2020-02-07T17:57:46Z" version="1">
+        <nd ref="-308"/>
+        <nd ref="-307"/>
+        <nd ref="-306"/>
+        <nd ref="-305"/>
+        <nd ref="-304"/>
+        <nd ref="-303"/>
+        <nd ref="-302"/>
+        <nd ref="-301"/>
+        <nd ref="-300"/>
+        <nd ref="-299"/>
+        <nd ref="-298"/>
+        <nd ref="-297"/>
+        <nd ref="-296"/>
+        <nd ref="-295"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.845Z;2020-02-07T17:57:16.210Z;2020-02-07T17:57:15.838Z;2020-02-07T17:57:17.081Z;2020-02-07T17:57:16.152Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-42"/>
+        <tag k="source:datetime" v="2019-01-22T08:12:42Z;2020-02-07T17:57:47Z;2020-02-07T17:57:46Z;2020-02-07T17:57:43Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-41" timestamp="2020-02-07T17:57:42Z" version="1">
+        <nd ref="-39"/>
+        <nd ref="-38"/>
+        <nd ref="-37"/>
+        <nd ref="-36"/>
+        <nd ref="-35"/>
+        <nd ref="-34"/>
+        <nd ref="-33"/>
+        <nd ref="-32"/>
+        <nd ref="-31"/>
+        <nd ref="-30"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.215Z;2020-02-07T17:57:17.351Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="name" v="Princess Road"/>
+        <tag k="hoot:id" v="-41"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z;2020-02-07T17:57:46Z;2020-02-07T17:57:42Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-40" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-191"/>
+        <nd ref="-269"/>
+        <nd ref="-268"/>
+        <nd ref="-267"/>
+        <nd ref="-266"/>
+        <nd ref="-265"/>
+        <nd ref="-264"/>
+        <nd ref="-263"/>
+        <nd ref="-262"/>
+        <nd ref="-123"/>
+        <tag k="source" v="NextView"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.301Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="hoot:id" v="-40"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z;2020-02-07T17:57:45Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+        <tag k="junction" v="roundabout"/>
+    </way>
+    <way visible="true" id="-39" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-30"/>
+        <nd ref="-261"/>
+        <nd ref="-260"/>
+        <nd ref="-259"/>
+        <nd ref="-258"/>
+        <nd ref="-257"/>
+        <nd ref="-256"/>
+        <nd ref="-255"/>
+        <nd ref="-254"/>
+        <nd ref="-253"/>
+        <nd ref="-252"/>
+        <nd ref="-251"/>
+        <nd ref="-250"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.405Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:id" v="-39"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-38" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-39"/>
+        <nd ref="-249"/>
+        <nd ref="-248"/>
+        <nd ref="-247"/>
+        <nd ref="-246"/>
+        <nd ref="-245"/>
+        <nd ref="-244"/>
+        <nd ref="-243"/>
+        <nd ref="-242"/>
+        <nd ref="-241"/>
+        <nd ref="-188"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.425Z"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="Gulu - Kitgum Road"/>
+        <tag k="hoot:id" v="-38"/>
+        <tag k="source:datetime" v="2019-01-28T11:00:26Z;2020-02-07T17:57:45Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-37" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-187"/>
+        <nd ref="-240"/>
+        <nd ref="-239"/>
+        <nd ref="-238"/>
+        <nd ref="-237"/>
+        <nd ref="-236"/>
+        <nd ref="-235"/>
+        <nd ref="-234"/>
+        <nd ref="-219"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.468Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-37"/>
+        <tag k="source:datetime" v="2015-05-04T09:53:52Z;2020-02-07T17:57:45Z"/>
+        <tag k="surface" v="ground"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-31" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-43"/>
+        <nd ref="-175"/>
+        <nd ref="-174"/>
+        <nd ref="-173"/>
+        <nd ref="-172"/>
+        <nd ref="-171"/>
+        <nd ref="-170"/>
+        <nd ref="-169"/>
+        <nd ref="-168"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.775Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:id" v="-31"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-30" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-123"/>
+        <nd ref="-124"/>
+        <nd ref="-125"/>
+        <nd ref="-126"/>
+        <nd ref="-127"/>
+        <nd ref="-128"/>
+        <nd ref="-129"/>
+        <nd ref="-130"/>
+        <nd ref="-131"/>
+        <nd ref="-132"/>
+        <nd ref="-133"/>
+        <nd ref="-134"/>
+        <nd ref="-135"/>
+        <nd ref="-136"/>
+        <nd ref="-137"/>
+        <nd ref="-138"/>
+        <nd ref="-139"/>
+        <nd ref="-140"/>
+        <nd ref="-141"/>
+        <nd ref="-142"/>
+        <nd ref="-143"/>
+        <nd ref="-144"/>
+        <nd ref="-145"/>
+        <nd ref="-146"/>
+        <nd ref="-147"/>
+        <nd ref="-148"/>
+        <nd ref="-149"/>
+        <nd ref="-150"/>
+        <nd ref="-151"/>
+        <nd ref="-152"/>
+        <nd ref="-153"/>
+        <nd ref="-154"/>
+        <nd ref="-155"/>
+        <nd ref="-156"/>
+        <nd ref="-157"/>
+        <nd ref="-158"/>
+        <nd ref="-159"/>
+        <nd ref="-160"/>
+        <nd ref="-161"/>
+        <nd ref="-162"/>
+        <nd ref="-163"/>
+        <nd ref="-164"/>
+        <nd ref="-165"/>
+        <nd ref="-166"/>
+        <nd ref="-167"/>
+        <nd ref="-122"/>
+        <tag k="source" v="NextView"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.914Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="hoot:id" v="-30"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z;2020-02-07T17:57:44Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+        <tag k="junction" v="roundabout"/>
+    </way>
+    <way visible="true" id="-29" timestamp="2020-02-07T17:57:47Z" version="1">
+        <nd ref="-329"/>
+        <nd ref="-328"/>
+        <nd ref="-327"/>
+        <nd ref="-326"/>
+        <nd ref="-325"/>
+        <nd ref="-324"/>
+        <nd ref="-323"/>
+        <nd ref="-322"/>
+        <nd ref="-321"/>
+        <nd ref="-320"/>
+        <nd ref="-319"/>
+        <nd ref="-318"/>
+        <nd ref="-317"/>
+        <nd ref="-316"/>
+        <nd ref="-315"/>
+        <nd ref="-314"/>
+        <nd ref="-220"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.845Z;2020-02-07T17:57:16.210Z;2020-02-07T17:57:15.838Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-29"/>
+        <tag k="source:datetime" v="2019-01-22T08:12:42Z;2020-02-07T17:57:47Z;2020-02-07T17:57:46Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-28" timestamp="2020-02-07T17:57:43Z" version="1">
+        <nd ref="-39"/>
+        <nd ref="-48"/>
+        <nd ref="-47"/>
+        <nd ref="-46"/>
+        <nd ref="-45"/>
+        <nd ref="-44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.110Z"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="Gulu - Kitgum Road"/>
+        <tag k="hoot:id" v="-28"/>
+        <tag k="source:datetime" v="2019-01-28T11:00:26Z;2020-02-07T17:57:43Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-27" timestamp="2020-02-07T17:57:46Z" version="1">
+        <nd ref="-220"/>
+        <nd ref="-291"/>
+        <nd ref="-290"/>
+        <nd ref="-289"/>
+        <nd ref="-288"/>
+        <nd ref="-287"/>
+        <nd ref="-30"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.215Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="name" v="Princess Road"/>
+        <tag k="hoot:id" v="-27"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z;2020-02-07T17:57:46Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-26"/>
+        <nd ref="-168"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.542Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:id" v="-26"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:42Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-24"/>
+        <nd ref="-42"/>
+        <nd ref="-41"/>
+        <nd ref="-40"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.257Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:id" v="-24"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:42Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-22"/>
+        <nd ref="-87"/>
+        <nd ref="-86"/>
+        <nd ref="-85"/>
+        <nd ref="-84"/>
+        <nd ref="-83"/>
+        <nd ref="-82"/>
+        <nd ref="-81"/>
+        <nd ref="-80"/>
+        <nd ref="-79"/>
+        <nd ref="-78"/>
+        <nd ref="-77"/>
+        <nd ref="-76"/>
+        <nd ref="-75"/>
+        <nd ref="-74"/>
+        <nd ref="-73"/>
+        <nd ref="-72"/>
+        <nd ref="-71"/>
+        <nd ref="-70"/>
+        <nd ref="-69"/>
+        <nd ref="-68"/>
+        <nd ref="-67"/>
+        <nd ref="-66"/>
+        <nd ref="-65"/>
+        <nd ref="-64"/>
+        <nd ref="-63"/>
+        <nd ref="-62"/>
+        <nd ref="-61"/>
+        <nd ref="-60"/>
+        <nd ref="-59"/>
+        <nd ref="-58"/>
+        <nd ref="-57"/>
+        <nd ref="-56"/>
+        <nd ref="-55"/>
+        <nd ref="-54"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.069Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:id" v="-22"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:43Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-21"/>
+        <nd ref="-88"/>
+        <nd ref="-89"/>
+        <nd ref="-90"/>
+        <nd ref="-91"/>
+        <nd ref="-92"/>
+        <nd ref="-93"/>
+        <nd ref="-94"/>
+        <nd ref="-95"/>
+        <nd ref="-96"/>
+        <nd ref="-97"/>
+        <nd ref="-98"/>
+        <nd ref="-99"/>
+        <nd ref="-100"/>
+        <nd ref="-101"/>
+        <nd ref="-102"/>
+        <nd ref="-103"/>
+        <nd ref="-104"/>
+        <nd ref="-105"/>
+        <nd ref="-106"/>
+        <nd ref="-107"/>
+        <nd ref="-108"/>
+        <nd ref="-109"/>
+        <nd ref="-110"/>
+        <nd ref="-111"/>
+        <nd ref="-112"/>
+        <nd ref="-113"/>
+        <nd ref="-114"/>
+        <nd ref="-115"/>
+        <nd ref="-116"/>
+        <nd ref="-117"/>
+        <nd ref="-118"/>
+        <nd ref="-119"/>
+        <nd ref="-120"/>
+        <nd ref="-121"/>
+        <nd ref="-122"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.919Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="name" v="Eden Road"/>
+        <tag k="hoot:id" v="-21"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z;2020-02-07T17:57:44Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-219"/>
+        <nd ref="-286"/>
+        <nd ref="-285"/>
+        <nd ref="-284"/>
+        <nd ref="-283"/>
+        <nd ref="-282"/>
+        <nd ref="-281"/>
+        <nd ref="-280"/>
+        <nd ref="-279"/>
+        <nd ref="-278"/>
+        <nd ref="-277"/>
+        <nd ref="-276"/>
+        <nd ref="-275"/>
+        <nd ref="-274"/>
+        <nd ref="-273"/>
+        <nd ref="-272"/>
+        <nd ref="-271"/>
+        <nd ref="-270"/>
+        <nd ref="-16"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.261Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:id" v="-16"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:46Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15" timestamp="2020-02-07T17:57:43Z" version="1">
+        <nd ref="-40"/>
+        <nd ref="-53"/>
+        <nd ref="-52"/>
+        <nd ref="-51"/>
+        <nd ref="-50"/>
+        <nd ref="-49"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.845Z;2020-02-07T17:57:16.210Z;2020-02-07T17:57:15.838Z;2020-02-07T17:57:17.081Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-15"/>
+        <tag k="source:datetime" v="2019-01-22T08:12:42Z;2020-02-07T17:57:47Z;2020-02-07T17:57:46Z;2020-02-07T17:57:43Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23"/>
+        <nd ref="-43"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.255Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-11"/>
+        <tag k="source:datetime" v="2019-01-28T10:19:05Z;2020-02-07T17:57:42Z"/>
+        <tag k="surface" v="ground"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-43"/>
+        <nd ref="-233"/>
+        <nd ref="-232"/>
+        <nd ref="-231"/>
+        <nd ref="-230"/>
+        <nd ref="-229"/>
+        <nd ref="-228"/>
+        <nd ref="-227"/>
+        <nd ref="-226"/>
+        <nd ref="-18"/>
+        <tag k="oneway" v="no"/>
+        <tag k="source" v="NextView"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.533Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="name" v="Awere Road"/>
+        <tag k="hoot:id" v="-10"/>
+        <tag k="source:datetime" v="2019-01-28T12:47:24Z;2020-02-07T17:57:45Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-44"/>
+        <nd ref="-311"/>
+        <nd ref="-310"/>
+        <nd ref="-309"/>
+        <nd ref="-14"/>
+        <tag k="source" v="NextView"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.023Z"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="Nimule - Gulu Road"/>
+        <tag k="ref" v="A104"/>
+        <tag k="hoot:id" v="-9"/>
+        <tag k="source:datetime" v="2020-01-20T16:05:21Z;2020-02-07T17:57:46Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-15"/>
+        <nd ref="-294"/>
+        <nd ref="-293"/>
+        <nd ref="-292"/>
+        <nd ref="-54"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.845Z;2020-02-07T17:57:16.210Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-8"/>
+        <tag k="source:datetime" v="2019-01-22T08:12:42Z;2020-02-07T17:57:47Z;2020-02-07T17:57:46Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-187"/>
+        <nd ref="-29"/>
+        <nd ref="-28"/>
+        <nd ref="-27"/>
+        <nd ref="-25"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.539Z"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="Main Street"/>
+        <tag k="ref" v="A104"/>
+        <tag k="hoot:id" v="-7"/>
+        <tag k="source:datetime" v="2020-01-20T16:05:21Z;2020-02-07T17:57:42Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-20"/>
+        <nd ref="-190"/>
+        <nd ref="-189"/>
+        <nd ref="-188"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.745Z"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="Gulu - Kitgum Road"/>
+        <tag k="hoot:id" v="-6"/>
+        <tag k="source:datetime" v="2019-01-28T11:00:26Z;2020-02-07T17:57:44Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-39"/>
+        <nd ref="-17"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.346Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-5"/>
+        <tag k="source:datetime" v="2019-01-24T14:32:35Z;2020-02-07T17:57:45Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-188"/>
+        <nd ref="-199"/>
+        <nd ref="-19"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.673Z"/>
+        <tag k="highway" v="service"/>
+        <tag k="hoot:id" v="-1"/>
+        <tag k="source:datetime" v="2019-01-22T08:12:42Z;2020-02-07T17:57:44Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="176031521" timestamp="2020-02-07T17:57:47Z" version="1">
+        <nd ref="-219"/>
+        <nd ref="-387"/>
+        <nd ref="-386"/>
+        <nd ref="-385"/>
+        <nd ref="-384"/>
+        <nd ref="-383"/>
+        <nd ref="-382"/>
+        <nd ref="-381"/>
+        <nd ref="-380"/>
+        <nd ref="-379"/>
+        <nd ref="-378"/>
+        <nd ref="-377"/>
+        <nd ref="-376"/>
+        <nd ref="-375"/>
+        <nd ref="-374"/>
+        <nd ref="-373"/>
+        <nd ref="-372"/>
+        <nd ref="-371"/>
+        <nd ref="-370"/>
+        <nd ref="-369"/>
+        <nd ref="-368"/>
+        <nd ref="-367"/>
+        <nd ref="-366"/>
+        <nd ref="-365"/>
+        <nd ref="-364"/>
+        <nd ref="-363"/>
+        <nd ref="-362"/>
+        <nd ref="-361"/>
+        <nd ref="-360"/>
+        <nd ref="-359"/>
+        <nd ref="-358"/>
+        <nd ref="-357"/>
+        <nd ref="-356"/>
+        <nd ref="-355"/>
+        <nd ref="-354"/>
+        <nd ref="-353"/>
+        <nd ref="-352"/>
+        <nd ref="-351"/>
+        <nd ref="-350"/>
+        <nd ref="-349"/>
+        <nd ref="-348"/>
+        <nd ref="-347"/>
+        <nd ref="-346"/>
+        <nd ref="-345"/>
+        <nd ref="-344"/>
+        <nd ref="-343"/>
+        <nd ref="-342"/>
+        <nd ref="-341"/>
+        <nd ref="-340"/>
+        <nd ref="-339"/>
+        <nd ref="-338"/>
+        <nd ref="-337"/>
+        <nd ref="-336"/>
+        <nd ref="-335"/>
+        <nd ref="-334"/>
+        <nd ref="-333"/>
+        <nd ref="-332"/>
+        <nd ref="-331"/>
+        <nd ref="-330"/>
+        <nd ref="-168"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.808Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="176031521"/>
+        <tag k="source:datetime" v="2015-05-04T09:53:52Z;2020-02-07T17:57:47Z"/>
+        <tag k="surface" v="ground"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="176124934" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-123"/>
+        <nd ref="-225"/>
+        <nd ref="-224"/>
+        <nd ref="-223"/>
+        <nd ref="-222"/>
+        <nd ref="-221"/>
+        <nd ref="-220"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.571Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="name" v="Princess Road"/>
+        <tag k="hoot:id" v="176124934"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z;2020-02-07T17:57:45Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="176237162" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-219"/>
+        <nd ref="-218"/>
+        <nd ref="-217"/>
+        <nd ref="-216"/>
+        <nd ref="-215"/>
+        <nd ref="-214"/>
+        <nd ref="-213"/>
+        <nd ref="-212"/>
+        <nd ref="-211"/>
+        <nd ref="-210"/>
+        <nd ref="-209"/>
+        <nd ref="-208"/>
+        <nd ref="-207"/>
+        <nd ref="-206"/>
+        <nd ref="-205"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.617Z"/>
+        <tag k="highway" v="service"/>
+        <tag k="hoot:id" v="176237162"/>
+        <tag k="source:datetime" v="2019-01-28T10:19:04Z;2020-02-07T17:57:45Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="176390103" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-122"/>
+        <nd ref="-200"/>
+        <nd ref="-201"/>
+        <nd ref="-202"/>
+        <nd ref="-203"/>
+        <nd ref="-204"/>
+        <nd ref="-191"/>
+        <nd ref="-192"/>
+        <nd ref="-193"/>
+        <nd ref="-194"/>
+        <nd ref="-195"/>
+        <nd ref="-196"/>
+        <nd ref="-197"/>
+        <nd ref="-198"/>
+        <nd ref="-187"/>
+        <tag k="source" v="NextView"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.644Z;2020-02-07T17:57:16.739Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="name" v="Main Street"/>
+        <tag k="hoot:id" v="176390103"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z;2020-02-07T17:57:44Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+        <tag k="junction" v="roundabout"/>
+    </way>
+    <way visible="true" id="342708823" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-187"/>
+        <nd ref="-186"/>
+        <nd ref="-185"/>
+        <nd ref="-184"/>
+        <nd ref="-183"/>
+        <nd ref="-182"/>
+        <nd ref="-181"/>
+        <nd ref="-180"/>
+        <nd ref="-179"/>
+        <nd ref="-178"/>
+        <nd ref="-177"/>
+        <nd ref="-176"/>
+        <nd ref="-44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.751Z"/>
+        <tag k="highway" v="primary"/>
+        <tag k="ref" v="A104"/>
+        <tag k="hoot:id" v="342708823"/>
+        <tag k="source:datetime" v="2020-01-20T16:05:21Z;2020-02-07T17:57:44Z"/>
+        <tag k="surface" v="ground"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+</osm>

--- a/test-files/cases/attribute/network/highway-3784-roundabouts-1/Input1.osm
+++ b/test-files/cases/attribute/network/highway-3784-roundabouts-1/Input1.osm
@@ -1,0 +1,1007 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="2.7766" minlon="32.2948" maxlat="2.7807" maxlon="32.2997"/>
+    <node visible="true" id="-424053" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7769704322783269" lon="32.2948000000000022"/>
+    <node visible="true" id="-424052" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2964543343445740"/>
+    <node visible="true" id="-424051" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7766000000000002" lon="32.2985227201807987"/>
+    <node visible="true" id="-424050" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7789980366231744" lon="32.2948000000000022"/>
+    <node visible="true" id="-424049" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7766000000000002" lon="32.2996925211341050"/>
+    <node visible="true" id="-424048" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7802302174146556" lon="32.2948000000000022"/>
+    <node visible="true" id="-424047" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2948615871501872"/>
+    <node visible="true" id="-424046" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7792108274089631" lon="32.2997000000000014"/>
+    <node visible="true" id="-424045" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2969940710825796"/>
+    <node visible="true" id="-424044" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7774845037998643" lon="32.2997000000000014"/>
+    <node visible="true" id="-424043" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2962170523098280"/>
+    <node visible="true" id="-424042" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7766000000000002" lon="32.2973002854333870"/>
+    <node visible="true" id="-424041" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7776847598532020" lon="32.2997000000000014"/>
+    <node visible="true" id="-400264" timestamp="2020-02-07T17:57:40Z" version="1" lat="2.7766812980759199" lon="32.2972883666062032"/>
+    <node visible="true" id="-400263" timestamp="2020-02-07T17:57:40Z" version="1" lat="2.7769523387945800" lon="32.2972517846122997"/>
+    <node visible="true" id="-400262" timestamp="2020-02-07T17:57:40Z" version="1" lat="2.7771899749620199" lon="32.2972141754824023"/>
+    <node visible="true" id="-362401" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7790747222463801" lon="32.2962826583056000"/>
+    <node visible="true" id="-362400" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7790576488356300" lon="32.2961947257553987"/>
+    <node visible="true" id="-362399" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7790489272173700" lon="32.2961377013033015"/>
+    <node visible="true" id="-362398" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7790278750120700" lon="32.2959181961172987"/>
+    <node visible="true" id="-362397" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789901570095998" lon="32.2956182804691991"/>
+    <node visible="true" id="-362396" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789809746809002" lon="32.2955324225370006"/>
+    <node visible="true" id="-362395" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789740140146200" lon="32.2954423091296974"/>
+    <node visible="true" id="-362394" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789699294789498" lon="32.2953520215660035"/>
+    <node visible="true" id="-362393" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789689964763600" lon="32.2952618810179999"/>
+    <node visible="true" id="-362392" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789724255123098" lon="32.2951664064648014"/>
+    <node visible="true" id="-341178" timestamp="2020-02-07T17:57:23Z" version="1" lat="2.7804266353601501" lon="32.2964348474243010"/>
+    <node visible="true" id="-341177" timestamp="2020-02-07T17:57:23Z" version="1" lat="2.7805079593334501" lon="32.2963666091931998"/>
+    <node visible="true" id="-341176" timestamp="2020-02-07T17:57:23Z" version="1" lat="2.7806846759986201" lon="32.2962260576761011"/>
+    <node visible="true" id="-340933" timestamp="2020-02-07T17:57:23Z" version="1" lat="2.7774371355780700" lon="32.2995936087139981"/>
+    <node visible="true" id="-309139" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7770739994837501" lon="32.2954084708673008"/>
+    <node visible="true" id="-309138" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7773665222192299" lon="32.2953558664478990"/>
+    <node visible="true" id="-309137" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7775371941190001" lon="32.2953307884130965"/>
+    <node visible="true" id="-309136" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7777085094541101" lon="32.2953098296460013"/>
+    <node visible="true" id="-309135" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7781376019073698" lon="32.2952631078974974"/>
+    <node visible="true" id="-302359" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7801906146286002" lon="32.2964597252812027"/>
+    <node visible="true" id="-302358" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7802249809171902" lon="32.2964536681096988"/>
+    <node visible="true" id="-302357" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7802751159966999" lon="32.2964463398967965"/>
+    <node visible="true" id="-302356" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7803254777025201" lon="32.2964407561984004"/>
+    <node visible="true" id="-302355" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7803760046767501" lon="32.2964369238178008"/>
+    <node visible="true" id="-299687" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805536100837802" lon="32.2964375926361029"/>
+    <node visible="true" id="-299686" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805448932981300" lon="32.2964562041460965"/>
+    <node visible="true" id="-299685" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805371092067901" lon="32.2964752201790972"/>
+    <node visible="true" id="-299684" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805302767189599" lon="32.2964945945410022"/>
+    <node visible="true" id="-299683" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805244124322499" lon="32.2965142801673011"/>
+    <node visible="true" id="-299682" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805195305922599" lon="32.2965342292375013"/>
+    <node visible="true" id="-299681" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805156430580400" lon="32.2965543932911032"/>
+    <node visible="true" id="-299680" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805127592732499" lon="32.2965747233452021"/>
+    <node visible="true" id="-299679" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805108862432300" lon="32.2965951700138021"/>
+    <node visible="true" id="-299678" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805100285179898" lon="32.2966156836275999"/>
+    <node visible="true" id="-299677" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805101881811400" lon="32.2966362143545993"/>
+    <node visible="true" id="-299676" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805113648448301" lon="32.2966567123213011"/>
+    <node visible="true" id="-299675" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805135556507099" lon="32.2966771277339006"/>
+    <node visible="true" id="-299674" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805167552768602" lon="32.2966974109988030"/>
+    <node visible="true" id="-299673" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805209559507098" lon="32.2967175128437987"/>
+    <node visible="true" id="-299672" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805261474679601" lon="32.2967373844371011"/>
+    <node visible="true" id="-299671" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805245569723098" lon="32.2967532985960020"/>
+    <node visible="true" id="-299670" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805240290916098" lon="32.2967692825488015"/>
+    <node visible="true" id="-299669" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805245661408300" lon="32.2967852661994996"/>
+    <node visible="true" id="-299668" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805261657648099" lon="32.2968011794537020"/>
+    <node visible="true" id="-299667" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805288209485899" lon="32.2968169525256030"/>
+    <node visible="true" id="-299666" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805325200481601" lon="32.2968325162441019"/>
+    <node visible="true" id="-299665" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805372468415501" lon="32.2968478023561971"/>
+    <node visible="true" id="-299664" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805429805999302" lon="32.2968627438264022"/>
+    <node visible="true" id="-299663" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805496961785701" lon="32.2968772751304982"/>
+    <node visible="true" id="-299662" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805573641270298" lon="32.2968913325430975"/>
+    <node visible="true" id="-299661" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805659508184002" lon="32.2969048544170008"/>
+    <node visible="true" id="-299660" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805754185966900" lon="32.2969177814534021"/>
+    <node visible="true" id="-299659" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805857259420201" lon="32.2969300569622035"/>
+    <node visible="true" id="-299658" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805968276526700" lon="32.2969416271105985"/>
+    <node visible="true" id="-299657" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7806086750433101" lon="32.2969524411589006"/>
+    <node visible="true" id="-299656" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7806240333863701" lon="32.2969601827374007"/>
+    <node visible="true" id="-299655" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7806583129355400" lon="32.2969763882787007"/>
+    <node visible="true" id="-299654" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7806931403000501" lon="32.2969913941988978"/>
+    <node visible="true" id="-263984" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792022892283499" lon="32.2996321148190972"/>
+    <node visible="true" id="-263983" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791902029950202" lon="32.2995085121716983"/>
+    <node visible="true" id="-263982" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791479205242302" lon="32.2989834577483990"/>
+    <node visible="true" id="-263981" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791315907305298" lon="32.2987766773950966"/>
+    <node visible="true" id="-263980" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791246982731699" lon="32.2986553633340989"/>
+    <node visible="true" id="-263979" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791230486703600" lon="32.2985744034322977"/>
+    <node visible="true" id="-263978" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791239709769000" lon="32.2985348622788990"/>
+    <node visible="true" id="-263977" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791282559892800" lon="32.2984823032194015"/>
+    <node visible="true" id="-263976" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791362574831102" lon="32.2984225754577992"/>
+    <node visible="true" id="-263975" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791482647869201" lon="32.2983674966233991"/>
+    <node visible="true" id="-263974" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791573715253901" lon="32.2983370555132012"/>
+    <node visible="true" id="-263973" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791681365765100" lon="32.2983031686358970"/>
+    <node visible="true" id="-263972" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791799282448499" lon="32.2982696353302998"/>
+    <node visible="true" id="-263971" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791925796028298" lon="32.2982363990170995"/>
+    <node visible="true" id="-263970" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792059237229001" lon="32.2982034031176966"/>
+    <node visible="true" id="-263969" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792194809194601" lon="32.2981713309427008"/>
+    <node visible="true" id="-263968" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792340225390002" lon="32.2981379062442002"/>
+    <node visible="true" id="-263967" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792771932894600" lon="32.2980400495640012"/>
+    <node visible="true" id="-263966" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792911885029801" lon="32.2980073079898986"/>
+    <node visible="true" id="-263965" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794221618565702" lon="32.2976955792871010"/>
+    <node visible="true" id="-263964" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794433005530799" lon="32.2976400568823010"/>
+    <node visible="true" id="-263963" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794570386275002" lon="32.2975972691074986"/>
+    <node visible="true" id="-263962" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794609369698202" lon="32.2975806660790994"/>
+    <node visible="true" id="-263961" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794632400624399" lon="32.2975539616876972"/>
+    <node visible="true" id="-263960" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794605108359001" lon="32.2975141534396002"/>
+    <node visible="true" id="-263959" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794552230133300" lon="32.2974880624872966"/>
+    <node visible="true" id="-263958" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794472236061298" lon="32.2974626635860034"/>
+    <node visible="true" id="-263957" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794372986509002" lon="32.2974413865974981"/>
+    <node visible="true" id="-263956" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792366533190900" lon="32.2973305133172985"/>
+    <node visible="true" id="-263955" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790590854791501" lon="32.2971950077516965"/>
+    <node visible="true" id="-263954" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790439614195099" lon="32.2971767879592022"/>
+    <node visible="true" id="-263953" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790294859569200" lon="32.2971580543520034"/>
+    <node visible="true" id="-263952" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790156767274601" lon="32.2971388297540969"/>
+    <node visible="true" id="-263951" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790025505555400" lon="32.2971191375876998"/>
+    <node visible="true" id="-263950" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789969358401998" lon="32.2971102347032968"/>
+    <node visible="true" id="-262373" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789158003601702" lon="32.2968977138286988"/>
+    <node visible="true" id="-262372" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789220950621401" lon="32.2968957985218026"/>
+    <node visible="true" id="-262371" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789299700752599" lon="32.2968936699360967"/>
+    <node visible="true" id="-262370" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789379149892102" lon="32.2968918159670011"/>
+    <node visible="true" id="-262369" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789459201243600" lon="32.2968902388730967"/>
+    <node visible="true" id="-262368" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789539757276800" lon="32.2968889405758972"/>
+    <node visible="true" id="-262367" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789620719846599" lon="32.2968879226572980"/>
+    <node visible="true" id="-262366" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789701990312601" lon="32.2968871863574023"/>
+    <node visible="true" id="-262365" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789783469659302" lon="32.2968867325731992"/>
+    <node visible="true" id="-262364" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789865058616701" lon="32.2968865618576970"/>
+    <node visible="true" id="-262363" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789946657781202" lon="32.2968866744188006"/>
+    <node visible="true" id="-262362" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790028167736800" lon="32.2968870701194035"/>
+    <node visible="true" id="-262361" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790109489176200" lon="32.2968877484774026"/>
+    <node visible="true" id="-262360" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790190523021798" lon="32.2968887086663017"/>
+    <node visible="true" id="-262359" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790278303351501" lon="32.2968920887473985"/>
+    <node visible="true" id="-262358" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790363374789999" lon="32.2968960957244988"/>
+    <node visible="true" id="-262357" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790445285368999" lon="32.2969007083091029"/>
+    <node visible="true" id="-262356" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790523599912902" lon="32.2969059019956006"/>
+    <node visible="true" id="-262355" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790597902351202" lon="32.2969116491907968"/>
+    <node visible="true" id="-262354" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790667797929101" lon="32.2969179193610003"/>
+    <node visible="true" id="-262353" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790732915304499" lon="32.2969246791940989"/>
+    <node visible="true" id="-262352" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790792908521000" lon="32.2969318927762004"/>
+    <node visible="true" id="-262351" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790847458845800" lon="32.2969395217830026"/>
+    <node visible="true" id="-262350" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790896276463202" lon="32.2969475256830023"/>
+    <node visible="true" id="-262349" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790939102014498" lon="32.2969558619530019"/>
+    <node visible="true" id="-262348" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790975707975401" lon="32.2969644863038994"/>
+    <node visible="true" id="-262347" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791005899865300" lon="32.2969733529161971"/>
+    <node visible="true" id="-262346" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791029517280301" lon="32.2969824146832991"/>
+    <node visible="true" id="-262345" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791046434745401" lon="32.2969916234616008"/>
+    <node visible="true" id="-262344" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791051378101401" lon="32.2970012255008001"/>
+    <node visible="true" id="-262343" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791047678590699" lon="32.2970108330748005"/>
+    <node visible="true" id="-262342" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791035365780701" lon="32.2970203693972024"/>
+    <node visible="true" id="-262341" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791014538078902" lon="32.2970297582508010"/>
+    <node visible="true" id="-262340" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790985361946499" lon="32.2970389245972029"/>
+    <node visible="true" id="-262339" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790948070567598" lon="32.2970477951761978"/>
+    <node visible="true" id="-262338" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790902961985702" lon="32.2970562990916008"/>
+    <node visible="true" id="-262337" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790850396722000" lon="32.2970643683775975"/>
+    <node visible="true" id="-262336" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790790794893199" lon="32.2970719385419969"/>
+    <node visible="true" id="-262335" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790724632854902" lon="32.2970789490819996"/>
+    <node visible="true" id="-262334" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790652439393200" lon="32.2970853439671970"/>
+    <node visible="true" id="-262333" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790574791499600" lon="32.2970910720879019"/>
+    <node visible="true" id="-262332" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790492309758599" lon="32.2970960876630997"/>
+    <node visible="true" id="-262331" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790405653388501" lon="32.2971003506071028"/>
+    <node visible="true" id="-262330" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790315514972499" lon="32.2971038268491029"/>
+    <node visible="true" id="-262329" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790242644109999" lon="32.2971056841855031"/>
+    <node visible="true" id="-234613" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7776826474353000" lon="32.2992821264148020"/>
+    <node visible="true" id="-234612" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7776719875511802" lon="32.2993044213613985"/>
+    <node visible="true" id="-234611" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7776440386302998" lon="32.2993568839232026"/>
+    <node visible="true" id="-234610" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7776133843055302" lon="32.2994078301435010"/>
+    <node visible="true" id="-234609" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7775801075251700" lon="32.2994571221653999"/>
+    <node visible="true" id="-234608" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7775318157337399" lon="32.2995200418195978"/>
+    <node visible="true" id="-234607" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7774710615923799" lon="32.2995745703018997"/>
+    <node visible="true" id="-234606" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7774541148099798" lon="32.2995857555438022"/>
+    <node visible="true" id="-228909" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770787292631698" lon="32.2954424312888975"/>
+    <node visible="true" id="-228908" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770807222976899" lon="32.2954718424969016"/>
+    <node visible="true" id="-228907" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770782669788101" lon="32.2955808140050991"/>
+    <node visible="true" id="-228906" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770817892337001" lon="32.2956705918687987"/>
+    <node visible="true" id="-228905" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770881015616600" lon="32.2957475602725026"/>
+    <node visible="true" id="-228904" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7771043240371598" lon="32.2959079210252966"/>
+    <node visible="true" id="-228903" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7771116826745001" lon="32.2960116855251016"/>
+    <node visible="true" id="-228902" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7771202173468099" lon="32.2961424051902029"/>
+    <node visible="true" id="-228901" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7771294554076400" lon="32.2962343203032987"/>
+    <node visible="true" id="-228900" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7772307442505402" lon="32.2969431351758018"/>
+    <node visible="true" id="-228899" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7772501254376700" lon="32.2970529479139969"/>
+    <node visible="true" id="-228898" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7772836575038702" lon="32.2972018287101008"/>
+    <node visible="true" id="-227403" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7802820953679199" lon="32.2949715954966976"/>
+    <node visible="true" id="-227402" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7803884947554902" lon="32.2949496516802981"/>
+    <node visible="true" id="-227401" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7804898163031702" lon="32.2949240333992975"/>
+    <node visible="true" id="-225781" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7787246979159801" lon="32.2970775161554968"/>
+    <node visible="true" id="-225780" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7786797299840198" lon="32.2970641285152027"/>
+    <node visible="true" id="-225779" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7786626640867498" lon="32.2970611807515979"/>
+    <node visible="true" id="-225778" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7786476470914199" lon="32.2970604072307026"/>
+    <node visible="true" id="-225777" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7785026490386202" lon="32.2970730894105031"/>
+    <node visible="true" id="-225776" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7782770375765700" lon="32.2970885723320009"/>
+    <node visible="true" id="-225775" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7780744641452100" lon="32.2971089943925023"/>
+    <node visible="true" id="-225774" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7774859531654599" lon="32.2971798678577002"/>
+    <node visible="true" id="-210677" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7802648640015999" lon="32.2949085176392998"/>
+    <node visible="true" id="-203354" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7789756518014199" lon="32.2971137787374971"/>
+    <node visible="true" id="-203353" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7789264630866199" lon="32.2971169087592997"/>
+    <node visible="true" id="-203352" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7788772095489001" lon="32.2971150417172979"/>
+    <node visible="true" id="-203351" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7788284031443000" lon="32.2971081970185026"/>
+    <node visible="true" id="-203350" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7787963648221199" lon="32.2971009015447024"/>
+    <node visible="true" id="-197552" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7777625781590798" lon="32.2982053222500980"/>
+    <node visible="true" id="-197551" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7777592718040300" lon="32.2982069500548974"/>
+    <node visible="true" id="-197550" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7777360311306998" lon="32.2982178231942001"/>
+    <node visible="true" id="-197549" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7777124230451200" lon="32.2982278830908029"/>
+    <node visible="true" id="-197548" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7776884763101299" lon="32.2982371174884975"/>
+    <node visible="true" id="-197547" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7776642201011699" lon="32.2982455151365002"/>
+    <node visible="true" id="-197546" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7776396839707300" lon="32.2982530658035998"/>
+    <node visible="true" id="-197545" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7776148978123198" lon="32.2982597602904988"/>
+    <node visible="true" id="-197544" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7775898918241002" lon="32.2982655904410976"/>
+    <node visible="true" id="-197543" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7775646964720200" lon="32.2982705491522992"/>
+    <node visible="true" id="-197542" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7775393424527901" lon="32.2982746303827000"/>
+    <node visible="true" id="-197541" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7775138606563701" lon="32.2982778291599999"/>
+    <node visible="true" id="-197540" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7774882821284401" lon="32.2982801415870000"/>
+    <node visible="true" id="-197539" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7774626380325098" lon="32.2982815648464978"/>
+    <node visible="true" id="-197538" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7774369596119799" lon="32.2982820972044991"/>
+    <node visible="true" id="-188837" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7790849044578998" lon="32.2966474247637976"/>
+    <node visible="true" id="-188836" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7790754723971700" lon="32.2966777410874002"/>
+    <node visible="true" id="-188835" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7790487077257802" lon="32.2967350256286991"/>
+    <node visible="true" id="-188834" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7790156438949700" lon="32.2967881261537002"/>
+    <node visible="true" id="-188833" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7789777924808599" lon="32.2968364954355991"/>
+    <node visible="true" id="-188832" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7789366650597498" lon="32.2968795862481031"/>
+    <node visible="true" id="-179534" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7767254579384502" lon="32.2996735266724002"/>
+    <node visible="true" id="-179533" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7770877203034501" lon="32.2996131343109028"/>
+    <node visible="true" id="-179532" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7772090356714800" lon="32.2995961566197991"/>
+    <node visible="true" id="-179531" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7772671674411900" lon="32.2995912485744014"/>
+    <node visible="true" id="-179530" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7772893357687201" lon="32.2995909546071971"/>
+    <node visible="true" id="-179529" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773724616824600" lon="32.2996009689238974"/>
+    <node visible="true" id="-179528" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773915670920002" lon="32.2996018872200992"/>
+    <node visible="true" id="-179527" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7774156763440998" lon="32.2995995663855027"/>
+    <node visible="true" id="-164548" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7774251529098199" lon="32.2982169092732008"/>
+    <node visible="true" id="-164547" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7774179126540699" lon="32.2981668106442967"/>
+    <node visible="true" id="-164546" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7774030133222798" lon="32.2980314393681027"/>
+    <node visible="true" id="-164545" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773906753164899" lon="32.2978988167995027"/>
+    <node visible="true" id="-164544" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773727898948302" lon="32.2977247211759035"/>
+    <node visible="true" id="-164543" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773336814374101" lon="32.2974426710620008"/>
+    <node visible="true" id="-164542" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773145289795398" lon="32.2973382157608029"/>
+    <node visible="true" id="-154708" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7801431587327698" lon="32.2949945766952027"/>
+    <node visible="true" id="-154707" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7793237368115800" lon="32.2951133933273979"/>
+    <node visible="true" id="-154706" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7792989576203100" lon="32.2951171252784022"/>
+    <node visible="true" id="-154705" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7792494921451198" lon="32.2951252056762996"/>
+    <node visible="true" id="-154704" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7791753777756401" lon="32.2951378700906986"/>
+    <node visible="true" id="-154703" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7791456877739402" lon="32.2951427593902025"/>
+    <node visible="true" id="-154702" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7791259086498701" lon="32.2951458998063998"/>
+    <node visible="true" id="-154701" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7791011265381602" lon="32.2951495912118034"/>
+    <node visible="true" id="-154700" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7790762995339202" lon="32.2951529783225979"/>
+    <node visible="true" id="-148937" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7783277573913798" lon="32.2962925453375007"/>
+    <node visible="true" id="-148936" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7783644627528599" lon="32.2963051594362014"/>
+    <node visible="true" id="-148935" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7783756213934598" lon="32.2963076869760002"/>
+    <node visible="true" id="-148934" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7784549540499199" lon="32.2963174243649007"/>
+    <node visible="true" id="-148933" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7785335638757300" lon="32.2963240213678020"/>
+    <node visible="true" id="-148932" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7786210910917499" lon="32.2963291251494979"/>
+    <node visible="true" id="-148931" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7787358522794001" lon="32.2963312827966007"/>
+    <node visible="true" id="-148930" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7787924492000000" lon="32.2963296854335979"/>
+    <node visible="true" id="-148929" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7788489621043699" lon="32.2963262285276969"/>
+    <node visible="true" id="-148928" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7789053292336101" lon="32.2963209158563984"/>
+    <node visible="true" id="-148927" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7789614889881200" lon="32.2963137532252986"/>
+    <node visible="true" id="-148926" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7789893211751799" lon="32.2962968428053969"/>
+    <node visible="true" id="-127659" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7788937732080199" lon="32.2969168513654026"/>
+    <node visible="true" id="-127658" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7788506285021701" lon="32.2969477435619012"/>
+    <node visible="true" id="-127657" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7788087425187098" lon="32.2969717156124005"/>
+    <node visible="true" id="-127656" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787511992954101" lon="32.2970004466722997"/>
+    <node visible="true" id="-127655" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787435002936900" lon="32.2970068167703985"/>
+    <node visible="true" id="-127654" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787364401982200" lon="32.2970180036822967"/>
+    <node visible="true" id="-127653" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787309531035702" lon="32.2970335158837969"/>
+    <node visible="true" id="-127652" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787270390095600" lon="32.2970533533747997"/>
+    <node visible="true" id="-118002" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766088786048702" lon="32.2985195814665005"/>
+    <node visible="true" id="-118001" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766309113177701" lon="32.2985105594903033"/>
+    <node visible="true" id="-118000" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766524727091100" lon="32.2985004740034967"/>
+    <node visible="true" id="-117999" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766735109103799" lon="32.2984893492679035"/>
+    <node visible="true" id="-117998" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766939753116500" lon="32.2984772120453982"/>
+    <node visible="true" id="-117997" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7767138166833498" lon="32.2984640915333969"/>
+    <node visible="true" id="-117996" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7767329872946700" lon="32.2984500192949966"/>
+    <node visible="true" id="-117995" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7767952554397999" lon="32.2984237017090976"/>
+    <node visible="true" id="-117994" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7768679156497500" lon="32.2983897691734967"/>
+    <node visible="true" id="-117993" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7769000417745802" lon="32.2983774209166015"/>
+    <node visible="true" id="-117992" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7769349978565998" lon="32.2983687012281990"/>
+    <node visible="true" id="-117991" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7769725299953301" lon="32.2983627060958014"/>
+    <node visible="true" id="-117990" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7771433411058801" lon="32.2983478908695005"/>
+    <node visible="true" id="-117989" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7771899450191602" lon="32.2983419583240021"/>
+    <node visible="true" id="-117988" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7772376015852398" lon="32.2983333262564969"/>
+    <node visible="true" id="-117987" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7772860569032298" lon="32.2983210906537010"/>
+    <node visible="true" id="-117986" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7773390139459302" lon="32.2983055209448011"/>
+    <node visible="true" id="-107327" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7790862553409301" lon="32.2963451450642012"/>
+    <node visible="true" id="-107326" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7790934061626000" lon="32.2963965733989014"/>
+    <node visible="true" id="-107325" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7791028556961499" lon="32.2964862556406018"/>
+    <node visible="true" id="-107324" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7791040579580000" lon="32.2965528088653997"/>
+    <node visible="true" id="-107323" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7790944263331601" lon="32.2966168197570980"/>
+    <node visible="true" id="-106325" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7805785326282200" lon="32.2964391687532029"/>
+    <node visible="true" id="-106324" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7806289611560100" lon="32.2964441201833026"/>
+    <node visible="true" id="-106323" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7806791852046899" lon="32.2964508188340034"/>
+    <node visible="true" id="-92693" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7793061826668599" lon="32.2965840227615004"/>
+    <node visible="true" id="-92692" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7793714551548900" lon="32.2965687687937972"/>
+    <node visible="true" id="-92691" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7793869065920900" lon="32.2965579304608994"/>
+    <node visible="true" id="-92690" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7794303706162600" lon="32.2965450561986032"/>
+    <node visible="true" id="-92689" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7794444617889198" lon="32.2965452244570983"/>
+    <node visible="true" id="-92688" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7795905576110398" lon="32.2965205264260007"/>
+    <node visible="true" id="-92687" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7797573833053399" lon="32.2964819104586027"/>
+    <node visible="true" id="-92686" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7798251073870599" lon="32.2964721617457968"/>
+    <node visible="true" id="-92685" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7798659443090501" lon="32.2964713657132023"/>
+    <node visible="true" id="-92684" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799190543354100" lon="32.2964677480541980"/>
+    <node visible="true" id="-92683" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799565540837601" lon="32.2964673701593981"/>
+    <node visible="true" id="-92682" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799515256394498" lon="32.2963401706744975"/>
+    <node visible="true" id="-92681" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799286005237200" lon="32.2960484939745029"/>
+    <node visible="true" id="-92680" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799148692709998" lon="32.2958915832183990"/>
+    <node visible="true" id="-61423" timestamp="2020-02-07T17:57:36Z" version="1" lat="2.7770137855736001" lon="32.2951331858425021"/>
+    <node visible="true" id="-61422" timestamp="2020-02-07T17:57:36Z" version="1" lat="2.7770279992641802" lon="32.2952081316341975"/>
+    <node visible="true" id="-61421" timestamp="2020-02-07T17:57:36Z" version="1" lat="2.7770631254490201" lon="32.2953548897616969"/>
+    <node visible="true" id="-16396" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7804773080670699" lon="32.2964345295478026"/>
+    <node visible="true" id="-16395" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7805279610607099" lon="32.2964359705758994"/>
+    <node visible="true" id="-15034" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7790860759842801" lon="32.2966468860918994"/>
+    <node visible="true" id="-15033" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7790993915745101" lon="32.2966392191333966"/>
+    <node visible="true" id="-15032" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791130274220599" lon="32.2966321307132986"/>
+    <node visible="true" id="-15031" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791269581266498" lon="32.2966256340356992"/>
+    <node visible="true" id="-15030" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791411577387000" lon="32.2966197412023988"/>
+    <node visible="true" id="-15029" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791555998077699" lon="32.2966144631904015"/>
+    <node visible="true" id="-15028" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791702574317498" lon="32.2966098098312031"/>
+    <node visible="true" id="-15027" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791851033070198" lon="32.2966057897930980"/>
+    <node visible="true" id="-15026" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792001097792700" lon="32.2966024105643967"/>
+    <node visible="true" id="-15025" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792152488950599" lon="32.2965996784397973"/>
+    <node visible="true" id="-15024" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792304924538498" lon="32.2965975985086970"/>
+    <node visible="true" id="-15023" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792458120605499" lon="32.2965961746454013"/>
+    <node visible="true" id="-15022" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792611791784201" lon="32.2965954095024017"/>
+    <node visible="true" id="-15021" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792765651822098" lon="32.2965953045047982"/>
+    <node visible="true" id="-15020" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792919414114801" lon="32.2965958598485017"/>
+    <node visible="true" id="-15019" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7793072792240099" lon="32.2965970744986990"/>
+    <node visible="true" id="-10520" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776844812841599" lon="32.2992782909542981"/>
+    <node visible="true" id="-10519" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776890795083502" lon="32.2992686738545984"/>
+    <node visible="true" id="-10518" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777123550695801" lon="32.2992140013760007"/>
+    <node visible="true" id="-10517" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777327403677599" lon="32.2991581991857970"/>
+    <node visible="true" id="-10516" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777501802418501" lon="32.2991014182805998"/>
+    <node visible="true" id="-10515" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777646275009098" lon="32.2990438123054986"/>
+    <node visible="true" id="-10514" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777739975855300" lon="32.2989894864088996"/>
+    <node visible="true" id="-10513" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777767883036200" lon="32.2989851063192006"/>
+    <node visible="true" id="-10512" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777790341722999" lon="32.2989804266602007"/>
+    <node visible="true" id="-10511" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777807031720601" lon="32.2989755141502002"/>
+    <node visible="true" id="-10510" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777817715078301" lon="32.2989704388271974"/>
+    <node visible="true" id="-10509" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777822239482699" lon="32.2989652730505981"/>
+    <node visible="true" id="-10508" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777820540428899" lon="32.2989600904691017"/>
+    <node visible="true" id="-10507" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777812642140498" lon="32.2989549649713013"/>
+    <node visible="true" id="-10506" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777798657224202" lon="32.2989499696318987"/>
+    <node visible="true" id="-10505" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777778785063898" lon="32.2989451756697008"/>
+    <node visible="true" id="-10504" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777753308978701" lon="32.2989406514326021"/>
+    <node visible="true" id="-10503" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777722592183198" lon="32.2989364614232031"/>
+    <node visible="true" id="-10502" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777687072609001" lon="32.2989326653786009"/>
+    <node visible="true" id="-10501" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777647256661600" lon="32.2989293174193008"/>
+    <node visible="true" id="-10500" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777603712000198" lon="32.2989264652775034"/>
+    <node visible="true" id="-10499" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777557059444300" lon="32.2989241496163970"/>
+    <node visible="true" id="-10498" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777478114333500" lon="32.2989233451452975"/>
+    <node visible="true" id="-10497" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777398507003501" lon="32.2989228115486995"/>
+    <node visible="true" id="-10496" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777318760913601" lon="32.2989225545717034"/>
+    <node visible="true" id="-10495" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777238973222400" lon="32.2989225745276016"/>
+    <node visible="true" id="-10494" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777159241138700" lon="32.2989228713919019"/>
+    <node visible="true" id="-10493" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777079661803801" lon="32.2989234448031013"/>
+    <node visible="true" id="-10492" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777000332172901" lon="32.2989242940624024"/>
+    <node visible="true" id="-10491" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776921348896901" lon="32.2989254181351981"/>
+    <node visible="true" id="-10490" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776842808204698" lon="32.2989268156520026"/>
+    <node visible="true" id="-10489" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776764805786001" lon="32.2989284849100997"/>
+    <node visible="true" id="-10488" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776687436674701" lon="32.2989304238757029"/>
+    <node visible="true" id="-10487" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776610795133201" lon="32.2989326301865987"/>
+    <node visible="true" id="-10486" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776534974537301" lon="32.2989351011545978"/>
+    <node visible="true" id="-10485" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776449427915599" lon="32.2989374769300994"/>
+    <node visible="true" id="-10484" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776361905600400" lon="32.2989389811164997"/>
+    <node visible="true" id="-10483" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776273303062098" lon="32.2989395983240968"/>
+    <node visible="true" id="-10482" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776184526823302" lon="32.2989393222380983"/>
+    <node visible="true" id="-10481" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776096485183501" lon="32.2989381556831034"/>
+    <node visible="true" id="-10480" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776010078926401" lon="32.2989361105947026"/>
+    <node visible="true" id="-10479" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775926192103602" lon="32.2989332078967024"/>
+    <node visible="true" id="-10478" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775845682989302" lon="32.2989294772878992"/>
+    <node visible="true" id="-10477" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775769375299402" lon="32.2989249569370998"/>
+    <node visible="true" id="-10476" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775698049763502" lon="32.2989196930938007"/>
+    <node visible="true" id="-10475" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775632436137001" lon="32.2989137396141004"/>
+    <node visible="true" id="-10474" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775573205735000" lon="32.2989071574099000"/>
+    <node visible="true" id="-10473" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775520964563598" lon="32.2989000138261986"/>
+    <node visible="true" id="-10472" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775476247119602" lon="32.2988923819512976"/>
+    <node visible="true" id="-10471" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775439510922300" lon="32.2988843398694030"/>
+    <node visible="true" id="-10470" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775400313390599" lon="32.2988718176950016"/>
+    <node visible="true" id="-10469" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775350054177399" lon="32.2988538996008003"/>
+    <node visible="true" id="-10468" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775306113552500" lon="32.2988358179865003"/>
+    <node visible="true" id="-10467" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775268545050702" lon="32.2988175948816973"/>
+    <node visible="true" id="-10466" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775237394443399" lon="32.2987992524884007"/>
+    <node visible="true" id="-10465" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775212699682599" lon="32.2987808131540035"/>
+    <node visible="true" id="-10464" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775194490855002" lon="32.2987622993437995"/>
+    <node visible="true" id="-10463" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775182790145099" lon="32.2987437336142023"/>
+    <way visible="true" id="-15993" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-309139"/>
+        <nd ref="-61421"/>
+        <nd ref="-61422"/>
+        <nd ref="-61423"/>
+        <nd ref="-424053"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.023Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:46Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15992" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-424052"/>
+        <nd ref="-106323"/>
+        <nd ref="-106324"/>
+        <nd ref="-106325"/>
+        <nd ref="-299687"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.210Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:46Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15991" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-197538"/>
+        <nd ref="-117986"/>
+        <nd ref="-117987"/>
+        <nd ref="-117988"/>
+        <nd ref="-117989"/>
+        <nd ref="-117990"/>
+        <nd ref="-117991"/>
+        <nd ref="-117992"/>
+        <nd ref="-117993"/>
+        <nd ref="-117994"/>
+        <nd ref="-117995"/>
+        <nd ref="-117996"/>
+        <nd ref="-117997"/>
+        <nd ref="-117998"/>
+        <nd ref="-117999"/>
+        <nd ref="-118000"/>
+        <nd ref="-118001"/>
+        <nd ref="-118002"/>
+        <nd ref="-424051"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.261Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:46Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15990" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-362392"/>
+        <nd ref="-424050"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.346Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15989" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-340933"/>
+        <nd ref="-179527"/>
+        <nd ref="-179528"/>
+        <nd ref="-179529"/>
+        <nd ref="-179530"/>
+        <nd ref="-179531"/>
+        <nd ref="-179532"/>
+        <nd ref="-179533"/>
+        <nd ref="-179534"/>
+        <nd ref="-424049"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.533Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15988" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-227403"/>
+        <nd ref="-210677"/>
+        <nd ref="-424048"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.673Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15987" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-424047"/>
+        <nd ref="-227401"/>
+        <nd ref="-227402"/>
+        <nd ref="-227403"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.745Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15986" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-263950"/>
+        <nd ref="-263951"/>
+        <nd ref="-263952"/>
+        <nd ref="-263953"/>
+        <nd ref="-263954"/>
+        <nd ref="-263955"/>
+        <nd ref="-263956"/>
+        <nd ref="-263957"/>
+        <nd ref="-263958"/>
+        <nd ref="-263959"/>
+        <nd ref="-263960"/>
+        <nd ref="-263961"/>
+        <nd ref="-263962"/>
+        <nd ref="-263963"/>
+        <nd ref="-263964"/>
+        <nd ref="-263965"/>
+        <nd ref="-263966"/>
+        <nd ref="-263967"/>
+        <nd ref="-263968"/>
+        <nd ref="-263969"/>
+        <nd ref="-263970"/>
+        <nd ref="-263971"/>
+        <nd ref="-263972"/>
+        <nd ref="-263973"/>
+        <nd ref="-263974"/>
+        <nd ref="-263975"/>
+        <nd ref="-263976"/>
+        <nd ref="-263977"/>
+        <nd ref="-263978"/>
+        <nd ref="-263979"/>
+        <nd ref="-263980"/>
+        <nd ref="-263981"/>
+        <nd ref="-263982"/>
+        <nd ref="-263983"/>
+        <nd ref="-263984"/>
+        <nd ref="-424046"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.919Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15985" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-424045"/>
+        <nd ref="-299654"/>
+        <nd ref="-299655"/>
+        <nd ref="-299656"/>
+        <nd ref="-299657"/>
+        <nd ref="-299658"/>
+        <nd ref="-299659"/>
+        <nd ref="-299660"/>
+        <nd ref="-299661"/>
+        <nd ref="-299662"/>
+        <nd ref="-299663"/>
+        <nd ref="-299664"/>
+        <nd ref="-299665"/>
+        <nd ref="-299666"/>
+        <nd ref="-299667"/>
+        <nd ref="-299668"/>
+        <nd ref="-299669"/>
+        <nd ref="-299670"/>
+        <nd ref="-299671"/>
+        <nd ref="-299672"/>
+        <nd ref="-299673"/>
+        <nd ref="-299674"/>
+        <nd ref="-299675"/>
+        <nd ref="-299676"/>
+        <nd ref="-299677"/>
+        <nd ref="-299678"/>
+        <nd ref="-299679"/>
+        <nd ref="-299680"/>
+        <nd ref="-299681"/>
+        <nd ref="-299682"/>
+        <nd ref="-299683"/>
+        <nd ref="-299684"/>
+        <nd ref="-299685"/>
+        <nd ref="-299686"/>
+        <nd ref="-299687"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.069Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:43Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15984" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-424044"/>
+        <nd ref="-340933"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.255Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:42Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15983" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-424043"/>
+        <nd ref="-341176"/>
+        <nd ref="-341177"/>
+        <nd ref="-341178"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.257Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:42Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15982" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-228898"/>
+        <nd ref="-400262"/>
+        <nd ref="-400263"/>
+        <nd ref="-400264"/>
+        <nd ref="-424042"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.539Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:42Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15981" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-424041"/>
+        <nd ref="-234613"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.542Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:42Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-13555" timestamp="2020-02-07T17:57:42Z" version="1">
+        <nd ref="-362392"/>
+        <nd ref="-362393"/>
+        <nd ref="-362394"/>
+        <nd ref="-362395"/>
+        <nd ref="-362396"/>
+        <nd ref="-362397"/>
+        <nd ref="-362398"/>
+        <nd ref="-362399"/>
+        <nd ref="-362400"/>
+        <nd ref="-362401"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.351Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:42Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-11323" timestamp="2020-02-07T17:57:43Z" version="1">
+        <nd ref="-362392"/>
+        <nd ref="-309135"/>
+        <nd ref="-309136"/>
+        <nd ref="-309137"/>
+        <nd ref="-309138"/>
+        <nd ref="-309139"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.110Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:43Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-11056" timestamp="2020-02-07T17:57:43Z" version="1">
+        <nd ref="-341178"/>
+        <nd ref="-302355"/>
+        <nd ref="-302356"/>
+        <nd ref="-302357"/>
+        <nd ref="-302358"/>
+        <nd ref="-302359"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.081Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:43Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-9545" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-263950"/>
+        <nd ref="-262329"/>
+        <nd ref="-262330"/>
+        <nd ref="-262331"/>
+        <nd ref="-262332"/>
+        <nd ref="-262333"/>
+        <nd ref="-262334"/>
+        <nd ref="-262335"/>
+        <nd ref="-262336"/>
+        <nd ref="-262337"/>
+        <nd ref="-262338"/>
+        <nd ref="-262339"/>
+        <nd ref="-262340"/>
+        <nd ref="-262341"/>
+        <nd ref="-262342"/>
+        <nd ref="-262343"/>
+        <nd ref="-262344"/>
+        <nd ref="-262345"/>
+        <nd ref="-262346"/>
+        <nd ref="-262347"/>
+        <nd ref="-262348"/>
+        <nd ref="-262349"/>
+        <nd ref="-262350"/>
+        <nd ref="-262351"/>
+        <nd ref="-262352"/>
+        <nd ref="-262353"/>
+        <nd ref="-262354"/>
+        <nd ref="-262355"/>
+        <nd ref="-262356"/>
+        <nd ref="-262357"/>
+        <nd ref="-262358"/>
+        <nd ref="-262359"/>
+        <nd ref="-262360"/>
+        <nd ref="-262361"/>
+        <nd ref="-262362"/>
+        <nd ref="-262363"/>
+        <nd ref="-262364"/>
+        <nd ref="-262365"/>
+        <nd ref="-262366"/>
+        <nd ref="-262367"/>
+        <nd ref="-262368"/>
+        <nd ref="-262369"/>
+        <nd ref="-262370"/>
+        <nd ref="-262371"/>
+        <nd ref="-262372"/>
+        <nd ref="-262373"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.914Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-8505" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-340933"/>
+        <nd ref="-234606"/>
+        <nd ref="-234607"/>
+        <nd ref="-234608"/>
+        <nd ref="-234609"/>
+        <nd ref="-234610"/>
+        <nd ref="-234611"/>
+        <nd ref="-234612"/>
+        <nd ref="-234613"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.775Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-8296" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-228898"/>
+        <nd ref="-228899"/>
+        <nd ref="-228900"/>
+        <nd ref="-228901"/>
+        <nd ref="-228902"/>
+        <nd ref="-228903"/>
+        <nd ref="-228904"/>
+        <nd ref="-228905"/>
+        <nd ref="-228906"/>
+        <nd ref="-228907"/>
+        <nd ref="-228908"/>
+        <nd ref="-228909"/>
+        <nd ref="-309139"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.751Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-8183" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-228898"/>
+        <nd ref="-225774"/>
+        <nd ref="-225775"/>
+        <nd ref="-225776"/>
+        <nd ref="-225777"/>
+        <nd ref="-225778"/>
+        <nd ref="-225779"/>
+        <nd ref="-225780"/>
+        <nd ref="-225781"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.739Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-7341" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-225781"/>
+        <nd ref="-203350"/>
+        <nd ref="-203351"/>
+        <nd ref="-203352"/>
+        <nd ref="-203353"/>
+        <nd ref="-203354"/>
+        <nd ref="-263950"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.644Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-7083" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-197538"/>
+        <nd ref="-197539"/>
+        <nd ref="-197540"/>
+        <nd ref="-197541"/>
+        <nd ref="-197542"/>
+        <nd ref="-197543"/>
+        <nd ref="-197544"/>
+        <nd ref="-197545"/>
+        <nd ref="-197546"/>
+        <nd ref="-197547"/>
+        <nd ref="-197548"/>
+        <nd ref="-197549"/>
+        <nd ref="-197550"/>
+        <nd ref="-197551"/>
+        <nd ref="-197552"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.617Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-6750" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-262373"/>
+        <nd ref="-188832"/>
+        <nd ref="-188833"/>
+        <nd ref="-188834"/>
+        <nd ref="-188835"/>
+        <nd ref="-188836"/>
+        <nd ref="-188837"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.571Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-5818" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-228898"/>
+        <nd ref="-164542"/>
+        <nd ref="-164543"/>
+        <nd ref="-164544"/>
+        <nd ref="-164545"/>
+        <nd ref="-164546"/>
+        <nd ref="-164547"/>
+        <nd ref="-164548"/>
+        <nd ref="-197538"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.468Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-5428" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-362392"/>
+        <nd ref="-154700"/>
+        <nd ref="-154701"/>
+        <nd ref="-154702"/>
+        <nd ref="-154703"/>
+        <nd ref="-154704"/>
+        <nd ref="-154705"/>
+        <nd ref="-154706"/>
+        <nd ref="-154707"/>
+        <nd ref="-154708"/>
+        <nd ref="-227403"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.425Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-5262" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-362401"/>
+        <nd ref="-148926"/>
+        <nd ref="-148927"/>
+        <nd ref="-148928"/>
+        <nd ref="-148929"/>
+        <nd ref="-148930"/>
+        <nd ref="-148931"/>
+        <nd ref="-148932"/>
+        <nd ref="-148933"/>
+        <nd ref="-148934"/>
+        <nd ref="-148935"/>
+        <nd ref="-148936"/>
+        <nd ref="-148937"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.405Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-4430" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-225781"/>
+        <nd ref="-127652"/>
+        <nd ref="-127653"/>
+        <nd ref="-127654"/>
+        <nd ref="-127655"/>
+        <nd ref="-127656"/>
+        <nd ref="-127657"/>
+        <nd ref="-127658"/>
+        <nd ref="-127659"/>
+        <nd ref="-262373"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.301Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-3654" timestamp="2020-02-07T17:57:46Z" version="1">
+        <nd ref="-188837"/>
+        <nd ref="-107323"/>
+        <nd ref="-107324"/>
+        <nd ref="-107325"/>
+        <nd ref="-107326"/>
+        <nd ref="-107327"/>
+        <nd ref="-362401"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.215Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:46Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-3135" timestamp="2020-02-07T17:57:46Z" version="1">
+        <nd ref="-92680"/>
+        <nd ref="-92681"/>
+        <nd ref="-92682"/>
+        <nd ref="-92683"/>
+        <nd ref="-92684"/>
+        <nd ref="-92685"/>
+        <nd ref="-92686"/>
+        <nd ref="-92687"/>
+        <nd ref="-92688"/>
+        <nd ref="-92689"/>
+        <nd ref="-92690"/>
+        <nd ref="-92691"/>
+        <nd ref="-92692"/>
+        <nd ref="-92693"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.152Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:46Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-580" timestamp="2020-02-07T17:57:47Z" version="1">
+        <nd ref="-299687"/>
+        <nd ref="-16395"/>
+        <nd ref="-16396"/>
+        <nd ref="-341178"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.845Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:47Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-533" timestamp="2020-02-07T17:57:47Z" version="1">
+        <nd ref="-15019"/>
+        <nd ref="-15020"/>
+        <nd ref="-15021"/>
+        <nd ref="-15022"/>
+        <nd ref="-15023"/>
+        <nd ref="-15024"/>
+        <nd ref="-15025"/>
+        <nd ref="-15026"/>
+        <nd ref="-15027"/>
+        <nd ref="-15028"/>
+        <nd ref="-15029"/>
+        <nd ref="-15030"/>
+        <nd ref="-15031"/>
+        <nd ref="-15032"/>
+        <nd ref="-15033"/>
+        <nd ref="-15034"/>
+        <nd ref="-188837"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.838Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:47Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-350" timestamp="2020-02-07T17:57:47Z" version="1">
+        <nd ref="-197538"/>
+        <nd ref="-10463"/>
+        <nd ref="-10464"/>
+        <nd ref="-10465"/>
+        <nd ref="-10466"/>
+        <nd ref="-10467"/>
+        <nd ref="-10468"/>
+        <nd ref="-10469"/>
+        <nd ref="-10470"/>
+        <nd ref="-10471"/>
+        <nd ref="-10472"/>
+        <nd ref="-10473"/>
+        <nd ref="-10474"/>
+        <nd ref="-10475"/>
+        <nd ref="-10476"/>
+        <nd ref="-10477"/>
+        <nd ref="-10478"/>
+        <nd ref="-10479"/>
+        <nd ref="-10480"/>
+        <nd ref="-10481"/>
+        <nd ref="-10482"/>
+        <nd ref="-10483"/>
+        <nd ref="-10484"/>
+        <nd ref="-10485"/>
+        <nd ref="-10486"/>
+        <nd ref="-10487"/>
+        <nd ref="-10488"/>
+        <nd ref="-10489"/>
+        <nd ref="-10490"/>
+        <nd ref="-10491"/>
+        <nd ref="-10492"/>
+        <nd ref="-10493"/>
+        <nd ref="-10494"/>
+        <nd ref="-10495"/>
+        <nd ref="-10496"/>
+        <nd ref="-10497"/>
+        <nd ref="-10498"/>
+        <nd ref="-10499"/>
+        <nd ref="-10500"/>
+        <nd ref="-10501"/>
+        <nd ref="-10502"/>
+        <nd ref="-10503"/>
+        <nd ref="-10504"/>
+        <nd ref="-10505"/>
+        <nd ref="-10506"/>
+        <nd ref="-10507"/>
+        <nd ref="-10508"/>
+        <nd ref="-10509"/>
+        <nd ref="-10510"/>
+        <nd ref="-10511"/>
+        <nd ref="-10512"/>
+        <nd ref="-10513"/>
+        <nd ref="-10514"/>
+        <nd ref="-10515"/>
+        <nd ref="-10516"/>
+        <nd ref="-10517"/>
+        <nd ref="-10518"/>
+        <nd ref="-10519"/>
+        <nd ref="-10520"/>
+        <nd ref="-234613"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.808Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:47Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+</osm>

--- a/test-files/cases/attribute/network/highway-3784-roundabouts-1/Input2.osm
+++ b/test-files/cases/attribute/network/highway-3784-roundabouts-1/Input2.osm
@@ -1,0 +1,526 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="2.7766" minlon="32.2948" maxlat="2.7807" maxlon="32.2997"/>
+    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2981923006059262"/>
+    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7792125383213433" lon="32.2997000000000014"/>
+    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7775194937869836" lon="32.2997000000000014"/>
+    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7766000000000002" lon="32.2996697626409031"/>
+    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7769862639449943" lon="32.2948000000000022"/>
+    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2964712339079441"/>
+    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7766000000000002" lon="32.2973244582411496"/>
+    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2949115208270570"/>
+    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7789922377188030" lon="32.2948000000000022"/>
+    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2989407265984596"/>
+    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7775556232648908" lon="32.2948000000000022"/>
+    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2993639746683385"/>
+    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7803391641851123" lon="32.2948000000000022"/>
+    <node visible="true" id="1641684803" timestamp="2019-01-24T14:32:34Z" version="4" changeset="66603670" user="Penobscot" uid="9090196" lat="2.7789855999999999" lon="32.2955196999999998"/>
+    <node visible="true" id="1641684833" timestamp="2019-06-20T06:03:46Z" version="7" changeset="71427317" user="Okavango77" uid="9320580" lat="2.7770806000000001" lon="32.2954271999999989"/>
+    <node visible="true" id="1641684903" timestamp="2019-01-28T11:00:25Z" version="8" changeset="66701775" user="Penobscot" uid="9090196" lat="2.7789603999999999" lon="32.2951771999999977"/>
+    <node visible="true" id="1641684928" timestamp="2019-06-27T23:56:54Z" version="3" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7790826000000002" lon="32.2962042999999994"/>
+    <node visible="true" id="1641684950" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7792697999999998" lon="32.2973399999999984"/>
+    <node visible="true" id="1655884800" timestamp="2019-01-28T11:00:25Z" version="7" changeset="66701775" user="Penobscot" uid="9090196" lat="2.7772988000000001" lon="32.2972479000000021"/>
+    <node visible="true" id="1818542795" timestamp="2019-01-24T17:30:04Z" version="3" changeset="66608902" user="Penobscot" uid="9090196" lat="2.7774977999999999" lon="32.2987357000000017"/>
+    <node visible="true" id="1818542808" timestamp="2019-01-28T13:25:29Z" version="3" changeset="66706015" user="Penobscot" uid="9090196" lat="2.7791535000000001" lon="32.2985946000000013"/>
+    <node visible="true" id="1818542809" timestamp="2019-01-28T13:25:29Z" version="3" changeset="66706015" user="Penobscot" uid="9090196" lat="2.7791690000000000" lon="32.2984677999999974"/>
+    <node visible="true" id="1818542810" timestamp="2019-01-28T12:47:23Z" version="3" changeset="66704798" user="Penobscot" uid="9090196" lat="2.7791743000000002" lon="32.2992592000000016"/>
+    <node visible="true" id="1818542811" timestamp="2019-06-27T23:56:54Z" version="5" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791298000000002" lon="32.2966130000000007"/>
+    <node visible="true" id="1818542813" timestamp="2019-01-28T12:47:23Z" version="2" changeset="66704798" user="Penobscot" uid="9090196" lat="2.7792056000000001" lon="32.2996324000000001"/>
+    <node visible="true" id="1818542815" timestamp="2019-01-28T13:25:29Z" version="3" changeset="66706015" user="Penobscot" uid="9090196" lat="2.7792078999999998" lon="32.2983498999999981"/>
+    <node visible="true" id="1818542816" timestamp="2012-08-15T20:40:12Z" version="2" changeset="12744017" user="bmog" uid="65432" lat="2.7794903999999998" lon="32.2965877000000035"/>
+    <node visible="true" id="1818542817" timestamp="2019-06-27T23:56:54Z" version="5" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7795165000000002" lon="32.2976608000000027"/>
+    <node visible="true" id="1818542821" timestamp="2019-06-27T23:56:54Z" version="6" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7795456000000001" lon="32.2975552999999991"/>
+    <node visible="true" id="1818542822" timestamp="2019-01-28T12:47:24Z" version="3" changeset="66704798" user="Penobscot" uid="9090196" lat="2.7799971000000001" lon="32.2965208000000032"/>
+    <node visible="true" id="1818542824" timestamp="2019-01-28T10:19:03Z" version="6" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7792129000000001" lon="32.2951655000000031"/>
+    <node visible="true" id="1818542825" timestamp="2019-01-28T12:47:24Z" version="3" changeset="66704798" user="Penobscot" uid="9090196" lat="2.7803325000000001" lon="32.2964916000000031"/>
+    <node visible="true" id="1865920154" timestamp="2012-08-14T16:05:59Z" version="1" changeset="12728686" user="AndrewBuck" uid="214969" lat="2.7772640000000002" lon="32.2995745999999997"/>
+    <node visible="true" id="1865920156" timestamp="2019-01-28T10:19:03Z" version="3" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7774255999999999" lon="32.2996037999999999"/>
+    <node visible="true" id="1866869779" timestamp="2019-06-27T23:56:54Z" version="3" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7786156000000002" lon="32.2970832000000030"/>
+    <node visible="true" id="1866869782" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7789128000000001" lon="32.2969869000000003"/>
+    <node visible="true" id="1866869783" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7789027000000002" lon="32.2971032000000022"/>
+    <node visible="true" id="1866869785" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7789296999999999" lon="32.2969648999999990"/>
+    <node visible="true" id="1866869787" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7789530000000000" lon="32.2971647000000033"/>
+    <node visible="true" id="1866869789" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7789508000000001" lon="32.2969470999999970"/>
+    <node visible="true" id="1866869791" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7789826999999998" lon="32.2971789999999999"/>
+    <node visible="true" id="1866869793" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7790859999999999" lon="32.2969404999999981"/>
+    <node visible="true" id="1866869795" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7790151000000001" lon="32.2971853000000024"/>
+    <node visible="true" id="1866869798" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791123999999998" lon="32.2971508999999983"/>
+    <node visible="true" id="1866869802" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791465000000000" lon="32.2970109999999977"/>
+    <node visible="true" id="1866869804" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791522999999998" lon="32.2970333999999966"/>
+    <node visible="true" id="1866869805" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791541999999998" lon="32.2970564000000024"/>
+    <node visible="true" id="1866869806" timestamp="2019-06-27T23:56:54Z" version="3" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791263000000002" lon="32.2966659000000007"/>
+    <node visible="true" id="1866869809" timestamp="2019-06-27T23:56:54Z" version="4" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7797223000000000" lon="32.2976342999999986"/>
+    <node visible="true" id="1867808596" timestamp="2019-01-28T10:19:03Z" version="3" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7774402000000000" lon="32.2982901000000027"/>
+    <node visible="true" id="1867808684" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778415999999999" lon="32.2984020000000029"/>
+    <node visible="true" id="1867808695" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778228999999999" lon="32.2982403000000033"/>
+    <node visible="true" id="1867808698" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778325000000001" lon="32.2983224999999976"/>
+    <node visible="true" id="1867808710" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778114999999999" lon="32.2989694999999983"/>
+    <node visible="true" id="1867808716" timestamp="2019-01-28T11:00:25Z" version="4" changeset="66701775" user="Penobscot" uid="9090196" lat="2.7778258999999998" lon="32.2953266999999968"/>
+    <node visible="true" id="1867808736" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778136000000000" lon="32.2989954000000026"/>
+    <node visible="true" id="1867808753" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778282999999999" lon="32.2981476000000001"/>
+    <node visible="true" id="1867808767" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7779318000000002" lon="32.2979867999999968"/>
+    <node visible="true" id="1867808817" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778282999999999" lon="32.2990125999999975"/>
+    <node visible="true" id="1867808820" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7780993999999999" lon="32.2979635000000016"/>
+    <node visible="true" id="1867808834" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778515000000001" lon="32.2980510000000010"/>
+    <node visible="true" id="1867808839" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778527999999998" lon="32.2990240999999969"/>
+    <node visible="true" id="1867808845" timestamp="2019-01-28T10:19:04Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778797000000002" lon="32.2990293000000008"/>
+    <node visible="true" id="1867808889" timestamp="2019-01-28T10:19:04Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7782062999999999" lon="32.2979476000000005"/>
+    <node visible="true" id="1867809124" timestamp="2012-08-15T20:09:55Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7785859999999998" lon="32.2976061999999970"/>
+    <node visible="true" id="1867809178" timestamp="2019-01-28T11:00:25Z" version="2" changeset="66701775" user="Penobscot" uid="9090196" lat="2.7786297000000002" lon="32.2976904000000005"/>
+    <node visible="true" id="1867809276" timestamp="2012-08-15T20:09:58Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7786843000000001" lon="32.2977228000000025"/>
+    <node visible="true" id="1867809646" timestamp="2019-01-28T10:19:04Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7781720999999999" lon="32.2990489999999966"/>
+    <node visible="true" id="1867809725" timestamp="2019-01-24T14:32:34Z" version="5" changeset="66603670" user="Penobscot" uid="9090196" lat="2.7787364000000001" lon="32.2951996999999977"/>
+    <node visible="true" id="1867809777" timestamp="2012-08-15T20:10:04Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7789974000000002" lon="32.2976809000000031"/>
+    <node visible="true" id="1867809787" timestamp="2019-01-28T10:19:04Z" version="3" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7789823000000000" lon="32.2949120999999977"/>
+    <node visible="true" id="1867809882" timestamp="2019-01-28T12:47:24Z" version="2" changeset="66704798" user="Penobscot" uid="9090196" lat="2.7791679000000000" lon="32.2990708000000026"/>
+    <node visible="true" id="1867809886" timestamp="2019-01-28T12:47:24Z" version="2" changeset="66704798" user="Penobscot" uid="9090196" lat="2.7791801999999999" lon="32.2993369000000001"/>
+    <node visible="true" id="1867809894" timestamp="2012-08-15T20:10:06Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7792678000000000" lon="32.2992982999999967"/>
+    <node visible="true" id="1867809896" timestamp="2012-08-15T20:10:06Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7792688999999999" lon="32.2990780000000015">
+        <tag k="barrier" v="gate"/>
+        <tag k="error:circular" v="15"/>
+    </node>
+    <node visible="true" id="1867809913" timestamp="2012-08-15T20:10:06Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7793489000000000" lon="32.2992623000000023"/>
+    <node visible="true" id="1867809920" timestamp="2012-08-15T20:10:06Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7793635999999999" lon="32.2990726000000024"/>
+    <node visible="true" id="1867809950" timestamp="2012-08-15T20:10:07Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7794164000000001" lon="32.2990070000000031"/>
+    <node visible="true" id="1867809968" timestamp="2012-08-15T20:10:07Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7794563999999999" lon="32.2989194999999967"/>
+    <node visible="true" id="1867810001" timestamp="2012-08-15T20:10:08Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7795182999999999" lon="32.2988337999999970"/>
+    <node visible="true" id="1867810003" timestamp="2012-08-15T20:10:08Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7795188000000000" lon="32.2992545000000035"/>
+    <node visible="true" id="1867810040" timestamp="2012-08-15T20:10:08Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7796093000000002" lon="32.2988009999999974"/>
+    <node visible="true" id="1867810065" timestamp="2012-08-15T20:10:09Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7796449000000001" lon="32.2992159000000001"/>
+    <node visible="true" id="1867810121" timestamp="2012-08-15T20:10:10Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7797914000000001" lon="32.2988957999999968"/>
+    <node visible="true" id="1867810133" timestamp="2012-08-15T20:10:10Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7798470000000002" lon="32.2991694999999979"/>
+    <node visible="true" id="1867810163" timestamp="2012-08-15T20:10:10Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7799719000000001" lon="32.2991643000000010"/>
+    <node visible="true" id="1867810194" timestamp="2012-08-15T20:10:11Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7800452999999998" lon="32.2991732999999996"/>
+    <node visible="true" id="1867810201" timestamp="2012-08-15T20:10:11Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7801095999999998" lon="32.2992042999999995"/>
+    <node visible="true" id="1867810204" timestamp="2012-08-15T20:10:11Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7801160000000000" lon="32.2991178999999988"/>
+    <node visible="true" id="1867810237" timestamp="2012-08-15T20:10:11Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7802049000000002" lon="32.2990999000000016"/>
+    <node visible="true" id="1867810259" timestamp="2012-08-15T20:10:12Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7802435000000001" lon="32.2992480999999998"/>
+    <node visible="true" id="1867810275" timestamp="2012-08-15T20:10:12Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7802999000000002" lon="32.2990697999999981"/>
+    <node visible="true" id="1867810312" timestamp="2019-01-28T10:19:04Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7804228000000002" lon="32.2949970000000022"/>
+    <node visible="true" id="1867810315" timestamp="2012-08-15T20:10:12Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7803998999999999" lon="32.2992647000000019"/>
+    <node visible="true" id="1867810354" timestamp="2012-08-15T20:10:13Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7804836000000002" lon="32.2994342000000003"/>
+    <node visible="true" id="1867810379" timestamp="2012-08-15T20:10:13Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7805268999999999" lon="32.2993086000000034"/>
+    <node visible="true" id="1867810423" timestamp="2012-08-15T20:10:14Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7806180000000000" lon="32.2991037000000034"/>
+    <node visible="true" id="1867810430" timestamp="2012-08-15T20:10:14Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7806544000000000" lon="32.2989906999999974"/>
+    <node visible="true" id="2323064411" timestamp="2015-05-03T08:26:09Z" version="2" changeset="30740772" user="Jotam" uid="768145" lat="2.7796021000000000" lon="32.2975104000000002">
+        <tag k="highway" v="stop"/>
+        <tag k="error:circular" v="15"/>
+    </node>
+    <node visible="true" id="6226381386" timestamp="2019-01-28T12:47:24Z" version="2" changeset="66704798" user="Penobscot" uid="9090196" lat="2.7806321000000001" lon="32.2964679999999973"/>
+    <node visible="true" id="6232990131" timestamp="2019-01-28T11:00:26Z" version="2" changeset="66701775" user="Penobscot" uid="9090196" lat="2.7782746000000000" lon="32.2952543000000034"/>
+    <node visible="true" id="6232990132" timestamp="2019-01-28T10:19:04Z" version="3" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7800589000000002" lon="32.2950719000000035"/>
+    <node visible="true" id="6232990134" timestamp="2019-01-28T10:19:04Z" version="3" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7802772999999998" lon="32.2950398999999990"/>
+    <node visible="true" id="6233141407" timestamp="2019-01-28T10:19:04Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7798927999999998" lon="32.2950967000000020"/>
+    <node visible="true" id="6241408579" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7777877000000002" lon="32.2986841999999967"/>
+    <node visible="true" id="6241408580" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778453000000001" lon="32.2985977000000020"/>
+    <node visible="true" id="6241408581" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7777949999999998" lon="32.2986554000000012"/>
+    <node visible="true" id="6241408582" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778204999999998" lon="32.2986284999999995"/>
+    <node visible="true" id="6241408583" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7777897000000000" lon="32.2987157000000025"/>
+    <node visible="true" id="6241408584" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778573000000000" lon="32.2985568000000001"/>
+    <node visible="true" id="6241409485" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7784890000000000" lon="32.2971000000000004"/>
+    <node visible="true" id="6241409486" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7774882999999999" lon="32.2996504999999985"/>
+    <node visible="true" id="6241409487" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7773503000000002" lon="32.2995767000000029"/>
+    <node visible="true" id="6241468066" timestamp="2019-01-28T11:00:25Z" version="1" changeset="66701775" user="Penobscot" uid="9090196" lat="2.7768693999999998" lon="32.2972995000000012"/>
+    <node visible="true" id="6241468067" timestamp="2019-01-28T11:00:25Z" version="1" changeset="66701775" user="Penobscot" uid="9090196" lat="2.7785867000000000" lon="32.2952167999999986"/>
+    <node visible="true" id="6241468068" timestamp="2019-01-28T11:00:25Z" version="1" changeset="66701775" user="Penobscot" uid="9090196" lat="2.7788305000000002" lon="32.2951912999999990"/>
+    <node visible="true" id="6241673191" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791429999999999" lon="32.2971079000000003"/>
+    <node visible="true" id="6241673192" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7790412000000000" lon="32.2969257999999968"/>
+    <node visible="true" id="6241673193" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791519999999998" lon="32.2968162000000021"/>
+    <node visible="true" id="6241673194" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7790178999999999" lon="32.2968495000000004"/>
+    <node visible="true" id="6241673195" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7792097999999998" lon="32.2971973000000006"/>
+    <node visible="true" id="6241673196" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791283999999998" lon="32.2972595000000027"/>
+    <node visible="true" id="6241673197" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7788938000000001" lon="32.2970639999999989"/>
+    <node visible="true" id="6241673199" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7788224000000001" lon="32.2970161000000004"/>
+    <node visible="true" id="6241673200" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7788168999999998" lon="32.2971369999999993"/>
+    <node visible="true" id="6241741870" timestamp="2019-01-28T13:25:29Z" version="1" changeset="66706015" user="Penobscot" uid="9090196" lat="2.7795551999999999" lon="32.2988056000000014"/>
+    <node visible="true" id="6241741872" timestamp="2019-01-28T13:25:29Z" version="1" changeset="66706015" user="Penobscot" uid="9090196" lat="2.7791587000000000" lon="32.2985320000000016"/>
+    <node visible="true" id="6241741873" timestamp="2019-01-28T13:25:29Z" version="1" changeset="66706015" user="Penobscot" uid="9090196" lat="2.7791868000000002" lon="32.2984079000000008"/>
+    <node visible="true" id="6575693889" timestamp="2019-06-27T23:56:54Z" version="1" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7795321000000000" lon="32.2975211999999985"/>
+    <node visible="true" id="6575693890" timestamp="2019-06-27T23:56:54Z" version="1" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7795388999999999" lon="32.2976006000000027"/>
+    <node visible="true" id="6575693891" timestamp="2019-06-27T23:56:54Z" version="1" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791562000000001" lon="32.2969123000000025"/>
+    <node visible="true" id="6575693892" timestamp="2019-06-27T23:56:54Z" version="1" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7789229999999998" lon="32.2971379000000027"/>
+    <node visible="true" id="6575693893" timestamp="2019-06-27T23:56:54Z" version="1" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7790672999999999" lon="32.2971781999999976"/>
+    <node visible="true" id="6575693894" timestamp="2019-06-27T23:56:54Z" version="1" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7788973000000001" lon="32.2970238999999992"/>
+    <node visible="true" id="6575693895" timestamp="2019-06-27T23:56:54Z" version="1" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7789940000000000" lon="32.2969281000000024"/>
+    <node visible="true" id="6575693896" timestamp="2019-06-27T23:56:54Z" version="1" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791228000000001" lon="32.2969701999999970"/>
+    <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="1818542821"/>
+        <nd ref="1866869809"/>
+        <nd ref="-13"/>
+        <tag k="highway" v="residential"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+    </way>
+    <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-12"/>
+        <nd ref="1818542813"/>
+        <nd ref="1867809886"/>
+        <nd ref="1818542810"/>
+        <nd ref="1867809882"/>
+        <nd ref="1818542808"/>
+        <nd ref="6241741872"/>
+        <nd ref="1818542809"/>
+        <nd ref="6241741873"/>
+        <nd ref="1818542815"/>
+        <nd ref="1818542817"/>
+        <nd ref="6575693890"/>
+        <nd ref="1818542821"/>
+        <nd ref="6575693889"/>
+        <nd ref="1641684950"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="name" v="Eden Road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+    </way>
+    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-11"/>
+        <nd ref="6241409486"/>
+        <nd ref="1865920156"/>
+        <tag k="highway" v="residential"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T10:19:05Z"/>
+        <tag k="surface" v="ground"/>
+    </way>
+    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="1865920156"/>
+        <nd ref="6241409487"/>
+        <nd ref="1865920154"/>
+        <nd ref="-10"/>
+        <tag k="highway" v="residential"/>
+        <tag k="name" v="Awere Road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T12:47:24Z"/>
+        <tag k="oneway" v="no"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-9"/>
+        <nd ref="1641684833"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="Nimule - Gulu Road"/>
+        <tag k="ref" v="A104"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2020-01-20T16:05:21Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="1818542811"/>
+        <nd ref="1818542816"/>
+        <nd ref="1818542822"/>
+        <nd ref="1818542825"/>
+        <nd ref="6226381386"/>
+        <nd ref="-8"/>
+        <tag k="highway" v="residential"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-22T08:12:42Z"/>
+    </way>
+    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="1655884800"/>
+        <nd ref="6241468066"/>
+        <nd ref="-7"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="Main Street"/>
+        <tag k="ref" v="A104"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2020-01-20T16:05:21Z"/>
+        <tag k="surface" v="paved"/>
+    </way>
+    <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-6"/>
+        <nd ref="1867810312"/>
+        <nd ref="6232990134"/>
+        <nd ref="6232990132"/>
+        <nd ref="6233141407"/>
+        <nd ref="1818542824"/>
+        <nd ref="1641684903"/>
+        <nd ref="6241468068"/>
+        <nd ref="1867809725"/>
+        <nd ref="6241468067"/>
+        <nd ref="6232990131"/>
+        <nd ref="1867808716"/>
+        <nd ref="1641684833"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="Gulu - Kitgum Road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T11:00:26Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="source" v="Bing"/>
+    </way>
+    <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-5"/>
+        <nd ref="1867809787"/>
+        <nd ref="1641684903"/>
+        <tag k="highway" v="residential"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-24T14:32:35Z"/>
+    </way>
+    <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-4"/>
+        <nd ref="1867810430"/>
+        <nd ref="1867810423"/>
+        <tag k="highway" v="residential"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2012-08-15T20:11:11Z"/>
+    </way>
+    <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="1867808716"/>
+        <nd ref="-3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-24T14:32:35Z"/>
+    </way>
+    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2"/>
+        <nd ref="1867810379"/>
+        <nd ref="1867810354"/>
+        <tag k="highway" v="residential"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2012-08-15T20:11:05Z"/>
+    </way>
+    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1"/>
+        <nd ref="1867810312"/>
+        <tag k="highway" v="service"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-22T08:12:42Z"/>
+    </way>
+    <way visible="true" id="176031521" timestamp="2015-05-04T09:53:52Z" version="8" changeset="30773664" user="Jotam" uid="768145">
+        <nd ref="1818542795"/>
+        <nd ref="1867808596"/>
+        <nd ref="1655884800"/>
+        <tag k="highway" v="residential"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2015-05-04T09:53:52Z"/>
+        <tag k="surface" v="ground"/>
+    </way>
+    <way visible="true" id="176124934" timestamp="2019-06-27T23:56:54Z" version="5" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1866869806"/>
+        <nd ref="1818542811"/>
+        <nd ref="1641684928"/>
+        <nd ref="1641684803"/>
+        <nd ref="1641684903"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="name" v="Princess Road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="unpaved"/>
+    </way>
+    <way visible="true" id="176124940" timestamp="2019-06-27T23:56:54Z" version="5" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1866869795"/>
+        <nd ref="1866869791"/>
+        <nd ref="1866869787"/>
+        <nd ref="6575693892"/>
+        <nd ref="1866869783"/>
+        <nd ref="6241673197"/>
+        <nd ref="6575693894"/>
+        <nd ref="1866869782"/>
+        <nd ref="1866869785"/>
+        <nd ref="1866869789"/>
+        <nd ref="6575693895"/>
+        <nd ref="6241673192"/>
+        <nd ref="1866869793"/>
+        <nd ref="6575693896"/>
+        <nd ref="1866869802"/>
+        <nd ref="1866869804"/>
+        <nd ref="1866869805"/>
+        <nd ref="6241673191"/>
+        <nd ref="1866869798"/>
+        <nd ref="6575693893"/>
+        <nd ref="1866869795"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="junction" v="roundabout"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="176124943" timestamp="2019-06-27T23:56:54Z" version="4" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1866869805"/>
+        <nd ref="6241673195"/>
+        <nd ref="1641684950"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="176124944" timestamp="2019-06-27T23:56:54Z" version="5" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1866869787"/>
+        <nd ref="6241673200"/>
+        <nd ref="1866869779"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="176124945" timestamp="2019-06-27T23:56:54Z" version="5" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1866869779"/>
+        <nd ref="6241673199"/>
+        <nd ref="1866869782"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="176124946" timestamp="2019-06-27T23:56:54Z" version="4" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1866869789"/>
+        <nd ref="6241673194"/>
+        <nd ref="1866869806"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="176124948" timestamp="2019-06-27T23:56:54Z" version="4" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1641684950"/>
+        <nd ref="6241673196"/>
+        <nd ref="1866869795"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="176124949" timestamp="2019-06-27T23:56:54Z" version="4" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1866869806"/>
+        <nd ref="6241673193"/>
+        <nd ref="6575693891"/>
+        <nd ref="1866869802"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="176237124" timestamp="2019-01-28T10:19:04Z" version="2" changeset="66700762" user="Penobscot" uid="9090196">
+        <nd ref="1867808695"/>
+        <nd ref="1867808698"/>
+        <nd ref="1867808684"/>
+        <nd ref="6241408584"/>
+        <nd ref="6241408580"/>
+        <nd ref="6241408582"/>
+        <nd ref="6241408581"/>
+        <nd ref="6241408579"/>
+        <nd ref="6241408583"/>
+        <nd ref="1867808710"/>
+        <nd ref="1867808736"/>
+        <nd ref="1867808817"/>
+        <nd ref="1867808839"/>
+        <nd ref="1867808845"/>
+        <nd ref="1867809646"/>
+        <tag k="highway" v="service"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T10:19:04Z"/>
+    </way>
+    <way visible="true" id="176237126" timestamp="2016-11-07T00:51:47Z" version="2" changeset="43454915" user="Johnwhelan" uid="186592">
+        <nd ref="1867810423"/>
+        <nd ref="1867810379"/>
+        <nd ref="1867810315"/>
+        <nd ref="1867810259"/>
+        <nd ref="1867810201"/>
+        <nd ref="1867810194"/>
+        <nd ref="1867810163"/>
+        <nd ref="1867810133"/>
+        <nd ref="1867810065"/>
+        <nd ref="1867810003"/>
+        <nd ref="1867809913"/>
+        <nd ref="1867809894"/>
+        <nd ref="1867809886"/>
+        <tag k="highway" v="path"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2016-11-07T00:51:47Z"/>
+    </way>
+    <way visible="true" id="176237162" timestamp="2019-01-28T10:19:04Z" version="2" changeset="66700762" user="Penobscot" uid="9090196">
+        <nd ref="1867808596"/>
+        <nd ref="1867808695"/>
+        <tag k="highway" v="service"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T10:19:04Z"/>
+    </way>
+    <way visible="true" id="176237183" timestamp="2019-01-28T10:19:04Z" version="2" changeset="66700762" user="Penobscot" uid="9090196">
+        <nd ref="1867808820"/>
+        <nd ref="1867808889"/>
+        <tag k="highway" v="service"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T10:19:04Z"/>
+    </way>
+    <way visible="true" id="176237239" timestamp="2019-01-28T10:19:05Z" version="3" changeset="66700762" user="Penobscot" uid="9090196">
+        <nd ref="1867808695"/>
+        <nd ref="1867808753"/>
+        <nd ref="1867808834"/>
+        <tag k="highway" v="service"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T10:19:05Z"/>
+    </way>
+    <way visible="true" id="176237251" timestamp="2016-11-07T00:53:50Z" version="2" changeset="43454915" user="Johnwhelan" uid="186592">
+        <nd ref="1867810275"/>
+        <nd ref="1867810237"/>
+        <nd ref="1867810204"/>
+        <nd ref="1867810194"/>
+        <tag k="highway" v="path"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2016-11-07T00:53:50Z"/>
+    </way>
+    <way visible="true" id="176237258" timestamp="2019-01-28T10:19:05Z" version="3" changeset="66700762" user="Penobscot" uid="9090196">
+        <nd ref="6241409485"/>
+        <nd ref="1867809124"/>
+        <nd ref="1867809178"/>
+        <nd ref="1867809276"/>
+        <nd ref="1867809777"/>
+        <tag k="highway" v="path"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T10:19:05Z"/>
+    </way>
+    <way visible="true" id="176237263" timestamp="2019-01-28T10:19:05Z" version="2" changeset="66700762" user="Penobscot" uid="9090196">
+        <nd ref="1867808834"/>
+        <nd ref="1867808767"/>
+        <nd ref="1867808820"/>
+        <tag k="highway" v="service"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T10:19:05Z"/>
+    </way>
+    <way visible="true" id="176237297" timestamp="2019-01-28T13:25:30Z" version="2" changeset="66706015" user="Penobscot" uid="9090196">
+        <nd ref="1867809882"/>
+        <nd ref="1867809896"/>
+        <nd ref="1867809920"/>
+        <nd ref="1867809950"/>
+        <nd ref="1867809968"/>
+        <nd ref="1867810001"/>
+        <nd ref="6241741870"/>
+        <nd ref="1867810040"/>
+        <nd ref="1867810121"/>
+        <tag k="highway" v="service"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T13:25:30Z"/>
+    </way>
+    <way visible="true" id="176390103" timestamp="2019-06-27T23:56:54Z" version="6" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1866869779"/>
+        <nd ref="6241409485"/>
+        <nd ref="1655884800"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="name" v="Main Street"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="paved"/>
+    </way>
+    <way visible="true" id="342708823" timestamp="2020-01-20T16:05:21Z" version="4" changeset="79806055" user="Bert Araali" uid="3302662">
+        <nd ref="1641684833"/>
+        <nd ref="1655884800"/>
+        <tag k="highway" v="primary"/>
+        <tag k="ref" v="A104"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2020-01-20T16:05:21Z"/>
+        <tag k="surface" v="ground"/>
+    </way>
+</osm>

--- a/test-files/cases/attribute/network/highway-3784-roundabouts-1/README.txt
+++ b/test-files/cases/attribute/network/highway-3784-roundabouts-1/README.txt
@@ -1,0 +1,4 @@
+Test to make sure roundabouts are conflated properly with the Network Roads alg. Roundabout removal/replacement is bypassed since we always 
+keep reference geometries with Attribute Conflation.
+
+

--- a/test-files/cases/attribute/unifying/highway-3784-roundabouts-1/Expected.osm
+++ b/test-files/cases/attribute/unifying/highway-3784-roundabouts-1/Expected.osm
@@ -1,0 +1,2197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="2.7766" minlon="32.2948" maxlat="2.7807" maxlon="32.2997"/>
+    <node visible="true" id="-387" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775182790145094" lon="32.2987437336142023">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-387"/>
+    </node>
+    <node visible="true" id="-386" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775194490855006" lon="32.2987622993437995">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-386"/>
+    </node>
+    <node visible="true" id="-385" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775212699682599" lon="32.2987808131540035">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-385"/>
+    </node>
+    <node visible="true" id="-384" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775237394443395" lon="32.2987992524884007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-384"/>
+    </node>
+    <node visible="true" id="-383" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775268545050698" lon="32.2988175948816973">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-383"/>
+    </node>
+    <node visible="true" id="-382" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775306113552500" lon="32.2988358179865003">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-382"/>
+    </node>
+    <node visible="true" id="-381" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775350054177395" lon="32.2988538996008003">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-381"/>
+    </node>
+    <node visible="true" id="-380" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775400313390599" lon="32.2988718176950016">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-380"/>
+    </node>
+    <node visible="true" id="-379" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775439510922300" lon="32.2988843398693959">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-379"/>
+    </node>
+    <node visible="true" id="-378" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775476247119597" lon="32.2988923819512976">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-378"/>
+    </node>
+    <node visible="true" id="-377" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775520964563594" lon="32.2989000138261986">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-377"/>
+    </node>
+    <node visible="true" id="-376" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775573205735005" lon="32.2989071574099000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-376"/>
+    </node>
+    <node visible="true" id="-375" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775632436136997" lon="32.2989137396141004">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-375"/>
+    </node>
+    <node visible="true" id="-374" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775698049763502" lon="32.2989196930938007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-374"/>
+    </node>
+    <node visible="true" id="-373" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775769375299397" lon="32.2989249569370998">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-373"/>
+    </node>
+    <node visible="true" id="-372" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775845682989302" lon="32.2989294772878992">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-372"/>
+    </node>
+    <node visible="true" id="-371" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775926192103602" lon="32.2989332078967024">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-371"/>
+    </node>
+    <node visible="true" id="-370" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776010078926401" lon="32.2989361105947026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-370"/>
+    </node>
+    <node visible="true" id="-369" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776096485183497" lon="32.2989381556830963">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-369"/>
+    </node>
+    <node visible="true" id="-368" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776184526823298" lon="32.2989393222380983">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-368"/>
+    </node>
+    <node visible="true" id="-367" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776273303062093" lon="32.2989395983240968">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-367"/>
+    </node>
+    <node visible="true" id="-366" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776361905600395" lon="32.2989389811164926">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-366"/>
+    </node>
+    <node visible="true" id="-365" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776449427915590" lon="32.2989374769300994">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-365"/>
+    </node>
+    <node visible="true" id="-364" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776534974537297" lon="32.2989351011545978">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-364"/>
+    </node>
+    <node visible="true" id="-363" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776610795133205" lon="32.2989326301865987">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-363"/>
+    </node>
+    <node visible="true" id="-362" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776687436674705" lon="32.2989304238757029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-362"/>
+    </node>
+    <node visible="true" id="-361" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776764805786005" lon="32.2989284849100997">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-361"/>
+    </node>
+    <node visible="true" id="-360" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776842808204694" lon="32.2989268156520026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-360"/>
+    </node>
+    <node visible="true" id="-359" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776921348896901" lon="32.2989254181351910">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-359"/>
+    </node>
+    <node visible="true" id="-358" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777000332172896" lon="32.2989242940624024">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-358"/>
+    </node>
+    <node visible="true" id="-357" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777079661803796" lon="32.2989234448031013">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-357"/>
+    </node>
+    <node visible="true" id="-356" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777159241138700" lon="32.2989228713919019">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-356"/>
+    </node>
+    <node visible="true" id="-355" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777238973222400" lon="32.2989225745275945">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-355"/>
+    </node>
+    <node visible="true" id="-354" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777318760913592" lon="32.2989225545717034">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-354"/>
+    </node>
+    <node visible="true" id="-353" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777398507003501" lon="32.2989228115486995">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-353"/>
+    </node>
+    <node visible="true" id="-352" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777478114333496" lon="32.2989233451452975">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-352"/>
+    </node>
+    <node visible="true" id="-351" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777557059444296" lon="32.2989241496163970">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-351"/>
+    </node>
+    <node visible="true" id="-350" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777603712000198" lon="32.2989264652775034">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-350"/>
+    </node>
+    <node visible="true" id="-349" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777647256661595" lon="32.2989293174193008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-349"/>
+    </node>
+    <node visible="true" id="-348" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777687072609001" lon="32.2989326653786009">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-348"/>
+    </node>
+    <node visible="true" id="-347" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777722592183198" lon="32.2989364614232031">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-347"/>
+    </node>
+    <node visible="true" id="-346" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777753308978701" lon="32.2989406514326021">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-346"/>
+    </node>
+    <node visible="true" id="-345" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777778785063898" lon="32.2989451756697008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-345"/>
+    </node>
+    <node visible="true" id="-344" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777798657224202" lon="32.2989499696318987">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-344"/>
+    </node>
+    <node visible="true" id="-343" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777812642140494" lon="32.2989549649713013">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-343"/>
+    </node>
+    <node visible="true" id="-342" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777820540428904" lon="32.2989600904691017">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-342"/>
+    </node>
+    <node visible="true" id="-341" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777822239482695" lon="32.2989652730505981">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-341"/>
+    </node>
+    <node visible="true" id="-340" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777817715078297" lon="32.2989704388271974">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-340"/>
+    </node>
+    <node visible="true" id="-339" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777807031720601" lon="32.2989755141502002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-339"/>
+    </node>
+    <node visible="true" id="-338" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777790341722994" lon="32.2989804266602007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-338"/>
+    </node>
+    <node visible="true" id="-337" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777767883036200" lon="32.2989851063192006">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-337"/>
+    </node>
+    <node visible="true" id="-336" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777739975855296" lon="32.2989894864088996">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-336"/>
+    </node>
+    <node visible="true" id="-335" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777646275009094" lon="32.2990438123054986">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-335"/>
+    </node>
+    <node visible="true" id="-334" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777501802418496" lon="32.2991014182805998">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-334"/>
+    </node>
+    <node visible="true" id="-333" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777327403677594" lon="32.2991581991857970">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-333"/>
+    </node>
+    <node visible="true" id="-332" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777123550695801" lon="32.2992140013760007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-332"/>
+    </node>
+    <node visible="true" id="-331" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776890795083506" lon="32.2992686738545984">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-331"/>
+    </node>
+    <node visible="true" id="-330" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776844812841599" lon="32.2992782909542981">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-330"/>
+    </node>
+    <node visible="true" id="-329" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7793072792240094" lon="32.2965970744986990">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-329"/>
+    </node>
+    <node visible="true" id="-328" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792919414114792" lon="32.2965958598485017">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-328"/>
+    </node>
+    <node visible="true" id="-327" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792765651822093" lon="32.2965953045047982">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-327"/>
+    </node>
+    <node visible="true" id="-326" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792611791784196" lon="32.2965954095024017">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-326"/>
+    </node>
+    <node visible="true" id="-325" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792458120605494" lon="32.2965961746454013">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-325"/>
+    </node>
+    <node visible="true" id="-324" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792304924538493" lon="32.2965975985086970">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-324"/>
+    </node>
+    <node visible="true" id="-323" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792152488950594" lon="32.2965996784397973">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-323"/>
+    </node>
+    <node visible="true" id="-322" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792001097792700" lon="32.2966024105643896">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-322"/>
+    </node>
+    <node visible="true" id="-321" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791851033070194" lon="32.2966057897930980">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-321"/>
+    </node>
+    <node visible="true" id="-320" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791702574317498" lon="32.2966098098312031">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-320"/>
+    </node>
+    <node visible="true" id="-319" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791555998077695" lon="32.2966144631904015">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-319"/>
+    </node>
+    <node visible="true" id="-318" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791411577387000" lon="32.2966197412023988">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-318"/>
+    </node>
+    <node visible="true" id="-317" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791269581266493" lon="32.2966256340356992">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-317"/>
+    </node>
+    <node visible="true" id="-316" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791130274220595" lon="32.2966321307132986">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-316"/>
+    </node>
+    <node visible="true" id="-315" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7790993915745092" lon="32.2966392191333966">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-315"/>
+    </node>
+    <node visible="true" id="-314" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7790860759842801" lon="32.2966468860918994">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-314"/>
+    </node>
+    <node visible="true" id="-313" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7805279610607099" lon="32.2964359705758994">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-313"/>
+    </node>
+    <node visible="true" id="-312" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7804773080670695" lon="32.2964345295478026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-312"/>
+    </node>
+    <node visible="true" id="-311" timestamp="2020-02-07T17:57:36Z" version="1" lat="2.7770631254490197" lon="32.2953548897616969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-311"/>
+    </node>
+    <node visible="true" id="-310" timestamp="2020-02-07T17:57:36Z" version="1" lat="2.7770279992641798" lon="32.2952081316341975">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-310"/>
+    </node>
+    <node visible="true" id="-309" timestamp="2020-02-07T17:57:36Z" version="1" lat="2.7770137855736001" lon="32.2951331858424950">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-309"/>
+    </node>
+    <node visible="true" id="-308" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799148692709994" lon="32.2958915832183990">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-308"/>
+    </node>
+    <node visible="true" id="-307" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799286005237192" lon="32.2960484939745029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-307"/>
+    </node>
+    <node visible="true" id="-306" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799515256394494" lon="32.2963401706744975">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-306"/>
+    </node>
+    <node visible="true" id="-305" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799565540837596" lon="32.2964673701593981">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-305"/>
+    </node>
+    <node visible="true" id="-304" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799190543354095" lon="32.2964677480541980">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-304"/>
+    </node>
+    <node visible="true" id="-303" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7798659443090497" lon="32.2964713657132023">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-303"/>
+    </node>
+    <node visible="true" id="-302" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7798251073870599" lon="32.2964721617457968">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-302"/>
+    </node>
+    <node visible="true" id="-301" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7797573833053395" lon="32.2964819104586027">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-301"/>
+    </node>
+    <node visible="true" id="-300" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7795905576110393" lon="32.2965205264260007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-300"/>
+    </node>
+    <node visible="true" id="-299" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7794444617889198" lon="32.2965452244570983">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-299"/>
+    </node>
+    <node visible="true" id="-298" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7794303706162595" lon="32.2965450561986032">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-298"/>
+    </node>
+    <node visible="true" id="-297" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7793869065920895" lon="32.2965579304608923">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-297"/>
+    </node>
+    <node visible="true" id="-296" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7793714551548900" lon="32.2965687687937972">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-296"/>
+    </node>
+    <node visible="true" id="-295" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7793061826668599" lon="32.2965840227614933">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-295"/>
+    </node>
+    <node visible="true" id="-294" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7806791852046904" lon="32.2964508188340034">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-294"/>
+    </node>
+    <node visible="true" id="-293" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7806289611560095" lon="32.2964441201832955">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-293"/>
+    </node>
+    <node visible="true" id="-292" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7805785326282191" lon="32.2964391687532029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-292"/>
+    </node>
+    <node visible="true" id="-291" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7790944263331601" lon="32.2966168197570980">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-291"/>
+    </node>
+    <node visible="true" id="-290" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7791040579579995" lon="32.2965528088653997">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-290"/>
+    </node>
+    <node visible="true" id="-289" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7791028556961495" lon="32.2964862556405947">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-289"/>
+    </node>
+    <node visible="true" id="-288" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7790934061625991" lon="32.2963965733989014">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-288"/>
+    </node>
+    <node visible="true" id="-287" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7790862553409301" lon="32.2963451450642012">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-287"/>
+    </node>
+    <node visible="true" id="-286" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7773390139459297" lon="32.2983055209448011">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-286"/>
+    </node>
+    <node visible="true" id="-285" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7772860569032298" lon="32.2983210906537010">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-285"/>
+    </node>
+    <node visible="true" id="-284" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7772376015852398" lon="32.2983333262564969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-284"/>
+    </node>
+    <node visible="true" id="-283" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7771899450191602" lon="32.2983419583239950">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-283"/>
+    </node>
+    <node visible="true" id="-282" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7771433411058797" lon="32.2983478908695005">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-282"/>
+    </node>
+    <node visible="true" id="-281" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7769725299953301" lon="32.2983627060958014">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-281"/>
+    </node>
+    <node visible="true" id="-280" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7769349978565998" lon="32.2983687012281990">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-280"/>
+    </node>
+    <node visible="true" id="-279" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7769000417745797" lon="32.2983774209166015">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-279"/>
+    </node>
+    <node visible="true" id="-278" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7768679156497500" lon="32.2983897691734967">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-278"/>
+    </node>
+    <node visible="true" id="-277" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7767952554397999" lon="32.2984237017090976">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-277"/>
+    </node>
+    <node visible="true" id="-276" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7767329872946691" lon="32.2984500192949966">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-276"/>
+    </node>
+    <node visible="true" id="-275" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7767138166833489" lon="32.2984640915333969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-275"/>
+    </node>
+    <node visible="true" id="-274" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766939753116495" lon="32.2984772120453982">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-274"/>
+    </node>
+    <node visible="true" id="-273" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766735109103799" lon="32.2984893492679035">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-273"/>
+    </node>
+    <node visible="true" id="-272" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766524727091100" lon="32.2985004740034967">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-272"/>
+    </node>
+    <node visible="true" id="-271" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766309113177696" lon="32.2985105594903033">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-271"/>
+    </node>
+    <node visible="true" id="-270" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766088786048702" lon="32.2985195814665005">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-270"/>
+    </node>
+    <node visible="true" id="-269" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787270390095595" lon="32.2970533533747997">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-269"/>
+    </node>
+    <node visible="true" id="-268" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787309531035702" lon="32.2970335158837969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-268"/>
+    </node>
+    <node visible="true" id="-267" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787364401982191" lon="32.2970180036822967">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-267"/>
+    </node>
+    <node visible="true" id="-266" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787435002936896" lon="32.2970068167703985">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-266"/>
+    </node>
+    <node visible="true" id="-265" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787511992954097" lon="32.2970004466722997">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-265"/>
+    </node>
+    <node visible="true" id="-264" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7788087425187094" lon="32.2969717156124005">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-264"/>
+    </node>
+    <node visible="true" id="-263" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7788506285021701" lon="32.2969477435619012">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-263"/>
+    </node>
+    <node visible="true" id="-262" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7788937732080199" lon="32.2969168513654026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-262"/>
+    </node>
+    <node visible="true" id="-261" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7789893211751795" lon="32.2962968428053969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-261"/>
+    </node>
+    <node visible="true" id="-260" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7789614889881196" lon="32.2963137532252986">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-260"/>
+    </node>
+    <node visible="true" id="-259" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7789053292336101" lon="32.2963209158563984">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-259"/>
+    </node>
+    <node visible="true" id="-258" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7788489621043695" lon="32.2963262285276969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-258"/>
+    </node>
+    <node visible="true" id="-257" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7787924491999996" lon="32.2963296854335979">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-257"/>
+    </node>
+    <node visible="true" id="-256" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7787358522793997" lon="32.2963312827966007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-256"/>
+    </node>
+    <node visible="true" id="-255" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7786210910917495" lon="32.2963291251494979">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-255"/>
+    </node>
+    <node visible="true" id="-254" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7785335638757296" lon="32.2963240213678020">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-254"/>
+    </node>
+    <node visible="true" id="-253" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7784549540499190" lon="32.2963174243649007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-253"/>
+    </node>
+    <node visible="true" id="-252" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7783756213934598" lon="32.2963076869760002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-252"/>
+    </node>
+    <node visible="true" id="-251" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7783644627528590" lon="32.2963051594362014">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-251"/>
+    </node>
+    <node visible="true" id="-250" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7783277573913798" lon="32.2962925453375007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-250"/>
+    </node>
+    <node visible="true" id="-249" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7790762995339198" lon="32.2951529783225979">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-249"/>
+    </node>
+    <node visible="true" id="-248" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7791011265381602" lon="32.2951495912118034">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-248"/>
+    </node>
+    <node visible="true" id="-247" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7791259086498701" lon="32.2951458998063998">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-247"/>
+    </node>
+    <node visible="true" id="-246" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7791456877739402" lon="32.2951427593902025">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-246"/>
+    </node>
+    <node visible="true" id="-245" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7791753777756396" lon="32.2951378700906986">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-245"/>
+    </node>
+    <node visible="true" id="-244" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7792494921451198" lon="32.2951252056762996">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-244"/>
+    </node>
+    <node visible="true" id="-243" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7792989576203095" lon="32.2951171252784022">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-243"/>
+    </node>
+    <node visible="true" id="-242" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7793237368115795" lon="32.2951133933273979">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-242"/>
+    </node>
+    <node visible="true" id="-241" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7801431587327694" lon="32.2949945766952027">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-241"/>
+    </node>
+    <node visible="true" id="-240" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773145289795398" lon="32.2973382157608029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-240"/>
+    </node>
+    <node visible="true" id="-239" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773336814374101" lon="32.2974426710620008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-239"/>
+    </node>
+    <node visible="true" id="-238" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773727898948297" lon="32.2977247211759035">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-238"/>
+    </node>
+    <node visible="true" id="-237" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773906753164899" lon="32.2978988167995027">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-237"/>
+    </node>
+    <node visible="true" id="-236" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7774030133222793" lon="32.2980314393681027">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-236"/>
+    </node>
+    <node visible="true" id="-235" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7774179126540690" lon="32.2981668106442967">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-235"/>
+    </node>
+    <node visible="true" id="-234" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7774251529098195" lon="32.2982169092732008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-234"/>
+    </node>
+    <node visible="true" id="-233" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7774156763440994" lon="32.2995995663855027">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-233"/>
+    </node>
+    <node visible="true" id="-232" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773915670919997" lon="32.2996018872200992">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-232"/>
+    </node>
+    <node visible="true" id="-231" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773724616824595" lon="32.2996009689238903">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-231"/>
+    </node>
+    <node visible="true" id="-230" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7772893357687201" lon="32.2995909546071971">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-230"/>
+    </node>
+    <node visible="true" id="-229" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7772671674411900" lon="32.2995912485744014">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-229"/>
+    </node>
+    <node visible="true" id="-228" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7772090356714805" lon="32.2995961566197991">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-228"/>
+    </node>
+    <node visible="true" id="-227" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7770877203034496" lon="32.2996131343109028">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-227"/>
+    </node>
+    <node visible="true" id="-226" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7767254579384497" lon="32.2996735266724002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-226"/>
+    </node>
+    <node visible="true" id="-225" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7789366650597493" lon="32.2968795862481031">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-225"/>
+    </node>
+    <node visible="true" id="-224" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7789777924808599" lon="32.2968364954355920">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-224"/>
+    </node>
+    <node visible="true" id="-223" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7790156438949696" lon="32.2967881261537002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-223"/>
+    </node>
+    <node visible="true" id="-222" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7790487077257802" lon="32.2967350256286991">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-222"/>
+    </node>
+    <node visible="true" id="-221" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7790754723971696" lon="32.2966777410874002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-221"/>
+    </node>
+    <node visible="true" id="-220" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7790849044578998" lon="32.2966474247637976">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-220"/>
+    </node>
+    <node visible="true" id="-219" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7774369596119795" lon="32.2982820972044991">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-219"/>
+    </node>
+    <node visible="true" id="-218" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7774626380325098" lon="32.2982815648464978">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-218"/>
+    </node>
+    <node visible="true" id="-217" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7774882821284392" lon="32.2982801415870000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-217"/>
+    </node>
+    <node visible="true" id="-216" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7775138606563705" lon="32.2982778291599999">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-216"/>
+    </node>
+    <node visible="true" id="-215" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7775393424527901" lon="32.2982746303827000">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-215"/>
+    </node>
+    <node visible="true" id="-214" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7775646964720195" lon="32.2982705491522992">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-214"/>
+    </node>
+    <node visible="true" id="-213" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7775898918240998" lon="32.2982655904410905">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-213"/>
+    </node>
+    <node visible="true" id="-212" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7776148978123198" lon="32.2982597602904917">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-212"/>
+    </node>
+    <node visible="true" id="-211" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7776396839707300" lon="32.2982530658035927">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-211"/>
+    </node>
+    <node visible="true" id="-210" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7776642201011699" lon="32.2982455151365002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-210"/>
+    </node>
+    <node visible="true" id="-209" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7776884763101295" lon="32.2982371174884975">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-209"/>
+    </node>
+    <node visible="true" id="-208" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7777124230451200" lon="32.2982278830908029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-208"/>
+    </node>
+    <node visible="true" id="-207" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7777360311307002" lon="32.2982178231942001">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-207"/>
+    </node>
+    <node visible="true" id="-206" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7777592718040296" lon="32.2982069500548903">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-206"/>
+    </node>
+    <node visible="true" id="-205" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7777625781590793" lon="32.2982053222500980">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-205"/>
+    </node>
+    <node visible="true" id="-204" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7787963648221194" lon="32.2971009015447024">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-204"/>
+    </node>
+    <node visible="true" id="-203" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7788284031442996" lon="32.2971081970185026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-203"/>
+    </node>
+    <node visible="true" id="-202" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7788772095488996" lon="32.2971150417172979">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-202"/>
+    </node>
+    <node visible="true" id="-201" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7789264630866199" lon="32.2971169087592997">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-201"/>
+    </node>
+    <node visible="true" id="-200" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7789756518014195" lon="32.2971137787374971">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-200"/>
+    </node>
+    <node visible="true" id="-199" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7802648640015990" lon="32.2949085176392998">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-199"/>
+    </node>
+    <node visible="true" id="-198" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7774859531654603" lon="32.2971798678577002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-198"/>
+    </node>
+    <node visible="true" id="-197" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7780744641452095" lon="32.2971089943925023">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-197"/>
+    </node>
+    <node visible="true" id="-196" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7782770375765700" lon="32.2970885723319938">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-196"/>
+    </node>
+    <node visible="true" id="-195" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7785026490386202" lon="32.2970730894105031">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-195"/>
+    </node>
+    <node visible="true" id="-194" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7786476470914194" lon="32.2970604072306955">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-194"/>
+    </node>
+    <node visible="true" id="-193" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7786626640867493" lon="32.2970611807515979">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-193"/>
+    </node>
+    <node visible="true" id="-192" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7786797299840194" lon="32.2970641285152027">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-192"/>
+    </node>
+    <node visible="true" id="-191" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7787246979159801" lon="32.2970775161554968">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-191"/>
+    </node>
+    <node visible="true" id="-190" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7804898163031706" lon="32.2949240333992975">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-190"/>
+    </node>
+    <node visible="true" id="-189" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7803884947554898" lon="32.2949496516802981">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-189"/>
+    </node>
+    <node visible="true" id="-188" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7802820953679195" lon="32.2949715954966976">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-188"/>
+    </node>
+    <node visible="true" id="-187" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7772836575038697" lon="32.2972018287101008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-187"/>
+    </node>
+    <node visible="true" id="-186" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7772501254376700" lon="32.2970529479139969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-186"/>
+    </node>
+    <node visible="true" id="-185" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7772307442505402" lon="32.2969431351758018">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-185"/>
+    </node>
+    <node visible="true" id="-184" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7771294554076396" lon="32.2962343203032987">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-184"/>
+    </node>
+    <node visible="true" id="-183" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7771202173468099" lon="32.2961424051902029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-183"/>
+    </node>
+    <node visible="true" id="-182" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7771116826744997" lon="32.2960116855251016">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-182"/>
+    </node>
+    <node visible="true" id="-181" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7771043240371598" lon="32.2959079210252966">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-181"/>
+    </node>
+    <node visible="true" id="-180" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770881015616595" lon="32.2957475602725026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-180"/>
+    </node>
+    <node visible="true" id="-179" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770817892336996" lon="32.2956705918687987">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-179"/>
+    </node>
+    <node visible="true" id="-178" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770782669788097" lon="32.2955808140050991">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-178"/>
+    </node>
+    <node visible="true" id="-177" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770807222976890" lon="32.2954718424969016">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-177"/>
+    </node>
+    <node visible="true" id="-176" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770787292631693" lon="32.2954424312888904">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-176"/>
+    </node>
+    <node visible="true" id="-175" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7774541148099803" lon="32.2995857555437951">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-175"/>
+    </node>
+    <node visible="true" id="-174" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7774710615923790" lon="32.2995745703018926">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-174"/>
+    </node>
+    <node visible="true" id="-173" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7775318157337399" lon="32.2995200418195978">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-173"/>
+    </node>
+    <node visible="true" id="-172" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7775801075251696" lon="32.2994571221653999">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-172"/>
+    </node>
+    <node visible="true" id="-171" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7776133843055297" lon="32.2994078301435010">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-171"/>
+    </node>
+    <node visible="true" id="-170" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7776440386302998" lon="32.2993568839232026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-170"/>
+    </node>
+    <node visible="true" id="-169" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7776719875511797" lon="32.2993044213613985">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-169"/>
+    </node>
+    <node visible="true" id="-168" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7776826474353000" lon="32.2992821264148020">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-168"/>
+    </node>
+    <node visible="true" id="-167" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790242644109999" lon="32.2971056841855031">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-167"/>
+    </node>
+    <node visible="true" id="-166" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790315514972499" lon="32.2971038268491029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-166"/>
+    </node>
+    <node visible="true" id="-165" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790405653388497" lon="32.2971003506071028">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-165"/>
+    </node>
+    <node visible="true" id="-164" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790492309758594" lon="32.2970960876630926">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-164"/>
+    </node>
+    <node visible="true" id="-163" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790574791499600" lon="32.2970910720879019">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-163"/>
+    </node>
+    <node visible="true" id="-162" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790652439393195" lon="32.2970853439671970">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-162"/>
+    </node>
+    <node visible="true" id="-161" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790724632854906" lon="32.2970789490819996">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-161"/>
+    </node>
+    <node visible="true" id="-160" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790790794893199" lon="32.2970719385419969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-160"/>
+    </node>
+    <node visible="true" id="-159" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790850396722004" lon="32.2970643683775975">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-159"/>
+    </node>
+    <node visible="true" id="-158" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790902961985697" lon="32.2970562990916008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-158"/>
+    </node>
+    <node visible="true" id="-157" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790948070567598" lon="32.2970477951761978">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-157"/>
+    </node>
+    <node visible="true" id="-156" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790985361946494" lon="32.2970389245972029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-156"/>
+    </node>
+    <node visible="true" id="-155" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791014538078898" lon="32.2970297582508010">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-155"/>
+    </node>
+    <node visible="true" id="-154" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791035365780692" lon="32.2970203693972024">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-154"/>
+    </node>
+    <node visible="true" id="-153" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791047678590695" lon="32.2970108330748005">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-153"/>
+    </node>
+    <node visible="true" id="-152" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791051378101401" lon="32.2970012255008001">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-152"/>
+    </node>
+    <node visible="true" id="-151" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791046434745397" lon="32.2969916234616008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-151"/>
+    </node>
+    <node visible="true" id="-150" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791029517280301" lon="32.2969824146832920">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-150"/>
+    </node>
+    <node visible="true" id="-149" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791005899865300" lon="32.2969733529161971">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-149"/>
+    </node>
+    <node visible="true" id="-148" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790975707975401" lon="32.2969644863038923">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-148"/>
+    </node>
+    <node visible="true" id="-147" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790939102014489" lon="32.2969558619530019">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-147"/>
+    </node>
+    <node visible="true" id="-146" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790896276463202" lon="32.2969475256830023">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-146"/>
+    </node>
+    <node visible="true" id="-145" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790847458845800" lon="32.2969395217829955">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-145"/>
+    </node>
+    <node visible="true" id="-144" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790792908520991" lon="32.2969318927762004">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-144"/>
+    </node>
+    <node visible="true" id="-143" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790732915304490" lon="32.2969246791940989">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-143"/>
+    </node>
+    <node visible="true" id="-142" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790667797929096" lon="32.2969179193610003">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-142"/>
+    </node>
+    <node visible="true" id="-141" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790597902351197" lon="32.2969116491907968">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-141"/>
+    </node>
+    <node visible="true" id="-140" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790523599912897" lon="32.2969059019956006">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-140"/>
+    </node>
+    <node visible="true" id="-139" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790445285368999" lon="32.2969007083091029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-139"/>
+    </node>
+    <node visible="true" id="-138" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790363374789999" lon="32.2968960957244988">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-138"/>
+    </node>
+    <node visible="true" id="-137" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790278303351501" lon="32.2968920887473985">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-137"/>
+    </node>
+    <node visible="true" id="-136" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790190523021798" lon="32.2968887086663017">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-136"/>
+    </node>
+    <node visible="true" id="-135" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790109489176200" lon="32.2968877484774026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-135"/>
+    </node>
+    <node visible="true" id="-134" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790028167736796" lon="32.2968870701194035">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-134"/>
+    </node>
+    <node visible="true" id="-133" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789946657781202" lon="32.2968866744188006">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-133"/>
+    </node>
+    <node visible="true" id="-132" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789865058616696" lon="32.2968865618576970">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-132"/>
+    </node>
+    <node visible="true" id="-131" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789783469659306" lon="32.2968867325731992">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-131"/>
+    </node>
+    <node visible="true" id="-130" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789701990312596" lon="32.2968871863574023">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-130"/>
+    </node>
+    <node visible="true" id="-129" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789620719846595" lon="32.2968879226572980">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-129"/>
+    </node>
+    <node visible="true" id="-128" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789539757276800" lon="32.2968889405758972">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-128"/>
+    </node>
+    <node visible="true" id="-127" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789459201243600" lon="32.2968902388730967">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-127"/>
+    </node>
+    <node visible="true" id="-126" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789379149892097" lon="32.2968918159670011">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-126"/>
+    </node>
+    <node visible="true" id="-125" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789299700752599" lon="32.2968936699360967">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-125"/>
+    </node>
+    <node visible="true" id="-124" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789220950621401" lon="32.2968957985218026">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-124"/>
+    </node>
+    <node visible="true" id="-123" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789158003601693" lon="32.2968977138286988">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-123"/>
+    </node>
+    <node visible="true" id="-122" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789969358401998" lon="32.2971102347032968">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-122"/>
+    </node>
+    <node visible="true" id="-121" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790025505555400" lon="32.2971191375876998">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-121"/>
+    </node>
+    <node visible="true" id="-120" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790156767274601" lon="32.2971388297540969">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-120"/>
+    </node>
+    <node visible="true" id="-119" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790294859569196" lon="32.2971580543520034">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-119"/>
+    </node>
+    <node visible="true" id="-118" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790439614195095" lon="32.2971767879592022">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-118"/>
+    </node>
+    <node visible="true" id="-117" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790590854791493" lon="32.2971950077516965">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-117"/>
+    </node>
+    <node visible="true" id="-116" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792366533190895" lon="32.2973305133172985">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-116"/>
+    </node>
+    <node visible="true" id="-115" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794372986508997" lon="32.2974413865974981">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-115"/>
+    </node>
+    <node visible="true" id="-114" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794472236061289" lon="32.2974626635860034">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-114"/>
+    </node>
+    <node visible="true" id="-113" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794552230133291" lon="32.2974880624872966">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-113"/>
+    </node>
+    <node visible="true" id="-112" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794605108359001" lon="32.2975141534396002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-112"/>
+    </node>
+    <node visible="true" id="-111" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794632400624395" lon="32.2975539616876972">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-111"/>
+    </node>
+    <node visible="true" id="-110" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794609369698202" lon="32.2975806660790994">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-110"/>
+    </node>
+    <node visible="true" id="-109" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794570386275002" lon="32.2975972691074986">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-109"/>
+    </node>
+    <node visible="true" id="-108" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794433005530799" lon="32.2976400568823010">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-108"/>
+    </node>
+    <node visible="true" id="-107" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794221618565693" lon="32.2976955792871010">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-107"/>
+    </node>
+    <node visible="true" id="-106" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792911885029801" lon="32.2980073079898986">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-106"/>
+    </node>
+    <node visible="true" id="-105" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792771932894604" lon="32.2980400495640012">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-105"/>
+    </node>
+    <node visible="true" id="-104" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792340225389993" lon="32.2981379062442002">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-104"/>
+    </node>
+    <node visible="true" id="-103" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792194809194601" lon="32.2981713309427008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-103"/>
+    </node>
+    <node visible="true" id="-102" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792059237228997" lon="32.2982034031176966">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-102"/>
+    </node>
+    <node visible="true" id="-101" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791925796028298" lon="32.2982363990170995">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-101"/>
+    </node>
+    <node visible="true" id="-100" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791799282448499" lon="32.2982696353302998">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-100"/>
+    </node>
+    <node visible="true" id="-99" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791681365765095" lon="32.2983031686358970">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-99"/>
+    </node>
+    <node visible="true" id="-98" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791573715253901" lon="32.2983370555132012">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-98"/>
+    </node>
+    <node visible="true" id="-97" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791482647869201" lon="32.2983674966233991">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-97"/>
+    </node>
+    <node visible="true" id="-96" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791362574831098" lon="32.2984225754577992">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-96"/>
+    </node>
+    <node visible="true" id="-95" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791282559892796" lon="32.2984823032193944">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-95"/>
+    </node>
+    <node visible="true" id="-94" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791239709769004" lon="32.2985348622788990">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-94"/>
+    </node>
+    <node visible="true" id="-93" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791230486703595" lon="32.2985744034322977">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-93"/>
+    </node>
+    <node visible="true" id="-92" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791246982731694" lon="32.2986553633340989">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-92"/>
+    </node>
+    <node visible="true" id="-91" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791315907305294" lon="32.2987766773950966">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-91"/>
+    </node>
+    <node visible="true" id="-90" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791479205242298" lon="32.2989834577483990">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-90"/>
+    </node>
+    <node visible="true" id="-89" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791902029950202" lon="32.2995085121716983">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-89"/>
+    </node>
+    <node visible="true" id="-88" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792022892283490" lon="32.2996321148190901">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-88"/>
+    </node>
+    <node visible="true" id="-87" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7806931403000497" lon="32.2969913941988978">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-87"/>
+    </node>
+    <node visible="true" id="-86" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7806583129355396" lon="32.2969763882787007">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-86"/>
+    </node>
+    <node visible="true" id="-85" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7806240333863697" lon="32.2969601827373936">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-85"/>
+    </node>
+    <node visible="true" id="-84" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7806086750433101" lon="32.2969524411589006">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-84"/>
+    </node>
+    <node visible="true" id="-83" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805968276526696" lon="32.2969416271105985">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-83"/>
+    </node>
+    <node visible="true" id="-82" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805857259420201" lon="32.2969300569622035">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-82"/>
+    </node>
+    <node visible="true" id="-81" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805754185966896" lon="32.2969177814534021">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-81"/>
+    </node>
+    <node visible="true" id="-80" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805659508184002" lon="32.2969048544170008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-80"/>
+    </node>
+    <node visible="true" id="-79" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805573641270294" lon="32.2968913325430975">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-79"/>
+    </node>
+    <node visible="true" id="-78" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805496961785692" lon="32.2968772751304982">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-78"/>
+    </node>
+    <node visible="true" id="-77" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805429805999298" lon="32.2968627438264022">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-77"/>
+    </node>
+    <node visible="true" id="-76" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805372468415497" lon="32.2968478023561971">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-76"/>
+    </node>
+    <node visible="true" id="-75" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805325200481597" lon="32.2968325162440948">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-75"/>
+    </node>
+    <node visible="true" id="-74" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805288209485899" lon="32.2968169525255959">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-74"/>
+    </node>
+    <node visible="true" id="-73" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805261657648095" lon="32.2968011794536949">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-73"/>
+    </node>
+    <node visible="true" id="-72" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805245661408300" lon="32.2967852661994996">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-72"/>
+    </node>
+    <node visible="true" id="-71" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805240290916098" lon="32.2967692825488015">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-71"/>
+    </node>
+    <node visible="true" id="-70" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805245569723094" lon="32.2967532985960020">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-70"/>
+    </node>
+    <node visible="true" id="-69" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805261474679601" lon="32.2967373844371011">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-69"/>
+    </node>
+    <node visible="true" id="-68" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805209559507098" lon="32.2967175128437987">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-68"/>
+    </node>
+    <node visible="true" id="-67" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805167552768602" lon="32.2966974109988030">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-67"/>
+    </node>
+    <node visible="true" id="-66" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805135556507095" lon="32.2966771277339006">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-66"/>
+    </node>
+    <node visible="true" id="-65" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805113648448301" lon="32.2966567123213011">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-65"/>
+    </node>
+    <node visible="true" id="-64" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805101881811396" lon="32.2966362143545993">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-64"/>
+    </node>
+    <node visible="true" id="-63" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805100285179902" lon="32.2966156836275999">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-63"/>
+    </node>
+    <node visible="true" id="-62" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805108862432300" lon="32.2965951700138021">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-62"/>
+    </node>
+    <node visible="true" id="-61" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805127592732499" lon="32.2965747233452021">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-61"/>
+    </node>
+    <node visible="true" id="-60" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805156430580400" lon="32.2965543932911032">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-60"/>
+    </node>
+    <node visible="true" id="-59" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805195305922603" lon="32.2965342292375013">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-59"/>
+    </node>
+    <node visible="true" id="-58" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805244124322495" lon="32.2965142801673011">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-58"/>
+    </node>
+    <node visible="true" id="-57" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805302767189599" lon="32.2964945945410022">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-57"/>
+    </node>
+    <node visible="true" id="-56" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805371092067896" lon="32.2964752201790901">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-56"/>
+    </node>
+    <node visible="true" id="-55" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805448932981300" lon="32.2964562041460965">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-55"/>
+    </node>
+    <node visible="true" id="-54" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805536100837798" lon="32.2964375926361029">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-54"/>
+    </node>
+    <node visible="true" id="-53" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7803760046767496" lon="32.2964369238177937">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-53"/>
+    </node>
+    <node visible="true" id="-52" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7803254777025197" lon="32.2964407561984004">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-52"/>
+    </node>
+    <node visible="true" id="-51" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7802751159966999" lon="32.2964463398967965">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-51"/>
+    </node>
+    <node visible="true" id="-50" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7802249809171897" lon="32.2964536681096988">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-50"/>
+    </node>
+    <node visible="true" id="-49" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7801906146286002" lon="32.2964597252812027">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-49"/>
+    </node>
+    <node visible="true" id="-48" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7781376019073698" lon="32.2952631078974974">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-48"/>
+    </node>
+    <node visible="true" id="-47" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7777085094541092" lon="32.2953098296460013">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-47"/>
+    </node>
+    <node visible="true" id="-46" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7775371941190001" lon="32.2953307884130965">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-46"/>
+    </node>
+    <node visible="true" id="-45" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7773665222192294" lon="32.2953558664478990">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-45"/>
+    </node>
+    <node visible="true" id="-44" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7770739994837497" lon="32.2954084708673008">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-44"/>
+    </node>
+    <node visible="true" id="-43" timestamp="2020-02-07T17:57:23Z" version="1" lat="2.7774371355780696" lon="32.2995936087139910">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-43"/>
+    </node>
+    <node visible="true" id="-42" timestamp="2020-02-07T17:57:23Z" version="1" lat="2.7806846759986197" lon="32.2962260576761011">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-42"/>
+    </node>
+    <node visible="true" id="-41" timestamp="2020-02-07T17:57:23Z" version="1" lat="2.7805079593334501" lon="32.2963666091931927">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-41"/>
+    </node>
+    <node visible="true" id="-40" timestamp="2020-02-07T17:57:23Z" version="1" lat="2.7804266353601501" lon="32.2964348474243010">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-40"/>
+    </node>
+    <node visible="true" id="-39" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789724255123094" lon="32.2951664064648014">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-39"/>
+    </node>
+    <node visible="true" id="-38" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789689964763595" lon="32.2952618810179999">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-38"/>
+    </node>
+    <node visible="true" id="-37" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789699294789494" lon="32.2953520215660035">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-37"/>
+    </node>
+    <node visible="true" id="-36" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789740140146200" lon="32.2954423091296974">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-36"/>
+    </node>
+    <node visible="true" id="-35" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789809746809002" lon="32.2955324225370006">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-35"/>
+    </node>
+    <node visible="true" id="-34" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789901570095994" lon="32.2956182804691991">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-34"/>
+    </node>
+    <node visible="true" id="-33" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7790278750120700" lon="32.2959181961172987">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-33"/>
+    </node>
+    <node visible="true" id="-32" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7790489272173700" lon="32.2961377013033015">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-32"/>
+    </node>
+    <node visible="true" id="-31" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7790576488356300" lon="32.2961947257553987">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-31"/>
+    </node>
+    <node visible="true" id="-30" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7790747222463801" lon="32.2962826583055929">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-30"/>
+    </node>
+    <node visible="true" id="-29" timestamp="2020-02-07T17:57:40Z" version="1" lat="2.7771899749620195" lon="32.2972141754823951">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-29"/>
+    </node>
+    <node visible="true" id="-28" timestamp="2020-02-07T17:57:40Z" version="1" lat="2.7769523387945796" lon="32.2972517846122997">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-28"/>
+    </node>
+    <node visible="true" id="-27" timestamp="2020-02-07T17:57:40Z" version="1" lat="2.7766812980759195" lon="32.2972883666062032">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-27"/>
+    </node>
+    <node visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7776847598532020" lon="32.2997000000000014">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-26"/>
+    </node>
+    <node visible="true" id="-25" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7765999999999997" lon="32.2973002854333870">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-25"/>
+    </node>
+    <node visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2962170523098280">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-24"/>
+    </node>
+    <node visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7774845037998643" lon="32.2997000000000014">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-23"/>
+    </node>
+    <node visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7807000000000004" lon="32.2969940710825796">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-22"/>
+    </node>
+    <node visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7792108274089626" lon="32.2997000000000014">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-21"/>
+    </node>
+    <node visible="true" id="-20" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999995" lon="32.2948615871501872">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-20"/>
+    </node>
+    <node visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7802302174146551" lon="32.2948000000000022">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-19"/>
+    </node>
+    <node visible="true" id="-18" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7765999999999997" lon="32.2996925211341050">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-18"/>
+    </node>
+    <node visible="true" id="-17" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7789980366231744" lon="32.2948000000000022">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-17"/>
+    </node>
+    <node visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7765999999999997" lon="32.2985227201807987">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-16"/>
+    </node>
+    <node visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2964543343445740">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-15"/>
+    </node>
+    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7769704322783269" lon="32.2948000000000022">
+        <tag k="hoot:status" v="1"/>
+        <tag k="hoot:id" v="-14"/>
+    </node>
+    <way visible="true" id="-44" timestamp="2020-02-07T17:57:47Z" version="1">
+        <nd ref="-54"/>
+        <nd ref="-313"/>
+        <nd ref="-312"/>
+        <nd ref="-40"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.845Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-44"/>
+        <tag k="source:datetime" v="2019-01-22T08:12:42Z;2020-02-07T17:57:47Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-42" timestamp="2020-02-07T17:57:46Z" version="1">
+        <nd ref="-308"/>
+        <nd ref="-307"/>
+        <nd ref="-306"/>
+        <nd ref="-305"/>
+        <nd ref="-304"/>
+        <nd ref="-303"/>
+        <nd ref="-302"/>
+        <nd ref="-301"/>
+        <nd ref="-300"/>
+        <nd ref="-299"/>
+        <nd ref="-298"/>
+        <nd ref="-297"/>
+        <nd ref="-296"/>
+        <nd ref="-295"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.845Z;2020-02-07T17:57:16.210Z;2020-02-07T17:57:15.838Z;2020-02-07T17:57:17.081Z;2020-02-07T17:57:16.152Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-42"/>
+        <tag k="source:datetime" v="2019-01-22T08:12:42Z;2020-02-07T17:57:47Z;2020-02-07T17:57:46Z;2020-02-07T17:57:43Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-41" timestamp="2020-02-07T17:57:42Z" version="1">
+        <nd ref="-39"/>
+        <nd ref="-38"/>
+        <nd ref="-37"/>
+        <nd ref="-36"/>
+        <nd ref="-35"/>
+        <nd ref="-34"/>
+        <nd ref="-33"/>
+        <nd ref="-32"/>
+        <nd ref="-31"/>
+        <nd ref="-30"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.215Z;2020-02-07T17:57:17.351Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="name" v="Princess Road"/>
+        <tag k="hoot:id" v="-41"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z;2020-02-07T17:57:46Z;2020-02-07T17:57:42Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-39" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-30"/>
+        <nd ref="-261"/>
+        <nd ref="-260"/>
+        <nd ref="-259"/>
+        <nd ref="-258"/>
+        <nd ref="-257"/>
+        <nd ref="-256"/>
+        <nd ref="-255"/>
+        <nd ref="-254"/>
+        <nd ref="-253"/>
+        <nd ref="-252"/>
+        <nd ref="-251"/>
+        <nd ref="-250"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.405Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:id" v="-39"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-38" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-20"/>
+        <nd ref="-190"/>
+        <nd ref="-189"/>
+        <nd ref="-188"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.745Z"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="Gulu - Kitgum Road"/>
+        <tag k="hoot:id" v="-38"/>
+        <tag k="source:datetime" v="2019-01-28T11:00:26Z;2020-02-07T17:57:44Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-37" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-187"/>
+        <nd ref="-240"/>
+        <nd ref="-239"/>
+        <nd ref="-238"/>
+        <nd ref="-237"/>
+        <nd ref="-236"/>
+        <nd ref="-235"/>
+        <nd ref="-234"/>
+        <nd ref="-219"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.468Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-37"/>
+        <tag k="source:datetime" v="2015-05-04T09:53:52Z;2020-02-07T17:57:45Z"/>
+        <tag k="surface" v="ground"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-31" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-43"/>
+        <nd ref="-175"/>
+        <nd ref="-174"/>
+        <nd ref="-173"/>
+        <nd ref="-172"/>
+        <nd ref="-171"/>
+        <nd ref="-170"/>
+        <nd ref="-169"/>
+        <nd ref="-168"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.775Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:id" v="-31"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-30" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-122"/>
+        <nd ref="-167"/>
+        <nd ref="-166"/>
+        <nd ref="-165"/>
+        <nd ref="-164"/>
+        <nd ref="-163"/>
+        <nd ref="-162"/>
+        <nd ref="-161"/>
+        <nd ref="-160"/>
+        <nd ref="-159"/>
+        <nd ref="-158"/>
+        <nd ref="-157"/>
+        <nd ref="-156"/>
+        <nd ref="-155"/>
+        <nd ref="-154"/>
+        <nd ref="-153"/>
+        <nd ref="-152"/>
+        <nd ref="-151"/>
+        <nd ref="-150"/>
+        <nd ref="-149"/>
+        <nd ref="-148"/>
+        <nd ref="-147"/>
+        <nd ref="-146"/>
+        <nd ref="-145"/>
+        <nd ref="-144"/>
+        <nd ref="-143"/>
+        <nd ref="-142"/>
+        <nd ref="-141"/>
+        <nd ref="-140"/>
+        <nd ref="-139"/>
+        <nd ref="-138"/>
+        <nd ref="-137"/>
+        <nd ref="-136"/>
+        <nd ref="-135"/>
+        <nd ref="-134"/>
+        <nd ref="-133"/>
+        <nd ref="-132"/>
+        <nd ref="-131"/>
+        <nd ref="-130"/>
+        <nd ref="-129"/>
+        <nd ref="-128"/>
+        <nd ref="-127"/>
+        <nd ref="-126"/>
+        <nd ref="-125"/>
+        <nd ref="-124"/>
+        <nd ref="-123"/>
+        <tag k="source" v="NextView"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.914Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="hoot:id" v="-30"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z;2020-02-07T17:57:44Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+        <tag k="junction" v="roundabout"/>
+    </way>
+    <way visible="true" id="-29" timestamp="2020-02-07T17:57:47Z" version="1">
+        <nd ref="-329"/>
+        <nd ref="-328"/>
+        <nd ref="-327"/>
+        <nd ref="-326"/>
+        <nd ref="-325"/>
+        <nd ref="-324"/>
+        <nd ref="-323"/>
+        <nd ref="-322"/>
+        <nd ref="-321"/>
+        <nd ref="-320"/>
+        <nd ref="-319"/>
+        <nd ref="-318"/>
+        <nd ref="-317"/>
+        <nd ref="-316"/>
+        <nd ref="-315"/>
+        <nd ref="-314"/>
+        <nd ref="-220"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.845Z;2020-02-07T17:57:16.210Z;2020-02-07T17:57:15.838Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-29"/>
+        <tag k="source:datetime" v="2019-01-22T08:12:42Z;2020-02-07T17:57:47Z;2020-02-07T17:57:46Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-28" timestamp="2020-02-07T17:57:43Z" version="1">
+        <nd ref="-39"/>
+        <nd ref="-48"/>
+        <nd ref="-47"/>
+        <nd ref="-46"/>
+        <nd ref="-45"/>
+        <nd ref="-44"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.110Z"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="Gulu - Kitgum Road"/>
+        <tag k="hoot:id" v="-28"/>
+        <tag k="source:datetime" v="2019-01-28T11:00:26Z;2020-02-07T17:57:43Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-27" timestamp="2020-02-07T17:57:46Z" version="1">
+        <nd ref="-220"/>
+        <nd ref="-291"/>
+        <nd ref="-290"/>
+        <nd ref="-289"/>
+        <nd ref="-288"/>
+        <nd ref="-287"/>
+        <nd ref="-30"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.215Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="name" v="Princess Road"/>
+        <tag k="hoot:id" v="-27"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z;2020-02-07T17:57:46Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-26" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-26"/>
+        <nd ref="-168"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.542Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:id" v="-26"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:42Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-24"/>
+        <nd ref="-42"/>
+        <nd ref="-41"/>
+        <nd ref="-40"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.257Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:id" v="-24"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:42Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23"/>
+        <nd ref="-43"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.255Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:id" v="-23"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:42Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-22" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-22"/>
+        <nd ref="-87"/>
+        <nd ref="-86"/>
+        <nd ref="-85"/>
+        <nd ref="-84"/>
+        <nd ref="-83"/>
+        <nd ref="-82"/>
+        <nd ref="-81"/>
+        <nd ref="-80"/>
+        <nd ref="-79"/>
+        <nd ref="-78"/>
+        <nd ref="-77"/>
+        <nd ref="-76"/>
+        <nd ref="-75"/>
+        <nd ref="-74"/>
+        <nd ref="-73"/>
+        <nd ref="-72"/>
+        <nd ref="-71"/>
+        <nd ref="-70"/>
+        <nd ref="-69"/>
+        <nd ref="-68"/>
+        <nd ref="-67"/>
+        <nd ref="-66"/>
+        <nd ref="-65"/>
+        <nd ref="-64"/>
+        <nd ref="-63"/>
+        <nd ref="-62"/>
+        <nd ref="-61"/>
+        <nd ref="-60"/>
+        <nd ref="-59"/>
+        <nd ref="-58"/>
+        <nd ref="-57"/>
+        <nd ref="-56"/>
+        <nd ref="-55"/>
+        <nd ref="-54"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.069Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:id" v="-22"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:43Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-21" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-21"/>
+        <nd ref="-88"/>
+        <nd ref="-89"/>
+        <nd ref="-90"/>
+        <nd ref="-91"/>
+        <nd ref="-92"/>
+        <nd ref="-93"/>
+        <nd ref="-94"/>
+        <nd ref="-95"/>
+        <nd ref="-96"/>
+        <nd ref="-97"/>
+        <nd ref="-98"/>
+        <nd ref="-99"/>
+        <nd ref="-100"/>
+        <nd ref="-101"/>
+        <nd ref="-102"/>
+        <nd ref="-103"/>
+        <nd ref="-104"/>
+        <nd ref="-105"/>
+        <nd ref="-106"/>
+        <nd ref="-107"/>
+        <nd ref="-108"/>
+        <nd ref="-109"/>
+        <nd ref="-110"/>
+        <nd ref="-111"/>
+        <nd ref="-112"/>
+        <nd ref="-113"/>
+        <nd ref="-114"/>
+        <nd ref="-115"/>
+        <nd ref="-116"/>
+        <nd ref="-117"/>
+        <nd ref="-118"/>
+        <nd ref="-119"/>
+        <nd ref="-120"/>
+        <nd ref="-121"/>
+        <nd ref="-122"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.919Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="name" v="Eden Road"/>
+        <tag k="hoot:id" v="-21"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z;2020-02-07T17:57:44Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-188"/>
+        <nd ref="-199"/>
+        <nd ref="-19"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.673Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:id" v="-19"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-219"/>
+        <nd ref="-286"/>
+        <nd ref="-285"/>
+        <nd ref="-284"/>
+        <nd ref="-283"/>
+        <nd ref="-282"/>
+        <nd ref="-281"/>
+        <nd ref="-280"/>
+        <nd ref="-279"/>
+        <nd ref="-278"/>
+        <nd ref="-277"/>
+        <nd ref="-276"/>
+        <nd ref="-275"/>
+        <nd ref="-274"/>
+        <nd ref="-273"/>
+        <nd ref="-272"/>
+        <nd ref="-271"/>
+        <nd ref="-270"/>
+        <nd ref="-16"/>
+        <tag k="hoot:status" v="1"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.261Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="hoot:id" v="-16"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:46Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15" timestamp="2020-02-07T17:57:43Z" version="1">
+        <nd ref="-40"/>
+        <nd ref="-53"/>
+        <nd ref="-52"/>
+        <nd ref="-51"/>
+        <nd ref="-50"/>
+        <nd ref="-49"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.845Z;2020-02-07T17:57:16.210Z;2020-02-07T17:57:15.838Z;2020-02-07T17:57:17.081Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-15"/>
+        <tag k="source:datetime" v="2019-01-22T08:12:42Z;2020-02-07T17:57:47Z;2020-02-07T17:57:46Z;2020-02-07T17:57:43Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-43"/>
+        <nd ref="-233"/>
+        <nd ref="-232"/>
+        <nd ref="-231"/>
+        <nd ref="-230"/>
+        <nd ref="-229"/>
+        <nd ref="-228"/>
+        <nd ref="-227"/>
+        <nd ref="-226"/>
+        <nd ref="-18"/>
+        <tag k="oneway" v="no"/>
+        <tag k="source" v="NextView"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.533Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="name" v="Awere Road"/>
+        <tag k="hoot:id" v="-10"/>
+        <tag k="source:datetime" v="2019-01-28T12:47:24Z;2020-02-07T17:57:45Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-44"/>
+        <nd ref="-311"/>
+        <nd ref="-310"/>
+        <nd ref="-309"/>
+        <nd ref="-14"/>
+        <tag k="source" v="NextView"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.023Z"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="Nimule - Gulu Road"/>
+        <tag k="ref" v="A104"/>
+        <tag k="hoot:id" v="-9"/>
+        <tag k="source:datetime" v="2020-01-20T16:05:21Z;2020-02-07T17:57:46Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-15"/>
+        <nd ref="-294"/>
+        <nd ref="-293"/>
+        <nd ref="-292"/>
+        <nd ref="-54"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.845Z;2020-02-07T17:57:16.210Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-8"/>
+        <tag k="source:datetime" v="2019-01-22T08:12:42Z;2020-02-07T17:57:47Z;2020-02-07T17:57:46Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-187"/>
+        <nd ref="-29"/>
+        <nd ref="-28"/>
+        <nd ref="-27"/>
+        <nd ref="-25"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.539Z"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="Main Street"/>
+        <tag k="ref" v="A104"/>
+        <tag k="hoot:id" v="-7"/>
+        <tag k="source:datetime" v="2020-01-20T16:05:21Z;2020-02-07T17:57:42Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-6" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-39"/>
+        <nd ref="-249"/>
+        <nd ref="-248"/>
+        <nd ref="-247"/>
+        <nd ref="-246"/>
+        <nd ref="-245"/>
+        <nd ref="-244"/>
+        <nd ref="-243"/>
+        <nd ref="-242"/>
+        <nd ref="-241"/>
+        <nd ref="-188"/>
+        <tag k="source" v="Bing"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.745Z;2020-02-07T17:57:16.425Z"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="Gulu - Kitgum Road"/>
+        <tag k="hoot:id" v="-6"/>
+        <tag k="source:datetime" v="2019-01-28T11:00:26Z;2020-02-07T17:57:44Z;2020-02-07T17:57:45Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-39"/>
+        <nd ref="-17"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.346Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-5"/>
+        <tag k="source:datetime" v="2019-01-24T14:32:35Z;2020-02-07T17:57:45Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="176031521" timestamp="2020-02-07T17:57:47Z" version="1">
+        <nd ref="-219"/>
+        <nd ref="-387"/>
+        <nd ref="-386"/>
+        <nd ref="-385"/>
+        <nd ref="-384"/>
+        <nd ref="-383"/>
+        <nd ref="-382"/>
+        <nd ref="-381"/>
+        <nd ref="-380"/>
+        <nd ref="-379"/>
+        <nd ref="-378"/>
+        <nd ref="-377"/>
+        <nd ref="-376"/>
+        <nd ref="-375"/>
+        <nd ref="-374"/>
+        <nd ref="-373"/>
+        <nd ref="-372"/>
+        <nd ref="-371"/>
+        <nd ref="-370"/>
+        <nd ref="-369"/>
+        <nd ref="-368"/>
+        <nd ref="-367"/>
+        <nd ref="-366"/>
+        <nd ref="-365"/>
+        <nd ref="-364"/>
+        <nd ref="-363"/>
+        <nd ref="-362"/>
+        <nd ref="-361"/>
+        <nd ref="-360"/>
+        <nd ref="-359"/>
+        <nd ref="-358"/>
+        <nd ref="-357"/>
+        <nd ref="-356"/>
+        <nd ref="-355"/>
+        <nd ref="-354"/>
+        <nd ref="-353"/>
+        <nd ref="-352"/>
+        <nd ref="-351"/>
+        <nd ref="-350"/>
+        <nd ref="-349"/>
+        <nd ref="-348"/>
+        <nd ref="-347"/>
+        <nd ref="-346"/>
+        <nd ref="-345"/>
+        <nd ref="-344"/>
+        <nd ref="-343"/>
+        <nd ref="-342"/>
+        <nd ref="-341"/>
+        <nd ref="-340"/>
+        <nd ref="-339"/>
+        <nd ref="-338"/>
+        <nd ref="-337"/>
+        <nd ref="-336"/>
+        <nd ref="-335"/>
+        <nd ref="-334"/>
+        <nd ref="-333"/>
+        <nd ref="-332"/>
+        <nd ref="-331"/>
+        <nd ref="-330"/>
+        <nd ref="-168"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.808Z"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="176031521"/>
+        <tag k="source:datetime" v="2015-05-04T09:53:52Z;2020-02-07T17:57:47Z"/>
+        <tag k="surface" v="ground"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="176124944" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-122"/>
+        <nd ref="-200"/>
+        <nd ref="-201"/>
+        <nd ref="-202"/>
+        <nd ref="-203"/>
+        <nd ref="-204"/>
+        <nd ref="-191"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.644Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="hoot:id" v="176124944"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z;2020-02-07T17:57:44Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="176124946" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-123"/>
+        <nd ref="-225"/>
+        <nd ref="-224"/>
+        <nd ref="-223"/>
+        <nd ref="-222"/>
+        <nd ref="-221"/>
+        <nd ref="-220"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.571Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="hoot:id" v="176124946"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z;2020-02-07T17:57:45Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="176237162" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-219"/>
+        <nd ref="-218"/>
+        <nd ref="-217"/>
+        <nd ref="-216"/>
+        <nd ref="-215"/>
+        <nd ref="-214"/>
+        <nd ref="-213"/>
+        <nd ref="-212"/>
+        <nd ref="-211"/>
+        <nd ref="-210"/>
+        <nd ref="-209"/>
+        <nd ref="-208"/>
+        <nd ref="-207"/>
+        <nd ref="-206"/>
+        <nd ref="-205"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.617Z"/>
+        <tag k="highway" v="service"/>
+        <tag k="hoot:id" v="176237162"/>
+        <tag k="source:datetime" v="2019-01-28T10:19:04Z;2020-02-07T17:57:45Z"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="176390103" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-187"/>
+        <nd ref="-198"/>
+        <nd ref="-197"/>
+        <nd ref="-196"/>
+        <nd ref="-195"/>
+        <nd ref="-194"/>
+        <nd ref="-193"/>
+        <nd ref="-192"/>
+        <nd ref="-191"/>
+        <nd ref="-269"/>
+        <nd ref="-268"/>
+        <nd ref="-267"/>
+        <nd ref="-266"/>
+        <nd ref="-265"/>
+        <nd ref="-264"/>
+        <nd ref="-263"/>
+        <nd ref="-262"/>
+        <nd ref="-123"/>
+        <tag k="source" v="NextView"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.301Z;2020-02-07T17:57:16.739Z"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="name" v="Main Street"/>
+        <tag k="hoot:id" v="176390103"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z;2020-02-07T17:57:45Z;2020-02-07T17:57:44Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="342708823" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-187"/>
+        <nd ref="-186"/>
+        <nd ref="-185"/>
+        <nd ref="-184"/>
+        <nd ref="-183"/>
+        <nd ref="-182"/>
+        <nd ref="-181"/>
+        <nd ref="-180"/>
+        <nd ref="-179"/>
+        <nd ref="-178"/>
+        <nd ref="-177"/>
+        <nd ref="-176"/>
+        <nd ref="-44"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.751Z"/>
+        <tag k="highway" v="primary"/>
+        <tag k="ref" v="A104"/>
+        <tag k="hoot:id" v="342708823"/>
+        <tag k="source:datetime" v="2020-01-20T16:05:21Z;2020-02-07T17:57:44Z"/>
+        <tag k="surface" v="ground"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+</osm>

--- a/test-files/cases/attribute/unifying/highway-3784-roundabouts-1/Input1.osm
+++ b/test-files/cases/attribute/unifying/highway-3784-roundabouts-1/Input1.osm
@@ -1,0 +1,1007 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="2.7766" minlon="32.2948" maxlat="2.7807" maxlon="32.2997"/>
+    <node visible="true" id="-424053" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7769704322783269" lon="32.2948000000000022"/>
+    <node visible="true" id="-424052" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2964543343445740"/>
+    <node visible="true" id="-424051" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7766000000000002" lon="32.2985227201807987"/>
+    <node visible="true" id="-424050" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7789980366231744" lon="32.2948000000000022"/>
+    <node visible="true" id="-424049" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7766000000000002" lon="32.2996925211341050"/>
+    <node visible="true" id="-424048" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7802302174146556" lon="32.2948000000000022"/>
+    <node visible="true" id="-424047" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2948615871501872"/>
+    <node visible="true" id="-424046" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7792108274089631" lon="32.2997000000000014"/>
+    <node visible="true" id="-424045" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2969940710825796"/>
+    <node visible="true" id="-424044" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7774845037998643" lon="32.2997000000000014"/>
+    <node visible="true" id="-424043" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2962170523098280"/>
+    <node visible="true" id="-424042" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7766000000000002" lon="32.2973002854333870"/>
+    <node visible="true" id="-424041" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7776847598532020" lon="32.2997000000000014"/>
+    <node visible="true" id="-400264" timestamp="2020-02-07T17:57:40Z" version="1" lat="2.7766812980759199" lon="32.2972883666062032"/>
+    <node visible="true" id="-400263" timestamp="2020-02-07T17:57:40Z" version="1" lat="2.7769523387945800" lon="32.2972517846122997"/>
+    <node visible="true" id="-400262" timestamp="2020-02-07T17:57:40Z" version="1" lat="2.7771899749620199" lon="32.2972141754824023"/>
+    <node visible="true" id="-362401" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7790747222463801" lon="32.2962826583056000"/>
+    <node visible="true" id="-362400" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7790576488356300" lon="32.2961947257553987"/>
+    <node visible="true" id="-362399" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7790489272173700" lon="32.2961377013033015"/>
+    <node visible="true" id="-362398" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7790278750120700" lon="32.2959181961172987"/>
+    <node visible="true" id="-362397" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789901570095998" lon="32.2956182804691991"/>
+    <node visible="true" id="-362396" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789809746809002" lon="32.2955324225370006"/>
+    <node visible="true" id="-362395" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789740140146200" lon="32.2954423091296974"/>
+    <node visible="true" id="-362394" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789699294789498" lon="32.2953520215660035"/>
+    <node visible="true" id="-362393" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789689964763600" lon="32.2952618810179999"/>
+    <node visible="true" id="-362392" timestamp="2020-02-07T17:57:22Z" version="1" lat="2.7789724255123098" lon="32.2951664064648014"/>
+    <node visible="true" id="-341178" timestamp="2020-02-07T17:57:23Z" version="1" lat="2.7804266353601501" lon="32.2964348474243010"/>
+    <node visible="true" id="-341177" timestamp="2020-02-07T17:57:23Z" version="1" lat="2.7805079593334501" lon="32.2963666091931998"/>
+    <node visible="true" id="-341176" timestamp="2020-02-07T17:57:23Z" version="1" lat="2.7806846759986201" lon="32.2962260576761011"/>
+    <node visible="true" id="-340933" timestamp="2020-02-07T17:57:23Z" version="1" lat="2.7774371355780700" lon="32.2995936087139981"/>
+    <node visible="true" id="-309139" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7770739994837501" lon="32.2954084708673008"/>
+    <node visible="true" id="-309138" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7773665222192299" lon="32.2953558664478990"/>
+    <node visible="true" id="-309137" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7775371941190001" lon="32.2953307884130965"/>
+    <node visible="true" id="-309136" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7777085094541101" lon="32.2953098296460013"/>
+    <node visible="true" id="-309135" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7781376019073698" lon="32.2952631078974974"/>
+    <node visible="true" id="-302359" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7801906146286002" lon="32.2964597252812027"/>
+    <node visible="true" id="-302358" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7802249809171902" lon="32.2964536681096988"/>
+    <node visible="true" id="-302357" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7802751159966999" lon="32.2964463398967965"/>
+    <node visible="true" id="-302356" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7803254777025201" lon="32.2964407561984004"/>
+    <node visible="true" id="-302355" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7803760046767501" lon="32.2964369238178008"/>
+    <node visible="true" id="-299687" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805536100837802" lon="32.2964375926361029"/>
+    <node visible="true" id="-299686" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805448932981300" lon="32.2964562041460965"/>
+    <node visible="true" id="-299685" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805371092067901" lon="32.2964752201790972"/>
+    <node visible="true" id="-299684" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805302767189599" lon="32.2964945945410022"/>
+    <node visible="true" id="-299683" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805244124322499" lon="32.2965142801673011"/>
+    <node visible="true" id="-299682" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805195305922599" lon="32.2965342292375013"/>
+    <node visible="true" id="-299681" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805156430580400" lon="32.2965543932911032"/>
+    <node visible="true" id="-299680" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805127592732499" lon="32.2965747233452021"/>
+    <node visible="true" id="-299679" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805108862432300" lon="32.2965951700138021"/>
+    <node visible="true" id="-299678" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805100285179898" lon="32.2966156836275999"/>
+    <node visible="true" id="-299677" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805101881811400" lon="32.2966362143545993"/>
+    <node visible="true" id="-299676" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805113648448301" lon="32.2966567123213011"/>
+    <node visible="true" id="-299675" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805135556507099" lon="32.2966771277339006"/>
+    <node visible="true" id="-299674" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805167552768602" lon="32.2966974109988030"/>
+    <node visible="true" id="-299673" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805209559507098" lon="32.2967175128437987"/>
+    <node visible="true" id="-299672" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805261474679601" lon="32.2967373844371011"/>
+    <node visible="true" id="-299671" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805245569723098" lon="32.2967532985960020"/>
+    <node visible="true" id="-299670" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805240290916098" lon="32.2967692825488015"/>
+    <node visible="true" id="-299669" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805245661408300" lon="32.2967852661994996"/>
+    <node visible="true" id="-299668" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805261657648099" lon="32.2968011794537020"/>
+    <node visible="true" id="-299667" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805288209485899" lon="32.2968169525256030"/>
+    <node visible="true" id="-299666" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805325200481601" lon="32.2968325162441019"/>
+    <node visible="true" id="-299665" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805372468415501" lon="32.2968478023561971"/>
+    <node visible="true" id="-299664" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805429805999302" lon="32.2968627438264022"/>
+    <node visible="true" id="-299663" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805496961785701" lon="32.2968772751304982"/>
+    <node visible="true" id="-299662" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805573641270298" lon="32.2968913325430975"/>
+    <node visible="true" id="-299661" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805659508184002" lon="32.2969048544170008"/>
+    <node visible="true" id="-299660" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805754185966900" lon="32.2969177814534021"/>
+    <node visible="true" id="-299659" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805857259420201" lon="32.2969300569622035"/>
+    <node visible="true" id="-299658" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7805968276526700" lon="32.2969416271105985"/>
+    <node visible="true" id="-299657" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7806086750433101" lon="32.2969524411589006"/>
+    <node visible="true" id="-299656" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7806240333863701" lon="32.2969601827374007"/>
+    <node visible="true" id="-299655" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7806583129355400" lon="32.2969763882787007"/>
+    <node visible="true" id="-299654" timestamp="2020-02-07T17:57:25Z" version="1" lat="2.7806931403000501" lon="32.2969913941988978"/>
+    <node visible="true" id="-263984" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792022892283499" lon="32.2996321148190972"/>
+    <node visible="true" id="-263983" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791902029950202" lon="32.2995085121716983"/>
+    <node visible="true" id="-263982" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791479205242302" lon="32.2989834577483990"/>
+    <node visible="true" id="-263981" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791315907305298" lon="32.2987766773950966"/>
+    <node visible="true" id="-263980" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791246982731699" lon="32.2986553633340989"/>
+    <node visible="true" id="-263979" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791230486703600" lon="32.2985744034322977"/>
+    <node visible="true" id="-263978" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791239709769000" lon="32.2985348622788990"/>
+    <node visible="true" id="-263977" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791282559892800" lon="32.2984823032194015"/>
+    <node visible="true" id="-263976" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791362574831102" lon="32.2984225754577992"/>
+    <node visible="true" id="-263975" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791482647869201" lon="32.2983674966233991"/>
+    <node visible="true" id="-263974" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791573715253901" lon="32.2983370555132012"/>
+    <node visible="true" id="-263973" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791681365765100" lon="32.2983031686358970"/>
+    <node visible="true" id="-263972" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791799282448499" lon="32.2982696353302998"/>
+    <node visible="true" id="-263971" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791925796028298" lon="32.2982363990170995"/>
+    <node visible="true" id="-263970" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792059237229001" lon="32.2982034031176966"/>
+    <node visible="true" id="-263969" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792194809194601" lon="32.2981713309427008"/>
+    <node visible="true" id="-263968" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792340225390002" lon="32.2981379062442002"/>
+    <node visible="true" id="-263967" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792771932894600" lon="32.2980400495640012"/>
+    <node visible="true" id="-263966" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792911885029801" lon="32.2980073079898986"/>
+    <node visible="true" id="-263965" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794221618565702" lon="32.2976955792871010"/>
+    <node visible="true" id="-263964" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794433005530799" lon="32.2976400568823010"/>
+    <node visible="true" id="-263963" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794570386275002" lon="32.2975972691074986"/>
+    <node visible="true" id="-263962" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794609369698202" lon="32.2975806660790994"/>
+    <node visible="true" id="-263961" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794632400624399" lon="32.2975539616876972"/>
+    <node visible="true" id="-263960" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794605108359001" lon="32.2975141534396002"/>
+    <node visible="true" id="-263959" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794552230133300" lon="32.2974880624872966"/>
+    <node visible="true" id="-263958" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794472236061298" lon="32.2974626635860034"/>
+    <node visible="true" id="-263957" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7794372986509002" lon="32.2974413865974981"/>
+    <node visible="true" id="-263956" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7792366533190900" lon="32.2973305133172985"/>
+    <node visible="true" id="-263955" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790590854791501" lon="32.2971950077516965"/>
+    <node visible="true" id="-263954" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790439614195099" lon="32.2971767879592022"/>
+    <node visible="true" id="-263953" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790294859569200" lon="32.2971580543520034"/>
+    <node visible="true" id="-263952" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790156767274601" lon="32.2971388297540969"/>
+    <node visible="true" id="-263951" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790025505555400" lon="32.2971191375876998"/>
+    <node visible="true" id="-263950" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789969358401998" lon="32.2971102347032968"/>
+    <node visible="true" id="-262373" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789158003601702" lon="32.2968977138286988"/>
+    <node visible="true" id="-262372" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789220950621401" lon="32.2968957985218026"/>
+    <node visible="true" id="-262371" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789299700752599" lon="32.2968936699360967"/>
+    <node visible="true" id="-262370" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789379149892102" lon="32.2968918159670011"/>
+    <node visible="true" id="-262369" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789459201243600" lon="32.2968902388730967"/>
+    <node visible="true" id="-262368" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789539757276800" lon="32.2968889405758972"/>
+    <node visible="true" id="-262367" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789620719846599" lon="32.2968879226572980"/>
+    <node visible="true" id="-262366" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789701990312601" lon="32.2968871863574023"/>
+    <node visible="true" id="-262365" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789783469659302" lon="32.2968867325731992"/>
+    <node visible="true" id="-262364" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789865058616701" lon="32.2968865618576970"/>
+    <node visible="true" id="-262363" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7789946657781202" lon="32.2968866744188006"/>
+    <node visible="true" id="-262362" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790028167736800" lon="32.2968870701194035"/>
+    <node visible="true" id="-262361" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790109489176200" lon="32.2968877484774026"/>
+    <node visible="true" id="-262360" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790190523021798" lon="32.2968887086663017"/>
+    <node visible="true" id="-262359" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790278303351501" lon="32.2968920887473985"/>
+    <node visible="true" id="-262358" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790363374789999" lon="32.2968960957244988"/>
+    <node visible="true" id="-262357" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790445285368999" lon="32.2969007083091029"/>
+    <node visible="true" id="-262356" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790523599912902" lon="32.2969059019956006"/>
+    <node visible="true" id="-262355" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790597902351202" lon="32.2969116491907968"/>
+    <node visible="true" id="-262354" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790667797929101" lon="32.2969179193610003"/>
+    <node visible="true" id="-262353" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790732915304499" lon="32.2969246791940989"/>
+    <node visible="true" id="-262352" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790792908521000" lon="32.2969318927762004"/>
+    <node visible="true" id="-262351" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790847458845800" lon="32.2969395217830026"/>
+    <node visible="true" id="-262350" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790896276463202" lon="32.2969475256830023"/>
+    <node visible="true" id="-262349" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790939102014498" lon="32.2969558619530019"/>
+    <node visible="true" id="-262348" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790975707975401" lon="32.2969644863038994"/>
+    <node visible="true" id="-262347" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791005899865300" lon="32.2969733529161971"/>
+    <node visible="true" id="-262346" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791029517280301" lon="32.2969824146832991"/>
+    <node visible="true" id="-262345" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791046434745401" lon="32.2969916234616008"/>
+    <node visible="true" id="-262344" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791051378101401" lon="32.2970012255008001"/>
+    <node visible="true" id="-262343" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791047678590699" lon="32.2970108330748005"/>
+    <node visible="true" id="-262342" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791035365780701" lon="32.2970203693972024"/>
+    <node visible="true" id="-262341" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7791014538078902" lon="32.2970297582508010"/>
+    <node visible="true" id="-262340" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790985361946499" lon="32.2970389245972029"/>
+    <node visible="true" id="-262339" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790948070567598" lon="32.2970477951761978"/>
+    <node visible="true" id="-262338" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790902961985702" lon="32.2970562990916008"/>
+    <node visible="true" id="-262337" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790850396722000" lon="32.2970643683775975"/>
+    <node visible="true" id="-262336" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790790794893199" lon="32.2970719385419969"/>
+    <node visible="true" id="-262335" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790724632854902" lon="32.2970789490819996"/>
+    <node visible="true" id="-262334" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790652439393200" lon="32.2970853439671970"/>
+    <node visible="true" id="-262333" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790574791499600" lon="32.2970910720879019"/>
+    <node visible="true" id="-262332" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790492309758599" lon="32.2970960876630997"/>
+    <node visible="true" id="-262331" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790405653388501" lon="32.2971003506071028"/>
+    <node visible="true" id="-262330" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790315514972499" lon="32.2971038268491029"/>
+    <node visible="true" id="-262329" timestamp="2020-02-07T17:57:27Z" version="1" lat="2.7790242644109999" lon="32.2971056841855031"/>
+    <node visible="true" id="-234613" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7776826474353000" lon="32.2992821264148020"/>
+    <node visible="true" id="-234612" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7776719875511802" lon="32.2993044213613985"/>
+    <node visible="true" id="-234611" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7776440386302998" lon="32.2993568839232026"/>
+    <node visible="true" id="-234610" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7776133843055302" lon="32.2994078301435010"/>
+    <node visible="true" id="-234609" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7775801075251700" lon="32.2994571221653999"/>
+    <node visible="true" id="-234608" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7775318157337399" lon="32.2995200418195978"/>
+    <node visible="true" id="-234607" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7774710615923799" lon="32.2995745703018997"/>
+    <node visible="true" id="-234606" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7774541148099798" lon="32.2995857555438022"/>
+    <node visible="true" id="-228909" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770787292631698" lon="32.2954424312888975"/>
+    <node visible="true" id="-228908" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770807222976899" lon="32.2954718424969016"/>
+    <node visible="true" id="-228907" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770782669788101" lon="32.2955808140050991"/>
+    <node visible="true" id="-228906" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770817892337001" lon="32.2956705918687987"/>
+    <node visible="true" id="-228905" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7770881015616600" lon="32.2957475602725026"/>
+    <node visible="true" id="-228904" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7771043240371598" lon="32.2959079210252966"/>
+    <node visible="true" id="-228903" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7771116826745001" lon="32.2960116855251016"/>
+    <node visible="true" id="-228902" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7771202173468099" lon="32.2961424051902029"/>
+    <node visible="true" id="-228901" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7771294554076400" lon="32.2962343203032987"/>
+    <node visible="true" id="-228900" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7772307442505402" lon="32.2969431351758018"/>
+    <node visible="true" id="-228899" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7772501254376700" lon="32.2970529479139969"/>
+    <node visible="true" id="-228898" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7772836575038702" lon="32.2972018287101008"/>
+    <node visible="true" id="-227403" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7802820953679199" lon="32.2949715954966976"/>
+    <node visible="true" id="-227402" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7803884947554902" lon="32.2949496516802981"/>
+    <node visible="true" id="-227401" timestamp="2020-02-07T17:57:28Z" version="1" lat="2.7804898163031702" lon="32.2949240333992975"/>
+    <node visible="true" id="-225781" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7787246979159801" lon="32.2970775161554968"/>
+    <node visible="true" id="-225780" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7786797299840198" lon="32.2970641285152027"/>
+    <node visible="true" id="-225779" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7786626640867498" lon="32.2970611807515979"/>
+    <node visible="true" id="-225778" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7786476470914199" lon="32.2970604072307026"/>
+    <node visible="true" id="-225777" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7785026490386202" lon="32.2970730894105031"/>
+    <node visible="true" id="-225776" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7782770375765700" lon="32.2970885723320009"/>
+    <node visible="true" id="-225775" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7780744641452100" lon="32.2971089943925023"/>
+    <node visible="true" id="-225774" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7774859531654599" lon="32.2971798678577002"/>
+    <node visible="true" id="-210677" timestamp="2020-02-07T17:57:29Z" version="1" lat="2.7802648640015999" lon="32.2949085176392998"/>
+    <node visible="true" id="-203354" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7789756518014199" lon="32.2971137787374971"/>
+    <node visible="true" id="-203353" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7789264630866199" lon="32.2971169087592997"/>
+    <node visible="true" id="-203352" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7788772095489001" lon="32.2971150417172979"/>
+    <node visible="true" id="-203351" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7788284031443000" lon="32.2971081970185026"/>
+    <node visible="true" id="-203350" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7787963648221199" lon="32.2971009015447024"/>
+    <node visible="true" id="-197552" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7777625781590798" lon="32.2982053222500980"/>
+    <node visible="true" id="-197551" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7777592718040300" lon="32.2982069500548974"/>
+    <node visible="true" id="-197550" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7777360311306998" lon="32.2982178231942001"/>
+    <node visible="true" id="-197549" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7777124230451200" lon="32.2982278830908029"/>
+    <node visible="true" id="-197548" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7776884763101299" lon="32.2982371174884975"/>
+    <node visible="true" id="-197547" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7776642201011699" lon="32.2982455151365002"/>
+    <node visible="true" id="-197546" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7776396839707300" lon="32.2982530658035998"/>
+    <node visible="true" id="-197545" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7776148978123198" lon="32.2982597602904988"/>
+    <node visible="true" id="-197544" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7775898918241002" lon="32.2982655904410976"/>
+    <node visible="true" id="-197543" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7775646964720200" lon="32.2982705491522992"/>
+    <node visible="true" id="-197542" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7775393424527901" lon="32.2982746303827000"/>
+    <node visible="true" id="-197541" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7775138606563701" lon="32.2982778291599999"/>
+    <node visible="true" id="-197540" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7774882821284401" lon="32.2982801415870000"/>
+    <node visible="true" id="-197539" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7774626380325098" lon="32.2982815648464978"/>
+    <node visible="true" id="-197538" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7774369596119799" lon="32.2982820972044991"/>
+    <node visible="true" id="-188837" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7790849044578998" lon="32.2966474247637976"/>
+    <node visible="true" id="-188836" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7790754723971700" lon="32.2966777410874002"/>
+    <node visible="true" id="-188835" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7790487077257802" lon="32.2967350256286991"/>
+    <node visible="true" id="-188834" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7790156438949700" lon="32.2967881261537002"/>
+    <node visible="true" id="-188833" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7789777924808599" lon="32.2968364954355991"/>
+    <node visible="true" id="-188832" timestamp="2020-02-07T17:57:30Z" version="1" lat="2.7789366650597498" lon="32.2968795862481031"/>
+    <node visible="true" id="-179534" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7767254579384502" lon="32.2996735266724002"/>
+    <node visible="true" id="-179533" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7770877203034501" lon="32.2996131343109028"/>
+    <node visible="true" id="-179532" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7772090356714800" lon="32.2995961566197991"/>
+    <node visible="true" id="-179531" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7772671674411900" lon="32.2995912485744014"/>
+    <node visible="true" id="-179530" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7772893357687201" lon="32.2995909546071971"/>
+    <node visible="true" id="-179529" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773724616824600" lon="32.2996009689238974"/>
+    <node visible="true" id="-179528" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773915670920002" lon="32.2996018872200992"/>
+    <node visible="true" id="-179527" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7774156763440998" lon="32.2995995663855027"/>
+    <node visible="true" id="-164548" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7774251529098199" lon="32.2982169092732008"/>
+    <node visible="true" id="-164547" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7774179126540699" lon="32.2981668106442967"/>
+    <node visible="true" id="-164546" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7774030133222798" lon="32.2980314393681027"/>
+    <node visible="true" id="-164545" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773906753164899" lon="32.2978988167995027"/>
+    <node visible="true" id="-164544" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773727898948302" lon="32.2977247211759035"/>
+    <node visible="true" id="-164543" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773336814374101" lon="32.2974426710620008"/>
+    <node visible="true" id="-164542" timestamp="2020-02-07T17:57:31Z" version="1" lat="2.7773145289795398" lon="32.2973382157608029"/>
+    <node visible="true" id="-154708" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7801431587327698" lon="32.2949945766952027"/>
+    <node visible="true" id="-154707" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7793237368115800" lon="32.2951133933273979"/>
+    <node visible="true" id="-154706" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7792989576203100" lon="32.2951171252784022"/>
+    <node visible="true" id="-154705" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7792494921451198" lon="32.2951252056762996"/>
+    <node visible="true" id="-154704" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7791753777756401" lon="32.2951378700906986"/>
+    <node visible="true" id="-154703" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7791456877739402" lon="32.2951427593902025"/>
+    <node visible="true" id="-154702" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7791259086498701" lon="32.2951458998063998"/>
+    <node visible="true" id="-154701" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7791011265381602" lon="32.2951495912118034"/>
+    <node visible="true" id="-154700" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7790762995339202" lon="32.2951529783225979"/>
+    <node visible="true" id="-148937" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7783277573913798" lon="32.2962925453375007"/>
+    <node visible="true" id="-148936" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7783644627528599" lon="32.2963051594362014"/>
+    <node visible="true" id="-148935" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7783756213934598" lon="32.2963076869760002"/>
+    <node visible="true" id="-148934" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7784549540499199" lon="32.2963174243649007"/>
+    <node visible="true" id="-148933" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7785335638757300" lon="32.2963240213678020"/>
+    <node visible="true" id="-148932" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7786210910917499" lon="32.2963291251494979"/>
+    <node visible="true" id="-148931" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7787358522794001" lon="32.2963312827966007"/>
+    <node visible="true" id="-148930" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7787924492000000" lon="32.2963296854335979"/>
+    <node visible="true" id="-148929" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7788489621043699" lon="32.2963262285276969"/>
+    <node visible="true" id="-148928" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7789053292336101" lon="32.2963209158563984"/>
+    <node visible="true" id="-148927" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7789614889881200" lon="32.2963137532252986"/>
+    <node visible="true" id="-148926" timestamp="2020-02-07T17:57:32Z" version="1" lat="2.7789893211751799" lon="32.2962968428053969"/>
+    <node visible="true" id="-127659" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7788937732080199" lon="32.2969168513654026"/>
+    <node visible="true" id="-127658" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7788506285021701" lon="32.2969477435619012"/>
+    <node visible="true" id="-127657" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7788087425187098" lon="32.2969717156124005"/>
+    <node visible="true" id="-127656" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787511992954101" lon="32.2970004466722997"/>
+    <node visible="true" id="-127655" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787435002936900" lon="32.2970068167703985"/>
+    <node visible="true" id="-127654" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787364401982200" lon="32.2970180036822967"/>
+    <node visible="true" id="-127653" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787309531035702" lon="32.2970335158837969"/>
+    <node visible="true" id="-127652" timestamp="2020-02-07T17:57:33Z" version="1" lat="2.7787270390095600" lon="32.2970533533747997"/>
+    <node visible="true" id="-118002" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766088786048702" lon="32.2985195814665005"/>
+    <node visible="true" id="-118001" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766309113177701" lon="32.2985105594903033"/>
+    <node visible="true" id="-118000" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766524727091100" lon="32.2985004740034967"/>
+    <node visible="true" id="-117999" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766735109103799" lon="32.2984893492679035"/>
+    <node visible="true" id="-117998" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7766939753116500" lon="32.2984772120453982"/>
+    <node visible="true" id="-117997" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7767138166833498" lon="32.2984640915333969"/>
+    <node visible="true" id="-117996" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7767329872946700" lon="32.2984500192949966"/>
+    <node visible="true" id="-117995" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7767952554397999" lon="32.2984237017090976"/>
+    <node visible="true" id="-117994" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7768679156497500" lon="32.2983897691734967"/>
+    <node visible="true" id="-117993" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7769000417745802" lon="32.2983774209166015"/>
+    <node visible="true" id="-117992" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7769349978565998" lon="32.2983687012281990"/>
+    <node visible="true" id="-117991" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7769725299953301" lon="32.2983627060958014"/>
+    <node visible="true" id="-117990" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7771433411058801" lon="32.2983478908695005"/>
+    <node visible="true" id="-117989" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7771899450191602" lon="32.2983419583240021"/>
+    <node visible="true" id="-117988" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7772376015852398" lon="32.2983333262564969"/>
+    <node visible="true" id="-117987" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7772860569032298" lon="32.2983210906537010"/>
+    <node visible="true" id="-117986" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7773390139459302" lon="32.2983055209448011"/>
+    <node visible="true" id="-107327" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7790862553409301" lon="32.2963451450642012"/>
+    <node visible="true" id="-107326" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7790934061626000" lon="32.2963965733989014"/>
+    <node visible="true" id="-107325" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7791028556961499" lon="32.2964862556406018"/>
+    <node visible="true" id="-107324" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7791040579580000" lon="32.2965528088653997"/>
+    <node visible="true" id="-107323" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7790944263331601" lon="32.2966168197570980"/>
+    <node visible="true" id="-106325" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7805785326282200" lon="32.2964391687532029"/>
+    <node visible="true" id="-106324" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7806289611560100" lon="32.2964441201833026"/>
+    <node visible="true" id="-106323" timestamp="2020-02-07T17:57:34Z" version="1" lat="2.7806791852046899" lon="32.2964508188340034"/>
+    <node visible="true" id="-92693" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7793061826668599" lon="32.2965840227615004"/>
+    <node visible="true" id="-92692" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7793714551548900" lon="32.2965687687937972"/>
+    <node visible="true" id="-92691" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7793869065920900" lon="32.2965579304608994"/>
+    <node visible="true" id="-92690" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7794303706162600" lon="32.2965450561986032"/>
+    <node visible="true" id="-92689" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7794444617889198" lon="32.2965452244570983"/>
+    <node visible="true" id="-92688" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7795905576110398" lon="32.2965205264260007"/>
+    <node visible="true" id="-92687" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7797573833053399" lon="32.2964819104586027"/>
+    <node visible="true" id="-92686" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7798251073870599" lon="32.2964721617457968"/>
+    <node visible="true" id="-92685" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7798659443090501" lon="32.2964713657132023"/>
+    <node visible="true" id="-92684" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799190543354100" lon="32.2964677480541980"/>
+    <node visible="true" id="-92683" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799565540837601" lon="32.2964673701593981"/>
+    <node visible="true" id="-92682" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799515256394498" lon="32.2963401706744975"/>
+    <node visible="true" id="-92681" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799286005237200" lon="32.2960484939745029"/>
+    <node visible="true" id="-92680" timestamp="2020-02-07T17:57:35Z" version="1" lat="2.7799148692709998" lon="32.2958915832183990"/>
+    <node visible="true" id="-61423" timestamp="2020-02-07T17:57:36Z" version="1" lat="2.7770137855736001" lon="32.2951331858425021"/>
+    <node visible="true" id="-61422" timestamp="2020-02-07T17:57:36Z" version="1" lat="2.7770279992641802" lon="32.2952081316341975"/>
+    <node visible="true" id="-61421" timestamp="2020-02-07T17:57:36Z" version="1" lat="2.7770631254490201" lon="32.2953548897616969"/>
+    <node visible="true" id="-16396" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7804773080670699" lon="32.2964345295478026"/>
+    <node visible="true" id="-16395" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7805279610607099" lon="32.2964359705758994"/>
+    <node visible="true" id="-15034" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7790860759842801" lon="32.2966468860918994"/>
+    <node visible="true" id="-15033" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7790993915745101" lon="32.2966392191333966"/>
+    <node visible="true" id="-15032" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791130274220599" lon="32.2966321307132986"/>
+    <node visible="true" id="-15031" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791269581266498" lon="32.2966256340356992"/>
+    <node visible="true" id="-15030" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791411577387000" lon="32.2966197412023988"/>
+    <node visible="true" id="-15029" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791555998077699" lon="32.2966144631904015"/>
+    <node visible="true" id="-15028" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791702574317498" lon="32.2966098098312031"/>
+    <node visible="true" id="-15027" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7791851033070198" lon="32.2966057897930980"/>
+    <node visible="true" id="-15026" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792001097792700" lon="32.2966024105643967"/>
+    <node visible="true" id="-15025" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792152488950599" lon="32.2965996784397973"/>
+    <node visible="true" id="-15024" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792304924538498" lon="32.2965975985086970"/>
+    <node visible="true" id="-15023" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792458120605499" lon="32.2965961746454013"/>
+    <node visible="true" id="-15022" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792611791784201" lon="32.2965954095024017"/>
+    <node visible="true" id="-15021" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792765651822098" lon="32.2965953045047982"/>
+    <node visible="true" id="-15020" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7792919414114801" lon="32.2965958598485017"/>
+    <node visible="true" id="-15019" timestamp="2020-02-07T17:57:38Z" version="1" lat="2.7793072792240099" lon="32.2965970744986990"/>
+    <node visible="true" id="-10520" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776844812841599" lon="32.2992782909542981"/>
+    <node visible="true" id="-10519" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776890795083502" lon="32.2992686738545984"/>
+    <node visible="true" id="-10518" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777123550695801" lon="32.2992140013760007"/>
+    <node visible="true" id="-10517" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777327403677599" lon="32.2991581991857970"/>
+    <node visible="true" id="-10516" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777501802418501" lon="32.2991014182805998"/>
+    <node visible="true" id="-10515" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777646275009098" lon="32.2990438123054986"/>
+    <node visible="true" id="-10514" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777739975855300" lon="32.2989894864088996"/>
+    <node visible="true" id="-10513" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777767883036200" lon="32.2989851063192006"/>
+    <node visible="true" id="-10512" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777790341722999" lon="32.2989804266602007"/>
+    <node visible="true" id="-10511" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777807031720601" lon="32.2989755141502002"/>
+    <node visible="true" id="-10510" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777817715078301" lon="32.2989704388271974"/>
+    <node visible="true" id="-10509" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777822239482699" lon="32.2989652730505981"/>
+    <node visible="true" id="-10508" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777820540428899" lon="32.2989600904691017"/>
+    <node visible="true" id="-10507" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777812642140498" lon="32.2989549649713013"/>
+    <node visible="true" id="-10506" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777798657224202" lon="32.2989499696318987"/>
+    <node visible="true" id="-10505" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777778785063898" lon="32.2989451756697008"/>
+    <node visible="true" id="-10504" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777753308978701" lon="32.2989406514326021"/>
+    <node visible="true" id="-10503" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777722592183198" lon="32.2989364614232031"/>
+    <node visible="true" id="-10502" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777687072609001" lon="32.2989326653786009"/>
+    <node visible="true" id="-10501" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777647256661600" lon="32.2989293174193008"/>
+    <node visible="true" id="-10500" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777603712000198" lon="32.2989264652775034"/>
+    <node visible="true" id="-10499" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777557059444300" lon="32.2989241496163970"/>
+    <node visible="true" id="-10498" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777478114333500" lon="32.2989233451452975"/>
+    <node visible="true" id="-10497" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777398507003501" lon="32.2989228115486995"/>
+    <node visible="true" id="-10496" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777318760913601" lon="32.2989225545717034"/>
+    <node visible="true" id="-10495" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777238973222400" lon="32.2989225745276016"/>
+    <node visible="true" id="-10494" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777159241138700" lon="32.2989228713919019"/>
+    <node visible="true" id="-10493" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777079661803801" lon="32.2989234448031013"/>
+    <node visible="true" id="-10492" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7777000332172901" lon="32.2989242940624024"/>
+    <node visible="true" id="-10491" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776921348896901" lon="32.2989254181351981"/>
+    <node visible="true" id="-10490" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776842808204698" lon="32.2989268156520026"/>
+    <node visible="true" id="-10489" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776764805786001" lon="32.2989284849100997"/>
+    <node visible="true" id="-10488" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776687436674701" lon="32.2989304238757029"/>
+    <node visible="true" id="-10487" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776610795133201" lon="32.2989326301865987"/>
+    <node visible="true" id="-10486" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776534974537301" lon="32.2989351011545978"/>
+    <node visible="true" id="-10485" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776449427915599" lon="32.2989374769300994"/>
+    <node visible="true" id="-10484" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776361905600400" lon="32.2989389811164997"/>
+    <node visible="true" id="-10483" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776273303062098" lon="32.2989395983240968"/>
+    <node visible="true" id="-10482" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776184526823302" lon="32.2989393222380983"/>
+    <node visible="true" id="-10481" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776096485183501" lon="32.2989381556831034"/>
+    <node visible="true" id="-10480" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7776010078926401" lon="32.2989361105947026"/>
+    <node visible="true" id="-10479" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775926192103602" lon="32.2989332078967024"/>
+    <node visible="true" id="-10478" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775845682989302" lon="32.2989294772878992"/>
+    <node visible="true" id="-10477" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775769375299402" lon="32.2989249569370998"/>
+    <node visible="true" id="-10476" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775698049763502" lon="32.2989196930938007"/>
+    <node visible="true" id="-10475" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775632436137001" lon="32.2989137396141004"/>
+    <node visible="true" id="-10474" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775573205735000" lon="32.2989071574099000"/>
+    <node visible="true" id="-10473" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775520964563598" lon="32.2989000138261986"/>
+    <node visible="true" id="-10472" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775476247119602" lon="32.2988923819512976"/>
+    <node visible="true" id="-10471" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775439510922300" lon="32.2988843398694030"/>
+    <node visible="true" id="-10470" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775400313390599" lon="32.2988718176950016"/>
+    <node visible="true" id="-10469" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775350054177399" lon="32.2988538996008003"/>
+    <node visible="true" id="-10468" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775306113552500" lon="32.2988358179865003"/>
+    <node visible="true" id="-10467" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775268545050702" lon="32.2988175948816973"/>
+    <node visible="true" id="-10466" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775237394443399" lon="32.2987992524884007"/>
+    <node visible="true" id="-10465" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775212699682599" lon="32.2987808131540035"/>
+    <node visible="true" id="-10464" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775194490855002" lon="32.2987622993437995"/>
+    <node visible="true" id="-10463" timestamp="2020-02-07T17:57:39Z" version="1" lat="2.7775182790145099" lon="32.2987437336142023"/>
+    <way visible="true" id="-15993" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-309139"/>
+        <nd ref="-61421"/>
+        <nd ref="-61422"/>
+        <nd ref="-61423"/>
+        <nd ref="-424053"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.023Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:46Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15992" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-424052"/>
+        <nd ref="-106323"/>
+        <nd ref="-106324"/>
+        <nd ref="-106325"/>
+        <nd ref="-299687"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.210Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:46Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15991" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-197538"/>
+        <nd ref="-117986"/>
+        <nd ref="-117987"/>
+        <nd ref="-117988"/>
+        <nd ref="-117989"/>
+        <nd ref="-117990"/>
+        <nd ref="-117991"/>
+        <nd ref="-117992"/>
+        <nd ref="-117993"/>
+        <nd ref="-117994"/>
+        <nd ref="-117995"/>
+        <nd ref="-117996"/>
+        <nd ref="-117997"/>
+        <nd ref="-117998"/>
+        <nd ref="-117999"/>
+        <nd ref="-118000"/>
+        <nd ref="-118001"/>
+        <nd ref="-118002"/>
+        <nd ref="-424051"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.261Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:46Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15990" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-362392"/>
+        <nd ref="-424050"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.346Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15989" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-340933"/>
+        <nd ref="-179527"/>
+        <nd ref="-179528"/>
+        <nd ref="-179529"/>
+        <nd ref="-179530"/>
+        <nd ref="-179531"/>
+        <nd ref="-179532"/>
+        <nd ref="-179533"/>
+        <nd ref="-179534"/>
+        <nd ref="-424049"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.533Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15988" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-227403"/>
+        <nd ref="-210677"/>
+        <nd ref="-424048"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.673Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15987" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-424047"/>
+        <nd ref="-227401"/>
+        <nd ref="-227402"/>
+        <nd ref="-227403"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.745Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15986" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-263950"/>
+        <nd ref="-263951"/>
+        <nd ref="-263952"/>
+        <nd ref="-263953"/>
+        <nd ref="-263954"/>
+        <nd ref="-263955"/>
+        <nd ref="-263956"/>
+        <nd ref="-263957"/>
+        <nd ref="-263958"/>
+        <nd ref="-263959"/>
+        <nd ref="-263960"/>
+        <nd ref="-263961"/>
+        <nd ref="-263962"/>
+        <nd ref="-263963"/>
+        <nd ref="-263964"/>
+        <nd ref="-263965"/>
+        <nd ref="-263966"/>
+        <nd ref="-263967"/>
+        <nd ref="-263968"/>
+        <nd ref="-263969"/>
+        <nd ref="-263970"/>
+        <nd ref="-263971"/>
+        <nd ref="-263972"/>
+        <nd ref="-263973"/>
+        <nd ref="-263974"/>
+        <nd ref="-263975"/>
+        <nd ref="-263976"/>
+        <nd ref="-263977"/>
+        <nd ref="-263978"/>
+        <nd ref="-263979"/>
+        <nd ref="-263980"/>
+        <nd ref="-263981"/>
+        <nd ref="-263982"/>
+        <nd ref="-263983"/>
+        <nd ref="-263984"/>
+        <nd ref="-424046"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.919Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15985" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-424045"/>
+        <nd ref="-299654"/>
+        <nd ref="-299655"/>
+        <nd ref="-299656"/>
+        <nd ref="-299657"/>
+        <nd ref="-299658"/>
+        <nd ref="-299659"/>
+        <nd ref="-299660"/>
+        <nd ref="-299661"/>
+        <nd ref="-299662"/>
+        <nd ref="-299663"/>
+        <nd ref="-299664"/>
+        <nd ref="-299665"/>
+        <nd ref="-299666"/>
+        <nd ref="-299667"/>
+        <nd ref="-299668"/>
+        <nd ref="-299669"/>
+        <nd ref="-299670"/>
+        <nd ref="-299671"/>
+        <nd ref="-299672"/>
+        <nd ref="-299673"/>
+        <nd ref="-299674"/>
+        <nd ref="-299675"/>
+        <nd ref="-299676"/>
+        <nd ref="-299677"/>
+        <nd ref="-299678"/>
+        <nd ref="-299679"/>
+        <nd ref="-299680"/>
+        <nd ref="-299681"/>
+        <nd ref="-299682"/>
+        <nd ref="-299683"/>
+        <nd ref="-299684"/>
+        <nd ref="-299685"/>
+        <nd ref="-299686"/>
+        <nd ref="-299687"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.069Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:43Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15984" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-424044"/>
+        <nd ref="-340933"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.255Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:42Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15983" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-424043"/>
+        <nd ref="-341176"/>
+        <nd ref="-341177"/>
+        <nd ref="-341178"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.257Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:42Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15982" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-228898"/>
+        <nd ref="-400262"/>
+        <nd ref="-400263"/>
+        <nd ref="-400264"/>
+        <nd ref="-424042"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.539Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:42Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-15981" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-424041"/>
+        <nd ref="-234613"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.542Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:42Z"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-13555" timestamp="2020-02-07T17:57:42Z" version="1">
+        <nd ref="-362392"/>
+        <nd ref="-362393"/>
+        <nd ref="-362394"/>
+        <nd ref="-362395"/>
+        <nd ref="-362396"/>
+        <nd ref="-362397"/>
+        <nd ref="-362398"/>
+        <nd ref="-362399"/>
+        <nd ref="-362400"/>
+        <nd ref="-362401"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.351Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:42Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-11323" timestamp="2020-02-07T17:57:43Z" version="1">
+        <nd ref="-362392"/>
+        <nd ref="-309135"/>
+        <nd ref="-309136"/>
+        <nd ref="-309137"/>
+        <nd ref="-309138"/>
+        <nd ref="-309139"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.110Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:43Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-11056" timestamp="2020-02-07T17:57:43Z" version="1">
+        <nd ref="-341178"/>
+        <nd ref="-302355"/>
+        <nd ref="-302356"/>
+        <nd ref="-302357"/>
+        <nd ref="-302358"/>
+        <nd ref="-302359"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:17.081Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:43Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-9545" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-263950"/>
+        <nd ref="-262329"/>
+        <nd ref="-262330"/>
+        <nd ref="-262331"/>
+        <nd ref="-262332"/>
+        <nd ref="-262333"/>
+        <nd ref="-262334"/>
+        <nd ref="-262335"/>
+        <nd ref="-262336"/>
+        <nd ref="-262337"/>
+        <nd ref="-262338"/>
+        <nd ref="-262339"/>
+        <nd ref="-262340"/>
+        <nd ref="-262341"/>
+        <nd ref="-262342"/>
+        <nd ref="-262343"/>
+        <nd ref="-262344"/>
+        <nd ref="-262345"/>
+        <nd ref="-262346"/>
+        <nd ref="-262347"/>
+        <nd ref="-262348"/>
+        <nd ref="-262349"/>
+        <nd ref="-262350"/>
+        <nd ref="-262351"/>
+        <nd ref="-262352"/>
+        <nd ref="-262353"/>
+        <nd ref="-262354"/>
+        <nd ref="-262355"/>
+        <nd ref="-262356"/>
+        <nd ref="-262357"/>
+        <nd ref="-262358"/>
+        <nd ref="-262359"/>
+        <nd ref="-262360"/>
+        <nd ref="-262361"/>
+        <nd ref="-262362"/>
+        <nd ref="-262363"/>
+        <nd ref="-262364"/>
+        <nd ref="-262365"/>
+        <nd ref="-262366"/>
+        <nd ref="-262367"/>
+        <nd ref="-262368"/>
+        <nd ref="-262369"/>
+        <nd ref="-262370"/>
+        <nd ref="-262371"/>
+        <nd ref="-262372"/>
+        <nd ref="-262373"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.914Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-8505" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-340933"/>
+        <nd ref="-234606"/>
+        <nd ref="-234607"/>
+        <nd ref="-234608"/>
+        <nd ref="-234609"/>
+        <nd ref="-234610"/>
+        <nd ref="-234611"/>
+        <nd ref="-234612"/>
+        <nd ref="-234613"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.775Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-8296" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-228898"/>
+        <nd ref="-228899"/>
+        <nd ref="-228900"/>
+        <nd ref="-228901"/>
+        <nd ref="-228902"/>
+        <nd ref="-228903"/>
+        <nd ref="-228904"/>
+        <nd ref="-228905"/>
+        <nd ref="-228906"/>
+        <nd ref="-228907"/>
+        <nd ref="-228908"/>
+        <nd ref="-228909"/>
+        <nd ref="-309139"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.751Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-8183" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-228898"/>
+        <nd ref="-225774"/>
+        <nd ref="-225775"/>
+        <nd ref="-225776"/>
+        <nd ref="-225777"/>
+        <nd ref="-225778"/>
+        <nd ref="-225779"/>
+        <nd ref="-225780"/>
+        <nd ref="-225781"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.739Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-7341" timestamp="2020-02-07T17:57:44Z" version="1">
+        <nd ref="-225781"/>
+        <nd ref="-203350"/>
+        <nd ref="-203351"/>
+        <nd ref="-203352"/>
+        <nd ref="-203353"/>
+        <nd ref="-203354"/>
+        <nd ref="-263950"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.644Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:44Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-7083" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-197538"/>
+        <nd ref="-197539"/>
+        <nd ref="-197540"/>
+        <nd ref="-197541"/>
+        <nd ref="-197542"/>
+        <nd ref="-197543"/>
+        <nd ref="-197544"/>
+        <nd ref="-197545"/>
+        <nd ref="-197546"/>
+        <nd ref="-197547"/>
+        <nd ref="-197548"/>
+        <nd ref="-197549"/>
+        <nd ref="-197550"/>
+        <nd ref="-197551"/>
+        <nd ref="-197552"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.617Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-6750" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-262373"/>
+        <nd ref="-188832"/>
+        <nd ref="-188833"/>
+        <nd ref="-188834"/>
+        <nd ref="-188835"/>
+        <nd ref="-188836"/>
+        <nd ref="-188837"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.571Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-5818" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-228898"/>
+        <nd ref="-164542"/>
+        <nd ref="-164543"/>
+        <nd ref="-164544"/>
+        <nd ref="-164545"/>
+        <nd ref="-164546"/>
+        <nd ref="-164547"/>
+        <nd ref="-164548"/>
+        <nd ref="-197538"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.468Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-5428" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-362392"/>
+        <nd ref="-154700"/>
+        <nd ref="-154701"/>
+        <nd ref="-154702"/>
+        <nd ref="-154703"/>
+        <nd ref="-154704"/>
+        <nd ref="-154705"/>
+        <nd ref="-154706"/>
+        <nd ref="-154707"/>
+        <nd ref="-154708"/>
+        <nd ref="-227403"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.425Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-5262" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-362401"/>
+        <nd ref="-148926"/>
+        <nd ref="-148927"/>
+        <nd ref="-148928"/>
+        <nd ref="-148929"/>
+        <nd ref="-148930"/>
+        <nd ref="-148931"/>
+        <nd ref="-148932"/>
+        <nd ref="-148933"/>
+        <nd ref="-148934"/>
+        <nd ref="-148935"/>
+        <nd ref="-148936"/>
+        <nd ref="-148937"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.405Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-4430" timestamp="2020-02-07T17:57:45Z" version="1">
+        <nd ref="-225781"/>
+        <nd ref="-127652"/>
+        <nd ref="-127653"/>
+        <nd ref="-127654"/>
+        <nd ref="-127655"/>
+        <nd ref="-127656"/>
+        <nd ref="-127657"/>
+        <nd ref="-127658"/>
+        <nd ref="-127659"/>
+        <nd ref="-262373"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.301Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:45Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-3654" timestamp="2020-02-07T17:57:46Z" version="1">
+        <nd ref="-188837"/>
+        <nd ref="-107323"/>
+        <nd ref="-107324"/>
+        <nd ref="-107325"/>
+        <nd ref="-107326"/>
+        <nd ref="-107327"/>
+        <nd ref="-362401"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.215Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:46Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-3135" timestamp="2020-02-07T17:57:46Z" version="1">
+        <nd ref="-92680"/>
+        <nd ref="-92681"/>
+        <nd ref="-92682"/>
+        <nd ref="-92683"/>
+        <nd ref="-92684"/>
+        <nd ref="-92685"/>
+        <nd ref="-92686"/>
+        <nd ref="-92687"/>
+        <nd ref="-92688"/>
+        <nd ref="-92689"/>
+        <nd ref="-92690"/>
+        <nd ref="-92691"/>
+        <nd ref="-92692"/>
+        <nd ref="-92693"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:16.152Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:46Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-580" timestamp="2020-02-07T17:57:47Z" version="1">
+        <nd ref="-299687"/>
+        <nd ref="-16395"/>
+        <nd ref="-16396"/>
+        <nd ref="-341178"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.845Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:47Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-533" timestamp="2020-02-07T17:57:47Z" version="1">
+        <nd ref="-15019"/>
+        <nd ref="-15020"/>
+        <nd ref="-15021"/>
+        <nd ref="-15022"/>
+        <nd ref="-15023"/>
+        <nd ref="-15024"/>
+        <nd ref="-15025"/>
+        <nd ref="-15026"/>
+        <nd ref="-15027"/>
+        <nd ref="-15028"/>
+        <nd ref="-15029"/>
+        <nd ref="-15030"/>
+        <nd ref="-15031"/>
+        <nd ref="-15032"/>
+        <nd ref="-15033"/>
+        <nd ref="-15034"/>
+        <nd ref="-188837"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.838Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:47Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+    <way visible="true" id="-350" timestamp="2020-02-07T17:57:47Z" version="1">
+        <nd ref="-197538"/>
+        <nd ref="-10463"/>
+        <nd ref="-10464"/>
+        <nd ref="-10465"/>
+        <nd ref="-10466"/>
+        <nd ref="-10467"/>
+        <nd ref="-10468"/>
+        <nd ref="-10469"/>
+        <nd ref="-10470"/>
+        <nd ref="-10471"/>
+        <nd ref="-10472"/>
+        <nd ref="-10473"/>
+        <nd ref="-10474"/>
+        <nd ref="-10475"/>
+        <nd ref="-10476"/>
+        <nd ref="-10477"/>
+        <nd ref="-10478"/>
+        <nd ref="-10479"/>
+        <nd ref="-10480"/>
+        <nd ref="-10481"/>
+        <nd ref="-10482"/>
+        <nd ref="-10483"/>
+        <nd ref="-10484"/>
+        <nd ref="-10485"/>
+        <nd ref="-10486"/>
+        <nd ref="-10487"/>
+        <nd ref="-10488"/>
+        <nd ref="-10489"/>
+        <nd ref="-10490"/>
+        <nd ref="-10491"/>
+        <nd ref="-10492"/>
+        <nd ref="-10493"/>
+        <nd ref="-10494"/>
+        <nd ref="-10495"/>
+        <nd ref="-10496"/>
+        <nd ref="-10497"/>
+        <nd ref="-10498"/>
+        <nd ref="-10499"/>
+        <nd ref="-10500"/>
+        <nd ref="-10501"/>
+        <nd ref="-10502"/>
+        <nd ref="-10503"/>
+        <nd ref="-10504"/>
+        <nd ref="-10505"/>
+        <nd ref="-10506"/>
+        <nd ref="-10507"/>
+        <nd ref="-10508"/>
+        <nd ref="-10509"/>
+        <nd ref="-10510"/>
+        <nd ref="-10511"/>
+        <nd ref="-10512"/>
+        <nd ref="-10513"/>
+        <nd ref="-10514"/>
+        <nd ref="-10515"/>
+        <nd ref="-10516"/>
+        <nd ref="-10517"/>
+        <nd ref="-10518"/>
+        <nd ref="-10519"/>
+        <nd ref="-10520"/>
+        <nd ref="-234613"/>
+        <tag k="source:ingest:datetime" v="2020-02-07T17:57:15.808Z"/>
+        <tag k="source:datetime" v="2020-02-07T17:57:47Z"/>
+        <tag k="highway" v="road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:imagery:datetime" v="2019-09-20"/>
+    </way>
+</osm>

--- a/test-files/cases/attribute/unifying/highway-3784-roundabouts-1/Input2.osm
+++ b/test-files/cases/attribute/unifying/highway-3784-roundabouts-1/Input2.osm
@@ -1,0 +1,526 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="2.7766" minlon="32.2948" maxlat="2.7807" maxlon="32.2997"/>
+    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2981923006059262"/>
+    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7792125383213433" lon="32.2997000000000014"/>
+    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7775194937869836" lon="32.2997000000000014"/>
+    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7766000000000002" lon="32.2996697626409031"/>
+    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7769862639449943" lon="32.2948000000000022"/>
+    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2964712339079441"/>
+    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7766000000000002" lon="32.2973244582411496"/>
+    <node visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2949115208270570"/>
+    <node visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7789922377188030" lon="32.2948000000000022"/>
+    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2989407265984596"/>
+    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7775556232648908" lon="32.2948000000000022"/>
+    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7806999999999999" lon="32.2993639746683385"/>
+    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="2.7803391641851123" lon="32.2948000000000022"/>
+    <node visible="true" id="1641684803" timestamp="2019-01-24T14:32:34Z" version="4" changeset="66603670" user="Penobscot" uid="9090196" lat="2.7789855999999999" lon="32.2955196999999998"/>
+    <node visible="true" id="1641684833" timestamp="2019-06-20T06:03:46Z" version="7" changeset="71427317" user="Okavango77" uid="9320580" lat="2.7770806000000001" lon="32.2954271999999989"/>
+    <node visible="true" id="1641684903" timestamp="2019-01-28T11:00:25Z" version="8" changeset="66701775" user="Penobscot" uid="9090196" lat="2.7789603999999999" lon="32.2951771999999977"/>
+    <node visible="true" id="1641684928" timestamp="2019-06-27T23:56:54Z" version="3" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7790826000000002" lon="32.2962042999999994"/>
+    <node visible="true" id="1641684950" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7792697999999998" lon="32.2973399999999984"/>
+    <node visible="true" id="1655884800" timestamp="2019-01-28T11:00:25Z" version="7" changeset="66701775" user="Penobscot" uid="9090196" lat="2.7772988000000001" lon="32.2972479000000021"/>
+    <node visible="true" id="1818542795" timestamp="2019-01-24T17:30:04Z" version="3" changeset="66608902" user="Penobscot" uid="9090196" lat="2.7774977999999999" lon="32.2987357000000017"/>
+    <node visible="true" id="1818542808" timestamp="2019-01-28T13:25:29Z" version="3" changeset="66706015" user="Penobscot" uid="9090196" lat="2.7791535000000001" lon="32.2985946000000013"/>
+    <node visible="true" id="1818542809" timestamp="2019-01-28T13:25:29Z" version="3" changeset="66706015" user="Penobscot" uid="9090196" lat="2.7791690000000000" lon="32.2984677999999974"/>
+    <node visible="true" id="1818542810" timestamp="2019-01-28T12:47:23Z" version="3" changeset="66704798" user="Penobscot" uid="9090196" lat="2.7791743000000002" lon="32.2992592000000016"/>
+    <node visible="true" id="1818542811" timestamp="2019-06-27T23:56:54Z" version="5" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791298000000002" lon="32.2966130000000007"/>
+    <node visible="true" id="1818542813" timestamp="2019-01-28T12:47:23Z" version="2" changeset="66704798" user="Penobscot" uid="9090196" lat="2.7792056000000001" lon="32.2996324000000001"/>
+    <node visible="true" id="1818542815" timestamp="2019-01-28T13:25:29Z" version="3" changeset="66706015" user="Penobscot" uid="9090196" lat="2.7792078999999998" lon="32.2983498999999981"/>
+    <node visible="true" id="1818542816" timestamp="2012-08-15T20:40:12Z" version="2" changeset="12744017" user="bmog" uid="65432" lat="2.7794903999999998" lon="32.2965877000000035"/>
+    <node visible="true" id="1818542817" timestamp="2019-06-27T23:56:54Z" version="5" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7795165000000002" lon="32.2976608000000027"/>
+    <node visible="true" id="1818542821" timestamp="2019-06-27T23:56:54Z" version="6" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7795456000000001" lon="32.2975552999999991"/>
+    <node visible="true" id="1818542822" timestamp="2019-01-28T12:47:24Z" version="3" changeset="66704798" user="Penobscot" uid="9090196" lat="2.7799971000000001" lon="32.2965208000000032"/>
+    <node visible="true" id="1818542824" timestamp="2019-01-28T10:19:03Z" version="6" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7792129000000001" lon="32.2951655000000031"/>
+    <node visible="true" id="1818542825" timestamp="2019-01-28T12:47:24Z" version="3" changeset="66704798" user="Penobscot" uid="9090196" lat="2.7803325000000001" lon="32.2964916000000031"/>
+    <node visible="true" id="1865920154" timestamp="2012-08-14T16:05:59Z" version="1" changeset="12728686" user="AndrewBuck" uid="214969" lat="2.7772640000000002" lon="32.2995745999999997"/>
+    <node visible="true" id="1865920156" timestamp="2019-01-28T10:19:03Z" version="3" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7774255999999999" lon="32.2996037999999999"/>
+    <node visible="true" id="1866869779" timestamp="2019-06-27T23:56:54Z" version="3" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7786156000000002" lon="32.2970832000000030"/>
+    <node visible="true" id="1866869782" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7789128000000001" lon="32.2969869000000003"/>
+    <node visible="true" id="1866869783" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7789027000000002" lon="32.2971032000000022"/>
+    <node visible="true" id="1866869785" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7789296999999999" lon="32.2969648999999990"/>
+    <node visible="true" id="1866869787" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7789530000000000" lon="32.2971647000000033"/>
+    <node visible="true" id="1866869789" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7789508000000001" lon="32.2969470999999970"/>
+    <node visible="true" id="1866869791" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7789826999999998" lon="32.2971789999999999"/>
+    <node visible="true" id="1866869793" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7790859999999999" lon="32.2969404999999981"/>
+    <node visible="true" id="1866869795" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7790151000000001" lon="32.2971853000000024"/>
+    <node visible="true" id="1866869798" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791123999999998" lon="32.2971508999999983"/>
+    <node visible="true" id="1866869802" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791465000000000" lon="32.2970109999999977"/>
+    <node visible="true" id="1866869804" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791522999999998" lon="32.2970333999999966"/>
+    <node visible="true" id="1866869805" timestamp="2019-06-27T23:56:54Z" version="7" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791541999999998" lon="32.2970564000000024"/>
+    <node visible="true" id="1866869806" timestamp="2019-06-27T23:56:54Z" version="3" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791263000000002" lon="32.2966659000000007"/>
+    <node visible="true" id="1866869809" timestamp="2019-06-27T23:56:54Z" version="4" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7797223000000000" lon="32.2976342999999986"/>
+    <node visible="true" id="1867808596" timestamp="2019-01-28T10:19:03Z" version="3" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7774402000000000" lon="32.2982901000000027"/>
+    <node visible="true" id="1867808684" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778415999999999" lon="32.2984020000000029"/>
+    <node visible="true" id="1867808695" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778228999999999" lon="32.2982403000000033"/>
+    <node visible="true" id="1867808698" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778325000000001" lon="32.2983224999999976"/>
+    <node visible="true" id="1867808710" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778114999999999" lon="32.2989694999999983"/>
+    <node visible="true" id="1867808716" timestamp="2019-01-28T11:00:25Z" version="4" changeset="66701775" user="Penobscot" uid="9090196" lat="2.7778258999999998" lon="32.2953266999999968"/>
+    <node visible="true" id="1867808736" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778136000000000" lon="32.2989954000000026"/>
+    <node visible="true" id="1867808753" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778282999999999" lon="32.2981476000000001"/>
+    <node visible="true" id="1867808767" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7779318000000002" lon="32.2979867999999968"/>
+    <node visible="true" id="1867808817" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778282999999999" lon="32.2990125999999975"/>
+    <node visible="true" id="1867808820" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7780993999999999" lon="32.2979635000000016"/>
+    <node visible="true" id="1867808834" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778515000000001" lon="32.2980510000000010"/>
+    <node visible="true" id="1867808839" timestamp="2019-01-28T10:19:03Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778527999999998" lon="32.2990240999999969"/>
+    <node visible="true" id="1867808845" timestamp="2019-01-28T10:19:04Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778797000000002" lon="32.2990293000000008"/>
+    <node visible="true" id="1867808889" timestamp="2019-01-28T10:19:04Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7782062999999999" lon="32.2979476000000005"/>
+    <node visible="true" id="1867809124" timestamp="2012-08-15T20:09:55Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7785859999999998" lon="32.2976061999999970"/>
+    <node visible="true" id="1867809178" timestamp="2019-01-28T11:00:25Z" version="2" changeset="66701775" user="Penobscot" uid="9090196" lat="2.7786297000000002" lon="32.2976904000000005"/>
+    <node visible="true" id="1867809276" timestamp="2012-08-15T20:09:58Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7786843000000001" lon="32.2977228000000025"/>
+    <node visible="true" id="1867809646" timestamp="2019-01-28T10:19:04Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7781720999999999" lon="32.2990489999999966"/>
+    <node visible="true" id="1867809725" timestamp="2019-01-24T14:32:34Z" version="5" changeset="66603670" user="Penobscot" uid="9090196" lat="2.7787364000000001" lon="32.2951996999999977"/>
+    <node visible="true" id="1867809777" timestamp="2012-08-15T20:10:04Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7789974000000002" lon="32.2976809000000031"/>
+    <node visible="true" id="1867809787" timestamp="2019-01-28T10:19:04Z" version="3" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7789823000000000" lon="32.2949120999999977"/>
+    <node visible="true" id="1867809882" timestamp="2019-01-28T12:47:24Z" version="2" changeset="66704798" user="Penobscot" uid="9090196" lat="2.7791679000000000" lon="32.2990708000000026"/>
+    <node visible="true" id="1867809886" timestamp="2019-01-28T12:47:24Z" version="2" changeset="66704798" user="Penobscot" uid="9090196" lat="2.7791801999999999" lon="32.2993369000000001"/>
+    <node visible="true" id="1867809894" timestamp="2012-08-15T20:10:06Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7792678000000000" lon="32.2992982999999967"/>
+    <node visible="true" id="1867809896" timestamp="2012-08-15T20:10:06Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7792688999999999" lon="32.2990780000000015">
+        <tag k="barrier" v="gate"/>
+        <tag k="error:circular" v="15"/>
+    </node>
+    <node visible="true" id="1867809913" timestamp="2012-08-15T20:10:06Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7793489000000000" lon="32.2992623000000023"/>
+    <node visible="true" id="1867809920" timestamp="2012-08-15T20:10:06Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7793635999999999" lon="32.2990726000000024"/>
+    <node visible="true" id="1867809950" timestamp="2012-08-15T20:10:07Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7794164000000001" lon="32.2990070000000031"/>
+    <node visible="true" id="1867809968" timestamp="2012-08-15T20:10:07Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7794563999999999" lon="32.2989194999999967"/>
+    <node visible="true" id="1867810001" timestamp="2012-08-15T20:10:08Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7795182999999999" lon="32.2988337999999970"/>
+    <node visible="true" id="1867810003" timestamp="2012-08-15T20:10:08Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7795188000000000" lon="32.2992545000000035"/>
+    <node visible="true" id="1867810040" timestamp="2012-08-15T20:10:08Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7796093000000002" lon="32.2988009999999974"/>
+    <node visible="true" id="1867810065" timestamp="2012-08-15T20:10:09Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7796449000000001" lon="32.2992159000000001"/>
+    <node visible="true" id="1867810121" timestamp="2012-08-15T20:10:10Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7797914000000001" lon="32.2988957999999968"/>
+    <node visible="true" id="1867810133" timestamp="2012-08-15T20:10:10Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7798470000000002" lon="32.2991694999999979"/>
+    <node visible="true" id="1867810163" timestamp="2012-08-15T20:10:10Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7799719000000001" lon="32.2991643000000010"/>
+    <node visible="true" id="1867810194" timestamp="2012-08-15T20:10:11Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7800452999999998" lon="32.2991732999999996"/>
+    <node visible="true" id="1867810201" timestamp="2012-08-15T20:10:11Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7801095999999998" lon="32.2992042999999995"/>
+    <node visible="true" id="1867810204" timestamp="2012-08-15T20:10:11Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7801160000000000" lon="32.2991178999999988"/>
+    <node visible="true" id="1867810237" timestamp="2012-08-15T20:10:11Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7802049000000002" lon="32.2990999000000016"/>
+    <node visible="true" id="1867810259" timestamp="2012-08-15T20:10:12Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7802435000000001" lon="32.2992480999999998"/>
+    <node visible="true" id="1867810275" timestamp="2012-08-15T20:10:12Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7802999000000002" lon="32.2990697999999981"/>
+    <node visible="true" id="1867810312" timestamp="2019-01-28T10:19:04Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7804228000000002" lon="32.2949970000000022"/>
+    <node visible="true" id="1867810315" timestamp="2012-08-15T20:10:12Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7803998999999999" lon="32.2992647000000019"/>
+    <node visible="true" id="1867810354" timestamp="2012-08-15T20:10:13Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7804836000000002" lon="32.2994342000000003"/>
+    <node visible="true" id="1867810379" timestamp="2012-08-15T20:10:13Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7805268999999999" lon="32.2993086000000034"/>
+    <node visible="true" id="1867810423" timestamp="2012-08-15T20:10:14Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7806180000000000" lon="32.2991037000000034"/>
+    <node visible="true" id="1867810430" timestamp="2012-08-15T20:10:14Z" version="1" changeset="12743616" user="bmog" uid="65432" lat="2.7806544000000000" lon="32.2989906999999974"/>
+    <node visible="true" id="2323064411" timestamp="2015-05-03T08:26:09Z" version="2" changeset="30740772" user="Jotam" uid="768145" lat="2.7796021000000000" lon="32.2975104000000002">
+        <tag k="highway" v="stop"/>
+        <tag k="error:circular" v="15"/>
+    </node>
+    <node visible="true" id="6226381386" timestamp="2019-01-28T12:47:24Z" version="2" changeset="66704798" user="Penobscot" uid="9090196" lat="2.7806321000000001" lon="32.2964679999999973"/>
+    <node visible="true" id="6232990131" timestamp="2019-01-28T11:00:26Z" version="2" changeset="66701775" user="Penobscot" uid="9090196" lat="2.7782746000000000" lon="32.2952543000000034"/>
+    <node visible="true" id="6232990132" timestamp="2019-01-28T10:19:04Z" version="3" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7800589000000002" lon="32.2950719000000035"/>
+    <node visible="true" id="6232990134" timestamp="2019-01-28T10:19:04Z" version="3" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7802772999999998" lon="32.2950398999999990"/>
+    <node visible="true" id="6233141407" timestamp="2019-01-28T10:19:04Z" version="2" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7798927999999998" lon="32.2950967000000020"/>
+    <node visible="true" id="6241408579" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7777877000000002" lon="32.2986841999999967"/>
+    <node visible="true" id="6241408580" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778453000000001" lon="32.2985977000000020"/>
+    <node visible="true" id="6241408581" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7777949999999998" lon="32.2986554000000012"/>
+    <node visible="true" id="6241408582" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778204999999998" lon="32.2986284999999995"/>
+    <node visible="true" id="6241408583" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7777897000000000" lon="32.2987157000000025"/>
+    <node visible="true" id="6241408584" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7778573000000000" lon="32.2985568000000001"/>
+    <node visible="true" id="6241409485" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7784890000000000" lon="32.2971000000000004"/>
+    <node visible="true" id="6241409486" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7774882999999999" lon="32.2996504999999985"/>
+    <node visible="true" id="6241409487" timestamp="2019-01-28T10:19:03Z" version="1" changeset="66700762" user="Penobscot" uid="9090196" lat="2.7773503000000002" lon="32.2995767000000029"/>
+    <node visible="true" id="6241468066" timestamp="2019-01-28T11:00:25Z" version="1" changeset="66701775" user="Penobscot" uid="9090196" lat="2.7768693999999998" lon="32.2972995000000012"/>
+    <node visible="true" id="6241468067" timestamp="2019-01-28T11:00:25Z" version="1" changeset="66701775" user="Penobscot" uid="9090196" lat="2.7785867000000000" lon="32.2952167999999986"/>
+    <node visible="true" id="6241468068" timestamp="2019-01-28T11:00:25Z" version="1" changeset="66701775" user="Penobscot" uid="9090196" lat="2.7788305000000002" lon="32.2951912999999990"/>
+    <node visible="true" id="6241673191" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791429999999999" lon="32.2971079000000003"/>
+    <node visible="true" id="6241673192" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7790412000000000" lon="32.2969257999999968"/>
+    <node visible="true" id="6241673193" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791519999999998" lon="32.2968162000000021"/>
+    <node visible="true" id="6241673194" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7790178999999999" lon="32.2968495000000004"/>
+    <node visible="true" id="6241673195" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7792097999999998" lon="32.2971973000000006"/>
+    <node visible="true" id="6241673196" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791283999999998" lon="32.2972595000000027"/>
+    <node visible="true" id="6241673197" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7788938000000001" lon="32.2970639999999989"/>
+    <node visible="true" id="6241673199" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7788224000000001" lon="32.2970161000000004"/>
+    <node visible="true" id="6241673200" timestamp="2019-06-27T23:56:54Z" version="2" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7788168999999998" lon="32.2971369999999993"/>
+    <node visible="true" id="6241741870" timestamp="2019-01-28T13:25:29Z" version="1" changeset="66706015" user="Penobscot" uid="9090196" lat="2.7795551999999999" lon="32.2988056000000014"/>
+    <node visible="true" id="6241741872" timestamp="2019-01-28T13:25:29Z" version="1" changeset="66706015" user="Penobscot" uid="9090196" lat="2.7791587000000000" lon="32.2985320000000016"/>
+    <node visible="true" id="6241741873" timestamp="2019-01-28T13:25:29Z" version="1" changeset="66706015" user="Penobscot" uid="9090196" lat="2.7791868000000002" lon="32.2984079000000008"/>
+    <node visible="true" id="6575693889" timestamp="2019-06-27T23:56:54Z" version="1" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7795321000000000" lon="32.2975211999999985"/>
+    <node visible="true" id="6575693890" timestamp="2019-06-27T23:56:54Z" version="1" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7795388999999999" lon="32.2976006000000027"/>
+    <node visible="true" id="6575693891" timestamp="2019-06-27T23:56:54Z" version="1" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791562000000001" lon="32.2969123000000025"/>
+    <node visible="true" id="6575693892" timestamp="2019-06-27T23:56:54Z" version="1" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7789229999999998" lon="32.2971379000000027"/>
+    <node visible="true" id="6575693893" timestamp="2019-06-27T23:56:54Z" version="1" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7790672999999999" lon="32.2971781999999976"/>
+    <node visible="true" id="6575693894" timestamp="2019-06-27T23:56:54Z" version="1" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7788973000000001" lon="32.2970238999999992"/>
+    <node visible="true" id="6575693895" timestamp="2019-06-27T23:56:54Z" version="1" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7789940000000000" lon="32.2969281000000024"/>
+    <node visible="true" id="6575693896" timestamp="2019-06-27T23:56:54Z" version="1" changeset="71689516" user="RiverBearings" uid="7774118" lat="2.7791228000000001" lon="32.2969701999999970"/>
+    <way visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="1818542821"/>
+        <nd ref="1866869809"/>
+        <nd ref="-13"/>
+        <tag k="highway" v="residential"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+    </way>
+    <way visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-12"/>
+        <nd ref="1818542813"/>
+        <nd ref="1867809886"/>
+        <nd ref="1818542810"/>
+        <nd ref="1867809882"/>
+        <nd ref="1818542808"/>
+        <nd ref="6241741872"/>
+        <nd ref="1818542809"/>
+        <nd ref="6241741873"/>
+        <nd ref="1818542815"/>
+        <nd ref="1818542817"/>
+        <nd ref="6575693890"/>
+        <nd ref="1818542821"/>
+        <nd ref="6575693889"/>
+        <nd ref="1641684950"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="name" v="Eden Road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+    </way>
+    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-11"/>
+        <nd ref="6241409486"/>
+        <nd ref="1865920156"/>
+        <tag k="highway" v="residential"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T10:19:05Z"/>
+        <tag k="surface" v="ground"/>
+    </way>
+    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="1865920156"/>
+        <nd ref="6241409487"/>
+        <nd ref="1865920154"/>
+        <nd ref="-10"/>
+        <tag k="highway" v="residential"/>
+        <tag k="name" v="Awere Road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T12:47:24Z"/>
+        <tag k="oneway" v="no"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-9"/>
+        <nd ref="1641684833"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="Nimule - Gulu Road"/>
+        <tag k="ref" v="A104"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2020-01-20T16:05:21Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="1818542811"/>
+        <nd ref="1818542816"/>
+        <nd ref="1818542822"/>
+        <nd ref="1818542825"/>
+        <nd ref="6226381386"/>
+        <nd ref="-8"/>
+        <tag k="highway" v="residential"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-22T08:12:42Z"/>
+    </way>
+    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="1655884800"/>
+        <nd ref="6241468066"/>
+        <nd ref="-7"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="Main Street"/>
+        <tag k="ref" v="A104"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2020-01-20T16:05:21Z"/>
+        <tag k="surface" v="paved"/>
+    </way>
+    <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-6"/>
+        <nd ref="1867810312"/>
+        <nd ref="6232990134"/>
+        <nd ref="6232990132"/>
+        <nd ref="6233141407"/>
+        <nd ref="1818542824"/>
+        <nd ref="1641684903"/>
+        <nd ref="6241468068"/>
+        <nd ref="1867809725"/>
+        <nd ref="6241468067"/>
+        <nd ref="6232990131"/>
+        <nd ref="1867808716"/>
+        <nd ref="1641684833"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="Gulu - Kitgum Road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T11:00:26Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="source" v="Bing"/>
+    </way>
+    <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-5"/>
+        <nd ref="1867809787"/>
+        <nd ref="1641684903"/>
+        <tag k="highway" v="residential"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-24T14:32:35Z"/>
+    </way>
+    <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-4"/>
+        <nd ref="1867810430"/>
+        <nd ref="1867810423"/>
+        <tag k="highway" v="residential"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2012-08-15T20:11:11Z"/>
+    </way>
+    <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="1867808716"/>
+        <nd ref="-3"/>
+        <tag k="highway" v="residential"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-24T14:32:35Z"/>
+    </way>
+    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-2"/>
+        <nd ref="1867810379"/>
+        <nd ref="1867810354"/>
+        <tag k="highway" v="residential"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2012-08-15T20:11:05Z"/>
+    </way>
+    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1"/>
+        <nd ref="1867810312"/>
+        <tag k="highway" v="service"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-22T08:12:42Z"/>
+    </way>
+    <way visible="true" id="176031521" timestamp="2015-05-04T09:53:52Z" version="8" changeset="30773664" user="Jotam" uid="768145">
+        <nd ref="1818542795"/>
+        <nd ref="1867808596"/>
+        <nd ref="1655884800"/>
+        <tag k="highway" v="residential"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2015-05-04T09:53:52Z"/>
+        <tag k="surface" v="ground"/>
+    </way>
+    <way visible="true" id="176124934" timestamp="2019-06-27T23:56:54Z" version="5" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1866869806"/>
+        <nd ref="1818542811"/>
+        <nd ref="1641684928"/>
+        <nd ref="1641684803"/>
+        <nd ref="1641684903"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="name" v="Princess Road"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="unpaved"/>
+    </way>
+    <way visible="true" id="176124940" timestamp="2019-06-27T23:56:54Z" version="5" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1866869795"/>
+        <nd ref="1866869791"/>
+        <nd ref="1866869787"/>
+        <nd ref="6575693892"/>
+        <nd ref="1866869783"/>
+        <nd ref="6241673197"/>
+        <nd ref="6575693894"/>
+        <nd ref="1866869782"/>
+        <nd ref="1866869785"/>
+        <nd ref="1866869789"/>
+        <nd ref="6575693895"/>
+        <nd ref="6241673192"/>
+        <nd ref="1866869793"/>
+        <nd ref="6575693896"/>
+        <nd ref="1866869802"/>
+        <nd ref="1866869804"/>
+        <nd ref="1866869805"/>
+        <nd ref="6241673191"/>
+        <nd ref="1866869798"/>
+        <nd ref="6575693893"/>
+        <nd ref="1866869795"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="junction" v="roundabout"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="176124943" timestamp="2019-06-27T23:56:54Z" version="4" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1866869805"/>
+        <nd ref="6241673195"/>
+        <nd ref="1641684950"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="176124944" timestamp="2019-06-27T23:56:54Z" version="5" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1866869787"/>
+        <nd ref="6241673200"/>
+        <nd ref="1866869779"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="176124945" timestamp="2019-06-27T23:56:54Z" version="5" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1866869779"/>
+        <nd ref="6241673199"/>
+        <nd ref="1866869782"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="paved"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="176124946" timestamp="2019-06-27T23:56:54Z" version="4" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1866869789"/>
+        <nd ref="6241673194"/>
+        <nd ref="1866869806"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="176124948" timestamp="2019-06-27T23:56:54Z" version="4" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1641684950"/>
+        <nd ref="6241673196"/>
+        <nd ref="1866869795"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="176124949" timestamp="2019-06-27T23:56:54Z" version="4" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1866869806"/>
+        <nd ref="6241673193"/>
+        <nd ref="6575693891"/>
+        <nd ref="1866869802"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="unpaved"/>
+        <tag k="oneway" v="yes"/>
+        <tag k="source" v="NextView"/>
+    </way>
+    <way visible="true" id="176237124" timestamp="2019-01-28T10:19:04Z" version="2" changeset="66700762" user="Penobscot" uid="9090196">
+        <nd ref="1867808695"/>
+        <nd ref="1867808698"/>
+        <nd ref="1867808684"/>
+        <nd ref="6241408584"/>
+        <nd ref="6241408580"/>
+        <nd ref="6241408582"/>
+        <nd ref="6241408581"/>
+        <nd ref="6241408579"/>
+        <nd ref="6241408583"/>
+        <nd ref="1867808710"/>
+        <nd ref="1867808736"/>
+        <nd ref="1867808817"/>
+        <nd ref="1867808839"/>
+        <nd ref="1867808845"/>
+        <nd ref="1867809646"/>
+        <tag k="highway" v="service"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T10:19:04Z"/>
+    </way>
+    <way visible="true" id="176237126" timestamp="2016-11-07T00:51:47Z" version="2" changeset="43454915" user="Johnwhelan" uid="186592">
+        <nd ref="1867810423"/>
+        <nd ref="1867810379"/>
+        <nd ref="1867810315"/>
+        <nd ref="1867810259"/>
+        <nd ref="1867810201"/>
+        <nd ref="1867810194"/>
+        <nd ref="1867810163"/>
+        <nd ref="1867810133"/>
+        <nd ref="1867810065"/>
+        <nd ref="1867810003"/>
+        <nd ref="1867809913"/>
+        <nd ref="1867809894"/>
+        <nd ref="1867809886"/>
+        <tag k="highway" v="path"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2016-11-07T00:51:47Z"/>
+    </way>
+    <way visible="true" id="176237162" timestamp="2019-01-28T10:19:04Z" version="2" changeset="66700762" user="Penobscot" uid="9090196">
+        <nd ref="1867808596"/>
+        <nd ref="1867808695"/>
+        <tag k="highway" v="service"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T10:19:04Z"/>
+    </way>
+    <way visible="true" id="176237183" timestamp="2019-01-28T10:19:04Z" version="2" changeset="66700762" user="Penobscot" uid="9090196">
+        <nd ref="1867808820"/>
+        <nd ref="1867808889"/>
+        <tag k="highway" v="service"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T10:19:04Z"/>
+    </way>
+    <way visible="true" id="176237239" timestamp="2019-01-28T10:19:05Z" version="3" changeset="66700762" user="Penobscot" uid="9090196">
+        <nd ref="1867808695"/>
+        <nd ref="1867808753"/>
+        <nd ref="1867808834"/>
+        <tag k="highway" v="service"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T10:19:05Z"/>
+    </way>
+    <way visible="true" id="176237251" timestamp="2016-11-07T00:53:50Z" version="2" changeset="43454915" user="Johnwhelan" uid="186592">
+        <nd ref="1867810275"/>
+        <nd ref="1867810237"/>
+        <nd ref="1867810204"/>
+        <nd ref="1867810194"/>
+        <tag k="highway" v="path"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2016-11-07T00:53:50Z"/>
+    </way>
+    <way visible="true" id="176237258" timestamp="2019-01-28T10:19:05Z" version="3" changeset="66700762" user="Penobscot" uid="9090196">
+        <nd ref="6241409485"/>
+        <nd ref="1867809124"/>
+        <nd ref="1867809178"/>
+        <nd ref="1867809276"/>
+        <nd ref="1867809777"/>
+        <tag k="highway" v="path"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T10:19:05Z"/>
+    </way>
+    <way visible="true" id="176237263" timestamp="2019-01-28T10:19:05Z" version="2" changeset="66700762" user="Penobscot" uid="9090196">
+        <nd ref="1867808834"/>
+        <nd ref="1867808767"/>
+        <nd ref="1867808820"/>
+        <tag k="highway" v="service"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T10:19:05Z"/>
+    </way>
+    <way visible="true" id="176237297" timestamp="2019-01-28T13:25:30Z" version="2" changeset="66706015" user="Penobscot" uid="9090196">
+        <nd ref="1867809882"/>
+        <nd ref="1867809896"/>
+        <nd ref="1867809920"/>
+        <nd ref="1867809950"/>
+        <nd ref="1867809968"/>
+        <nd ref="1867810001"/>
+        <nd ref="6241741870"/>
+        <nd ref="1867810040"/>
+        <nd ref="1867810121"/>
+        <tag k="highway" v="service"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-01-28T13:25:30Z"/>
+    </way>
+    <way visible="true" id="176390103" timestamp="2019-06-27T23:56:54Z" version="6" changeset="71689516" user="RiverBearings" uid="7774118">
+        <nd ref="1866869779"/>
+        <nd ref="6241409485"/>
+        <nd ref="1655884800"/>
+        <tag k="highway" v="tertiary"/>
+        <tag k="name" v="Main Street"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2019-06-27T23:56:54Z"/>
+        <tag k="surface" v="paved"/>
+    </way>
+    <way visible="true" id="342708823" timestamp="2020-01-20T16:05:21Z" version="4" changeset="79806055" user="Bert Araali" uid="3302662">
+        <nd ref="1641684833"/>
+        <nd ref="1655884800"/>
+        <tag k="highway" v="primary"/>
+        <tag k="ref" v="A104"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="source:datetime" v="2020-01-20T16:05:21Z"/>
+        <tag k="surface" v="ground"/>
+    </way>
+</osm>

--- a/test-files/cases/attribute/unifying/highway-3784-roundabouts-1/README.txt
+++ b/test-files/cases/attribute/unifying/highway-3784-roundabouts-1/README.txt
@@ -1,0 +1,7 @@
+Test to make sure roundabouts are conflated properly with the Unifying Roads alg. Roundabout removal/replacement is bypassed since we always 
+keep reference geometries with Attribute Conflation. 
+
+TODO: Note that the direction of the roundabout road in the output is incorrect in sections and needs to be fixed. The Network Roads alg 
+version of this test does not have this problem.
+
+


### PR DESCRIPTION
Roundabout handling involving removal/replacement is not needed in Attribute Conflation and has been removed. Prior to this change it would cause portions of reference roads to be dropped in the output.