### PR TITLE
Translations: Layername matching fix

### DIFF
--- a/conf/schema/FCODE.json
+++ b/conf/schema/FCODE.json
@@ -436,4 +436,7 @@
 {"name":"FCODE=ZI031","geometries":["area"],"description":"Dataset","isA":"FCODE","objectType":"tag","aliases":["F_CODE=ZI031"]},
 {"name":"FCODE=ZI039","geometries":["area"],"description":"Entity Collection Metadata","isA":"FCODE","objectType":"tag","aliases":["F_CODE=ZI039"]},
 {"name":"FCODE=ZI040","geometries":["area"],"description":"Spatial Metadata Entity Collection","isA":"FCODE","objectType":"tag","aliases":["F_CODE=ZI040"]},
+{"name":"FCODE=HC100","geometries":["node","area"],"description":"Linguistic Entity","isA":"FCODE","objectType":"tag","aliases":["F_CODE=HC100"]},
+{"name":"FCODE=HG210","geometries":["node","area"],"description":"Belief System","isA":"FCODE","objectType":"tag","aliases":["F_CODE=HG210"]},
+{"name":"FCODE=ZI113","geometries":["node","area"],"description":"Ethnic Group","isA":"FCODE","objectType":"tag","aliases":["F_CODE=ZI113"]},
 {"name":"FCODE=ZI041","geometries":["area"],"description":"Non-spatial Metadata Entity Collection","isA":"FCODE","objectType":"tag","aliases":["F_CODE=ZI041"]}]

--- a/translations/tds61.js
+++ b/translations/tds61.js
@@ -719,7 +719,8 @@ tds61 = {
             {
                 for (var val in tds61.rules.fCodeMap[row][1])
                 {
-                    if (llayerName == tds61.rules.fCodeMap[row][1][val])
+                    // if (llayerName == tds61.rules.fCodeMap[row][1][val])
+                    if (llayerName.match(tds61.rules.fCodeMap[row][1][val]))
                     {
                         attrs.F_CODE = tds61.rules.fCodeMap[row][0];
                         break;
@@ -1153,6 +1154,10 @@ tds61 = {
                 if (tds61.rules.ge4List[tags[ge4meta[i]]])
                 {
                     tags[ge4meta[i]] = tds61.rules.ge4List[tags[ge4meta[i]]];
+                }
+                else if (tds61.rules.ge4List['ge:GENC:3:1-2:' + tags[ge4meta[i]]])
+                {
+                    tags[ge4meta[i]] = tds61.rules.ge4List['ge:GENC:3:1-2:' + tags[ge4meta[i]]];
                 }
                 else
                 {

--- a/translations/tds70.js
+++ b/translations/tds70.js
@@ -756,7 +756,7 @@ tds70 = {
             {
                 for (var val in tds70.rules.fCodeMap[row][1])
                 {
-                    if (llayerName == tds70.rules.fCodeMap[row][1][val])
+                    if (llayerName.match(tds70.rules.fCodeMap[row][1][val]))
                     {
                         attrs.F_CODE = tds70.rules.fCodeMap[row][0];
                         break;
@@ -2079,6 +2079,10 @@ tds70 = {
                 if (tds70.ge4Lookup[attrs[ge4attr[i]]])
                 {
                     attrs[ge4attr[i]] = tds70.ge4Lookup[attrs[ge4attr[i]]];
+                }
+                else if (tds70.ge4Lookup['ge:GENC:3:1-2:' + attrs[ge4attr[i]]])
+                {
+                    attrs[ge4attr[i]] = tds70.ge4Lookup['ge:GENC:3:1-2:' + attrs[ge4attr[i]]];
                 }
                 else
                 {


### PR DESCRIPTION
refs: #3888

Files without F_CODE fields rely on matching the layername. This changes it from `==` to a regexp match.