### PR TITLE
3805 - Don't calc tag diff when not running Differential Conflation w/ Tags

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
@@ -171,11 +171,14 @@ void DiffConflator::apply(OsmMapPtr& map)
 
   currentStep++;
 
-  // Use matches to calculate and store tag diff. We must do this before we create the map diff,
-  // because that operation deletes all of the info needed for calculating the tag diff.
-  _updateProgress(currentStep - 1, "Storing tag differentials...");
-  _calcAndStoreTagChanges();
-  currentStep++;
+  if (_conflateTags)
+  {
+    // Use matches to calculate and store tag diff. We must do this before we create the map diff,
+    // because that operation deletes all of the info needed for calculating the tag diff.
+    _updateProgress(currentStep - 1, "Storing tag differentials...");
+    _calcAndStoreTagChanges();
+    currentStep++;
+  }
 
   QString message = "Dropping match conflicts";
   if (ConfigOptions().getDifferentialSnapUnconnectedRoads())

--- a/test-files/cmd/slow/serial/ServiceDiffNetworkRoadSnapTest.sh.stdout
+++ b/test-files/cmd/slow/serial/ServiceDiffNetworkRoadSnapTest.sh.stdout
@@ -4,7 +4,7 @@
 (1 row)
 
 Changeset(s) Created: 1
-Changeset Details: min_lat=15.3478248, max_lat=15.3529463, min_lon=38.9427886, max_lon=38.9472101, num_changes=541
+Changeset Details: min_lat=15.3478249, max_lat=15.3529463, min_lon=38.9427886, max_lon=38.9472101, num_changes=541
 Node(s) Created: 440
 Node(s) Modified: 7
 Node(s) Deleted: 0


### PR DESCRIPTION
Bug where tag diff was being calculated regardless. This change will save a ton of runtime on very large jobs running Diff w/o tags.

merge after #3810