### PR TITLE
Performance fix for 3857

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.cpp
@@ -47,6 +47,7 @@
 #include <hoot/core/criterion/NotCriterion.h>
 #include <hoot/core/criterion/ElementInIdListCriterion.h>
 #include <hoot/core/ops/CopyMapSubsetOp.h>
+#include <hoot/core/conflate/poi-polygon/PoiPolygonInvalidReviewNodeRemover.h>
 
 // standard
 #include <algorithm>
@@ -313,6 +314,14 @@ void UnifyingConflator::apply(OsmMapPtr& map)
     // WARNING: Enabling this could result in a lot of files being generated.
     //OsmMapWriterFactory::writeDebugMap(map, "after-merging-" + _mergers[i]->toString().right(50));
   }
+
+  // Some cleanup due to a bug that has to be done. See the PoiPolygonInvalidReviewNodeRemover for
+  // more detail.
+  PoiPolygonInvalidReviewNodeRemover reviewCleaner;
+  LOG_INFO(reviewCleaner.getInitStatusMessage());
+  reviewCleaner.apply(map);
+  LOG_INFO(reviewCleaner.getCompletedStatusMessage());
+
   OsmMapWriterFactory::writeDebugMap(map, "after-merging");
 
   LOG_TRACE(SystemInfo::getMemoryUsageString());

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMerger.cpp
@@ -42,7 +42,6 @@
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/conflate/poi-polygon/PoiPolygonMatch.h>
-#include <hoot/core/conflate/poi-polygon/PoiPolygonInvalidReviewNodeRemover.h>
 
 using namespace std;
 
@@ -216,13 +215,6 @@ void PoiPolygonMerger::apply(const OsmMapPtr& map, vector<pair<ElementId, Elemen
 
   finalBuilding->setTags(finalBuildingTags);
   LOG_VART(finalBuilding);
-
-  // Some cleanup due to a bug that has to be done. See the PoiPolygonInvalidReviewNodeRemover for
-  // more detail.
-  PoiPolygonInvalidReviewNodeRemover reviewCleaner;
-  LOG_INFO("\t" << reviewCleaner.getInitStatusMessage());
-  reviewCleaner.apply(map);
-  LOG_INFO("\t" << reviewCleaner.getCompletedStatusMessage());
 }
 
 Tags PoiPolygonMerger::_mergePoiTags(const OsmMapPtr& map, Status s) const


### PR DESCRIPTION
was running the POI/Poly review cleanup in multiple merges rather than at the end of the conflate job