### PR TITLE
fix bug where jobs with legit error were still getting marked success

### DIFF
--- a/hoot-services/src/main/java/hoot/services/job/JobRunnable.java
+++ b/hoot-services/src/main/java/hoot/services/job/JobRunnable.java
@@ -81,7 +81,8 @@ class JobRunnable implements Runnable {
                 CommandResult result = command.execute();
 
                 if (result.failed()) {
-                    if (JobStatus.FAILED.equals(jobStatusManager.getJobStatusObj(job.getJobId()).getStatus())) {
+                    //Cancelled jobs also have non-zero exit code, but should not be marked FAILED
+                    if (!JobStatus.CANCELLED.equals(jobStatusManager.getJobStatusObj(job.getJobId()).getStatus())) {
                         jobStatusManager.setFailed(job.getJobId(), "Command with ID = " + result.getId() + " caused the failure.");
                     }
                     break;


### PR DESCRIPTION
introduced when making sure cancelled jobs didn't call setFailed()
because exit codes are also non-zero