### PR TITLE
'changeset-apply' with huge relations fails

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -578,7 +578,7 @@ for conflation campaigns
 === changeset.max.size
 
 * Data Type: long
-* Default Value: `50000`
+* Default Value: `10000`
 
 The maximum allowed element size of an OSM changeset that can be written to an OSM API database
 in a single changeset.

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementType.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementType.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef ELEMENTTYPE_H
 #define ELEMENTTYPE_H
@@ -45,7 +45,8 @@ public:
     Node = 0,
     Way = 1,
     Relation = 2,
-    Unknown
+    Unknown = 3,
+    Max = 3
   } Type;
 
   ElementType() : _type(Unknown) { }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -59,6 +59,7 @@ typedef std::map<long, std::set<long>> NodeIdToWayIdMap;
 typedef std::map<long, std::set<long>> NodeIdToRelationIdMap;
 typedef std::map<long, std::set<long>> WayIdToRelationIdMap;
 typedef std::map<long, std::set<long>> RelationIdToRelationIdMap;
+typedef std::vector<std::set<long>> ElementCountSet;
 
 /** XML Changeset data object */
 class XmlChangeset
@@ -424,11 +425,15 @@ private:
    * @brief getObjectCount Get the number of elements affected by this node/way/relation
    * @param changeset Subset containing the element
    * @param node/way/relation Pointer to the element to count
+   * @param elements Reference to a vector of sets of IDs so that node/way/relation IDs aren't counted twice
    * @return total number of elements within this element
    */
-  size_t getObjectCount(ChangesetInfoPtr& changeset, ChangesetNode* node);
-  size_t getObjectCount(ChangesetInfoPtr& changeset, ChangesetWay* way);
-  size_t getObjectCount(ChangesetInfoPtr& changeset, ChangesetRelation* relation);
+  size_t getObjectCount(ChangesetNode* node, ElementCountSet& elements);
+  size_t getObjectCount(ChangesetWay* way, ElementCountSet& elements);
+  size_t getObjectCount(ChangesetRelation* relation, ElementCountSet& elements);
+  size_t getObjectCount(ChangesetInfoPtr& changeset, ChangesetNode* node, ElementCountSet& elements);
+  size_t getObjectCount(ChangesetInfoPtr& changeset, ChangesetWay* way, ElementCountSet& elements);
+  size_t getObjectCount(ChangesetInfoPtr& changeset, ChangesetRelation* relation, ElementCountSet& elements);
   /**
    * @brief isSent Check if this element's status is buffering, sent, or finalized
    * @param element Pointer to the element to check
@@ -499,8 +504,10 @@ private:
   ChangesetTypeMap _relations;
   /** Element ID to ID data structure for checking old ID to new ID and new ID to old ID lookups */
   ElementIdToIdMap _idMap;
-  /** Maximum changeset push size */
+  /** Maximum changeset push size, could be slightly over to get an entire element */
   long _maxPushSize;
+  /** Maximum size of a changeset that cannot be exceeded */
+  long _maxChangesetSize;
   /** Count of elements that have been sent */
   long _sentCount;
   /** Count of elements that have been processed */


### PR DESCRIPTION
Check the size of the element and associated elements before trying to put together a huge changeset.  Also changed `changeset.max.size` from 50k (which is the limit for `api/0.6/map`) to 10k (which is the limit for `api/0.6/changeset/<id>/upload`).

Closes #3890 