### PR TITLE
3864 - Preserve element version in HootApiDbWriter during new element write

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -1509,6 +1509,14 @@ relations that were written to the database.
 If set to true then if there is already a map with the specified name then it will be removed before
 a new map is written.
 
+=== hootapi.db.writer.preserve.version.on.insert
+
+* Data Type: bool
+* Default Value: `false`
+
+If true, versions for elements are retained on new writes to the Hootenanny API database. If false,
+versions are reset to an initial version of 1.
+
 === hootapi.db.writer.remap.ids
 
 * Data Type: bool

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
@@ -63,6 +63,7 @@ class ServiceHootApiDbWriterTest : public HootTestFixture
   CPPUNIT_TEST(twoMapsSameNameSameUserOverwriteDisabledTest);
   CPPUNIT_TEST(twoMapsSameNameSameUserOverwriteEnabledTest);
   CPPUNIT_TEST(jobIdTest);
+  CPPUNIT_TEST(preserveVersionOnInsertTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -108,6 +109,7 @@ public:
     HootApiDbWriter writer;
     writer.setUserEmail(userEmail());
     writer.setIncludeDebug(true);
+    writer.setPreserveVersionOnInsert(false);
     writer.open(ServicesDbTestUtils::getDbModifyUrl(_testName).toString());
 
     OsmMapPtr map(new OsmMap());
@@ -143,6 +145,7 @@ public:
     writer.setRemap(false);
     writer.setUserEmail(userEmail());
     writer.setIncludeDebug(true);
+    writer.setPreserveVersionOnInsert(false);
     writer.open(ServicesDbTestUtils::getDbModifyUrl(_testName).toString());
 
     OsmMapPtr map(new OsmMap());
@@ -255,6 +258,7 @@ public:
     HootApiDbWriter writer;
     writer.setUserEmail(userEmail());
     writer.setIncludeDebug(true);
+    writer.setPreserveVersionOnInsert(false);
     writer.open(ServicesDbTestUtils::getDbModifyUrl(_testName).toString());
 
     OsmMapPtr map(new OsmMap());
@@ -356,6 +360,7 @@ public:
     writer.setRemap(false);
     writer.setUserEmail(userEmail());
     writer.setIncludeDebug(true);
+    writer.setPreserveVersionOnInsert(false);
     writer.open(ServicesDbTestUtils::getDbModifyUrl(_testName).toString());
     OsmMapPtr map(new OsmMap());
     NodePtr n1(new Node(Status::Unknown1, 1, 0.0, 0.0, 10.0));
@@ -381,6 +386,7 @@ public:
     writer2.setRemap(false);
     writer2.setIncludeDebug(true);
     writer2.setUserEmail(differentUserEmail);
+    writer2.setPreserveVersionOnInsert(false);
     LOG_DEBUG("Attempting to open db for writing second map...");
     writer2.open(ServicesDbTestUtils::getDbModifyUrl(_testName).toString());
     // This should not fail, since we allow different users to write maps with the same name (just
@@ -407,6 +413,7 @@ public:
     writer.setRemap(false);
     writer.setUserEmail(userEmail());
     writer.setIncludeDebug(true);
+    writer.setPreserveVersionOnInsert(false);
     writer.open(ServicesDbTestUtils::getDbModifyUrl(_testName).toString());
     writer.write(map1);
     const long mapId = writer.getMapId();
@@ -424,6 +431,7 @@ public:
     writer2.setIncludeDebug(true);
     writer2.setUserEmail(userEmail());
     writer2.setOverwriteMap(false);
+    writer2.setPreserveVersionOnInsert(false);
     writer2.open(ServicesDbTestUtils::getDbModifyUrl(_testName).toString());
     writer2.write(map2);
     writer2.close();
@@ -453,6 +461,7 @@ public:
     writer.setRemap(false);
     writer.setUserEmail(userEmail());
     writer.setIncludeDebug(true);
+    writer.setPreserveVersionOnInsert(false);
     writer.open(ServicesDbTestUtils::getDbModifyUrl(_testName).toString());
     writer.write(map);
     const long firstMapId = writer.getMapId();
@@ -470,6 +479,7 @@ public:
     writer2.setRemap(false);
     writer2.setIncludeDebug(true);
     writer2.setUserEmail(userEmail());
+    writer2.setPreserveVersionOnInsert(false);
     writer2.open(ServicesDbTestUtils::getDbModifyUrl(_testName).toString());
     writer2.write(map2);
     const long secondMapId = writer2.getMapId();
@@ -513,6 +523,7 @@ public:
     writer.setRemap(false);
     writer.setUserEmail(userEmail());
     writer.setIncludeDebug(true);
+    writer.setPreserveVersionOnInsert(false);
     writer.open(ServicesDbTestUtils::getDbModifyUrl(_testName).toString());
     writer.write(map);
     const long firstMapId = writer.getMapId();
@@ -525,6 +536,7 @@ public:
     writer2.setRemap(false);
     writer2.setUserEmail(userEmail());
     writer2.setIncludeDebug(true);
+    writer2.setPreserveVersionOnInsert(false);
     writer2.open(ServicesDbTestUtils::getDbModifyUrl(_testName + "2").toString());
     writer2.write(map);
     const long secondMapId = writer2.getMapId();
@@ -545,6 +557,97 @@ public:
     db.deleteMap(secondMapId);
     db._deleteJob(jobId);
     db.close();
+  }
+
+  void preserveVersionOnInsertTest()
+  {
+    setUpTest("runInsertTest");
+    // populate the database.
+    HootApiDbWriter writer;
+    writer.setRemap(false);
+    writer.setUserEmail(userEmail());
+    writer.setIncludeDebug(true);
+    writer.setPreserveVersionOnInsert(true);
+    writer.open(ServicesDbTestUtils::getDbModifyUrl(_testName).toString());
+
+    OsmMapPtr map(new OsmMap());
+
+    NodePtr n1(new Node(Status::Unknown1, 1, 0.0, 0.0, 10.0));
+    n1->setTag("note", "n1");
+    NodePtr n2(new Node(Status::Unknown2, 2, 0.1, 0.0, 11.0));
+    n2->setTag("note", "n2");
+    n2->setVersion(2);
+    NodePtr n3(new Node(Status::Conflated, 3, 0.2, 0.0, 12.0));
+    n3->setTag("note", "n3");
+    n3->setVersion(1);
+    map->addNode(n1);
+    map->addNode(n2);
+    map->addNode(n3);
+
+    WayPtr w1(new Way(Status::Unknown1, 1, 13.0));
+    w1->addNode(1);
+    w1->addNode(2);
+    w1->setTag("note", "w1");
+    w1->setVersion(3);
+    WayPtr w2(new Way(Status::Unknown2, 2, 14.0));
+    w2->addNode(2);
+    w2->addNode(3);
+    w2->setTag("note", "w2");
+    map->addWay(w1);
+    map->addWay(w2);
+
+    RelationPtr r1(new Relation(Status::Unknown1, 1, 15.0, MetadataTags::RelationCollection()));
+    r1->addElement("n1", n1->getElementId());
+    r1->addElement("w1", w1->getElementId());
+    r1->setTag("note", "r1");
+    r1->setVersion(2);
+    map->addRelation(r1);
+
+    writer.write(map);
+
+    _mapId = writer.getMapId();
+    writer.close();
+
+    ServicesDbTestUtils::compareRecords("SELECT latitude, longitude, visible, tile, version, tags FROM " +
+                                        HootApiDb::getCurrentNodesTableName(_mapId) +
+                                        " ORDER BY longitude",
+                                        "0;0;true;3221225472;1;\"note\"=>\"n1\", \"" +
+                                          MetadataTags::HootId() + "\"=>\"1\", \"" +
+                                          MetadataTags::HootStatus() + "\"=>\"1\", \"" +
+                                          MetadataTags::ErrorCircular() + "\"=>\"10\"\n"
+                                        "0;0.1;true;3221225992;2;\"note\"=>\"n2\", \"" +
+                                          MetadataTags::HootId() + "\"=>\"2\", \"" +
+                                          MetadataTags::HootStatus() + "\"=>\"2\", \"" +
+                                          MetadataTags::ErrorCircular() + "\"=>\"11\"\n"
+                                        "0;0.2;true;3221227552;1;\"note\"=>\"n3\", \"" +
+                                          MetadataTags::HootId() + "\"=>\"3\", \"" +
+                                          MetadataTags::HootStatus() + "\"=>\"3\", \"" +
+                                          MetadataTags::ErrorCircular() + "\"=>\"12\"",
+                                        _testName,
+                                        (qlonglong)_mapId);
+
+    ServicesDbTestUtils::compareRecords("SELECT id, visible, version, tags FROM " +
+                                        HootApiDb::getCurrentWaysTableName(_mapId) +
+                                        " ORDER BY id",
+                                        "1;true;3;\"note\"=>\"w1\", \"" + MetadataTags::HootId() +
+                                          "\"=>\"1\", \"" + MetadataTags::HootStatus() +
+                                          "\"=>\"1\", \"" + MetadataTags::ErrorCircular() +
+                                          "\"=>\"13\"\n"
+                                        "2;true;1;\"note\"=>\"w2\", \"" + MetadataTags::HootId() +
+                                          "\"=>\"2\", \"" + MetadataTags::HootStatus() +
+                                          "\"=>\"2\", \"" + MetadataTags::ErrorCircular() +
+                                          "\"=>\"14\"",
+                                        _testName,
+                                        (qlonglong)_mapId);
+
+    ServicesDbTestUtils::compareRecords("SELECT id, visible, version, tags FROM " +
+                                        HootApiDb::getCurrentRelationsTableName(_mapId),
+                                        "1;true;2;\"note\"=>\"r1\", \"type\"=>\"collection\", \"" +
+                                          MetadataTags::HootId() + "\"=>\"1\", \"" +
+                                          MetadataTags::HootStatus() + "\"=>\"1\", \"" +
+                                          MetadataTags::ErrorCircular() + "\"=>\"15\"",
+                                        _testName,
+                                        (qlonglong)_mapId);
   }
 
 private:

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbWriterTest.cpp
@@ -561,7 +561,7 @@ public:
 
   void preserveVersionOnInsertTest()
   {
-    setUpTest("runInsertTest");
+    setUpTest("preserveVersionOnInsertTest");
     // populate the database.
     HootApiDbWriter writer;
     writer.setRemap(false);

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
@@ -782,14 +782,16 @@ long HootApiDb::insertMap(QString displayName)
   return mapId;
 }
 
