### PR TITLE
Add 'diff' option for changeset apply debug output

### DIFF
--- a/docs/commands/diff.asciidoc
+++ b/docs/commands/diff.asciidoc
@@ -4,7 +4,8 @@
 === Description
 
 The +diff+ command checks to see if maps are essentially the same. It returns 0 if they are the same or 1 if they differ
-significantly. If they differ significantly, warnings will be printed with more information.
+significantly. If they differ significantly, warnings will be printed with more information.  Can also compare .osc changeset
+files and directories.  Directories will load into on `<osmChange>` file to be compared to the other file/directory.
 
 * +input1+          - Input 1; may be any supported input format (e.g. OSM file).
 * +intpu2+          - Input 2; may be any supported input format (e.g. OSM file).

--- a/hoot-core/src/main/cpp/hoot/core/cmd/DiffCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/DiffCmd.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core/src/main/cpp/hoot/core/cmd/DiffCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/DiffCmd.cpp
@@ -26,16 +26,20 @@
  */
 
 // Hoot
-#include <hoot/core/util/Factory.h>
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/cmd/BaseCommand.h>
-#include <hoot/core/scoring/MapComparator.h>
-#include <hoot/core/util/Settings.h>
 #include <hoot/core/elements/OsmMap.h>
-#include <hoot/core/util/Log.h>
 #include <hoot/core/io/IoUtils.h>
+#include <hoot/core/io/OsmApiChangeset.h>
+#include <hoot/core/scoring/MapComparator.h>
+#include <hoot/core/util/Factory.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
+#include <hoot/core/util/Settings.h>
 
 using namespace std;
+
+#include <QDir>
+#include <QFileInfo>
 
 namespace hoot
 {
@@ -51,36 +55,39 @@ public:
   virtual QString getName() const override { return "diff"; }
 
   virtual QString getDescription() const override
-  { return "Calculates the difference between two maps"; }
+  { return "Calculates the difference between two maps or changesets"; }
 
   virtual int runSimple(QStringList& args) override
   {
-    MapComparator mapCompare;
+    bool ignoreUuid = false;
+    bool useDateTime = false;
+    bool setErrorLimit = false;
+    int errorLimit = -1;
 
     if (args.contains("--ignore-uuid"))
     {
       args.removeAll("--ignore-uuid");
-      mapCompare.setIgnoreUUID();
+      ignoreUuid = true;
     }
 
     if (args.contains("--use-datetime"))
     {
       args.removeAll("--use-datetime");
-      mapCompare.setUseDateTime();
+      useDateTime = true;
     }
 
     if (args.contains("--error-limit"))
     {
       const int errorLimitIndex = args.indexOf("--error-limit");
       bool ok = false;
-      const int errorLimit = args.at(errorLimitIndex + 1).trimmed().toInt(&ok);
+      errorLimit = args.at(errorLimitIndex + 1).trimmed().toInt(&ok);
       if (!ok)
       {
         throw IllegalArgumentException("Invalid error limit: " + args.at(errorLimitIndex + 1));
       }
       args.removeAt(errorLimitIndex + 1);
       args.removeAt(errorLimitIndex);
-      mapCompare.setErrorLimit(errorLimit);
+      setErrorLimit = true;
     }
 
     if (args.size() != 2)
@@ -89,25 +96,62 @@ public:
       throw HootException(QString("%1 takes two parameters.").arg(getName()));
     }
 
-    OsmMapPtr map1(new OsmMap());
-    IoUtils::loadMap(map1, args[0], true, Status::Unknown1);
-    //  Some maps that don't have IDs cooked in will fail comparison if the IDs aren't reset
-    OsmMap::resetCounters();
-    OsmMapPtr map2(new OsmMap());
-    IoUtils::loadMap(map2, args[1], true, Status::Unknown1);
+    QString pathname1 = args[0];
+    QString pathname2 = args[1];
 
-    int result;
-
-    if (mapCompare.isMatch(map1, map2))
+    int result = 1;
+    //  Compare changesets differently than all other types
+    if (pathIsChangeset(pathname1) && pathIsChangeset(pathname2))
     {
-      result = 0;
+      XmlChangeset changeset1(pathname1);
+      XmlChangeset changeset2(pathname2);
+
+      if (changeset1.isMatch(changeset2))
+        result = 0;
     }
     else
     {
-      result = 1;
+      MapComparator mapCompare;
+      if (ignoreUuid)
+        mapCompare.setIgnoreUUID();
+      if (useDateTime)
+        mapCompare.setUseDateTime();
+      if (setErrorLimit)
+        mapCompare.setErrorLimit(errorLimit);
+
+      OsmMapPtr map1(new OsmMap());
+      IoUtils::loadMap(map1, pathname1, true, Status::Unknown1);
+      //  Some maps that don't have IDs cooked in will fail comparison if the IDs aren't reset
+      OsmMap::resetCounters();
+      OsmMapPtr map2(new OsmMap());
+      IoUtils::loadMap(map2, pathname2, true, Status::Unknown1);
+
+      if (mapCompare.isMatch(map1, map2))
+        result = 0;
     }
 
     return result;
+  }
+
+  bool pathIsChangeset(const QString& path)
+  {
+    QFileInfo fi(path);
+    //  .osc files
+    if (fi.exists() && path.endsWith(".osc", Qt::CaseInsensitive))
+      return true;
+    //  Directories containing .osc files
+    if (fi.isDir())
+    {
+      QDir dir(path);
+      dir.setFilter(QDir::Files | QDir::NoDotAndDotDot);
+      dir.setSorting(QDir::Name | QDir::IgnoreCase);
+      QStringList filters;
+      filters << "*.osc";
+      dir.setNameFilters(filters);
+      //  As long as the directory contains at least one .osc file
+      return dir.entryInfoList().size() > 0;
+    }
+    return false;
   }
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -1944,6 +1944,7 @@ bool XmlChangeset::isMatch(const XmlChangeset& changeset)
       else
         missingNodes.insert(node->id());
     }
+    //  Output missing nodes in full
     if (missingNodes.size() > 0)
     {
       QString buffer;
@@ -1978,6 +1979,7 @@ bool XmlChangeset::isMatch(const XmlChangeset& changeset)
       else
         missingWays.insert(way->id());
     }
+    //  Output missing ways in full
     if (missingWays.size() > 0)
     {
       QString buffer;
@@ -2012,6 +2014,7 @@ bool XmlChangeset::isMatch(const XmlChangeset& changeset)
       else
         missingRelations.insert(relation->id());
     }
+    //  Output missing relations in full
     if (missingRelations.size() > 0)
     {
       QString buffer;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -32,6 +32,7 @@
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/Log.h>
+#include <hoot/core/util/StringUtils.h>
 
 //  Standard
 #include <algorithm>
@@ -56,7 +57,19 @@ XmlChangeset::XmlChangeset()
 {
 }
 
-XmlChangeset::XmlChangeset(const QList<QString> &changesets)
+XmlChangeset::XmlChangeset(const QString& changeset)
+  : _nodes(ChangesetType::TypeMax),
+    _ways(ChangesetType::TypeMax),
+    _relations(ChangesetType::TypeMax),
+    _maxPushSize(ConfigOptions().getChangesetApidbSizeMax()),
+    _sentCount(0),
+    _processedCount(0),
+    _failedCount(0)
+{
+  loadChangeset(changeset);
+}
+
+XmlChangeset::XmlChangeset(const QList<QString>& changesets)
   : _nodes(ChangesetType::TypeMax),
     _ways(ChangesetType::TypeMax),
     _relations(ChangesetType::TypeMax),
@@ -69,10 +82,16 @@ XmlChangeset::XmlChangeset(const QList<QString> &changesets)
     loadChangeset(*it);
 }
 
