### PR TITLE
Update Changeset Derive to use the reference version number if different

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetCreatorTest.cpp
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2020 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+// Hoot
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/algorithms/changeset/ChangesetCreator.h>
+#include <hoot/core/util/Log.h>
+
+namespace hoot
+{
+
+class ChangesetCreatorTest : public HootTestFixture
+{
+  CPPUNIT_TEST_SUITE(ChangesetCreatorTest);
+  CPPUNIT_TEST(runUpdateVersionTest);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  ChangesetCreatorTest() :
+  HootTestFixture("test-files/algorithms/changeset/ChangesetCreatorTest/",
+                  "test-output/algorithms/changeset/ChangesetCreatorTest/")
+  {
+  }
+
+  void runUpdateVersionTest()
+  {
+    QString reference = _inputPath + "ChangesetDeriveUpdateVersion_ref.osm";
+    QString secondary = _inputPath + "ChangesetDeriveUpdateVersion_sec.osm";
+    QString output = _outputPath + "ChangsetDeriveUpdateVersion_output.osm";
+    QString expected = _inputPath + "ChangesetDeriveUpdateVersion_expected.osm";
+
+    ChangesetCreator(false, "").create(output, reference, secondary);
+
+    HOOT_FILE_EQUALS(output, expected);
+  }
+};
+
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ChangesetCreatorTest, "quick");
+
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetCreatorTest.cpp
@@ -51,8 +51,8 @@ public:
   {
     QString reference = _inputPath + "ChangesetDeriveUpdateVersion_ref.osm";
     QString secondary = _inputPath + "ChangesetDeriveUpdateVersion_sec.osm";
-    QString output = _outputPath + "ChangsetDeriveUpdateVersion_output.osm";
-    QString expected = _inputPath + "ChangesetDeriveUpdateVersion_expected.osm";
+    QString output = _outputPath + "ChangsetDeriveUpdateVersion_output.osc";
+    QString expected = _inputPath + "ChangesetDeriveUpdateVersion_expected.osc";
 
     ChangesetCreator(false, "").create(output, reference, secondary);
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetDeriveCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetDeriveCmd.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetDeriveCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetDeriveCmd.cpp
@@ -26,12 +26,9 @@
  */
 
 // Hoot
-#include <hoot/core/util/Factory.h>
-#include <hoot/core/cmd/BoundedCommand.h>
 #include <hoot/core/algorithms/changeset/ChangesetCreator.h>
-#include <hoot/core/io/OsmMapWriterFactory.h>
-#include <hoot/core/util/GeometryUtils.h>
-#include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/cmd/BoundedCommand.h>
+#include <hoot/core/util/Factory.h>
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlChangesetFileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlChangesetFileWriter.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef OSMXMLCHANGESETFILEWRITER_H
 #define OSMXMLCHANGESETFILEWRITER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlChangesetFileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlChangesetFileWriter.h
@@ -102,9 +102,9 @@ private:
   ScoreMatrix<long> _stats;
 
   /** Helper functions to write nodes, ways, and relations. */
-  void _writeNode(QXmlStreamWriter& writer, ConstNodePtr n);
-  void _writeWay(QXmlStreamWriter& writer, ConstWayPtr w);
-  void _writeRelation(QXmlStreamWriter& writer, ConstRelationPtr r);
+  void _writeNode(QXmlStreamWriter& writer, ConstElementPtr node, ConstElementPtr previous);
+  void _writeWay(QXmlStreamWriter& writer, ConstElementPtr way, ConstElementPtr previous);
+  void _writeRelation(QXmlStreamWriter& writer, ConstElementPtr relation, ConstElementPtr previous);
   void _writeTags(QXmlStreamWriter& writer, Tags& tags, const Element* element);
 
   void _initIdCounters();

--- a/test-files/algorithms/changeset/ChangesetCreatorTest/ChangesetDeriveUpdateVersion_expected.osc
+++ b/test-files/algorithms/changeset/ChangesetCreatorTest/ChangesetDeriveUpdateVersion_expected.osc
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+    <create>
+        <node id="-1" version="0" lat="42.4762854000000019" lon="-71.4715554999999938" timestamp=""/>
+        <node id="-2" version="0" lat="42.4762847000000008" lon="-71.4714519999999993" timestamp=""/>
+        <node id="-3" version="0" lat="42.4761649000000006" lon="-71.4714538000000061" timestamp=""/>
+        <node id="-4" version="0" lat="42.4761627999999973" lon="-71.4715541000000059" timestamp=""/>
+    </create>
+    <delete>
+        <node id="1" version="1" lat="42.4765293999999969" lon="-71.4715228999999965" timestamp=""/>
+        <node id="2" version="1" lat="42.4762369000000035" lon="-71.4720827999999955" timestamp="">
+            <tag k="name" v="Office of Michael Rosenfeld, Inc., Architects"/>
+            <tag k="shop" v="architect"/>
+        </node>
+        <node id="3" version="1" lat="42.4764004000000028" lon="-71.4730938999999950" timestamp="">
+            <tag k="name" v="New London Style Pizza"/>
+            <tag k="amenity" v="restaurant"/>
+        </node>
+        <node id="5" version="1" lat="42.4763037000000026" lon="-71.4724917000000062" timestamp="">
+            <tag k="name" v="West Acton Mobil"/>
+            <tag k="amenity" v="fuel"/>
+        </node>
+        <node id="6" version="1" lat="42.4763269999999977" lon="-71.4728103000000061" timestamp="">
+            <tag k="shop" v="convenience"/>
+        </node>
+        <node id="35" version="1" lat="42.4764575000000022" lon="-71.4715237000000059" timestamp=""/>
+        <node id="36" version="1" lat="42.4765288999999981" lon="-71.4714352999999960" timestamp=""/>
+        <node id="37" version="1" lat="42.4764569000000023" lon="-71.4714361000000054" timestamp=""/>
+    </delete>
+    <create>
+        <way id="-1" version="0" timestamp="">
+            <nd ref="-4"/>
+            <nd ref="-3"/>
+            <nd ref="-2"/>
+            <nd ref="-1"/>
+            <nd ref="-4"/>
+            <tag k="addr:street" v="Massachusetts Avenue"/>
+            <tag k="addr:state" v="MA"/>
+            <tag k="name" v="Twin Seafood"/>
+            <tag k="length" v="13.6"/>
+            <tag k="building" v="yes"/>
+            <tag k="addr:country" v="US"/>
+            <tag k="feature_area" v="112.5"/>
+            <tag k="width" v="8.5"/>
+            <tag k="addr:housenumber" v="541"/>
+            <tag k="addr:city" v="Acton"/>
+            <tag k="amenity" v="cafe"/>
+            <tag k="angle" v="179.5"/>
+        </way>
+    </create>
+    <modify>
+        <way id="1" version="1" timestamp="">
+            <nd ref="7"/>
+            <nd ref="8"/>
+            <nd ref="9"/>
+            <nd ref="10"/>
+            <nd ref="11"/>
+            <nd ref="7"/>
+            <tag k="name" v="New London Style Pizza"/>
+            <tag k="length" v="25.4"/>
+            <tag k="building" v="yes"/>
+            <tag k="feature_area" v="313.5"/>
+            <tag k="width" v="16.1"/>
+            <tag k="amenity" v="restaurant"/>
+            <tag k="angle" v="163.8"/>
+        </way>
+    </modify>
+    <delete>
+        <way id="5" version="1" timestamp="">
+            <nd ref="35"/>
+            <nd ref="1"/>
+            <nd ref="36"/>
+            <nd ref="37"/>
+            <nd ref="35"/>
+            <tag k="length" v="8.0"/>
+            <tag k="building" v="yes"/>
+            <tag k="feature_area" v="57.4"/>
+            <tag k="width" v="7.2"/>
+            <tag k="angle" v="180.5"/>
+        </way>
+    </delete>
+    <modify>
+        <way id="6" version="1" timestamp="">
+            <nd ref="38"/>
+            <nd ref="39"/>
+            <nd ref="40"/>
+            <nd ref="41"/>
+            <nd ref="38"/>
+            <tag k="addr:street" v="Massachusetts Avenue"/>
+            <tag k="addr:state" v="MA"/>
+            <tag k="name" v="Office of Michael Rosenfeld, Inc., Architects"/>
+            <tag k="length" v="26.5"/>
+            <tag k="shop" v="architect"/>
+            <tag k="building" v="yes"/>
+            <tag k="addr:country" v="US"/>
+            <tag k="feature_area" v="294.6"/>
+            <tag k="width" v="11.7"/>
+            <tag k="addr:housenumber" v="543"/>
+            <tag k="addr:city" v="Acton"/>
+            <tag k="angle" v="271.2"/>
+        </way>
+        <way id="8" version="1" timestamp="">
+            <nd ref="50"/>
+            <nd ref="51"/>
+            <nd ref="52"/>
+            <nd ref="53"/>
+            <nd ref="50"/>
+            <tag k="name" v="West Acton Mobil"/>
+            <tag k="length" v="23.9"/>
+            <tag k="building" v="roof"/>
+            <tag k="feature_area" v="192.4"/>
+            <tag k="width" v="8.1"/>
+            <tag k="amenity" v="fuel"/>
+            <tag k="angle" v="271.8"/>
+        </way>
+        <way id="9" version="1" timestamp="">
+            <nd ref="54"/>
+            <nd ref="55"/>
+            <nd ref="56"/>
+            <nd ref="57"/>
+            <nd ref="58"/>
+            <nd ref="4"/>
+            <nd ref="54"/>
+            <tag k="length" v="16.1"/>
+            <tag k="shop" v="convenience"/>
+            <tag k="building" v="yes"/>
+            <tag k="feature_area" v="124.7"/>
+            <tag k="width" v="8.3"/>
+            <tag k="angle" v="180.9"/>
+        </way>
+    </modify>
+</osmChange>

--- a/test-files/algorithms/changeset/ChangesetCreatorTest/ChangesetDeriveUpdateVersion_expected.osc
+++ b/test-files/algorithms/changeset/ChangesetCreatorTest/ChangesetDeriveUpdateVersion_expected.osc
@@ -13,12 +13,12 @@
             <tag k="shop" v="architect"/>
         </node>
         <node id="3" version="1" lat="42.4764004000000028" lon="-71.4730938999999950" timestamp="">
-            <tag k="name" v="New London Style Pizza"/>
             <tag k="amenity" v="restaurant"/>
+            <tag k="name" v="New London Style Pizza"/>
         </node>
         <node id="5" version="1" lat="42.4763037000000026" lon="-71.4724917000000062" timestamp="">
-            <tag k="name" v="West Acton Mobil"/>
             <tag k="amenity" v="fuel"/>
+            <tag k="name" v="West Acton Mobil"/>
         </node>
         <node id="6" version="1" lat="42.4763269999999977" lon="-71.4728103000000061" timestamp="">
             <tag k="shop" v="convenience"/>
@@ -34,18 +34,18 @@
             <nd ref="-2"/>
             <nd ref="-1"/>
             <nd ref="-4"/>
+            <tag k="addr:country" v="US"/>
+            <tag k="feature_area" v="112.5"/>
+            <tag k="amenity" v="cafe"/>
             <tag k="addr:street" v="Massachusetts Avenue"/>
             <tag k="addr:state" v="MA"/>
             <tag k="name" v="Twin Seafood"/>
-            <tag k="length" v="13.6"/>
             <tag k="building" v="yes"/>
-            <tag k="addr:country" v="US"/>
-            <tag k="feature_area" v="112.5"/>
+            <tag k="addr:city" v="Acton"/>
             <tag k="width" v="8.5"/>
             <tag k="addr:housenumber" v="541"/>
-            <tag k="addr:city" v="Acton"/>
-            <tag k="amenity" v="cafe"/>
             <tag k="angle" v="179.5"/>
+            <tag k="length" v="13.6"/>
         </way>
     </create>
     <modify>
@@ -56,13 +56,13 @@
             <nd ref="10"/>
             <nd ref="11"/>
             <nd ref="7"/>
-            <tag k="name" v="New London Style Pizza"/>
-            <tag k="length" v="25.4"/>
-            <tag k="building" v="yes"/>
             <tag k="feature_area" v="313.5"/>
-            <tag k="width" v="16.1"/>
             <tag k="amenity" v="restaurant"/>
+            <tag k="name" v="New London Style Pizza"/>
+            <tag k="building" v="yes"/>
+            <tag k="width" v="16.1"/>
             <tag k="angle" v="163.8"/>
+            <tag k="length" v="25.4"/>
         </way>
     </modify>
     <delete>
@@ -72,11 +72,11 @@
             <nd ref="36"/>
             <nd ref="37"/>
             <nd ref="35"/>
-            <tag k="length" v="8.0"/>
-            <tag k="building" v="yes"/>
             <tag k="feature_area" v="57.4"/>
+            <tag k="building" v="yes"/>
             <tag k="width" v="7.2"/>
             <tag k="angle" v="180.5"/>
+            <tag k="length" v="8.0"/>
         </way>
     </delete>
     <modify>
@@ -86,18 +86,18 @@
             <nd ref="40"/>
             <nd ref="41"/>
             <nd ref="38"/>
+            <tag k="addr:country" v="US"/>
+            <tag k="feature_area" v="294.6"/>
             <tag k="addr:street" v="Massachusetts Avenue"/>
             <tag k="addr:state" v="MA"/>
             <tag k="name" v="Office of Michael Rosenfeld, Inc., Architects"/>
-            <tag k="length" v="26.5"/>
             <tag k="shop" v="architect"/>
             <tag k="building" v="yes"/>
-            <tag k="addr:country" v="US"/>
-            <tag k="feature_area" v="294.6"/>
+            <tag k="addr:city" v="Acton"/>
             <tag k="width" v="11.7"/>
             <tag k="addr:housenumber" v="543"/>
-            <tag k="addr:city" v="Acton"/>
             <tag k="angle" v="271.2"/>
+            <tag k="length" v="26.5"/>
         </way>
         <way id="8" version="1" timestamp="">
             <nd ref="50"/>
@@ -105,13 +105,13 @@
             <nd ref="52"/>
             <nd ref="53"/>
             <nd ref="50"/>
-            <tag k="name" v="West Acton Mobil"/>
-            <tag k="length" v="23.9"/>
-            <tag k="building" v="roof"/>
             <tag k="feature_area" v="192.4"/>
-            <tag k="width" v="8.1"/>
             <tag k="amenity" v="fuel"/>
+            <tag k="name" v="West Acton Mobil"/>
+            <tag k="building" v="roof"/>
+            <tag k="width" v="8.1"/>
             <tag k="angle" v="271.8"/>
+            <tag k="length" v="23.9"/>
         </way>
         <way id="9" version="1" timestamp="">
             <nd ref="54"/>
@@ -121,12 +121,12 @@
             <nd ref="58"/>
             <nd ref="4"/>
             <nd ref="54"/>
-            <tag k="length" v="16.1"/>
+            <tag k="feature_area" v="124.7"/>
             <tag k="shop" v="convenience"/>
             <tag k="building" v="yes"/>
-            <tag k="feature_area" v="124.7"/>
             <tag k="width" v="8.3"/>
             <tag k="angle" v="180.9"/>
+            <tag k="length" v="16.1"/>
         </way>
     </modify>
 </osmChange>

--- a/test-files/algorithms/changeset/ChangesetCreatorTest/ChangesetDeriveUpdateVersion_ref.osm
+++ b/test-files/algorithms/changeset/ChangesetCreatorTest/ChangesetDeriveUpdateVersion_ref.osm
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="42.476178" minlon="-71.4732369" maxlat="42.4766752" maxlon="-71.4714353"/>
+    <node visible="true" id="1" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765293999999969" lon="-71.4715228999999965"/>
+    <node visible="true" id="2" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762369000000035" lon="-71.4720827999999955">
+        <tag k="name" v="Office of Michael Rosenfeld, Inc., Architects"/>
+        <tag k="shop" v="architect"/>
+    </node>
+    <node visible="true" id="3" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764004000000028" lon="-71.4730938999999950">
+        <tag k="amenity" v="restaurant"/>
+        <tag k="name" v="New London Style Pizza"/>
+    </node>
+    <node visible="true" id="4" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762902000000011" lon="-71.4728934999999979"/>
+    <node visible="true" id="5" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763037000000026" lon="-71.4724917000000062">
+        <tag k="amenity" v="fuel"/>
+        <tag k="name" v="West Acton Mobil"/>
+    </node>
+    <node visible="true" id="6" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763269999999977" lon="-71.4728103000000061">
+        <tag k="shop" v="convenience"/>
+    </node>
+    <node visible="true" id="7" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763336999999979" lon="-71.4731613999999951"/>
+    <node visible="true" id="8" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765030000000010" lon="-71.4732369000000034"/>
+    <node visible="true" id="9" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764982000000018" lon="-71.4730308999999977"/>
+    <node visible="true" id="10" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763240999999994" lon="-71.4729621999999978"/>
+    <node visible="true" id="11" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763231000000019" lon="-71.4729738000000054"/>
+    <node visible="true" id="12" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4761895999999979" lon="-71.4728848000000028"/>
+    <node visible="true" id="13" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763191999999989" lon="-71.4729118999999997"/>
+    <node visible="true" id="14" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763202000000035" lon="-71.4731285999999955"/>
+    <node visible="true" id="15" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4761954000000017" lon="-71.4730792000000008"/>
+    <node visible="true" id="16" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4766345000000030" lon="-71.4726260000000053"/>
+    <node visible="true" id="17" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765858000000023" lon="-71.4726000999999940"/>
+    <node visible="true" id="18" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765733999999995" lon="-71.4726423000000040"/>
+    <node visible="true" id="19" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765294999999981" lon="-71.4726189000000005"/>
+    <node visible="true" id="20" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764947000000035" lon="-71.4727378999999985"/>
+    <node visible="true" id="21" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765423999999996" lon="-71.4727632999999969"/>
+    <node visible="true" id="22" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765176000000011" lon="-71.4728479000000050"/>
+    <node visible="true" id="23" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765656000000007" lon="-71.4728735000000057"/>
+    <node visible="true" id="24" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765828000000027" lon="-71.4728680999999995"/>
+    <node visible="true" id="25" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765924000000012" lon="-71.4728347000000070"/>
+    <node visible="true" id="26" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765766000000013" lon="-71.4728259000000037"/>
+    <node visible="true" id="27" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765885999999995" lon="-71.4727848999999935"/>
+    <node visible="true" id="28" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4766294000000002" lon="-71.4728044999999952"/>
+    <node visible="true" id="29" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4766632999999985" lon="-71.4726883000000015"/>
+    <node visible="true" id="30" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4766225999999989" lon="-71.4726665999999966"/>
+    <node visible="true" id="31" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4766568000000007" lon="-71.4723276999999939"/>
+    <node visible="true" id="32" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764691999999968" lon="-71.4722550999999982"/>
+    <node visible="true" id="33" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764604000000006" lon="-71.4721361999999942"/>
+    <node visible="true" id="34" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4766752000000025" lon="-71.4722318999999970"/>
+    <node visible="true" id="35" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764575000000022" lon="-71.4715237000000059"/>
+    <node visible="true" id="36" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765288999999981" lon="-71.4714352999999960"/>
+    <node visible="true" id="37" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764569000000023" lon="-71.4714361000000054"/>
+    <node visible="true" id="38" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762883000000002" lon="-71.4721215999999941"/>
+    <node visible="true" id="39" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762746999999976" lon="-71.4717995999999971"/>
+    <node visible="true" id="40" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4761779999999973" lon="-71.4718053999999938"/>
+    <node visible="true" id="41" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4761827999999966" lon="-71.4721226000000058"/>
+    <node visible="true" id="42" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765742000000017" lon="-71.4715802000000053"/>
+    <node visible="true" id="43" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765562999999986" lon="-71.4715800000000030"/>
+    <node visible="true" id="44" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765566000000021" lon="-71.4715338000000031"/>
+    <node visible="true" id="45" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764598000000007" lon="-71.4715326000000033"/>
+    <node visible="true" id="46" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764558999999977" lon="-71.4721109000000041"/>
+    <node visible="true" id="47" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4766077999999965" lon="-71.4721126999999967"/>
+    <node visible="true" id="48" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4766096999999974" lon="-71.4718227999999982"/>
+    <node visible="true" id="49" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765725000000032" lon="-71.4718222999999995"/>
+    <node visible="true" id="50" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762861000000029" lon="-71.4726983000000047"/>
+    <node visible="true" id="51" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763586999999987" lon="-71.4726952000000040"/>
+    <node visible="true" id="52" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763519999999986" lon="-71.4724046000000044"/>
+    <node visible="true" id="53" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762794000000028" lon="-71.4724075999999968"/>
+    <node visible="true" id="54" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762873000000027" lon="-71.4727948999999967"/>
+    <node visible="true" id="55" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764081000000004" lon="-71.4727898999999951"/>
+    <node visible="true" id="56" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764063000000007" lon="-71.4728142000000020"/>
+    <node visible="true" id="57" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764297999999982" lon="-71.4728152999999935"/>
+    <node visible="true" id="58" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764333999999977" lon="-71.4728905999999995"/>
+    <node visible="true" id="63" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764411000000024" lon="-71.4714591000000041"/>
+    <node visible="true" id="64" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764478999999966" lon="-71.4721255000000042"/>
+    <node visible="true" id="65" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764023999999978" lon="-71.4721322999999984"/>
+    <node visible="true" id="66" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763260000000002" lon="-71.4721265000000017"/>
+    <node visible="true" id="67" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762902000000011" lon="-71.4715712999999937"/>
+    <node visible="true" id="68" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762970000000024" lon="-71.4714532999999932"/>
+    <way visible="true" id="1" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="7"/>
+        <nd ref="8"/>
+        <nd ref="9"/>
+        <nd ref="10"/>
+        <nd ref="11"/>
+        <nd ref="7"/>
+        <tag k="width" v="16.1"/>
+        <tag k="angle" v="163.8"/>
+        <tag k="length" v="25.4"/>
+        <tag k="feature_area" v="313.5"/>
+        <tag k="building" v="yes"/>
+    </way>
+    <way visible="true" id="2" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="12"/>
+        <nd ref="13"/>
+        <nd ref="14"/>
+        <nd ref="15"/>
+        <nd ref="12"/>
+        <tag k="width" v="14.4"/>
+        <tag k="angle" v="270.4"/>
+        <tag k="access" v="customers"/>
+        <tag k="length" v="20.1"/>
+        <tag k="amenity" v="parking"/>
+        <tag k="feature_area" v="237.0"/>
+    </way>
+    <way visible="true" id="3" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="16"/>
+        <nd ref="17"/>
+        <nd ref="18"/>
+        <nd ref="19"/>
+        <nd ref="20"/>
+        <nd ref="21"/>
+        <nd ref="22"/>
+        <nd ref="23"/>
+        <nd ref="24"/>
+        <nd ref="25"/>
+        <nd ref="26"/>
+        <nd ref="27"/>
+        <nd ref="28"/>
+        <nd ref="29"/>
+        <nd ref="30"/>
+        <nd ref="16"/>
+        <tag k="width" v="16.0"/>
+        <tag k="angle" v="248.4"/>
+        <tag k="addr:street" v="Spruce Street"/>
+        <tag k="length" v="21.7"/>
+        <tag k="addr:country" v="US"/>
+        <tag k="feature_area" v="235.3"/>
+        <tag k="building" v="yes"/>
+        <tag k="addr:city" v="Acton"/>
+        <tag k="addr:state" v="MA"/>
+        <tag k="addr:housenumber" v="10"/>
+    </way>
+    <way visible="true" id="4" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="31"/>
+        <nd ref="32"/>
+        <nd ref="33"/>
+        <nd ref="34"/>
+        <nd ref="31"/>
+        <tag k="width" v="9.0"/>
+        <tag k="angle" v="341.8"/>
+        <tag k="addr:street" v="Spruce Street"/>
+        <tag k="length" v="25.7"/>
+        <tag k="addr:country" v="US"/>
+        <tag k="feature_area" v="200.4"/>
+        <tag k="building" v="yes"/>
+        <tag k="addr:city" v="Acton"/>
+        <tag k="addr:state" v="MA"/>
+        <tag k="addr:housenumber" v="5"/>
+    </way>
+    <way visible="true" id="5" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="35"/>
+        <nd ref="1"/>
+        <nd ref="36"/>
+        <nd ref="37"/>
+        <nd ref="35"/>
+        <tag k="width" v="7.2"/>
+        <tag k="angle" v="180.5"/>
+        <tag k="length" v="8.0"/>
+        <tag k="feature_area" v="57.4"/>
+        <tag k="building" v="yes"/>
+    </way>
+    <way visible="true" id="6" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="38"/>
+        <nd ref="39"/>
+        <nd ref="40"/>
+        <nd ref="41"/>
+        <nd ref="38"/>
+        <tag k="width" v="11.7"/>
+        <tag k="angle" v="271.2"/>
+        <tag k="addr:street" v="Massachusetts Avenue"/>
+        <tag k="length" v="26.5"/>
+        <tag k="addr:country" v="US"/>
+        <tag k="feature_area" v="294.6"/>
+        <tag k="building" v="yes"/>
+        <tag k="addr:city" v="Acton"/>
+        <tag k="addr:state" v="MA"/>
+        <tag k="addr:housenumber" v="543"/>
+    </way>
+    <way visible="true" id="7" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="42"/>
+        <nd ref="43"/>
+        <nd ref="44"/>
+        <nd ref="45"/>
+        <nd ref="46"/>
+        <nd ref="47"/>
+        <nd ref="48"/>
+        <nd ref="49"/>
+        <nd ref="42"/>
+        <tag k="width" v="16.9"/>
+        <tag k="angle" v="269.5"/>
+        <tag k="length" v="47.5"/>
+        <tag k="feature_area" v="694.7"/>
+        <tag k="building" v="yes"/>
+    </way>
+    <way visible="true" id="8" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="50"/>
+        <nd ref="51"/>
+        <nd ref="52"/>
+        <nd ref="53"/>
+        <nd ref="50"/>
+        <tag k="width" v="8.1"/>
+        <tag k="angle" v="271.8"/>
+        <tag k="length" v="23.9"/>
+        <tag k="feature_area" v="192.4"/>
+        <tag k="building" v="roof"/>
+    </way>
+    <way visible="true" id="9" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="54"/>
+        <nd ref="55"/>
+        <nd ref="56"/>
+        <nd ref="57"/>
+        <nd ref="58"/>
+        <nd ref="4"/>
+        <nd ref="54"/>
+        <tag k="width" v="8.3"/>
+        <tag k="angle" v="180.9"/>
+        <tag k="length" v="16.1"/>
+        <tag k="feature_area" v="124.7"/>
+        <tag k="building" v="yes"/>
+    </way>
+    <way visible="true" id="11" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="63"/>
+        <nd ref="64"/>
+        <nd ref="65"/>
+        <nd ref="66"/>
+        <nd ref="67"/>
+        <nd ref="68"/>
+        <nd ref="63"/>
+        <tag k="width" v="16.9"/>
+        <tag k="angle" v="270.8"/>
+        <tag k="access" v="customers"/>
+        <tag k="length" v="55.9"/>
+        <tag k="amenity" v="parking"/>
+        <tag k="feature_area" v="851.0"/>
+    </way>
+</osm>

--- a/test-files/algorithms/changeset/ChangesetCreatorTest/ChangesetDeriveUpdateVersion_sec.osm
+++ b/test-files/algorithms/changeset/ChangesetCreatorTest/ChangesetDeriveUpdateVersion_sec.osm
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="42.4761628" minlon="-71.4732369" maxlat="42.4766752" maxlon="-71.471452"/>
+    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762854000000019" lon="-71.4715554999999938"/>
+    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762847000000008" lon="-71.4714519999999993"/>
+    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4761649000000006" lon="-71.4714538000000061"/>
+    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4761627999999973" lon="-71.4715541000000059"/>
+    <node visible="true" id="4" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762902000000011" lon="-71.4728934999999979"/>
+    <node visible="true" id="7" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763336999999979" lon="-71.4731613999999951"/>
+    <node visible="true" id="8" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765030000000010" lon="-71.4732369000000034"/>
+    <node visible="true" id="9" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764982000000018" lon="-71.4730308999999977"/>
+    <node visible="true" id="10" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763240999999994" lon="-71.4729621999999978"/>
+    <node visible="true" id="11" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763231000000019" lon="-71.4729738000000054"/>
+    <node visible="true" id="12" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4761895999999979" lon="-71.4728848000000028"/>
+    <node visible="true" id="13" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763191999999989" lon="-71.4729118999999997"/>
+    <node visible="true" id="14" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763202000000035" lon="-71.4731285999999955"/>
+    <node visible="true" id="15" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4761954000000017" lon="-71.4730792000000008"/>
+    <node visible="true" id="16" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4766345000000030" lon="-71.4726260000000053"/>
+    <node visible="true" id="17" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765858000000023" lon="-71.4726000999999940"/>
+    <node visible="true" id="18" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765733999999995" lon="-71.4726423000000040"/>
+    <node visible="true" id="19" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765294999999981" lon="-71.4726189000000005"/>
+    <node visible="true" id="20" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764947000000035" lon="-71.4727378999999985"/>
+    <node visible="true" id="21" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765423999999996" lon="-71.4727632999999969"/>
+    <node visible="true" id="22" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765176000000011" lon="-71.4728479000000050"/>
+    <node visible="true" id="23" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765656000000007" lon="-71.4728735000000057"/>
+    <node visible="true" id="24" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765828000000027" lon="-71.4728680999999995"/>
+    <node visible="true" id="25" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765924000000012" lon="-71.4728347000000070"/>
+    <node visible="true" id="26" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765766000000013" lon="-71.4728259000000037"/>
+    <node visible="true" id="27" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765885999999995" lon="-71.4727848999999935"/>
+    <node visible="true" id="28" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4766294000000002" lon="-71.4728044999999952"/>
+    <node visible="true" id="29" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4766632999999985" lon="-71.4726883000000015"/>
+    <node visible="true" id="30" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4766225999999989" lon="-71.4726665999999966"/>
+    <node visible="true" id="31" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4766568000000007" lon="-71.4723276999999939"/>
+    <node visible="true" id="32" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764691999999968" lon="-71.4722550999999982"/>
+    <node visible="true" id="33" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764604000000006" lon="-71.4721361999999942"/>
+    <node visible="true" id="34" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4766752000000025" lon="-71.4722318999999970"/>
+    <node visible="true" id="38" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762883000000002" lon="-71.4721215999999941"/>
+    <node visible="true" id="39" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762746999999976" lon="-71.4717995999999971"/>
+    <node visible="true" id="40" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4761779999999973" lon="-71.4718053999999938"/>
+    <node visible="true" id="41" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4761827999999966" lon="-71.4721226000000058"/>
+    <node visible="true" id="42" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765742000000017" lon="-71.4715802000000053"/>
+    <node visible="true" id="43" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765562999999986" lon="-71.4715800000000030"/>
+    <node visible="true" id="44" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765566000000021" lon="-71.4715338000000031"/>
+    <node visible="true" id="45" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764598000000007" lon="-71.4715326000000033"/>
+    <node visible="true" id="46" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764558999999977" lon="-71.4721109000000041"/>
+    <node visible="true" id="47" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4766077999999965" lon="-71.4721126999999967"/>
+    <node visible="true" id="48" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4766096999999974" lon="-71.4718227999999982"/>
+    <node visible="true" id="49" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4765725000000032" lon="-71.4718222999999995"/>
+    <node visible="true" id="50" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762861000000029" lon="-71.4726983000000047"/>
+    <node visible="true" id="51" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763586999999987" lon="-71.4726952000000040"/>
+    <node visible="true" id="52" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763519999999986" lon="-71.4724046000000044"/>
+    <node visible="true" id="53" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762794000000028" lon="-71.4724075999999968"/>
+    <node visible="true" id="54" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762873000000027" lon="-71.4727948999999967"/>
+    <node visible="true" id="55" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764081000000004" lon="-71.4727898999999951"/>
+    <node visible="true" id="56" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764063000000007" lon="-71.4728142000000020"/>
+    <node visible="true" id="57" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764297999999982" lon="-71.4728152999999935"/>
+    <node visible="true" id="58" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764333999999977" lon="-71.4728905999999995"/>
+    <node visible="true" id="63" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764411000000024" lon="-71.4714591000000041"/>
+    <node visible="true" id="64" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764478999999966" lon="-71.4721255000000042"/>
+    <node visible="true" id="65" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4764023999999978" lon="-71.4721322999999984"/>
+    <node visible="true" id="66" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4763260000000002" lon="-71.4721265000000017"/>
+    <node visible="true" id="67" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762902000000011" lon="-71.4715712999999937"/>
+    <node visible="true" id="68" timestamp="1970-01-01T00:00:00Z" version="1" lat="42.4762970000000024" lon="-71.4714532999999932"/>
+    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1"/>
+        <nd ref="-2"/>
+        <nd ref="-3"/>
+        <nd ref="-4"/>
+        <nd ref="-1"/>
+        <tag k="feature_area" v="112.5"/>
+        <tag k="name" v="Twin Seafood"/>
+        <tag k="building" v="yes"/>
+        <tag k="length" v="13.6"/>
+        <tag k="amenity" v="cafe"/>
+        <tag k="width" v="8.5"/>
+        <tag k="angle" v="179.5"/>
+        <tag k="addr:housenumber" v="541"/>
+        <tag k="addr:street" v="Massachusetts Avenue"/>
+        <tag k="addr:state" v="MA"/>
+        <tag k="addr:country" v="US"/>
+        <tag k="addr:city" v="Acton"/>
+    </way>
+    <way visible="true" id="1" timestamp="1970-01-01T00:00:00Z" version="2">
+        <nd ref="7"/>
+        <nd ref="8"/>
+        <nd ref="9"/>
+        <nd ref="10"/>
+        <nd ref="11"/>
+        <nd ref="7"/>
+        <tag k="feature_area" v="313.5"/>
+        <tag k="name" v="New London Style Pizza"/>
+        <tag k="building" v="yes"/>
+        <tag k="amenity" v="restaurant"/>
+        <tag k="length" v="25.4"/>
+        <tag k="width" v="16.1"/>
+        <tag k="angle" v="163.8"/>
+    </way>
+    <way visible="true" id="2" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="12"/>
+        <nd ref="13"/>
+        <nd ref="14"/>
+        <nd ref="15"/>
+        <nd ref="12"/>
+        <tag k="feature_area" v="237.0"/>
+        <tag k="access" v="customers"/>
+        <tag k="length" v="20.1"/>
+        <tag k="amenity" v="parking"/>
+        <tag k="width" v="14.4"/>
+        <tag k="angle" v="270.4"/>
+    </way>
+    <way visible="true" id="3" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="16"/>
+        <nd ref="17"/>
+        <nd ref="18"/>
+        <nd ref="19"/>
+        <nd ref="20"/>
+        <nd ref="21"/>
+        <nd ref="22"/>
+        <nd ref="23"/>
+        <nd ref="24"/>
+        <nd ref="25"/>
+        <nd ref="26"/>
+        <nd ref="27"/>
+        <nd ref="28"/>
+        <nd ref="29"/>
+        <nd ref="30"/>
+        <nd ref="16"/>
+        <tag k="feature_area" v="235.3"/>
+        <tag k="building" v="yes"/>
+        <tag k="length" v="21.7"/>
+        <tag k="width" v="16.0"/>
+        <tag k="angle" v="248.4"/>
+        <tag k="addr:housenumber" v="10"/>
+        <tag k="addr:street" v="Spruce Street"/>
+        <tag k="addr:state" v="MA"/>
+        <tag k="addr:country" v="US"/>
+        <tag k="addr:city" v="Acton"/>
+    </way>
+    <way visible="true" id="4" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="31"/>
+        <nd ref="32"/>
+        <nd ref="33"/>
+        <nd ref="34"/>
+        <nd ref="31"/>
+        <tag k="feature_area" v="200.4"/>
+        <tag k="building" v="yes"/>
+        <tag k="length" v="25.7"/>
+        <tag k="width" v="9.0"/>
+        <tag k="angle" v="341.8"/>
+        <tag k="addr:housenumber" v="5"/>
+        <tag k="addr:street" v="Spruce Street"/>
+        <tag k="addr:state" v="MA"/>
+        <tag k="addr:country" v="US"/>
+        <tag k="addr:city" v="Acton"/>
+    </way>
+    <way visible="true" id="6" timestamp="1970-01-01T00:00:00Z" version="2">
+        <nd ref="38"/>
+        <nd ref="39"/>
+        <nd ref="40"/>
+        <nd ref="41"/>
+        <nd ref="38"/>
+        <tag k="feature_area" v="294.6"/>
+        <tag k="name" v="Office of Michael Rosenfeld, Inc., Architects"/>
+        <tag k="shop" v="architect"/>
+        <tag k="building" v="yes"/>
+        <tag k="length" v="26.5"/>
+        <tag k="width" v="11.7"/>
+        <tag k="angle" v="271.2"/>
+        <tag k="addr:housenumber" v="543"/>
+        <tag k="addr:street" v="Massachusetts Avenue"/>
+        <tag k="addr:state" v="MA"/>
+        <tag k="addr:country" v="US"/>
+        <tag k="addr:city" v="Acton"/>
+    </way>
+    <way visible="true" id="7" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="42"/>
+        <nd ref="43"/>
+        <nd ref="44"/>
+        <nd ref="45"/>
+        <nd ref="46"/>
+        <nd ref="47"/>
+        <nd ref="48"/>
+        <nd ref="49"/>
+        <nd ref="42"/>
+        <tag k="feature_area" v="694.7"/>
+        <tag k="building" v="yes"/>
+        <tag k="length" v="47.5"/>
+        <tag k="width" v="16.9"/>
+        <tag k="angle" v="269.5"/>
+    </way>
+    <way visible="true" id="8" timestamp="1970-01-01T00:00:00Z" version="2">
+        <nd ref="50"/>
+        <nd ref="51"/>
+        <nd ref="52"/>
+        <nd ref="53"/>
+        <nd ref="50"/>
+        <tag k="feature_area" v="192.4"/>
+        <tag k="name" v="West Acton Mobil"/>
+        <tag k="building" v="roof"/>
+        <tag k="amenity" v="fuel"/>
+        <tag k="length" v="23.9"/>
+        <tag k="width" v="8.1"/>
+        <tag k="angle" v="271.8"/>
+    </way>
+    <way visible="true" id="9" timestamp="1970-01-01T00:00:00Z" version="2">
+        <nd ref="54"/>
+        <nd ref="55"/>
+        <nd ref="56"/>
+        <nd ref="57"/>
+        <nd ref="58"/>
+        <nd ref="4"/>
+        <nd ref="54"/>
+        <tag k="feature_area" v="124.7"/>
+        <tag k="shop" v="convenience"/>
+        <tag k="building" v="yes"/>
+        <tag k="length" v="16.1"/>
+        <tag k="width" v="8.3"/>
+        <tag k="angle" v="180.9"/>
+    </way>
+    <way visible="true" id="11" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="63"/>
+        <nd ref="64"/>
+        <nd ref="65"/>
+        <nd ref="66"/>
+        <nd ref="67"/>
+        <nd ref="68"/>
+        <nd ref="63"/>
+        <tag k="feature_area" v="851.0"/>
+        <tag k="access" v="customers"/>
+        <tag k="length" v="55.9"/>
+        <tag k="amenity" v="parking"/>
+        <tag k="width" v="16.9"/>
+        <tag k="angle" v="270.8"/>
+    </way>
+</osm>


### PR DESCRIPTION
Use the reference dataset's version number for modify/delete operations when deriving a changeset because that has a higher likelihood of being the most current version in the API.

Closes #3870 