-bool HootApiDb::insertNode(const double lat, const double lon, const Tags& tags, long& assignedId)
+bool HootApiDb::insertNode(const double lat, const double lon, const Tags& tags, long& assignedId,
+                           long version)
 {
   assignedId = _getNextNodeId();
 
-  return insertNode(assignedId, lat, lon, tags);
+  return insertNode(assignedId, lat, lon, tags, version);
 }
 
-bool HootApiDb::insertNode(const long id, const double lat, const double lon, const Tags &tags)
+bool HootApiDb::insertNode(const long id, const double lat, const double lon, const Tags &tags,
+                           long version)
 {
   LOG_TRACE("Inserting node: " << id << "...");
 
@@ -804,7 +806,8 @@ bool HootApiDb::insertNode(const long id, const double lat, const double lon, co
     columns << "id" << "latitude" << "longitude" << "changeset_id" << "timestamp" <<
                "tile" << "version" << "tags";
 
-    _nodeBulkInsert.reset(new SqlBulkInsert(_db, getCurrentNodesTableName(mapId), columns, _ignoreInsertConflicts));
+    _nodeBulkInsert.reset(
+      new SqlBulkInsert(_db, getCurrentNodesTableName(mapId), columns, _ignoreInsertConflicts));
   }
 
   QList<QVariant> v;
@@ -814,7 +817,14 @@ bool HootApiDb::insertNode(const long id, const double lat, const double lon, co
   v.append((qlonglong)_currChangesetId);
   v.append(OsmUtils::currentTimeAsString());
   v.append(tileForPoint(lat, lon));
-  v.append((qlonglong)1);
+  if (version == 0)
+  {
+    v.append((qlonglong)1);
+  }
+  else
+  {
+    v.append((qlonglong)version);
+  }
   // escaping tags ensures that we won't introduce a SQL injection vulnerability, however, if a
   // bad tag is passed and it isn't escaped properly (shouldn't happen) it may result in a syntax
   // error.
@@ -842,9 +852,9 @@ bool HootApiDb::insertNode(const long id, const double lat, const double lon, co
   return true;
 }
 
-bool HootApiDb::insertNode(ConstNodePtr node)
+bool HootApiDb::insertNode(ConstNodePtr node, long version)
 {
-  return insertNode(node->getId(), node->getY(), node->getX(), node->getTags());
+  return insertNode(node->getId(), node->getY(), node->getX(), node->getTags(), version);
 }
 
 void HootApiDb::updateNode(ConstNodePtr node)
@@ -881,14 +891,14 @@ void HootApiDb::deleteNode(ConstNodePtr node)
   LOG_TRACE("Deleted node: " << ElementId(ElementType::Node, node->getId()));
 }
 
-bool HootApiDb::insertRelation(const Tags &tags, long& assignedId)
+bool HootApiDb::insertRelation(const Tags &tags, long& assignedId, long version)
 {
   assignedId = _getNextRelationId();
 
-  return insertRelation(assignedId, tags);
+  return insertRelation(assignedId, tags, version);
 }
 
-bool HootApiDb::insertRelation(const long relationId, const Tags &tags)
+bool HootApiDb::insertRelation(const long relationId, const Tags &tags, long version)
 {
   LOG_TRACE("Inserting relation: " << relationId << "...");
 
@@ -900,14 +910,22 @@ bool HootApiDb::insertRelation(const long relationId, const Tags &tags)
     QStringList columns;
     columns << "id" << "changeset_id" << "timestamp" << "version" << "tags";
 
-    _relationBulkInsert.reset(new SqlBulkInsert(_db, getCurrentRelationsTableName(mapId), columns, _ignoreInsertConflicts));
+    _relationBulkInsert.reset(
+      new SqlBulkInsert(_db, getCurrentRelationsTableName(mapId), columns, _ignoreInsertConflicts));
   }
 
   QList<QVariant> v;
   v.append((qlonglong)relationId);
   v.append((qlonglong)_currChangesetId);
   v.append(OsmUtils::currentTimeAsString());
-  v.append((qlonglong)1);
+  if (version == 0)
+  {
+    v.append((qlonglong)1);
+  }
+  else
+  {
+    v.append((qlonglong)version);
+  }
   // escaping tags ensures that we won't introduce a SQL injection vulnerability, however, if a
   // bad tag is passed and it isn't escaped properly (shouldn't happen) it may result in a syntax
   // error.
@@ -2229,14 +2247,14 @@ void HootApiDb::updateWay(const long id, const long version, const Tags& tags)
   LOG_TRACE("Updated way: " << ElementId(ElementType::Way, id));
 }
 