-void XmlChangeset::loadChangeset(const QString &changeset)
+void XmlChangeset::loadChangeset(const QString& changeset)
 {
-  if (QFile::exists(changeset))
-    loadChangesetFile(changeset);
+  QFileInfo fi(changeset);
+  if (fi.exists())
+  {
+    if (fi.isDir())
+      loadChangesetDirectory(changeset);
+    else
+      loadChangesetFile(changeset);
+  }
   else
     loadChangesetXml(changeset);
 }
@@ -95,7 +114,7 @@ void XmlChangeset::loadChangesetFile(const QString& path)
     loadOsmAsChangeset(reader);
 }
 
-void XmlChangeset::loadChangesetXml(const QString &changesetXml)
+void XmlChangeset::loadChangesetXml(const QString& changesetXml)
 {
   //  Load the XML directly into the reader
   QXmlStreamReader reader(changesetXml);
@@ -103,7 +122,49 @@ void XmlChangeset::loadChangesetXml(const QString &changesetXml)
   loadChangeset(reader);
 }
 
-void XmlChangeset::loadChangeset(QXmlStreamReader &reader)
+void XmlChangeset::loadChangesetDirectory(const QString& changesetDirectory)
+{
+  //  Iterate all of the files in the directory, loading them one by one
+  QDir dir(changesetDirectory);
+  dir.setFilter(QDir::Files | QDir::NoDotAndDotDot);
+  dir.setSorting(QDir::Name | QDir::IgnoreCase);
+  QStringList filters;
+  filters << "*.osc";
+  dir.setNameFilters(filters);
+
+  QFileInfoList files = dir.entryInfoList();
+  for (int i = 0; i < files.size(); ++i)
+  {
+    QFileInfo fileInfo = files.at(i);
+    QString filepath = fileInfo.absoluteFilePath();
+    //  Check if this file is in the request/response debug output format (including the error file)
+    if (filepath.contains("-Request--") && filepath.endsWith("000.osc", Qt::CaseInsensitive))
+    {
+      //  Only load the requests that were successful, i.e. response 200
+      QString response = filepath;
+      response.replace("-Request--", "-Response-").replace("000.osc", "200.osc");
+      if (QFile::exists(response))
+        loadChangesetFile(filepath);
+    }
+    else if (filepath.contains("-Response-") && filepath.endsWith("200.osc", Qt::CaseInsensitive))
+    {
+      //  Read in the update for new IDs
+      updateChangeset(FileUtils::readFully(filepath));
+    }
+    else if (filepath.endsWith("-error.osc", Qt::CaseInsensitive))
+    {
+      //  The changeset error file
+      loadChangesetFile(filepath);
+    }
+    else
+    {
+      //  Output the filename to the log
+      LOG_DEBUG("Skipping file in folder: " << filepath);
+    }
+  }
+}
+
+void XmlChangeset::loadChangeset(QXmlStreamReader& reader)
 {
   //  Make sure that the XML provided starts with the <diffResult> tag
   QXmlStreamReader::TokenType type = reader.readNext();
@@ -314,7 +375,18 @@ void XmlChangeset::fixMalformedInput()
   writeErrorFile();
 }
 
-void XmlChangeset::updateChangeset(const QString &changes)
+QString XmlChangeset::getString(ChangesetType type)
+{
+  switch (type)
+  {
+  case ChangesetType::TypeCreate:   return "<create>";
+  case ChangesetType::TypeModify:   return "<modify>";
+  case ChangesetType::TypeDelete:   return "<delete>";
+  default:                          return "";
+  }
+}
+
+void XmlChangeset::updateChangeset(const QString& changes)
 {
   /* <diffResult generator="OpenStreetMap Server" version="0.6">
    *   <node|way|relation old_id="#" new_id="#" new_version="#"/>
@@ -1827,6 +1899,134 @@ bool XmlChangeset::calculateRemainingChangeset(ChangesetInfoPtr &changeset)
   }
   //  Return true if there is anything in the changeset
   return !empty_changeset;
+}
+
+bool XmlChangeset::isMatch(const XmlChangeset& changeset)
+{
+  bool isEqual = true;
+  //  Check counts first
+  if (_allNodes.size() != changeset._allNodes.size())
+  {
+    LOG_WARN("Node count not equal (ref: " << _allNodes.size() << ", test: " << changeset._allNodes.size() << ")");
+    isEqual = false;
+  }
+  if (_allWays.size() != changeset._allWays.size())
+  {
+    LOG_WARN("Way count not equal (ref: " << _allWays.size() << ", test: " << changeset._allWays.size() << ")");
+    isEqual = false;
+  }
+  if (_allRelations.size() != changeset._allRelations.size())
+  {
+    LOG_WARN("Relation count not equal (ref: " << _allRelations.size() << ", test: " << changeset._allRelations.size() << ")");
+    isEqual = false;
+  }
+  //  Now check each type, create, modify, delete
+  for (int changeset_type = ChangesetType::TypeCreate; changeset_type != ChangesetType::TypeMax; ++changeset_type)
+  {
+    //  Iterate all of the nodes of "type" in the changeset
+    QSet<long> missingNodes;
+    for (ChangesetElementMap::iterator it = _nodes[changeset_type].begin(); it != _nodes[changeset_type].end(); ++it)
+    {
+      ChangesetNode* node = dynamic_cast<ChangesetNode*>(it->second.get());
+      ChangesetElementMap::const_iterator found = changeset._nodes[changeset_type].find(node->id());
+      if (found != changeset._nodes[changeset_type].end())
+      {
+        //  Compare the two nodes
+        ChangesetNode* node2 = dynamic_cast<ChangesetNode*>(found->second.get());
+        QString output;
+        if (!node->diff(*node2, output))
+        {
+          //  Display the node diff
+          output.chop(1);
+          LOG_WARN("Node ID " << node->id() << "\n" << output);
+        }
+      }
+      else
+        missingNodes.insert(node->id());
+    }
+    if (missingNodes.size() > 0)
+    {
+      QString buffer;
+      QTextStream ts(&buffer);
+      ts.setCodec("UTF-8");
+      for (QSet<long>::iterator it = missingNodes.begin(); it != missingNodes.end(); ++it)
+        ts << _nodes[changeset_type][*it]->toString(0);
+      buffer.chop(1);
+      buffer.replace("\n", "\n>");
+      LOG_WARN("Missing nodes: " << getString(static_cast<ChangesetType>(changeset_type)) <<
+               " - " << missingNodes << "\n>" << buffer);
+      isEqual = false;
+    }
+    //  Iterate all of the ways of "type" in the changeset
+    QSet<long> missingWays;
+    for (ChangesetElementMap::iterator it = _ways[changeset_type].begin(); it != _ways[changeset_type].end(); ++it)
+    {
+      ChangesetWay* way = dynamic_cast<ChangesetWay*>(it->second.get());
+      ChangesetElementMap::const_iterator found = changeset._ways[changeset_type].find(way->id());
+      if (found != changeset._ways[changeset_type].end())
+      {
+        //  Compare the two ways
+        ChangesetWay* way2 = dynamic_cast<ChangesetWay*>(found->second.get());
+        QString output;
+        if (!way->diff(*way2, output))
+        {
+          //  Display the way diff
+          output.chop(1);
+          LOG_WARN("Way ID " << way->id() << "\n" << output);
+        }
+      }
+      else
+        missingWays.insert(way->id());
+    }
+    if (missingWays.size() > 0)
+    {
+      QString buffer;
+      QTextStream ts(&buffer);
+      ts.setCodec("UTF-8");
+      for (QSet<long>::iterator it = missingWays.begin(); it != missingWays.end(); ++it)
+        ts << _ways[changeset_type][*it]->toString(0);
+      buffer.chop(1);
+      buffer.replace("\n", "\n>");
+      LOG_WARN("Missing ways: " << getString(static_cast<ChangesetType>(changeset_type)) <<
+               " - " << missingWays << "\n>" << buffer);
+      isEqual = false;
+    }
+    //  Iterate all of the relations of "type" in the changeset
+    QSet<long> missingRelations;
+    for (ChangesetElementMap::iterator it = _relations[changeset_type].begin(); it != _relations[changeset_type].end(); ++it)
+    {
+      ChangesetRelation* relation = dynamic_cast<ChangesetRelation*>(it->second.get());
+      ChangesetElementMap::const_iterator found = changeset._relations[changeset_type].find(relation->id());
+      if (found != changeset._relations[changeset_type].end())
+      {
+        //  Compare the two ways
+        ChangesetRelation* relation2 = dynamic_cast<ChangesetRelation*>(found->second.get());
+        QString output;
+        if (!relation->diff(*relation2, output))
+        {
+          //  Display the relation diff
+          output.chop(1);
+          LOG_WARN("Relation ID " << relation->id() << "\n" << output);
+        }
+      }
+      else
+        missingRelations.insert(relation->id());
+    }
+    if (missingRelations.size() > 0)
+    {
+      QString buffer;
+      QTextStream ts(&buffer);
+      ts.setCodec("UTF-8");
+      for (QSet<long>::iterator it = missingRelations.begin(); it != missingRelations.end(); ++it)
+        ts << _relations[changeset_type][*it]->toString(0);
+      buffer.chop(1);
+      buffer.replace("\n", "\n>");
+      LOG_WARN("Missing relations: " << getString(static_cast<ChangesetType>(changeset_type)) <<
+               " - " << missingRelations << "\n>" << buffer);
+      isEqual = false;
+    }
+  }
+  return isEqual;
 }
 
 ChangesetInfo::ChangesetInfo()

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -66,6 +66,7 @@ class XmlChangeset
 public:
   /** Constructors */
   XmlChangeset();
+  explicit XmlChangeset(const QString& changeset);
   explicit XmlChangeset(const QList<QString>& changesets);
   /**  Allow test class to access protected members for white box testing */
   friend class OsmApiChangesetTest;
@@ -115,6 +116,8 @@ public:
     TypeDelete,
     TypeMax
   };
