### PR TITLE
reduce core test parallel

### DIFF
--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -125,7 +125,7 @@ pipeline {
         stage("Core Tests") {
             when { expression { return params.Core_tests } }
             steps {
-                sh "vagrant ssh ${params.Box} -c 'cd hoot; source ./SetupEnv.sh; hoot version --debug; bin/HootTest --diff --glacial --parallel'"
+                sh "vagrant ssh ${params.Box} -c 'cd hoot; source ./SetupEnv.sh; hoot version --debug; bin/HootTest --diff --glacial --parallel 6'"
             }
         }
         stage("Services Tests") {


### PR DESCRIPTION
The core tests have been going deep into swap and slowing down unnecessarily for some time and recently running out of memory periodically. Some of the tests require extra memory now and the overall memory will have to be increased on the test vm to run in full parallel. This solves the issue for now.