-bool HootApiDb::insertWay(const Tags &tags, long &assignedId)
+bool HootApiDb::insertWay(const Tags &tags, long &assignedId, long version)
 {
   assignedId = _getNextWayId();
 
-  return insertWay(assignedId, tags);
+  return insertWay(assignedId, tags, version);
 }
 
-bool HootApiDb::insertWay(const long wayId, const Tags &tags)
+bool HootApiDb::insertWay(const long wayId, const Tags &tags, long version)
 {
   LOG_TRACE("Inserting way: " << wayId << "...");
 
@@ -2251,14 +2269,22 @@ bool HootApiDb::insertWay(const long wayId, const Tags &tags)
     QStringList columns;
     columns << "id" << "changeset_id" << "timestamp" << "version" << "tags";
 
-    _wayBulkInsert.reset(new SqlBulkInsert(_db, getCurrentWaysTableName(mapId), columns, _ignoreInsertConflicts));
+    _wayBulkInsert.reset(
+      new SqlBulkInsert(_db, getCurrentWaysTableName(mapId), columns, _ignoreInsertConflicts));
   }
 
   QList<QVariant> v;
   v.append((qlonglong)wayId);
   v.append((qlonglong)_currChangesetId);
   v.append(OsmUtils::currentTimeAsString());
