### PR TITLE
Make SuperfluousNodeRemover handle nodes in relations correctly

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/ops/SuperfluousNodeRemover.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/SuperfluousNodeRemover.cpp
@@ -59,6 +59,21 @@ void SuperfluousNodeRemover::apply(std::shared_ptr<OsmMap>& map)
   _numAffected = 0;
   _usedNodes.clear();
 
+  const RelationMap& relations = map->getRelations();
+  for (RelationMap::const_iterator it = relations.begin(); it != relations.end(); ++it)
+  {
+    ConstRelationPtr relation = it->second;
+    const vector<RelationData::Entry>& members = relation->getMembers();
+    for (size_t i = 0; i < members.size(); i++)
+    {
+      const RelationData::Entry member = members[i];
+      if (member.getElementId().getType() == ElementType::Node)
+      {
+        _usedNodes.insert(member.getElementId().getId());
+      }
+    }
+  }
+
   const WayMap& ways = map->getWays();
   for (WayMap::const_iterator it = ways.begin(); it != ways.end(); ++it)
   {

--- a/hoot-core/src/main/cpp/hoot/core/ops/SuperfluousNodeRemover.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/SuperfluousNodeRemover.h
@@ -46,7 +46,8 @@ namespace hoot
 class OsmMap;
 
 /**
- * Removes all the nodes from a map that aren't part of a way and have no information in them.
+ * Removes all the nodes from a map that aren't part of a way or a relation and have no information
+ * in them.
  *
  * If the bounds have been set via Boundable's setBounds then only nodes that are both not part
  * of a way and inside the bounds will be removed. This is most useful when performing tile based


### PR DESCRIPTION
Prior to this change `SuperfluousNodeRemover` was only checking for node way membership during removal.