+  /** Convert ChangesetType to string */
+  static QString getString(ChangesetType type);
   /**
    * @brief calculateChangeset Create an atomic subset of this changeset that can be sent independently from others
    * @param changeset - Pointer to a ChangesetInfo object holding IDs for a subset of the changeset
@@ -280,7 +283,6 @@ public:
    * @return true if the file was written successfully
    */
   bool writeErrorFile();
-
   /**
    * @brief calculateRemainingChangeset This function is an error correction case for when a changeset cannot finish
    *  and the upload stalls indefinitely.  Move all remaining elements into a changeset so the job can finish or error out.
@@ -288,6 +290,12 @@ public:
    * @return true if there is anything in the changeset
    */
   bool calculateRemainingChangeset(ChangesetInfoPtr &changeset);
+  /**
+   * @brief isMatch Function to compare two changesets
+   * @param changeset Changeset object to compare this changeset against
+   * @return true if they are equivalent
+   */
+  bool isMatch(const XmlChangeset& changeset);
 
 private:
   /**
@@ -300,6 +308,11 @@ private:
    * @param changesetXml
    */
   void loadChangesetXml(const QString& changesetXml);
+  /**
+   * @brief loadChangesetDirectory Load directory of changeset files, can include request/response changeset files
+   * @param changesetDirectory
+   */
+  void loadChangesetDirectory(const QString& changesetDirectory);
   /**
    * @brief loadChangeset Load a .osc changeset file
    * @param reader

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -310,7 +310,7 @@ private:
   void loadChangesetXml(const QString& changesetXml);
   /**
    * @brief loadChangesetDirectory Load directory of changeset files, can include request/response changeset files
-   * @param changesetDirectory
+   * @param changesetDirectory Full pathname of the directory to load
    */
   void loadChangesetDirectory(const QString& changesetDirectory);
   /**

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "OsmApiChangesetElement.h"

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
@@ -30,9 +30,6 @@
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/visitors/ApiTagTruncateVisitor.h>
 
-//  Qt
-#include <QTextStream>
-
 namespace hoot
 {
 
@@ -52,7 +49,11 @@ ChangesetElement::ChangesetElement(const XmlObject& object, ElementIdToIdMap* id
     _status(ChangesetElement::Available)
 {
   for (QXmlStreamAttributes::const_iterator it = object.second.begin(); it != object.second.end(); ++it)
-    _object.push_back(std::make_pair(it->name().toString(), it->value().toString()));
+  {
+    //  Ignore the changeset attribute because it will be replaced later even if it does exist
+    if (it->name().compare(QString("changeset")) != 0)
+      _object.push_back(std::make_pair(it->name().toString(), it->value().toString()));
+  }
 }
 
 ChangesetElement::ChangesetElement(const ChangesetElement& element)
@@ -162,6 +163,99 @@ QString ChangesetElement::toTagString(const ElementTag& tag) const
   return ts.readAll();
 }
 
+bool ChangesetElement::diffElement(const ChangesetElement* element, QTextStream& ts1, QTextStream& ts2) const
+{
+  bool success = true;
+  //  Compare the IDs
+  if (_id != element->_id)
+  {
+    ts1 << "< id = " << _id << "\n";
+    ts2 << "> id = " << element->_id << "\n";
+    success = false;
+  }
+  //  Compare the attributes
+  if (!diffAttributes(element->_object, ts1, ts2))
+    success = false;
+  //  Compare the tags
+  if (!diffTags(element->_tags, ts1, ts2))
+    success = false;
+  return success;
+}
+
+bool ChangesetElement::diffAttributes(const ElementAttributes& attributes, QTextStream& ts1, QTextStream& ts2) const
+{
+  bool success = true;
+  //  Compare the attributes by count first
+  if (_object.size() != attributes.size())
+  {
+    ts1 << "< attribute count = " << _object.size() << "\n";
+    for (size_t index = 0; index < _object.size(); ++index)
+      ts1 << "< " << _object[index].first << " = " << _object[index].second << "\n";
+    ts2 << "> attribute count = " << attributes.size() << "\n";
+    for (size_t index = 0; index < attributes.size(); ++index)
+      ts2 << "> " << attributes[index].first << " = " << attributes[index].second << "\n";
+    success = false;
+  }
+  else
+  {
+    //  Compare attributes one by one
+    for (size_t index = 0; index < _object.size(); ++index)
+    {
+      QString name1 = _object[index].first;
+      QString value1 = _object[index].second;
+      QString name2 = attributes[index].first;
+      QString value2 = attributes[index].second;
+      //  Some attributes can have different values and still be equivalent
+      if (name1 == "action" || name1 == "version" || name1 == "changeset")
+        continue;
+      //  Compare names and values
+      if (name1 != name2 && value1 != value2)
+      {
+        ts1 << "< " << name1 << " = " << value1 << "\n";
+        ts2 << "> " << name2 << " = " << value2 << "\n";
+        success = false;
+      }
+    }
+  }
+  return success;
+}
+
+bool ChangesetElement::diffTags(const ElementTags& tags,  QTextStream& ts1, QTextStream& ts2) const
+{
+  bool success = true;
+  //  Compare the tags by count first
+  if (_tags.size() != tags.size())
+  {
+    ts1 << "< tag count = " << _tags.size() << "\n";
+    for (size_t index = 0; index < _tags.size(); ++index)
+      ts1 << "< " << _tags[index].first << " = " << _tags[index].second << "\n";
+    ts2 << "> tag count = " << tags.size() << "\n";
+    for (size_t index = 0; index < tags.size(); ++index)
+      ts2 << "> " << tags[index].first << " = " << tags[index].second << "\n";
+    success = false;
+  }
+  else
+  {
+    //  Compare tags one by one
+    for (size_t index = 0; index < _tags.size(); ++index)
+    {
+      QString key1 = _tags[index].first;
+      QString value1 = _tags[index].second;
+      QString key2 = tags[index].first;
+      QString value2 = tags[index].second;
+      //  Ignore any tags here?
+      //  Compare keys and values
+      if (key1 != key2 && value1 != value2)
+      {
+        ts1 << "< " << key1 << " = " << value1 << "\n";
+        ts2 << "> " << key2 << " = " << value2 << "\n";
+        success = false;
+      }
+    }
+  }
+  return success;
+}
+
 ChangesetNode::ChangesetNode(const XmlObject& node, ElementIdToIdMap* idMap)
   : ChangesetElement(node, idMap)
 {
@@ -190,6 +284,28 @@ QString ChangesetNode::toString(long changesetId) const
   else
     ts << "/>\n";
   return ts.readAll();
+}
+
+bool ChangesetNode::diff(const ChangesetNode& node, QString& diffOutput) const
+{
+  bool success = true;
+  QString buffer1;
+  QTextStream ts1(&buffer1);
+  ts1.setCodec("UTF-8");
+  QString buffer2;
+  QTextStream ts2(&buffer2);
+  ts2.setCodec("UTF-8");
+  //  Compare the common element data
+  if (!diffElement(&node, ts1, ts2))
+    success = false;
+  //  Create the diff when the two nodes are different
+  if (!success)
+  {
+    ts1 << "--------------------\n" << ts2.readAll();
+    diffOutput = ts1.readAll();
+  }
+  //  Return success variable
+  return success;
 }
 
 ChangesetWay::ChangesetWay(const XmlObject& way, ElementIdToIdMap* idMap)
@@ -229,6 +345,60 @@ QString ChangesetWay::toString(long changesetId) const
   }
   ts << "\t\t</way>\n";
   return ts.readAll();
+}
+
+bool ChangesetWay::diff(const ChangesetWay& way, QString& diffOutput) const
+{
+  bool success = true;
+  QString buffer1;
+  QTextStream ts1(&buffer1);
+  ts1.setCodec("UTF-8");
+  QString buffer2;
+  QTextStream ts2(&buffer2);
+  ts2.setCodec("UTF-8");
+  //  Compare the common element data
+  if (!diffElement(&way, ts1, ts2))
+    success = false;
+  //  Compare the way nodes
+  if (_nodes.size() != way._nodes.size())
+  {
+    ts1 << "< node count = " << _nodes.size() << "\n";
+    for (int index = 0; index < _nodes.size(); ++index)
+      ts1 << "< " << _nodes[index] << "\n";
+    ts2 << "> node count = " << way._nodes.size() << "\n";
+    for (int index = 0; index < way._nodes.size(); ++index)
+      ts2 << "> " << way._nodes[index] << "\n";
+    success = false;
+  }
+  else
+  {
+    //  Compare node IDs one by one
+    for (int index = 0; index < _nodes.size(); ++index)
+    {
+      //  Node IDs
+      if (_nodes[index] != way._nodes[index] && _nodes[index] != way._idMap->getId(ElementType::Node, way._nodes[index]))
+      {
+        ts1 << "< nodes = ";
+        for (QVector<long>::const_iterator it = _nodes.begin(); it != _nodes.end(); ++it)
+          ts1 << *it << " ";
+        ts1 << "\n";
+        ts2 << "> nodes = ";
+        for (QVector<long>::const_iterator it = way._nodes.begin(); it != way._nodes.end(); ++it)
+          ts2 << *it << " ";
+        ts2 << "\n";
+        success = false;
+        break;
+      }
+    }
+  }
+  //  Create the diff when the two nodes are different
+  if (!success)
+  {
+    ts1 << "--------------------\n" << ts2.readAll();
+    diffOutput = ts1.readAll();
+  }
+  //  Return success variable
+  return success;
 }
 
 ChangesetRelation::ChangesetRelation(const XmlObject& relation, ElementIdToIdMap* idMap)
@@ -290,6 +460,44 @@ QString ChangesetRelation::toString(long changesetId) const
   return ts.readAll();
 }
 
+bool ChangesetRelation::diff(const ChangesetRelation& relation, QString& diffOutput) const
+{
+  bool success = true;
+  QString buffer1;
+  QTextStream ts1(&buffer1);
+  ts1.setCodec("UTF-8");
+  QString buffer2;
+  QTextStream ts2(&buffer2);
+  ts2.setCodec("UTF-8");
+  //  Compare the common element data
+  if (!diffElement(&relation, ts1, ts2))
+    success = false;
+  //  Compare the members
+  if (_members.size() != relation._members.size())
+  {
+    ts1 << "< member count = " << _members.size() << "\n";
+    ts2 << "> member count = " << relation._members.size() << "\n";
+    success = false;
+  }
+  else
+  {
+    //  Compare members one by one
+    for (int index = 0; index < _members.size(); ++index)
+    {
+      if (!_members[index].diff(relation._members[index], ts1, ts2))
+        success = false;
+    }
+  }
+  //  Create the diff when the two nodes are different
+  if (!success)
+  {
+    ts1 << "--------------------\n" << ts2.readAll();
+    diffOutput = ts1.readAll();
+  }
+  //  Return success variable
+  return success;
+}
+
 ChangesetRelationMember::ChangesetRelationMember(const QXmlStreamAttributes& member, ElementIdToIdMap* idMap)
   : _type(ElementType::fromString(member.value("type").toString().toLower())),
     _ref(member.value("ref").toString().toLong()),
@@ -307,6 +515,33 @@ QString ChangesetRelationMember::toString() const
      << (_idMap ? _idMap->getId(_type, _ref) : _ref)
      << "\" role=\"" << _role << "\"/>\n";
   return ts.readAll();
+}
+
+bool ChangesetRelationMember::diff(const ChangesetRelationMember& member, QTextStream& ts1, QTextStream& ts2) const
+{
+  bool success = true;
+  //  Compare the ref IDs
+  if (_ref != member._ref && _ref != member._idMap->getId(member._type, member._ref))
+  {
+    ts1 << "< ref = " << _ref << "\n";
+    ts2 << "> ref = " << member._ref << "\n";
+    success = false;
+  }
+  //  Compare the member type
+  if (_type != member._type)
+  {
+    ts1 << "< type = " << _type << "\n";
+    ts2 << "> type = " << member._type << "\n";
+    success = false;
+  }
+  //  Compare the member role
+  if (_role != member._role)
+  {
+    ts1 << "< role = " << _role << "\n";
+    ts2 << "> role = " << member._role << "\n";
+    success = false;
+  }
+  return success;
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef OSM_API_CHANGESET_ELEMENT_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
@@ -148,11 +148,31 @@ protected:
    * @return XML ecoded string
    */
   QString& escapeString(QString& value) const;