-  v.append((qlonglong)1);
+  if (version == 0)
+  {
+    v.append((qlonglong)1);
+  }
+  else
+  {
+    v.append((qlonglong)version);
+  }
   // escaping tags ensures that we won't introduce a SQL injection vulnerability, however, if a
   // bad tag is passed and it isn't escaped properly (shouldn't happen) it may result in a syntax
   // error.

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
@@ -192,21 +192,19 @@ public:
    */
   long insertMap(QString mapName);
 
-  bool insertNode(const double lat, const double lon, const Tags &tags, long& assignedId);
+  bool insertNode(const double lat, const double lon, const Tags &tags, long& assignedId,
+                  long version = 0);
+  bool insertNode(const long id, const double lat, const double lon, const Tags &tags,
+                  long version = 0);
+  bool insertNode(ConstNodePtr node, long version = 0);
 
-  bool insertNode(const long id, const double lat, const double lon, const Tags &tags);
-
-  bool insertNode(ConstNodePtr node);
-
-  bool insertWay(const Tags& tags, long& assignedId);
-
-  bool insertWay( const long wayId, const Tags& tags);
+  bool insertWay(const Tags& tags, long& assignedId, long version = 0);
+  bool insertWay( const long wayId, const Tags& tags, long version = 0);
 
   void insertWayNodes(long wayId, const std::vector<long>& nodeIds);
 
