### PR TITLE
Differential conflation cannot contain deletes.

### DIFF
--- a/conf/core/DifferentialConflation.conf
+++ b/conf/core/DifferentialConflation.conf
@@ -3,5 +3,7 @@
   "snap.unconnected.ways.snap.way.criterion" : "hoot::HighwayCriterion",
   "snap.unconnected.ways.snap.to.way.criterion" : "hoot::HighwayCriterion",
   "snap.unconnected.ways.snap.to.way.node.criterion" : "hoot::HighwayNodeCriterion",
+  "#": "Differential shouldn't include any deletes, create and modify only",
+  "changeset.allow.deleting.reference.features" : "false",
   "#": "end"
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
@@ -544,10 +544,11 @@ std::shared_ptr<ChangesetDeriver> DiffConflator::_sortInputs(OsmMapPtr pMap1, Os
 {
   // Conflation requires all data to be in memory, so no point in adding support for the
   // ExternalMergeElementSorter here.
-
   InMemoryElementSorterPtr sorted1(new InMemoryElementSorter(pMap1));
   InMemoryElementSorterPtr sorted2(new InMemoryElementSorter(pMap2));
   std::shared_ptr<ChangesetDeriver> delta(new ChangesetDeriver(sorted1, sorted2));
+  //  Deriving changesets for differential shouldn't include any deletes, create and modify only
+  delta->setAllowDeletingReferenceFeatures(false);
   return delta;
 }
 


### PR DESCRIPTION
When differential is run with `differential.snap.unconnected.roads` turned on, the reference map is passed in as the base for the changeset derivation, this causes every element in the reference to have a `<delete>` entry in the changeset.  This is bad.  This can be solved by setting `changeset.allow.deleting.reference.features=false` in the differential conflation configuration file.

Closes #3877 