-
+  /**
+   * @brief diffElement Compare (diff) two elements, this and element, adding diff output to the
+   *   text streams
+   * @param element Element to compare to this
+   * @param ts1 Text stream for diff lines for this
+   * @param ts2 Text stream for diff lines for element
+   * @return true if the elements are equivalent
+   */
   bool diffElement(const ChangesetElement* element, QTextStream& ts1, QTextStream& ts2) const;
-
+  /**
+   * @brief diffAttributes Compare (diff) the attributes of two elements adding diff output to the
+   *   text streams
+   * @param attributes Set of attributes to compare to this element's attributes
+   * @param ts1 Text stream for diff lines for this
+   * @param ts2 Text stream for diff lines for attributes
+   * @return true if the element's attributes are equivalent
+   */
   bool diffAttributes(const ElementAttributes& attributes, QTextStream& ts1, QTextStream& ts2) const;
-
+  /**
+   * @brief diffTags Compare (diff) the tags of two elements adding diff output to the text streams
+   * @param tags Set of tags to compare to this element's tags
+   * @param ts1 Text stream for diff lines for this
+   * @param ts2 Text stream for diff lines for tags
+   * @return true if the element's tags are equivalent
+   */
   bool diffTags(const ElementTags& tags, QTextStream& ts1, QTextStream& ts2) const;
   /** Element type node/way/relation */
   ElementType::Type _type;
