### PR TITLE
Add '--test-apply' flag to 'changeset-apply' command

### DIFF
--- a/docs/commands/changeset-apply.asciidoc
+++ b/docs/commands/changeset-apply.asciidoc
@@ -18,26 +18,36 @@ represented by a timestamp that intersect with a specified AOI, the command will
                         when writing the changeset directly to an OSM API database
 * +--stats+           - Output statistics (element, node, way, relation, failure, create, modify, and delete counts)
 * +--progress+        - Display progress as a percent complete while the upload is working
+* +--test-apply+      - Run the changeset-apply command but don't actually apply it to an OSM API
 
 === Usage
 
 --------------------------------------
 changeset-apply (changeset.os*) [changeset2.os* ...] (targetUrl) [--stats] [--progress]
+changeset-apply (changeset.os*) (changeset-output-file.osc) --test-apply [--stats] [--progress]
 changeset-apply (changeset.osc.sql) (targetUrl) [conflictAoi] [conflictTimestamp]
 --------------------------------------
 
 ==== Examples
 
 --------------------------------------
+# Apply 'changeset.osc' to 'localhost' using 'username' and 'password'
 hoot changeset-apply changeset.osc http://username:password@localhost/
 
+# Apply 'changeset.osc', 'changeset-001.osc', and 'changeset-002.osc' to 'localhost' using 'username' and 'password'
 hoot changeset-apply changeset.osc changeset-001.osc changeset-002.osc https://username:password@localhost/
 
+# Apply 'sourcedata.osm' as <create> operations to 'localhost' using 'username' and 'password', display stats and progress
 hoot changeset-apply sourcedata.osm http://username:password@localhost/ --stats --progress
 
+# Test apply 'changeset.osc' output each changeset upload to a different file
+hoot changeset-apply changeset.osc ~/changeset-split.osc --test-apply
+
+# Apply SQL file 'changeset.osc.sql' to 'localhost' using 'username' and 'password' to the database `databaseName'
 hoot changeset-apply changeset.osc.sql osmapidb://username:password@localhost:5432/databaseName
 
-hoot changeset-apply changeset.osc.sql osmapidb://username:password@localhost:5432/databaseName -93.89258,40.96917,-93.60583,41.0425 "2016-05-04 10:15:37.000"-93.89258,40.96917,-93.60583,41.0425
+# Apply SQL file 'changeset.osc.sql' to 'localhost' using 'username' and 'password' to the database `databaseName' with conflict AOI and conflict timestamp
+hoot changeset-apply changeset.osc.sql osmapidb://username:password@localhost:5432/databaseName -93.89258,40.96917,-93.60583,41.0425 "2016-05-04 10:15:37.000"
 --------------------------------------
 
 === See Also

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 //  hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTest.cpp
@@ -61,6 +61,7 @@ class OsmApiWriterTest : public HootTestFixture
   CPPUNIT_TEST(runChangesetConflictTest);
   CPPUNIT_TEST(oauthTest);
 #endif
+  CPPUNIT_TEST(runApplyTestTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -383,6 +384,33 @@ public:
 
     writer.apply();
 #endif
+  }
+
+  void runApplyTestTest()
+  {
+    QString toyInputFilename = _inputPath + "ToyTestA.osc";
+    QString toyOutputFilename = _outputPath + "ApplyChangesetTest-Output-1.osc";
+    std::shared_ptr<OsmApiWriter> writer(new OsmApiWriter(toyOutputFilename, toyInputFilename));
+    QStringList files = writer->testApply();
+
+    CPPUNIT_ASSERT_EQUAL(1, files.size());
+    //  Check the changeset error file
+    HOOT_FILE_EQUALS( _inputPath + "ApplyChangesetTest-Expected-1-0001.osc",
+                     files[0]);
+
+    toyOutputFilename = _outputPath + "ApplyChangesetTest-Output-2.osc";
+    writer.reset(new OsmApiWriter(toyOutputFilename, toyInputFilename));
+    Settings s;
+    s.set(ConfigOptions::getChangesetApidbSizeMaxKey(), 20);
+    writer->setConfiguration(s);
+    files = writer->testApply();
+
+    CPPUNIT_ASSERT_EQUAL(2, files.size());
+    //  Check the changeset error file
+    HOOT_FILE_EQUALS( _inputPath + "ApplyChangesetTest-Expected-2-0001.osc",
+                     files[0]);
+    HOOT_FILE_EQUALS( _inputPath + "ApplyChangesetTest-Expected-2-0002.osc",
+                     files[1]);
   }
 
   void checkStats(QList<SingleStat> stats,

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetApplyCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetApplyCmd.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -365,6 +365,41 @@ void XmlChangeset::updateChangeset(const QString &changes)
   }
 }
 