-  bool insertRelation(const Tags& tags, long& assignedId);
-
-  bool insertRelation(const long relationId, const Tags& tags);
+  bool insertRelation(const Tags& tags, long& assignedId, long version = 0);
+  bool insertRelation(const long relationId, const Tags& tags, long version = 0);
 
   /**
    * Insert a new member into an existing relation

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.cpp
@@ -557,7 +557,7 @@ void HootApiDbWriter::writePartial(const ConstRelationPtr& r)
     }
 
     _hootdb.insertRelationMember(relationId, relationMemberElementId.getType(),
-                              relationMemberElementId.getId(), e.role, i);
+                                 relationMemberElementId.getId(), e.role, i);
   }
 
   LOG_TRACE("All members added to relation " << QString::number(relationId));

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "HootApiDbWriter.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef HOOTAPIDBWRITER_H
 #define HOOTAPIDBWRITER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.h
@@ -75,6 +75,7 @@ public:
   void setRemap(bool remap) { _remapIds = remap; }
   void setUserEmail(const QString& email) { _userEmail = email; }
   void setJobId(const QString& id) { _jobId = id; }
+  void setPreserveVersionOnInsert(bool preserve) { _preserveVersionOnInsert = preserve; }
 
   virtual void writePartial(const ConstNodePtr& n) override;
   virtual void writePartial(const ConstWayPtr& w) override;
@@ -145,6 +146,9 @@ private:
   bool _textStatus;
   bool _includeCircularError;
   QString _jobId;
+  // If true the version of the element will be retained when writing to the db. Otherwise, the
+  // version is reset to the initial version of 1.
+  bool _preserveVersionOnInsert;
 
   bool _open;
 


### PR DESCRIPTION
Adds option for preserving existing element version during an insert to an Hoot API DB table. From the command line use the option `hootapi.db.writer.preserve.version.on.insert=true`.