@@ -304,11 +324,11 @@ public:
    */
   QString toString() const;
   /**
-   * @brief diff
-   * @param member
-   * @param ts1
-   * @param ts2
-   * @return
+   * @brief diff Compare two relation members and build a 'diff' style string in the text streams
+   * @param member Relation member to compare against this
+   * @param ts1 Text stream for diff lines for this
+   * @param ts2 Text stream for diff lines for member
+   * @return true if the relation members are equivalent
    */
   bool diff(const ChangesetRelationMember& member, QTextStream& ts1, QTextStream& ts2) const;
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
@@ -36,6 +36,7 @@
 #include <QMap>
 #include <QPair>
 #include <QString>
+#include <QTextStream>
 #include <QVector>
 #include <QXmlStreamReader>
 
@@ -85,12 +86,12 @@ public:
    * @brief getTagCount
    * @return Number of tags in this element
    */
-  int getTagCount() { return _tags.size(); }
+  int getTagCount() const { return _tags.size(); }
   /**
    * @brief id Get the element ID
    * @return Element ID
    */
-  long id() { return _id; }
+  long id() const { return _id; }
   /**
    * @brief changeId Change the ID of the element
    * @param id ID to change to
@@ -147,6 +148,12 @@ protected:
    * @return XML ecoded string
    */
   QString& escapeString(QString& value) const;
+
+  bool diffElement(const ChangesetElement* element, QTextStream& ts1, QTextStream& ts2) const;
+
+  bool diffAttributes(const ElementAttributes& attributes, QTextStream& ts1, QTextStream& ts2) const;
+
+  bool diffTags(const ElementTags& tags, QTextStream& ts1, QTextStream& ts2) const;
   /** Element type node/way/relation */
   ElementType::Type _type;
   /** Element ID */
@@ -188,6 +195,13 @@ public:
    * @return XML string
    */
   virtual QString toString(long changesetId) const;
+  /**
+   * @brief diff Compare two nodes and build a 'diff' style string
+   * @param node Node to compare this node against
+   * @param diffOutput Output of the diff between the two nodes
+   * @return True if they are equivalent
+   */
+  bool diff(const ChangesetNode& node, QString& diffOutput) const;
 };
 /** Handy typedef for node shared pointer */
 typedef std::shared_ptr<ChangesetNode> ChangesetNodePtr;
@@ -237,6 +251,13 @@ public:
    * @return XML string
    */
   virtual QString toString(long changesetId) const;
+  /**
+   * @brief diff Compare two ways and build a 'diff' style string
+   * @param way Way to compare this way against
+   * @param diffOutput Output of the diff between the two way
+   * @return True if they are equivalent
+   */
+  bool diff(const ChangesetWay& way, QString& diffOutput) const;
 
 private:
   /** Vector of node ID in the way */
@@ -282,6 +303,14 @@ public:
    * @return XML string
    */
   QString toString() const;
+  /**
+   * @brief diff
+   * @param member
+   * @param ts1
+   * @param ts2
+   * @return
+   */
+  bool diff(const ChangesetRelationMember& member, QTextStream& ts1, QTextStream& ts2) const;
 
 private:
   /** Member type (node/way/relation) */
@@ -340,6 +369,13 @@ public:
    * @return XML string
    */
   virtual QString toString(long changesetId) const;
+  /**
+   * @brief diff Compare two relations and build a 'diff' style string
+   * @param relation Relation to compare this relation against
+   * @param diffOutput Output of the diff between the two relations
+   * @return True if they are equivalent
+   */
+  bool diff(const ChangesetRelation& relation, QString& diffOutput) const;
 
 private:
   /** List of relation members */

--- a/test-files/cmd/quick/DiffCmdChangesetTest.sh
+++ b/test-files/cmd/quick/DiffCmdChangesetTest.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+input_file=$HOOT_HOME/test-files/io/OsmChangesetElementTest/ToyTestA.osc
+input_directory_success=$HOOT_HOME/test-files/cmd/quick/DiffCmdChangesetTest/Success/
+input_directory_failure=$HOOT_HOME/test-files/cmd/quick/DiffCmdChangesetTest/Failure/
+
+CONFIG="-C Testing.conf"
+
+# run the changeset diff on a complete directory
+hoot diff $CONFIG $input_file $input_directory_success
+
+# run the changeset diff on an incomplete directory
+hoot diff $CONFIG $input_file $input_directory_failure
+