+void XmlChangeset::updateChangeset(const ChangesetInfoPtr& changeset_info)
+{
+  //  Iterate the three changeset type arrays looking for elements to mark
+  for (int current_type = ChangesetType::TypeCreate; current_type != ChangesetType::TypeMax; ++current_type)
+  {
+    //  Set the relation's status to failed
+    for (ChangesetInfo::iterator it = changeset_info->begin(ElementType::Relation, (ChangesetType)current_type);
+         it != changeset_info->end(ElementType::Relation, (ChangesetType)current_type); ++it)
+    {
+      //  Finalize the relation
+      _allRelations[*it]->setStatus(ChangesetElement::ElementStatus::Finalized);
+      //  Update the processed count
+      _processedCount++;
+    }
+    //  Set the way's status to failed
+    for (ChangesetInfo::iterator it = changeset_info->begin(ElementType::Way, (ChangesetType)current_type);
+         it != changeset_info->end(ElementType::Way, (ChangesetType)current_type); ++it)
+    {
+      //  Finalize the way
+      _allWays[*it]->setStatus(ChangesetElement::ElementStatus::Finalized);
+      //  Update the processed count
+      _processedCount++;
+    }
+    //  Set the node's status to failed
+    for (ChangesetInfo::iterator it = changeset_info->begin(ElementType::Node, (ChangesetType)current_type);
+         it != changeset_info->end(ElementType::Node, (ChangesetType)current_type); ++it)
+    {
+      //  Finalize the node
+      _allNodes[*it]->setStatus(ChangesetElement::ElementStatus::Finalized);
+      //  Update the processed count
+      _processedCount++;
+    }
+  }
+}
+
 bool XmlChangeset::fixChangeset(const QString& update)
 {
   /* <osm>

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -85,6 +85,11 @@ public:
    */
   void updateChangeset(const QString& changes);
   /**
+   * @brief updateChangeset Update the changeset setting all elements to "uploaded" for the apply test scenario
+   * @param changeset_info - Pointer to the changeset info object
+   */
+  void updateChangeset(const ChangesetInfoPtr& changeset_info);
+  /**
    * @brief fixChangeset Update the underlying element to fix changeset upload errors
    * @param update - OSM XML from OSM API to fix changeset errors
    * @return True if a change was made to fix the changeset

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
@@ -55,6 +55,48 @@ const char* OsmApiWriter::API_PATH_CLOSE_CHANGESET = "/api/0.6/changeset/%1/clos
 const char* OsmApiWriter::API_PATH_UPLOAD_CHANGESET = "/api/0.6/changeset/%1/upload";
 const char* OsmApiWriter::API_PATH_GET_ELEMENT = "/api/0.6/%1/%2";
 
+const char* OsmApiWriter::CONTENT_TYPE_XML = "text/xml; charset=UTF-8";
+
+OsmApiWriter::OsmApiWriter(const QString& output_file, const QList<QString>& changesets)
+  : _changesets(changesets),
+    _description(ConfigOptions().getChangesetDescription()),
+    _source(ConfigOptions().getChangesetSource()),
+    _hashtags(ConfigOptions().getChangesetHashtags()),
+    _maxWriters(1),           //  Not used in test apply
+    _maxPushSize(ConfigOptions().getChangesetApidbSizeMax()),
+    _maxChangesetSize(ConfigOptions().getChangesetMaxSize()),
+    _throttleWriters(false),  //  Not used in test apply
+    _throttleTime(0),         //  Not used in test apply
+    _showProgress(false),
+    _consumerKey(""),         //  Not used in test apply
+    _consumerSecret(""),      //  Not used in test apply
+    _accessToken(""),         //  Not used in test apply
+    _secretToken(""),         //  Not used in test apply
+    _changesetCount(0),
+    _testApplyPathname(output_file)
+{
+}
+
+OsmApiWriter::OsmApiWriter(const QString& output_file, const QString& changeset)
+  : _description(ConfigOptions().getChangesetDescription()),
+    _source(ConfigOptions().getChangesetSource()),
+    _hashtags(ConfigOptions().getChangesetHashtags()),
+    _maxWriters(1),           //  Not used in test apply
+    _maxPushSize(ConfigOptions().getChangesetApidbSizeMax()),
+    _maxChangesetSize(ConfigOptions().getChangesetMaxSize()),
+    _throttleWriters(false),  //  Not used in test apply
+    _throttleTime(0),         //  Not used in test apply
+    _showProgress(false),
+    _consumerKey(""),         //  Not used in test apply
+    _consumerSecret(""),      //  Not used in test apply
+    _accessToken(""),         //  Not used in test apply
+    _secretToken(""),         //  Not used in test apply
+    _changesetCount(0),
+    _testApplyPathname(output_file)
+{
+  _changesets.push_back(changeset);
+}
+
 OsmApiWriter::OsmApiWriter(const QUrl &url, const QString &changeset)
   : _description(ConfigOptions().getChangesetDescription()),
     _source(ConfigOptions().getChangesetSource()),
@@ -69,7 +111,8 @@ OsmApiWriter::OsmApiWriter(const QUrl &url, const QString &changeset)
     _consumerSecret(ConfigOptions().getHootOsmAuthConsumerSecret()),
     _accessToken(ConfigOptions().getHootOsmAuthAccessToken()),
     _secretToken(ConfigOptions().getHootOsmAuthAccessTokenSecret()),
-    _changesetCount(0)
+    _changesetCount(0),
+    _testApplyPathname("")
 {
   _changesets.push_back(changeset);
   if (isSupported(url))
@@ -91,7 +134,8 @@ OsmApiWriter::OsmApiWriter(const QUrl& url, const QList<QString>& changesets)
     _consumerSecret(ConfigOptions().getHootOsmAuthConsumerSecret()),
     _accessToken(ConfigOptions().getHootOsmAuthAccessToken()),
     _secretToken(ConfigOptions().getHootOsmAuthAccessTokenSecret()),
-    _changesetCount(0)
+    _changesetCount(0),
+    _testApplyPathname("")
 {
   if (isSupported(url))
     _url = url;
@@ -234,6 +278,85 @@ bool OsmApiWriter::apply()
   _stats.append(SingleStat("Total Errors", _changeset.getFailedCount()));
   //  Return successfully
   return success;
+}
+
+QStringList OsmApiWriter::testApply()
+{
+  Timer timer;
+  QStringList output_paths;
+  //  Load all of the changesets into memory
+  _changeset.setMaxPushSize(_maxPushSize);
+  for (int i = 0; i < _changesets.size(); ++i)
+  {
+    LOG_INFO("Loading changeset: " << _changesets[i]);
+    _changeset.loadChangeset(_changesets[i]);
+    _stats.append(SingleStat(QString("Changeset (%1) Load Time (sec)").arg(_changesets[i]), timer.getElapsedAndRestart()));
+  }
+  //  Split any ways that need splitting
+  _changeset.splitLongWays(_capabilities.getWayNodes());
+  //  Setup the progress indicators
+  long total = _changeset.getTotalElementCount();
+  float progress = 0.0f;
+  float increment = 0.01f;
+  long id = 1;
+  long changesetSize = 0;
+  int file_id = 1;
+  //  Setup the increment
+  if (total < 10000)
+    increment = 0.1f;
+  else if (total < 100000)
+    increment = 0.05f;
+  QFileInfo file(_testApplyPathname);
+  //  Iterate all changes until there are no more elements to send
+  while (_changeset.hasElementsToSend())
+  {
+    //  Divide up the changes into atomic changesets
+    ChangesetInfoPtr changeset_info(new ChangesetInfo());
+    //  Repeat divide until all changes have been committed
+    _changeset.calculateChangeset(changeset_info);
+    //  Write out the changeset to disk
+    changesetSize += changeset_info->size();
+    //  Write out the changeset file
+    QString output = QString("%1/%2-%3.%4")
+        .arg(file.absolutePath())
+        .arg(file.baseName())
+        .arg(QString::number(file_id), 4, '0')
+        .arg(file.completeSuffix());
+    FileUtils::writeFully(output, _changeset.getChangesetString(changeset_info, id));
+    _changeset.updateChangeset(changeset_info);
+    changesetSize += changeset_info->size();
+    //  Keep the output pathname
+    output_paths.push_back(output);
+    //  When the current changeset is nearing the 50k max (or the specified max), close the changeset
+    //  otherwise keep it open and go again
+    if (changesetSize > _maxChangesetSize - (int)(_maxPushSize * 1.5))
+      id++;
+    //  Show the progress
+    if (_showProgress)
+    {
+      float percent_complete = _changeset.getProcessedCount() / (float)total;
+      //  Actual progress is calculated and once it passes the next increment it is reported
+      if (percent_complete >= progress + increment)
+      {
+        progress = percent_complete - fmod(percent_complete, increment);
+        _progress.set(percent_complete, "Apply changeset test...");
+      }
+    }
+    file_id++;
+  }
+  LOG_INFO("Apply test progress: 100%");
+  //  Keep some stats
+  _stats.append(SingleStat("API Upload Time (sec)", timer.getElapsedAndRestart()));
+  _stats.append(SingleStat("Total OSM Changesets Uploaded", _changesetCount));
+  _stats.append(SingleStat("Total Nodes in Changeset", _changeset.getTotalNodeCount()));
+  _stats.append(SingleStat("Total Ways in Changeset", _changeset.getTotalWayCount()));
+  _stats.append(SingleStat("Total Relations in Changeset", _changeset.getTotalRelationCount()));
+  _stats.append(SingleStat("Total Elements Created", _changeset.getTotalCreateCount()));
+  _stats.append(SingleStat("Total Elements Modified", _changeset.getTotalModifyCount()));
+  _stats.append(SingleStat("Total Elements Deleted", _changeset.getTotalDeleteCount()));
+  _stats.append(SingleStat("Total Errors", _changeset.getFailedCount()));
+  //  Return the output paths
+  return output_paths;
 }
 
 void OsmApiWriter::_changesetThreadFunc(int index)
@@ -602,7 +725,12 @@ long OsmApiWriter::_createChangeset(HootNetworkRequestPtr request,
       "  </changeset>"
       "</osm>").arg(HOOT_NAME).arg(description).arg(source).arg(hashtags);
 
-    request->networkRequest(changeset, QNetworkAccessManager::Operation::PutOperation, xml.toUtf8());
+    QByteArray content = xml.toUtf8();
+    QMap<QNetworkRequest::KnownHeaders, QVariant> headers;
+    headers[QNetworkRequest::ContentTypeHeader] = CONTENT_TYPE_XML;
+    headers[QNetworkRequest::ContentLengthHeader] = content.length();
+
+    request->networkRequest(changeset, QNetworkAccessManager::Operation::PutOperation, content);
 
     QString responseXml = QString::fromUtf8(request->getResponseContent().data());
 
@@ -682,10 +810,12 @@ OsmApiWriter::OsmApiFailureInfoPtr OsmApiWriter::_uploadChangeset(HootNetworkReq
     QUrl change = _url;
     change.setPath(QString(API_PATH_UPLOAD_CHANGESET).arg(id));
 
+    QByteArray content = changeset.toUtf8();
     QMap<QNetworkRequest::KnownHeaders, QVariant> headers;
-    headers[QNetworkRequest::ContentTypeHeader] = "text/xml";
+    headers[QNetworkRequest::ContentTypeHeader] = CONTENT_TYPE_XML;
+    headers[QNetworkRequest::ContentLengthHeader] = content.length();
 
-    request->networkRequest(change, headers, QNetworkAccessManager::Operation::PostOperation, changeset.toUtf8());
+    request->networkRequest(change, headers, QNetworkAccessManager::Operation::PostOperation, content);
 
     info->response = QString::fromUtf8(request->getResponseContent().data());
     info->status = request->getHttpStatus();

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -62,12 +62,19 @@ public:
   const static char* API_PATH_CLOSE_CHANGESET;
   const static char* API_PATH_UPLOAD_CHANGESET;
   const static char* API_PATH_GET_ELEMENT;
+  /** Default content type */
+  const static char* CONTENT_TYPE_XML;
   /**
    *  Max number of jobs waiting in the work queue = multiplier * number of threads,
    *  this keeps the producer thread from creating too many sub-changesets too early
    *  that only consist of nodes after ways are blocked.
    */
   const int QUEUE_SIZE_MULTIPLIER = 2;
+  /** Constructor with one or multiple files consisting of one large changeset to run
+   *  the test apply
+   */
+  OsmApiWriter(const QString& output_file, const QString& changeset);
+  OsmApiWriter(const QString& output_file, const QList<QString>& changesets);
   /** Constructors with one or multiple files consisting of one large changeset */
   OsmApiWriter(const QUrl& url, const QString& changeset);
   OsmApiWriter(const QUrl& url, const QList<QString>& changesets);
@@ -87,6 +94,11 @@ public:
    * @return success
    */
   bool apply();
+  /**
+   * @brief testApply Actually load, divide, and write the changesets to files instead of OSM API
+   * @return list of filepaths for output files
+   */
+  QStringList testApply();
   /**
    * @brief containsFailed
    * @return true if there are failed changes in the changeset
@@ -330,6 +342,8 @@ private:
   int _changesetCount;
   /** Mutex for changeset count */
   std::mutex _changesetCountMutex;
+  /** Full pathname of the output file created during --test-apply */
+  QString _testApplyPathname;
   /** For white box testing */
   friend class OsmApiWriterTest;
   /** Default constructor for testing purposes only */

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,8 @@ sonar.github.repository=ngageoint/hootenanny
 sonar.host.url=https://sonarcloud.io
 sonar.sources=./hoot-core/src/main,./hoot-js/src/main,./hoot-rnd/src/main,./tbs/src/main,./tgs/src/main
 sonar.issue.ignore.multicriteria=cout1,cout2,cout3,cout4,cout5,cout6,cout7,protected1,undef1,empty1,explicit1,override1,ruleOf5,floatcounter,commentedCode,singleDeclaration,literalSuffix,generalCatch,macroParenthesis,misraMacro,cognitiveComplexity
+# Remove the "Incremental analysis cache" warning
+sonar.cfamily.cache.enabled=false
 
 # Only the command, test, and selected other classes should output to standard out
 sonar.issue.ignore.multicriteria.cout1.ruleKey=cpp:S106

--- a/test-files/io/OsmChangesetElementTest/ApplyChangesetTest-Expected-1-0001.osc
+++ b/test-files/io/OsmChangesetElementTest/ApplyChangesetTest-Expected-1-0001.osc
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<create>
+		<node id="-1" version="0" lat="38.8549321261880536" lon="-104.8979050333482093" timestamp="" changeset="1"/>
+		<node id="-2" version="0" lat="38.8549524185660573" lon="-104.8987388916486054" timestamp="" changeset="1"/>
+		<node id="-3" version="0" lat="38.8540541370891077" lon="-104.9024316099691276" timestamp="" changeset="1"/>
+		<node id="-4" version="0" lat="38.8541298962059614" lon="-104.9023065312240703" timestamp="" changeset="1"/>
+		<node id="-5" version="0" lat="38.8543319201230304" lon="-104.9017876860593788" timestamp="" changeset="1"/>
+		<node id="-6" version="0" lat="38.8548207434768855" lon="-104.9008079025564655" timestamp="" changeset="1"/>
+		<node id="-7" version="0" lat="38.8549289695954272" lon="-104.9005253172435630" timestamp="" changeset="1"/>
+		<node id="-8" version="0" lat="38.8548514075605240" lon="-104.9005693264316363" timestamp="" changeset="1"/>
+		<node id="-9" version="0" lat="38.8549073243849037" lon="-104.8961823052623856" timestamp="" changeset="1"/>
+		<node id="-10" version="0" lat="38.8549019130812496" lon="-104.8964394115716487" timestamp="" changeset="1"/>
+		<node id="-11" version="0" lat="38.8548604264061623" lon="-104.8968586569948798" timestamp="" changeset="1"/>
+		<node id="-12" version="0" lat="38.8547197322843374" lon="-104.8973219116062410" timestamp="" changeset="1"/>
+		<node id="-13" version="0" lat="38.8546042907457476" lon="-104.8977759011253141" timestamp="" changeset="1"/>
+		<node id="-14" version="0" lat="38.8544293243065937" lon="-104.8980654352573794" timestamp="" changeset="1"/>
+		<node id="-15" version="0" lat="38.8542327120211866" lon="-104.8983109602013855" timestamp="" changeset="1"/>
+		<node id="-16" version="0" lat="38.8541767946664436" lon="-104.8987070428940598" timestamp="" changeset="1"/>
+		<node id="-17" version="0" lat="38.8541335037809361" lon="-104.8988900284655159" timestamp="" changeset="1"/>
+		<node id="-18" version="0" lat="38.8539585361836473" lon="-104.8989155074691695" timestamp="" changeset="1"/>
+		<node id="-19" version="0" lat="38.8537204352567329" lon="-104.8987232568054679" timestamp="" changeset="1"/>
+		<node id="-20" version="0" lat="38.8536194225014810" lon="-104.8987070428940598" timestamp="" changeset="1"/>
+		<node id="-21" version="0" lat="38.8535508780501431" lon="-104.8988321216391171" timestamp="" changeset="1"/>
+		<node id="-22" version="0" lat="38.8535689160700528" lon="-104.8990568001256065" timestamp="" changeset="1"/>
+		<node id="-23" version="0" lat="38.8535166057996975" lon="-104.8992698972467963" timestamp="" changeset="1"/>
+		<node id="-24" version="0" lat="38.8533470481072030" lon="-104.8993671807151884" timestamp="" changeset="1"/>
+		<node id="-25" version="0" lat="38.8533001490996028" lon="-104.8994528828182951" timestamp="" changeset="1"/>
+		<node id="-26" version="0" lat="38.8532424272016641" lon="-104.8996868263970015" timestamp="" changeset="1"/>
+		<node id="-27" version="0" lat="38.8532583477841484" lon="-104.8997542928851772" timestamp="" changeset="1"/>
+		<node id="-28" version="0" lat="38.8536248456666229" lon="-104.8996934957527998" timestamp="" changeset="1"/>
+		<node id="-29" version="0" lat="38.8539525522998730" lon="-104.8996840393162842" timestamp="" changeset="1"/>
+		<node id="-30" version="0" lat="38.8542618470630714" lon="-104.8997171368440888" timestamp="" changeset="1"/>
+		<node id="-31" version="0" lat="38.8545785045938388" lon="-104.8997171368440888" timestamp="" changeset="1"/>
+		<node id="-32" version="0" lat="38.8549614373988845" lon="-104.8997124086258452" timestamp="" changeset="1"/>
+		<node id="-33" version="0" lat="38.8542599687747341" lon="-104.9005795104799432" timestamp="" changeset="1"/>
+		<node id="-34" version="0" lat="38.8542471187715179" lon="-104.9010788637033329" timestamp="" changeset="1"/>
+		<node id="-35" version="0" lat="38.8540851073630833" lon="-104.9014476647277121" timestamp="" changeset="1"/>
+		<node id="-36" version="0" lat="38.8541670018907581" lon="-104.8997069874790355" timestamp="" changeset="1"/>
+		<way id="-1" version="0" timestamp="" changeset="1">
+			<nd ref="-32"/>
+			<nd ref="-2"/>
+			<nd ref="-1"/>
+			<tag k="note" v="1"/>
+			<tag k="highway" v="road"/>
+		</way>
+		<way id="-2" version="0" timestamp="" changeset="1">
+			<nd ref="-33"/>
+			<nd ref="-8"/>
+			<nd ref="-7"/>
+			<tag k="note" v="3"/>
+			<tag k="highway" v="road"/>
+		</way>
+		<way id="-3" version="0" timestamp="" changeset="1">
+			<nd ref="-3"/>
+			<nd ref="-4"/>
+			<nd ref="-5"/>
+			<nd ref="-6"/>
+			<nd ref="-7"/>
+			<nd ref="-32"/>
+			<nd ref="-31"/>
+			<nd ref="-30"/>
+			<nd ref="-36"/>
+			<nd ref="-29"/>
+			<nd ref="-28"/>
+			<nd ref="-27"/>
+			<nd ref="-26"/>
+			<nd ref="-25"/>
+			<nd ref="-24"/>
+			<nd ref="-23"/>
+			<nd ref="-22"/>
+			<nd ref="-21"/>
+			<nd ref="-20"/>
+			<nd ref="-19"/>
+			<nd ref="-18"/>
+			<nd ref="-17"/>
+			<nd ref="-16"/>
+			<nd ref="-15"/>
+			<nd ref="-14"/>
+			<nd ref="-13"/>
+			<nd ref="-12"/>
+			<nd ref="-11"/>
+			<nd ref="-10"/>
+			<nd ref="-9"/>
+			<tag k="note" v="0"/>
+			<tag k="highway" v="road"/>
+		</way>
+		<way id="-4" version="0" timestamp="" changeset="1">
+			<nd ref="-35"/>
+			<nd ref="-34"/>
+			<nd ref="-33"/>
+			<nd ref="-30"/>
+			<tag k="note" v="2"/>
+			<tag k="highway" v="road"/>
+		</way>
+	</create>
+</osmChange>

--- a/test-files/io/OsmChangesetElementTest/ApplyChangesetTest-Expected-2-0001.osc
+++ b/test-files/io/OsmChangesetElementTest/ApplyChangesetTest-Expected-2-0001.osc
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<create>
+		<node id="-1" version="0" lat="38.8549321261880536" lon="-104.8979050333482093" timestamp="" changeset="1"/>
+		<node id="-2" version="0" lat="38.8549524185660573" lon="-104.8987388916486054" timestamp="" changeset="1"/>
+		<node id="-3" version="0" lat="38.8540541370891077" lon="-104.9024316099691276" timestamp="" changeset="1"/>
+		<node id="-4" version="0" lat="38.8541298962059614" lon="-104.9023065312240703" timestamp="" changeset="1"/>
+		<node id="-5" version="0" lat="38.8543319201230304" lon="-104.9017876860593788" timestamp="" changeset="1"/>
+		<node id="-6" version="0" lat="38.8548207434768855" lon="-104.9008079025564655" timestamp="" changeset="1"/>
+		<node id="-7" version="0" lat="38.8549289695954272" lon="-104.9005253172435630" timestamp="" changeset="1"/>
+		<node id="-8" version="0" lat="38.8548514075605240" lon="-104.9005693264316363" timestamp="" changeset="1"/>
+		<node id="-9" version="0" lat="38.8549073243849037" lon="-104.8961823052623856" timestamp="" changeset="1"/>
+		<node id="-10" version="0" lat="38.8549019130812496" lon="-104.8964394115716487" timestamp="" changeset="1"/>
+		<node id="-11" version="0" lat="38.8548604264061623" lon="-104.8968586569948798" timestamp="" changeset="1"/>
+		<node id="-12" version="0" lat="38.8547197322843374" lon="-104.8973219116062410" timestamp="" changeset="1"/>
+		<node id="-13" version="0" lat="38.8546042907457476" lon="-104.8977759011253141" timestamp="" changeset="1"/>
+		<node id="-14" version="0" lat="38.8544293243065937" lon="-104.8980654352573794" timestamp="" changeset="1"/>
+		<node id="-15" version="0" lat="38.8542327120211866" lon="-104.8983109602013855" timestamp="" changeset="1"/>
+		<node id="-16" version="0" lat="38.8541767946664436" lon="-104.8987070428940598" timestamp="" changeset="1"/>
+		<node id="-17" version="0" lat="38.8541335037809361" lon="-104.8988900284655159" timestamp="" changeset="1"/>
+		<node id="-18" version="0" lat="38.8539585361836473" lon="-104.8989155074691695" timestamp="" changeset="1"/>
+		<node id="-19" version="0" lat="38.8537204352567329" lon="-104.8987232568054679" timestamp="" changeset="1"/>
+		<node id="-20" version="0" lat="38.8536194225014810" lon="-104.8987070428940598" timestamp="" changeset="1"/>
+		<node id="-21" version="0" lat="38.8535508780501431" lon="-104.8988321216391171" timestamp="" changeset="1"/>
+		<node id="-22" version="0" lat="38.8535689160700528" lon="-104.8990568001256065" timestamp="" changeset="1"/>
+		<node id="-23" version="0" lat="38.8535166057996975" lon="-104.8992698972467963" timestamp="" changeset="1"/>
+		<node id="-24" version="0" lat="38.8533470481072030" lon="-104.8993671807151884" timestamp="" changeset="1"/>
+		<node id="-25" version="0" lat="38.8533001490996028" lon="-104.8994528828182951" timestamp="" changeset="1"/>
+		<node id="-26" version="0" lat="38.8532424272016641" lon="-104.8996868263970015" timestamp="" changeset="1"/>
+		<node id="-27" version="0" lat="38.8532583477841484" lon="-104.8997542928851772" timestamp="" changeset="1"/>
+		<node id="-28" version="0" lat="38.8536248456666229" lon="-104.8996934957527998" timestamp="" changeset="1"/>
+		<node id="-29" version="0" lat="38.8539525522998730" lon="-104.8996840393162842" timestamp="" changeset="1"/>
+		<node id="-30" version="0" lat="38.8542618470630714" lon="-104.8997171368440888" timestamp="" changeset="1"/>
+		<node id="-31" version="0" lat="38.8545785045938388" lon="-104.8997171368440888" timestamp="" changeset="1"/>
+		<node id="-32" version="0" lat="38.8549614373988845" lon="-104.8997124086258452" timestamp="" changeset="1"/>
+		<node id="-33" version="0" lat="38.8542599687747341" lon="-104.9005795104799432" timestamp="" changeset="1"/>
+		<node id="-36" version="0" lat="38.8541670018907581" lon="-104.8997069874790355" timestamp="" changeset="1"/>
+		<way id="-1" version="0" timestamp="" changeset="1">
+			<nd ref="-32"/>
+			<nd ref="-2"/>
+			<nd ref="-1"/>
+			<tag k="note" v="1"/>
+			<tag k="highway" v="road"/>
+		</way>
+		<way id="-2" version="0" timestamp="" changeset="1">
+			<nd ref="-33"/>
+			<nd ref="-8"/>
+			<nd ref="-7"/>
+			<tag k="note" v="3"/>
+			<tag k="highway" v="road"/>
+		</way>
+		<way id="-3" version="0" timestamp="" changeset="1">
+			<nd ref="-3"/>
+			<nd ref="-4"/>
+			<nd ref="-5"/>
+			<nd ref="-6"/>
+			<nd ref="-7"/>
+			<nd ref="-32"/>
+			<nd ref="-31"/>
+			<nd ref="-30"/>
+			<nd ref="-36"/>
+			<nd ref="-29"/>
+			<nd ref="-28"/>
+			<nd ref="-27"/>
+			<nd ref="-26"/>
+			<nd ref="-25"/>
+			<nd ref="-24"/>
+			<nd ref="-23"/>
+			<nd ref="-22"/>
+			<nd ref="-21"/>
+			<nd ref="-20"/>
+			<nd ref="-19"/>
+			<nd ref="-18"/>
+			<nd ref="-17"/>
+			<nd ref="-16"/>
+			<nd ref="-15"/>
+			<nd ref="-14"/>
+			<nd ref="-13"/>
+			<nd ref="-12"/>
+			<nd ref="-11"/>
+			<nd ref="-10"/>
+			<nd ref="-9"/>
+			<tag k="note" v="0"/>
+			<tag k="highway" v="road"/>
+		</way>
+	</create>
+</osmChange>

--- a/test-files/io/OsmChangesetElementTest/ApplyChangesetTest-Expected-2-0002.osc
+++ b/test-files/io/OsmChangesetElementTest/ApplyChangesetTest-Expected-2-0002.osc
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<create>
+		<node id="-34" version="0" lat="38.8542471187715179" lon="-104.9010788637033329" timestamp="" changeset="1"/>
+		<node id="-35" version="0" lat="38.8540851073630833" lon="-104.9014476647277121" timestamp="" changeset="1"/>
+		<way id="-4" version="0" timestamp="" changeset="1">
+			<nd ref="-35"/>
+			<nd ref="-34"/>
+			<nd ref="-33"/>
+			<nd ref="-30"/>
+			<tag k="note" v="2"/>
+			<tag k="highway" v="road"/>
+		</way>
+	</create>
+</osmChange>


### PR DESCRIPTION
The `--test-apply` flag creates apply `.osc` files for each communication to the server that the `changeset-apply` would send.  These are for debugging purposes only because the files cannot be applied to the API by themselves.  Updated documentation and unit tests.

Bonus addition:  SonarCloud has a warning displayed for cached elements.  Turn off that option to make the warning go away since it isn't needed.

![image](https://user-images.githubusercontent.com/13385275/74193112-6d041200-4c1c-11ea-85ac-0da778af33c7.png)