--- a/test-files/cmd/quick/DiffCmdChangesetTest.sh.stdout
+++ b/test-files/cmd/quick/DiffCmdChangesetTest.sh.stdout
@@ -1,0 +1,19 @@
+19:13:24.318 WARN   ...ot/core/io/OsmApiChangeset.cpp(1910) Node count not equal (ref: 36, test: 33)
+19:13:24.318 WARN   ...ot/core/io/OsmApiChangeset.cpp(1915) Way count not equal (ref: 4, test: 3)
+19:13:24.318 WARN   ...ot/core/io/OsmApiChangeset.cpp(1957) Missing nodes: <create> - [-35, -30, -34]
+>		<node id="-35" version="0" lat="38.8540851073630833" lon="-104.9014476647277121" timestamp="" changeset="0"/>
+>		<node id="-30" version="0" lat="38.8542618470630714" lon="-104.8997171368440888" timestamp="" changeset="0"/>
+>		<node id="-34" version="0" lat="38.8542471187715179" lon="-104.9010788637033329" timestamp="" changeset="0"/>
+19:13:24.319 WARN   ...ot/core/io/OsmApiChangeset.cpp(1975) Way ID -3
+< nodes = -3 -4 -5 -6 -7 -32 -31 -30 -36 -29 -28 -27 -26 -25 -24 -23 -22 -21 -20 -19 -18 -17 -16 -15 -14 -13 -12 -11 -10 -9 
+--------------------
+> nodes = 43 44 45 46 39 41 71 63 72 70 69 68 67 66 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 
+19:13:24.319 WARN   ...ot/core/io/OsmApiChangeset.cpp(1991) Missing ways: <create> - [-4]
+>		<way id="-4" version="0" timestamp="" changeset="0">
+>			<nd ref="-35"/>
+>			<nd ref="-34"/>
+>			<nd ref="-33"/>
+>			<nd ref="-30"/>
+>			<tag k="note" v="2"/>
+>			<tag k="highway" v="road"/>
+>		</way>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Failure/OsmApiWriter-000001-00002-Request--000.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Failure/OsmApiWriter-000001-00002-Request--000.osc
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<create>
+		<node id="-1" version="0" lat="38.8549321261880536" lon="-104.8979050333482093" timestamp="" changeset="2"/>
+		<node id="-2" version="0" lat="38.8549524185660573" lon="-104.8987388916486054" timestamp="" changeset="2"/>
+		<node id="-7" version="0" lat="38.8549289695954272" lon="-104.9005253172435630" timestamp="" changeset="2"/>
+		<node id="-8" version="0" lat="38.8548514075605240" lon="-104.9005693264316363" timestamp="" changeset="2"/>
+		<node id="-32" version="0" lat="38.8549614373988845" lon="-104.8997124086258452" timestamp="" changeset="2"/>
+		<node id="-33" version="0" lat="38.8542599687747341" lon="-104.9005795104799432" timestamp="" changeset="2"/>
+		<way id="-1" version="0" timestamp="" changeset="2">
+			<nd ref="-32"/>
+			<nd ref="-2"/>
+			<nd ref="-1"/>
+			<tag k="note" v="1"/>
+			<tag k="highway" v="road"/>
+		</way>
+		<way id="-2" version="0" timestamp="" changeset="2">
+			<nd ref="-33"/>
+			<nd ref="-8"/>
+			<nd ref="-7"/>
+			<tag k="note" v="3"/>
+			<tag k="highway" v="road"/>
+		</way>
+	</create>
+</osmChange>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Failure/OsmApiWriter-000001-00002-Response-200.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Failure/OsmApiWriter-000001-00002-Response-200.osc
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<diffResult version="0.6" generator="CGImap 0.8.0" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+ <node old_id="-1" new_id="37" new_version="1"/>
+ <node old_id="-2" new_id="38" new_version="1"/>
+ <node old_id="-7" new_id="39" new_version="1"/>
+ <node old_id="-8" new_id="40" new_version="1"/>
+ <node old_id="-32" new_id="41" new_version="1"/>
+ <node old_id="-33" new_id="42" new_version="1"/>
+ <way old_id="-1" new_id="5" new_version="1"/>
+ <way old_id="-2" new_id="6" new_version="1"/>
+</diffResult>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Failure/OsmApiWriter-000002-00002-Request--000.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Failure/OsmApiWriter-000002-00002-Request--000.osc
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<create>
+		<node id="-3" version="0" lat="38.8540541370891077" lon="-104.9024316099691276" timestamp="" changeset="2"/>
+		<node id="-4" version="0" lat="38.8541298962059614" lon="-104.9023065312240703" timestamp="" changeset="2"/>
+		<node id="-5" version="0" lat="38.8543319201230304" lon="-104.9017876860593788" timestamp="" changeset="2"/>
+		<node id="-6" version="0" lat="38.8548207434768855" lon="-104.9008079025564655" timestamp="" changeset="2"/>
+		<node id="-9" version="0" lat="38.8549073243849037" lon="-104.8961823052623856" timestamp="" changeset="2"/>
+		<node id="-10" version="0" lat="38.8549019130812496" lon="-104.8964394115716487" timestamp="" changeset="2"/>
+		<node id="-11" version="0" lat="38.8548604264061623" lon="-104.8968586569948798" timestamp="" changeset="2"/>
+		<node id="-12" version="0" lat="38.8547197322843374" lon="-104.8973219116062410" timestamp="" changeset="2"/>
+		<node id="-13" version="0" lat="38.8546042907457476" lon="-104.8977759011253141" timestamp="" changeset="2"/>
+		<node id="-14" version="0" lat="38.8544293243065937" lon="-104.8980654352573794" timestamp="" changeset="2"/>
+		<node id="-15" version="0" lat="38.8542327120211866" lon="-104.8983109602013855" timestamp="" changeset="2"/>
+		<node id="-16" version="0" lat="38.8541767946664436" lon="-104.8987070428940598" timestamp="" changeset="2"/>
+		<node id="-17" version="0" lat="38.8541335037809361" lon="-104.8988900284655159" timestamp="" changeset="2"/>
+		<node id="-18" version="0" lat="38.8539585361836473" lon="-104.8989155074691695" timestamp="" changeset="2"/>
+		<node id="-19" version="0" lat="38.8537204352567329" lon="-104.8987232568054679" timestamp="" changeset="2"/>
+		<node id="-20" version="0" lat="38.8536194225014810" lon="-104.8987070428940598" timestamp="" changeset="2"/>
+		<node id="-21" version="0" lat="38.8535508780501431" lon="-104.8988321216391171" timestamp="" changeset="2"/>
+		<node id="-22" version="0" lat="38.8535689160700528" lon="-104.8990568001256065" timestamp="" changeset="2"/>
+		<node id="-23" version="0" lat="38.8535166057996975" lon="-104.8992698972467963" timestamp="" changeset="2"/>
+		<node id="-24" version="0" lat="38.8533470481072030" lon="-104.8993671807151884" timestamp="" changeset="2"/>
+	</create>
+</osmChange>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Failure/OsmApiWriter-000002-00002-Response-200.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Failure/OsmApiWriter-000002-00002-Response-200.osc
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<diffResult version="0.6" generator="CGImap 0.8.0" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+ <node old_id="-3" new_id="43" new_version="1"/>
+ <node old_id="-4" new_id="44" new_version="1"/>
+ <node old_id="-5" new_id="45" new_version="1"/>
+ <node old_id="-6" new_id="46" new_version="1"/>
+ <node old_id="-9" new_id="47" new_version="1"/>
+ <node old_id="-10" new_id="48" new_version="1"/>
+ <node old_id="-11" new_id="49" new_version="1"/>
+ <node old_id="-12" new_id="50" new_version="1"/>
+ <node old_id="-13" new_id="51" new_version="1"/>
+ <node old_id="-14" new_id="52" new_version="1"/>
+ <node old_id="-15" new_id="53" new_version="1"/>
+ <node old_id="-16" new_id="54" new_version="1"/>
+ <node old_id="-17" new_id="55" new_version="1"/>
+ <node old_id="-18" new_id="56" new_version="1"/>
+ <node old_id="-19" new_id="57" new_version="1"/>
+ <node old_id="-20" new_id="58" new_version="1"/>
+ <node old_id="-21" new_id="59" new_version="1"/>
+ <node old_id="-22" new_id="60" new_version="1"/>
+ <node old_id="-23" new_id="61" new_version="1"/>
+ <node old_id="-24" new_id="62" new_version="1"/>
+</diffResult>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Failure/OsmApiWriter-000005-00002-Request--000.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Failure/OsmApiWriter-000005-00002-Request--000.osc
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<create>
+		<node id="-25" version="0" lat="38.8533001490996028" lon="-104.8994528828182951" timestamp="" changeset="2"/>
+		<node id="-26" version="0" lat="38.8532424272016641" lon="-104.8996868263970015" timestamp="" changeset="2"/>
+		<node id="-27" version="0" lat="38.8532583477841484" lon="-104.8997542928851772" timestamp="" changeset="2"/>
+		<node id="-28" version="0" lat="38.8536248456666229" lon="-104.8996934957527998" timestamp="" changeset="2"/>
+		<node id="-29" version="0" lat="38.8539525522998730" lon="-104.8996840393162842" timestamp="" changeset="2"/>
+		<node id="-31" version="0" lat="38.8545785045938388" lon="-104.8997171368440888" timestamp="" changeset="2"/>
+		<node id="-36" version="0" lat="38.8541670018907581" lon="-104.8997069874790355" timestamp="" changeset="2"/>
+	</create>
+</osmChange>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Failure/OsmApiWriter-000005-00002-Response-200.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Failure/OsmApiWriter-000005-00002-Response-200.osc
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<diffResult version="0.6" generator="CGImap 0.8.0" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+ <node old_id="-25" new_id="66" new_version="1"/>
+ <node old_id="-26" new_id="67" new_version="1"/>
+ <node old_id="-27" new_id="68" new_version="1"/>
+ <node old_id="-28" new_id="69" new_version="1"/>
+ <node old_id="-29" new_id="70" new_version="1"/>
+ <node old_id="-31" new_id="71" new_version="1"/>
+ <node old_id="-36" new_id="72" new_version="1"/>
+</diffResult>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Failure/OsmApiWriter-000006-00002-Request--000.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Failure/OsmApiWriter-000006-00002-Request--000.osc
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<create>
+		<way id="-3" version="0" timestamp="" changeset="2">
+			<nd ref="43"/>
+			<nd ref="44"/>
+			<nd ref="45"/>
+			<nd ref="46"/>
+			<nd ref="39"/>
+			<nd ref="41"/>
+			<nd ref="71"/>
+			<nd ref="63"/>
+			<nd ref="72"/>
+			<nd ref="70"/>
+			<nd ref="69"/>
+			<nd ref="68"/>
+			<nd ref="67"/>
+			<nd ref="66"/>
+			<nd ref="62"/>
+			<nd ref="61"/>
+			<nd ref="60"/>
+			<nd ref="59"/>
+			<nd ref="58"/>
+			<nd ref="57"/>
+			<nd ref="56"/>
+			<nd ref="55"/>
+			<nd ref="54"/>
+			<nd ref="53"/>
+			<nd ref="52"/>
+			<nd ref="51"/>
+			<nd ref="50"/>
+			<nd ref="49"/>
+			<nd ref="48"/>
+			<nd ref="47"/>
+			<tag k="note" v="0"/>
+			<tag k="highway" v="road"/>
+		</way>
+	</create>
+</osmChange>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Failure/OsmApiWriter-000006-00002-Response-200.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Failure/OsmApiWriter-000006-00002-Response-200.osc
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<diffResult version="0.6" generator="CGImap 0.8.0" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+ <way old_id="-3" new_id="8" new_version="1"/>
+</diffResult>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000001-00002-Request--000.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000001-00002-Request--000.osc
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<create>
+		<node id="-1" version="0" lat="38.8549321261880536" lon="-104.8979050333482093" timestamp="" changeset="2"/>
+		<node id="-2" version="0" lat="38.8549524185660573" lon="-104.8987388916486054" timestamp="" changeset="2"/>
+		<node id="-7" version="0" lat="38.8549289695954272" lon="-104.9005253172435630" timestamp="" changeset="2"/>
+		<node id="-8" version="0" lat="38.8548514075605240" lon="-104.9005693264316363" timestamp="" changeset="2"/>
+		<node id="-32" version="0" lat="38.8549614373988845" lon="-104.8997124086258452" timestamp="" changeset="2"/>
+		<node id="-33" version="0" lat="38.8542599687747341" lon="-104.9005795104799432" timestamp="" changeset="2"/>
+		<way id="-1" version="0" timestamp="" changeset="2">
+			<nd ref="-32"/>
+			<nd ref="-2"/>
+			<nd ref="-1"/>
+			<tag k="note" v="1"/>
+			<tag k="highway" v="road"/>
+		</way>
+		<way id="-2" version="0" timestamp="" changeset="2">
+			<nd ref="-33"/>
+			<nd ref="-8"/>
+			<nd ref="-7"/>
+			<tag k="note" v="3"/>
+			<tag k="highway" v="road"/>
+		</way>
+	</create>
+</osmChange>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000001-00002-Response-200.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000001-00002-Response-200.osc
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<diffResult version="0.6" generator="CGImap 0.8.0 (32112 localhost.localdomain)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+<diffResult version="0.6" generator="CGImap 0.8.0" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
  <node old_id="-1" new_id="37" new_version="1"/>
  <node old_id="-2" new_id="38" new_version="1"/>
  <node old_id="-7" new_id="39" new_version="1"/>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000001-00002-Response-200.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000001-00002-Response-200.osc
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<diffResult version="0.6" generator="CGImap 0.8.0 (32112 localhost.localdomain)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+ <node old_id="-1" new_id="37" new_version="1"/>
+ <node old_id="-2" new_id="38" new_version="1"/>
+ <node old_id="-7" new_id="39" new_version="1"/>
+ <node old_id="-8" new_id="40" new_version="1"/>
+ <node old_id="-32" new_id="41" new_version="1"/>
+ <node old_id="-33" new_id="42" new_version="1"/>
+ <way old_id="-1" new_id="5" new_version="1"/>
+ <way old_id="-2" new_id="6" new_version="1"/>
+</diffResult>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000002-00002-Request--000.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000002-00002-Request--000.osc
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<create>
+		<node id="-3" version="0" lat="38.8540541370891077" lon="-104.9024316099691276" timestamp="" changeset="2"/>
+		<node id="-4" version="0" lat="38.8541298962059614" lon="-104.9023065312240703" timestamp="" changeset="2"/>
+		<node id="-5" version="0" lat="38.8543319201230304" lon="-104.9017876860593788" timestamp="" changeset="2"/>
+		<node id="-6" version="0" lat="38.8548207434768855" lon="-104.9008079025564655" timestamp="" changeset="2"/>
+		<node id="-9" version="0" lat="38.8549073243849037" lon="-104.8961823052623856" timestamp="" changeset="2"/>
+		<node id="-10" version="0" lat="38.8549019130812496" lon="-104.8964394115716487" timestamp="" changeset="2"/>
+		<node id="-11" version="0" lat="38.8548604264061623" lon="-104.8968586569948798" timestamp="" changeset="2"/>
+		<node id="-12" version="0" lat="38.8547197322843374" lon="-104.8973219116062410" timestamp="" changeset="2"/>
+	</create>
+</osmChange>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000002-00002-Response-200.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000002-00002-Response-200.osc
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<diffResult version="0.6" generator="CGImap 0.8.0 (32112 localhost.localdomain)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+<diffResult version="0.6" generator="CGImap 0.8.0" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
  <node old_id="-3" new_id="43" new_version="1"/>
  <node old_id="-4" new_id="44" new_version="1"/>
  <node old_id="-5" new_id="45" new_version="1"/>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000002-00002-Response-200.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000002-00002-Response-200.osc
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<diffResult version="0.6" generator="CGImap 0.8.0 (32112 localhost.localdomain)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+ <node old_id="-3" new_id="43" new_version="1"/>
+ <node old_id="-4" new_id="44" new_version="1"/>
+ <node old_id="-5" new_id="45" new_version="1"/>
+ <node old_id="-6" new_id="46" new_version="1"/>
+ <node old_id="-9" new_id="47" new_version="1"/>
+ <node old_id="-10" new_id="48" new_version="1"/>
+ <node old_id="-11" new_id="49" new_version="1"/>
+ <node old_id="-12" new_id="50" new_version="1"/>
+</diffResult>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000003-00002-Request--000.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000003-00002-Request--000.osc
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<create>
+		<node id="-13" version="0" lat="38.8546042907457476" lon="-104.8977759011253141" timestamp="" changeset="2"/>
+		<node id="-14" version="0" lat="38.8544293243065937" lon="-104.8980654352573794" timestamp="" changeset="2"/>
+		<node id="-15" version="0" lat="38.8542327120211866" lon="-104.8983109602013855" timestamp="" changeset="2"/>
+		<node id="-16" version="0" lat="38.8541767946664436" lon="-104.8987070428940598" timestamp="" changeset="2"/>
+		<node id="-17" version="0" lat="38.8541335037809361" lon="-104.8988900284655159" timestamp="" changeset="2"/>
+		<node id="-18" version="0" lat="38.8539585361836473" lon="-104.8989155074691695" timestamp="" changeset="2"/>
+		<node id="-19" version="0" lat="38.8537204352567329" lon="-104.8987232568054679" timestamp="" changeset="2"/>
+		<node id="-20" version="0" lat="38.8536194225014810" lon="-104.8987070428940598" timestamp="" changeset="2"/>
+	</create>
+</osmChange>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000003-00002-Response-200.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000003-00002-Response-200.osc
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<diffResult version="0.6" generator="CGImap 0.8.0 (32112 localhost.localdomain)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+<diffResult version="0.6" generator="CGImap 0.8.0" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
  <node old_id="-13" new_id="51" new_version="1"/>
  <node old_id="-14" new_id="52" new_version="1"/>
  <node old_id="-15" new_id="53" new_version="1"/>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000003-00002-Response-200.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000003-00002-Response-200.osc
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<diffResult version="0.6" generator="CGImap 0.8.0 (32112 localhost.localdomain)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+ <node old_id="-13" new_id="51" new_version="1"/>
+ <node old_id="-14" new_id="52" new_version="1"/>
+ <node old_id="-15" new_id="53" new_version="1"/>
+ <node old_id="-16" new_id="54" new_version="1"/>
+ <node old_id="-17" new_id="55" new_version="1"/>
+ <node old_id="-18" new_id="56" new_version="1"/>
+ <node old_id="-19" new_id="57" new_version="1"/>
+ <node old_id="-20" new_id="58" new_version="1"/>
+</diffResult>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000004-00002-Request--000.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000004-00002-Request--000.osc
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<create>
+		<node id="-21" version="0" lat="38.8535508780501431" lon="-104.8988321216391171" timestamp="" changeset="2"/>
+		<node id="-22" version="0" lat="38.8535689160700528" lon="-104.8990568001256065" timestamp="" changeset="2"/>
+		<node id="-23" version="0" lat="38.8535166057996975" lon="-104.8992698972467963" timestamp="" changeset="2"/>
+		<node id="-24" version="0" lat="38.8533470481072030" lon="-104.8993671807151884" timestamp="" changeset="2"/>
+		<node id="-30" version="0" lat="38.8542618470630714" lon="-104.8997171368440888" timestamp="" changeset="2"/>
+		<node id="-34" version="0" lat="38.8542471187715179" lon="-104.9010788637033329" timestamp="" changeset="2"/>
+		<node id="-35" version="0" lat="38.8540851073630833" lon="-104.9014476647277121" timestamp="" changeset="2"/>
+		<way id="-4" version="0" timestamp="" changeset="2">
+			<nd ref="-35"/>
+			<nd ref="-34"/>
+			<nd ref="42"/>
+			<nd ref="-30"/>
+			<tag k="note" v="2"/>
+			<tag k="highway" v="road"/>
+		</way>
+	</create>
+</osmChange>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000004-00002-Response-200.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000004-00002-Response-200.osc
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<diffResult version="0.6" generator="CGImap 0.8.0 (32112 localhost.localdomain)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+ <node old_id="-21" new_id="59" new_version="1"/>
+ <node old_id="-22" new_id="60" new_version="1"/>
+ <node old_id="-23" new_id="61" new_version="1"/>
+ <node old_id="-24" new_id="62" new_version="1"/>
+ <node old_id="-30" new_id="63" new_version="1"/>
+ <node old_id="-34" new_id="64" new_version="1"/>
+ <node old_id="-35" new_id="65" new_version="1"/>
+ <way old_id="-4" new_id="7" new_version="1"/>
+</diffResult>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000004-00002-Response-200.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000004-00002-Response-200.osc
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<diffResult version="0.6" generator="CGImap 0.8.0 (32112 localhost.localdomain)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+<diffResult version="0.6" generator="CGImap 0.8.0" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
  <node old_id="-21" new_id="59" new_version="1"/>
  <node old_id="-22" new_id="60" new_version="1"/>
  <node old_id="-23" new_id="61" new_version="1"/>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000005-00002-Request--000.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000005-00002-Request--000.osc
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<create>
+		<node id="-25" version="0" lat="38.8533001490996028" lon="-104.8994528828182951" timestamp="" changeset="2"/>
+		<node id="-26" version="0" lat="38.8532424272016641" lon="-104.8996868263970015" timestamp="" changeset="2"/>
+		<node id="-27" version="0" lat="38.8532583477841484" lon="-104.8997542928851772" timestamp="" changeset="2"/>
+		<node id="-28" version="0" lat="38.8536248456666229" lon="-104.8996934957527998" timestamp="" changeset="2"/>
+		<node id="-29" version="0" lat="38.8539525522998730" lon="-104.8996840393162842" timestamp="" changeset="2"/>
+		<node id="-31" version="0" lat="38.8545785045938388" lon="-104.8997171368440888" timestamp="" changeset="2"/>
+		<node id="-36" version="0" lat="38.8541670018907581" lon="-104.8997069874790355" timestamp="" changeset="2"/>
+	</create>
+</osmChange>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000005-00002-Response-200.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000005-00002-Response-200.osc
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<diffResult version="0.6" generator="CGImap 0.8.0 (32112 localhost.localdomain)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+<diffResult version="0.6" generator="CGImap 0.8.0" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
  <node old_id="-25" new_id="66" new_version="1"/>
  <node old_id="-26" new_id="67" new_version="1"/>
  <node old_id="-27" new_id="68" new_version="1"/>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000005-00002-Response-200.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000005-00002-Response-200.osc
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<diffResult version="0.6" generator="CGImap 0.8.0 (32112 localhost.localdomain)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+ <node old_id="-25" new_id="66" new_version="1"/>
+ <node old_id="-26" new_id="67" new_version="1"/>
+ <node old_id="-27" new_id="68" new_version="1"/>
+ <node old_id="-28" new_id="69" new_version="1"/>
+ <node old_id="-29" new_id="70" new_version="1"/>
+ <node old_id="-31" new_id="71" new_version="1"/>
+ <node old_id="-36" new_id="72" new_version="1"/>
+</diffResult>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000006-00002-Request--000.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000006-00002-Request--000.osc
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<create>
+		<way id="-3" version="0" timestamp="" changeset="2">
+			<nd ref="43"/>
+			<nd ref="44"/>
+			<nd ref="45"/>
+			<nd ref="46"/>
+			<nd ref="39"/>
+			<nd ref="41"/>
+			<nd ref="71"/>
+			<nd ref="63"/>
+			<nd ref="72"/>
+			<nd ref="70"/>
+			<nd ref="69"/>
+			<nd ref="68"/>
+			<nd ref="67"/>
+			<nd ref="66"/>
+			<nd ref="62"/>
+			<nd ref="61"/>
+			<nd ref="60"/>
+			<nd ref="59"/>
+			<nd ref="58"/>
+			<nd ref="57"/>
+			<nd ref="56"/>
+			<nd ref="55"/>
+			<nd ref="54"/>
+			<nd ref="53"/>
+			<nd ref="52"/>
+			<nd ref="51"/>
+			<nd ref="50"/>
+			<nd ref="49"/>
+			<nd ref="48"/>
+			<nd ref="47"/>
+			<tag k="note" v="0"/>
+			<tag k="highway" v="road"/>
+		</way>
+	</create>
+</osmChange>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000006-00002-Response-200.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000006-00002-Response-200.osc
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<diffResult version="0.6" generator="CGImap 0.8.0 (32112 localhost.localdomain)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+<diffResult version="0.6" generator="CGImap 0.8.0" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
  <way old_id="-3" new_id="8" new_version="1"/>
 </diffResult>

--- a/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000006-00002-Response-200.osc
+++ b/test-files/cmd/quick/DiffCmdChangesetTest/Success/OsmApiWriter-000006-00002-Response-200.osc
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<diffResult version="0.6" generator="CGImap 0.8.0 (32112 localhost.localdomain)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+ <way old_id="-3" new_id="8" new_version="1"/>
+</diffResult>


### PR DESCRIPTION
Add logic to the `hoot diff` command to read `.osc` files and directories of `.osc` files output from `hoot changeset-apply` to debug any upload issues that may occur.

Closes #3860 