### PR TITLE
3895 - Prevent sidewalks from conflating with roads

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/elements/Tags.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Tags.cpp
@@ -798,6 +798,11 @@ void Tags::_valueRegexParser(const QString& str, QString& num, QString& units) c
   units = copyStr.replace(sRegExp, QString("")).trimmed();
 }
 
+bool Tags::hasKvp(const QString& kvp) const
+{
+  return hasAnyKvp(QStringList(kvp));
+}
+
 bool Tags::hasAnyKvp(const QStringList& kvps) const
 {
   for (int i = 0; i < kvps.size(); i++)
@@ -880,6 +885,18 @@ bool Tags::intersects(const Tags& other) const
     }
   }
   return false;
+}
+
+bool Tags::bothContainKvp(const Tags& tags1, const Tags& tags2, const QString& kvp)
+{
+  return tags1.hasKvp(kvp) && tags2.hasKvp(kvp);
+}
+
+bool Tags::onlyOneContainsKvp(const Tags& tags1, const Tags& tags2, const QString& kvp)
+{
+  const bool firstHasKvp = tags1.hasKvp(kvp);
+  const bool secondHasKvp = tags2.hasKvp(kvp);
+  return (!firstHasKvp && secondHasKvp) || (firstHasKvp && !secondHasKvp);
 }
 
 QString Tags::getDiffString(const Tags& other) const

--- a/hoot-core/src/main/cpp/hoot/core/elements/Tags.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Tags.h
@@ -298,6 +298,14 @@ public:
   QString toString() const;
 
   /**
+   * Returns true if the tags have the specified kvp
+   *
+   * @param kvp kvp to search for
+   * @return true if tags contain the kvp; false otherwise
+   */
+  bool hasKvp(const QString& kvp) const;
+
+  /**
    * Returns true if the tags have any key=value in the input list
    *
    * @param kvps kvps to search for
@@ -362,6 +370,26 @@ public:
    * @return true if the tags being compared against have at least one tag in similar
    */
   bool intersects(const Tags& other) const;
+
+  /**
+   * Determines if two sets of tags contain a particular key/value pair
+   *
+   * @param tags1 first set of tags to examine
+   * @param tags2 second set of tags to examine
+   * @param kvp key/value pair to search for
+   * @return true if both sets of tags contain the key/value pair; false otherwise
+   */
+  static bool bothContainKvp(const Tags& tags1, const Tags& tags2, const QString& kvp);
+
+  /**
+   * Determines if either one of two sets of tags contain a particular key/value pair
+   *
+   * @param tags1 first set of tags to examine
+   * @param tags2 second set of tags to examine
+   * @param kvp key/value pair to search for
+   * @return true if exactly one of the sets of tags contain the key/value pair; false otherwise
+   */
+  static bool onlyOneContainsKvp(const Tags& tags1, const Tags& tags2, const QString& kvp);
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/SmallHighwayMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/SmallHighwayMerger.cpp
@@ -60,7 +60,6 @@ namespace hoot
 HOOT_FACTORY_REGISTER(OsmMapOperation, SmallHighwayMerger)
 
 SmallHighwayMerger::SmallHighwayMerger(Meters threshold)
-
 {
   ConfigOptions opts = ConfigOptions();
   if (threshold >= 0)

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
@@ -1814,7 +1814,6 @@ double OsmSchema::score(const QString& kvp, const Tags& tags)
     const QString value = tagItr.value().trimmed();
     if (!key.isEmpty() && !value.isEmpty())
     {
-      //QString kvp2 = tagItr.key() + "=" + tagItr.value();
       QString kvp2 = "";
       kvp2.append(key);
       kvp2.append("=");
@@ -1825,7 +1824,6 @@ double OsmSchema::score(const QString& kvp, const Tags& tags)
         maxScore = scoreVal;
       }
     }
-
   }
   return maxScore;
 }

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagAncestorDifferencer.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagAncestorDifferencer.h
@@ -40,6 +40,7 @@ namespace hoot
 class TagAncestorDifferencer : public TagFilteredDifferencer, public Configurable
 {
 public:
+
   static std::string className() { return "hoot::TagAncestorDifferencer"; }
 
   TagAncestorDifferencer() {}
@@ -50,6 +51,7 @@ public:
   virtual void setConfiguration(const Settings& conf);
 
 protected:
+
   QString _ancestor;
 
   virtual bool isValidTag(const SchemaVertex& sv) const;

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagAncestorDifferencer.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagAncestorDifferencer.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef __TAG_ANCESTOR_DIFFERENCER_H__
 #define __TAG_ANCESTOR_DIFFERENCER_H__

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagFilteredDifferencer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagFilteredDifferencer.cpp
@@ -40,6 +40,8 @@ TagFilteredDifferencer::TagFilteredDifferencer()
 double TagFilteredDifferencer::diff(const ConstOsmMapPtr&, const ConstElementPtr& e1,
   const ConstElementPtr& e2) const
 {
+  //const ElementId debugId = ElementId(ElementType::Way, -857);
+
   OsmSchema& schema = OsmSchema::getInstance();
 
   vector<SchemaVertex> v1 = schema.getUniqueSchemaVertices(e1->getTags());
@@ -55,11 +57,25 @@ double TagFilteredDifferencer::diff(const ConstOsmMapPtr&, const ConstElementPtr
       {
         if (isValidTag(v2[j]))
         {
-          result = min(1 - schema.score(v1[i], v2[j]), result);
+          const double score = 1 - schema.score(v1[i], v2[j]);
+
+//          if (e1->getElementId() == debugId || e2->getElementId() == debugId)
+//          {
+//            LOG_TRACE("Diff between: " << v1[i].name << " and " << v2[j].name << ": " << score);
+//          }
+
+          result = min(score, result);
         }
       }
     }
-  }
+  } 
+
+//  if (e1->getElementId() == debugId || e2->getElementId() == debugId)
+//  {
+//    LOG_TRACE(
+//      "Final diff between: " << e1->getElementId() << " and " << e2->getElementId() << ": " <<
+//      result);
+//  }
 
   return result;
 }

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagFilteredDifferencer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagFilteredDifferencer.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "TagFilteredDifferencer.h"
 

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.cpp
@@ -447,7 +447,7 @@ public:
       }
 
       LOG_STATUS(
-        "Script feature index created for: " << _scriptPath << "with " <<
+        "Script feature index created for: " << _scriptPath << " with " <<
         StringUtils::formatLargeNumber(numElementsIndexed) << " elements.");
     }
     return _index;
@@ -786,8 +786,7 @@ void ScriptMatchCreator::createMatches(
       "within a search radius of " + QString::number(searchRadius, 'g', 2) + " meters";
   }
   LOG_STATUS(
-    "Looking for matches with: " << className() << ";" << scriptFileInfo.fileName() << " " <<
-     searchRadiusStr << "...");
+    "Looking for matches with: " << scriptFileInfo.fileName() << " " << searchRadiusStr << "...");
   LOG_VARD(*threshold);
   const int matchesSizeBefore = matches.size();
 

--- a/test-files/cases/unifying/sidewalk-3895/Expected.osm
+++ b/test-files/cases/unifying/sidewalk-3895/Expected.osm
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="39.10359999999999" minlon="-94.53959999999999" maxlat="39.1048" maxlon="-94.53789999999999"/>
+    <node visible="true" id="-107" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1040936369806218" lon="-94.5389427097763928"/>
+    <node visible="true" id="-105" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1045445403752652" lon="-94.5388187680206329"/>
+    <node visible="true" id="-103" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1041546228033638" lon="-94.5388386970869732"/>
+    <node visible="true" id="-101" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1040402187479543" lon="-94.5388445287447468"/>
+    <node visible="true" id="-38" timestamp="2019-07-14T10:29:53Z" version="1" user="sannkc" uid="1561092" lat="39.1040565999999998" lon="-94.5389935000000037">
+        <tag k="water_source" v="main"/>
+        <tag k="emergency" v="fire_hydrant"/>
+        <tag k="fire_hydrant:type" v="pillar"/>
+        <tag k="error:circular" v="15"/>
+    </node>
+    <node visible="true" id="-37" timestamp="2018-05-20T10:53:34Z" version="1" user="sannkc" uid="1561092" lat="39.1041543999999988" lon="-94.5387824000000023"/>
+    <node visible="true" id="-36" timestamp="2018-05-20T10:53:34Z" version="1" user="sannkc" uid="1561092" lat="39.1041543999999988" lon="-94.5388183999999967"/>
+    <node visible="true" id="-35" timestamp="2018-05-20T10:53:34Z" version="1" user="sannkc" uid="1561092" lat="39.1041553000000022" lon="-94.5388606999999865">
+        <tag k="highway" v="crossing"/>
+        <tag k="error:circular" v="15"/>
+    </node>
+    <node visible="true" id="-34" timestamp="2018-05-20T10:53:34Z" version="1" user="sannkc" uid="1561092" lat="39.1041572999999971" lon="-94.5389394000000038"/>
+    <node visible="true" id="-33" timestamp="2018-05-20T10:53:34Z" version="1" user="sannkc" uid="1561092" lat="39.1045470999999978" lon="-94.5389176999999989"/>
+    <node visible="true" id="-32" timestamp="2018-05-20T10:53:33Z" version="1" user="sannkc" uid="1561092" lat="39.1045429999999925" lon="-94.5387630999999971"/>
+    <node visible="true" id="-31" timestamp="2018-05-20T10:53:33Z" version="1" user="sannkc" uid="1561092" lat="39.1041315000000012" lon="-94.5387834999999797"/>
+    <node visible="true" id="-30" timestamp="2018-05-20T10:53:33Z" version="1" user="sannkc" uid="1561092" lat="39.1040879999999973" lon="-94.5387857999999994">
+        <tag k="highway" v="crossing"/>
+        <tag k="hoot:hash" v="sha1sum:8c4ef4f187dc8c9cdc64f3dca7794497c815be1b"/>
+        <tag k="error:circular" v="15"/>
+    </node>
+    <node visible="true" id="-29" timestamp="2018-05-20T10:53:33Z" version="1" user="sannkc" uid="1561092" lat="39.1040556000000024" lon="-94.5387874999999980"/>
+    <node visible="true" id="-28" timestamp="2018-05-20T10:53:33Z" version="1" user="sannkc" uid="1561092" lat="39.1041387999999941" lon="-94.5389404000000013"/>
+    <node visible="true" id="-27" timestamp="2018-05-20T10:53:33Z" version="1" user="sannkc" uid="1561092" lat="39.1040937999999940" lon="-94.5389426999999927">
+        <tag k="highway" v="crossing"/>
+        <tag k="hoot:hash" v="sha1sum:34ffd4a5f79d1ea3fd674ea5893c8d06358dc1df"/>
+        <tag k="error:circular" v="15"/>
+    </node>
+    <node visible="true" id="-26" timestamp="2018-05-20T10:53:33Z" version="1" user="sannkc" uid="1561092" lat="39.1040617999999895" lon="-94.5389444000000054"/>
+    <node visible="true" id="-25" timestamp="2018-05-20T10:53:33Z" version="1" user="sannkc" uid="1561092" lat="39.1040427999999949" lon="-94.5389456999999993"/>
+    <node visible="true" id="-24" timestamp="2018-05-20T10:53:33Z" version="1" user="sannkc" uid="1561092" lat="39.1040399999999977" lon="-94.5387887999999919"/>
+    <node visible="true" id="-23" timestamp="2018-05-20T10:53:33Z" version="1" user="sannkc" uid="1561092" lat="39.1040400000000048" lon="-94.5388236999999805"/>
+    <node visible="true" id="-22" timestamp="2018-05-20T10:53:33Z" version="1" user="sannkc" uid="1561092" lat="39.1040409000000011" lon="-94.5388667999999939">
+        <tag k="highway" v="crossing"/>
+        <tag k="error:circular" v="15"/>
+    </node>
+    <node visible="true" id="-21" timestamp="2018-05-20T10:53:33Z" version="1" user="sannkc" uid="1561092" lat="39.1040419999999855" lon="-94.5389215999999948"/>
+    <node visible="true" id="-20" timestamp="2018-05-20T10:53:33Z" version="1" user="sannkc" uid="1561092" lat="39.1041564999999878" lon="-94.5389162999999968"/>
+    <node visible="true" id="-18" timestamp="2017-06-08T08:56:32Z" version="1" user="sannkc" uid="1561092" lat="39.1045572000000021" lon="-94.5393298999999985"/>
+    <node visible="true" id="-14" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1041792958899990" lon="-94.5395999999999930"/>
+    <node visible="true" id="-13" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1040643582600040" lon="-94.5395999999999930"/>
+    <node visible="true" id="-12" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1036000000000001" lon="-94.5388092513999965"/>
+    <node visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1036000000000001" lon="-94.5389669287699945"/>
+    <node visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1047999999999973" lon="-94.5387491297399976"/>
+    <node visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1047999999999973" lon="-94.5389036106799949"/>
+    <node visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1041228303800139" lon="-94.5378999999999934"/>
+    <node visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1045184353800011" lon="-94.5378999999999934"/>
+    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1035999999999930" lon="-94.5388668904382286"/>
+    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1047999999999973" lon="-94.5388057111111095"/>
+    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1040544990253309" lon="-94.5378999999999934"/>
+    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1041173718815713" lon="-94.5395999999999930">
+        <tag k="hoot:hash" v="sha1sum:f9359d7cdf58b9acc146a73d15f65d3fae0c0a07"/>
+    </node>
+    <node visible="true" id="191091793" timestamp="2016-02-02T18:28:17Z" version="1" changeset="2773" lat="39.1040899999999922" lon="-94.5388420000000025">
+        <tag k="hoot:hash" v="sha1sum:92f2a5159a07585f56aaa0cafc47d473db5da26e"/>
+    </node>
+    <way visible="true" id="-17" timestamp="2018-05-20T10:53:39Z" version="1">
+        <nd ref="-20"/>
+        <nd ref="-103"/>
+        <nd ref="-36"/>
+        <tag k="highway" v="footway"/>
+        <tag k="source:datetime" v="2018-05-20T10:53:39Z"/>
+        <tag k="footway" v="crossing"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-16" timestamp="2018-05-20T10:53:39Z" version="1">
+        <nd ref="-29"/>
+        <nd ref="191091793"/>
+        <nd ref="-31"/>
+        <tag k="highway" v="footway"/>
+        <tag k="source:datetime" v="2018-05-20T10:53:39Z"/>
+        <tag k="footway" v="crossing"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-15" timestamp="2018-05-20T10:53:39Z" version="1" user="sannkc" uid="1561092">
+        <nd ref="-24"/>
+        <nd ref="-29"/>
+        <tag k="highway" v="footway"/>
+        <tag k="source:datetime" v="2018-05-20T10:53:39Z"/>
+        <tag k="footway" v="sidewalk"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-14" timestamp="2018-05-20T10:53:39Z" version="1">
+        <nd ref="-26"/>
+        <nd ref="-107"/>
+        <nd ref="-28"/>
+        <tag k="highway" v="footway"/>
+        <tag k="source:datetime" v="2018-05-20T10:53:39Z"/>
+        <tag k="footway" v="crossing"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-13" timestamp="2018-05-20T10:53:38Z" version="1">
+        <nd ref="-21"/>
+        <nd ref="-101"/>
+        <nd ref="-23"/>
+        <tag k="highway" v="footway"/>
+        <tag k="source:datetime" v="2018-05-20T10:53:38Z"/>
+        <tag k="footway" v="crossing"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-11" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-14"/>
+        <nd ref="-34"/>
+        <nd ref="-20"/>
+        <tag k="highway" v="footway"/>
+        <tag k="source:datetime" v="2018-05-20T10:53:38Z"/>
+        <tag k="footway" v="sidewalk"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-10" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-13"/>
+        <nd ref="-25"/>
+        <nd ref="-21"/>
+        <tag k="highway" v="footway"/>
+        <tag k="source:datetime" v="2018-05-20T10:53:38Z"/>
+        <tag k="footway" v="sidewalk"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-9" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-23"/>
+        <nd ref="-24"/>
+        <nd ref="-12"/>
+        <tag k="highway" v="footway"/>
+        <tag k="source:datetime" v="2018-05-20T10:53:39Z"/>
+        <tag k="footway" v="sidewalk"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-8" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-11"/>
+        <nd ref="-25"/>
+        <nd ref="-26"/>
+        <tag k="highway" v="footway"/>
+        <tag k="source:datetime" v="2018-05-20T10:53:39Z"/>
+        <tag k="footway" v="sidewalk"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-7" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-31"/>
+        <nd ref="-37"/>
+        <nd ref="-32"/>
+        <nd ref="-10"/>
+        <tag k="highway" v="footway"/>
+        <tag k="source:datetime" v="2018-05-20T10:53:39Z"/>
+        <tag k="footway" v="sidewalk"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-6" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-9"/>
+        <nd ref="-33"/>
+        <nd ref="-34"/>
+        <nd ref="-28"/>
+        <tag k="highway" v="footway"/>
+        <tag k="source:datetime" v="2018-05-20T10:53:39Z"/>
+        <tag k="footway" v="sidewalk"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-5" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-36"/>
+        <nd ref="-37"/>
+        <nd ref="-8"/>
+        <tag k="highway" v="footway"/>
+        <tag k="source:datetime" v="2018-05-20T10:53:39Z"/>
+        <tag k="footway" v="sidewalk"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-18"/>
+        <nd ref="-33"/>
+        <nd ref="-105"/>
+        <nd ref="-32"/>
+        <nd ref="-7"/>
+        <tag k="highway" v="service"/>
+        <tag k="service" v="alley"/>
+        <tag k="source:datetime" v="2018-05-20T10:53:47Z"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-3"/>
+        <nd ref="-105"/>
+        <nd ref="-103"/>
+        <nd ref="191091793"/>
+        <nd ref="-101"/>
+        <nd ref="-4"/>
+        <tag k="highway" v="residential"/>
+        <tag k="name" v="Monroe Avenue"/>
+        <tag k="tiger:zip_left" v="64124"/>
+        <tag k="tiger:name_type" v="Ave"/>
+        <tag k="source:datetime" v="2013-04-21T00:38:20.000Z;2019-05-02T17:14:34Z"/>
+        <tag k="surface" v="asphalt"/>
+        <tag k="tiger:zip_right" v="64124"/>
+        <tag k="tiger:cfcc" v="A41"/>
+        <tag k="tiger:county" v="Jackson, MO"/>
+        <tag k="tiger:name_base" v="Monroe"/>
+        <tag k="tiger:reviewed" v="no"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1"/>
+        <nd ref="-107"/>
+        <nd ref="191091793"/>
+        <nd ref="-2"/>
+        <tag k="tiger:name_base_1" v="7"/>
+        <tag k="highway" v="residential"/>
+        <tag k="name_1" v="East 7 Street"/>
+        <tag k="name" v="East 7th Street"/>
+        <tag k="tiger:zip_left" v="64124"/>
+        <tag k="tiger:name_direction_prefix_1" v="E"/>
+        <tag k="tiger:name_direction_prefix" v="E"/>
+        <tag k="tiger:name_type" v="St"/>
+        <tag k="source:datetime" v="2013-04-21T00:43:18.000Z;2018-07-03T11:35:21Z"/>
+        <tag k="tiger:zip_right" v="64124"/>
+        <tag k="tiger:cfcc" v="A41"/>
+        <tag k="tiger:county" v="Jackson, MO"/>
+        <tag k="tiger:name_type_1" v="St"/>
+        <tag k="tiger:name_base" v="7th"/>
+        <tag k="tiger:reviewed" v="no"/>
+        <tag k="error:circular" v="15"/>
+    </way>
+</osm>

--- a/test-files/cases/unifying/sidewalk-3895/Input1.osm
+++ b/test-files/cases/unifying/sidewalk-3895/Input1.osm
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="39.1036" minlon="-94.53959999999999" maxlat="39.1048" maxlon="-94.53789999999999"/>
+    <node visible="true" id="-4" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1036000000000001" lon="-94.5388668904382428"/>
+    <node visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1047999999999973" lon="-94.5388057111111095"/>
+    <node visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1040544990253380" lon="-94.5378999999999934"/>
+    <node visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.1041173718815713" lon="-94.5395999999999930"/>
+    <node visible="true" id="191091793" timestamp="2016-02-02T18:28:17Z" version="1" changeset="2773" lat="39.1040899999999993" lon="-94.5388420000000025"/>
+    <way visible="true" id="-2" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-3"/>
+        <nd ref="191091793"/>
+        <nd ref="-4"/>
+        <tag k="tiger:name_type" v="Ave"/>
+        <tag k="source:datetime" v="2013-04-21T00:38:20.000Z"/>
+        <tag k="tiger:zip_right" v="64124"/>
+        <tag k="tiger:reviewed" v="no"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="highway" v="residential"/>
+        <tag k="tiger:cfcc" v="A41"/>
+        <tag k="tiger:name_base" v="Monroe"/>
+        <tag k="tiger:county" v="Jackson, MO"/>
+        <tag k="name" v="Monroe Avenue"/>
+        <tag k="tiger:zip_left" v="64124"/>
+    </way>
+    <way visible="true" id="-1" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1"/>
+        <nd ref="191091793"/>
+        <nd ref="-2"/>
+        <tag k="tiger:name_type" v="St"/>
+        <tag k="source:datetime" v="2013-04-21T00:43:18.000Z"/>
+        <tag k="tiger:zip_right" v="64124"/>
+        <tag k="tiger:name_direction_prefix" v="E"/>
+        <tag k="tiger:reviewed" v="no"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="highway" v="residential"/>
+        <tag k="tiger:name_type_1" v="St"/>
+        <tag k="tiger:cfcc" v="A41"/>
+        <tag k="tiger:name_base" v="7th"/>
+        <tag k="name_1" v="East 7 Street"/>
+        <tag k="tiger:name_base_1" v="7"/>
+        <tag k="tiger:county" v="Jackson, MO"/>
+        <tag k="name" v="East 7th Street"/>
+        <tag k="tiger:zip_left" v="64124"/>
+        <tag k="tiger:name_direction_prefix_1" v="E"/>
+    </way>
+</osm>

--- a/test-files/cases/unifying/sidewalk-3895/Input2.osm
+++ b/test-files/cases/unifying/sidewalk-3895/Input2.osm
@@ -1,0 +1,479 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <bounds minlat='39.1036' minlon='-94.5396' maxlat='39.1048' maxlon='-94.5379' origin='hootenanny' />
+  <node id='-253935142' visible='true' version='1' lat='39.1036' lon='-94.53889061245' />
+  <node id='-253935144' visible='true' version='1' lat='39.1048' lon='-94.53882724626' />
+  <node id='-253935146' visible='true' version='1' lat='39.10451843538' lon='-94.5379' />
+  <node id='-253935152' visible='true' version='1' lat='39.10412283038' lon='-94.5379' />
+  <node id='-253935154' visible='true' version='1' lat='39.1048' lon='-94.53890361068' />
+  <node id='-253935156' visible='true' version='1' lat='39.1048' lon='-94.53874912974' />
+  <node id='-253935158' visible='true' version='1' lat='39.1036' lon='-94.53896692877' />
+  <node id='-253935160' visible='true' version='1' lat='39.1036' lon='-94.5388092514' />
+  <node id='-253935162' visible='true' version='1' lat='39.10406435826' lon='-94.5396' />
+  <node id='-253935164' visible='true' version='1' lat='39.10417929589' lon='-94.5396' />
+  <node id='-253935166' visible='true' version='1' lat='39.10405504391' lon='-94.5379' />
+  <node id='-253935168' visible='true' version='1' lat='39.10411749358' lon='-94.5396' />
+  <node id='191091793' timestamp='2018-03-12T23:36:07Z' uid='1561092' user='sannkc' visible='true' version='3' changeset='57127547' lat='39.104091' lon='-94.5388641' />
+  <node id='4900759076' action='delete' timestamp='2017-06-07T02:53:01Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1036056' lon='-94.5395087' />
+  <node id='4900759571' action='delete' timestamp='2017-06-07T02:53:04Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1039748' lon='-94.5394898' />
+  <node id='4900759572' action='delete' timestamp='2017-06-07T02:53:04Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.103974' lon='-94.5394027' />
+  <node id='4900759573' action='delete' timestamp='2017-06-07T02:53:04Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038413' lon='-94.5394049' />
+  <node id='4900759574' action='delete' timestamp='2017-06-07T02:53:04Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038422' lon='-94.539492' />
+  <node id='4900759575' action='delete' timestamp='2017-06-07T02:53:04Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1039692' lon='-94.5393847' />
+  <node id='4900759576' action='delete' timestamp='2017-06-07T02:53:04Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1039677' lon='-94.5392995' />
+  <node id='4900759577' action='delete' timestamp='2017-06-07T02:53:04Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038527' lon='-94.5393029' />
+  <node id='4900759578' action='delete' timestamp='2017-06-07T02:53:04Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038542' lon='-94.5393881' />
+  <node id='4900759579' action='delete' timestamp='2017-06-07T02:53:04Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1039696' lon='-94.5392792' />
+  <node id='4900759580' action='delete' timestamp='2017-06-07T02:53:04Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1039676' lon='-94.5391962' />
+  <node id='4900759581' action='delete' timestamp='2017-06-07T02:53:04Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038293' lon='-94.5392017' />
+  <node id='4900759582' action='delete' timestamp='2017-06-07T02:53:04Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038306' lon='-94.5392562' />
+  <node id='4900759583' action='delete' timestamp='2017-06-07T02:53:04Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038564' lon='-94.5392552' />
+  <node id='4900759584' action='delete' timestamp='2017-06-07T02:53:04Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038571' lon='-94.5392837' />
+  <node id='4900759585' action='delete' timestamp='2017-06-07T02:53:04Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1039641' lon='-94.5391768' />
+  <node id='4900759586' action='delete' timestamp='2017-06-07T02:53:04Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1039629' lon='-94.5390857' />
+  <node id='4900759587' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038453' lon='-94.5390882' />
+  <node id='4900759588' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038465' lon='-94.5391794' />
+  <node id='4900759589' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1039624' lon='-94.5390673' />
+  <node id='4900759590' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1039605' lon='-94.5389788' />
+  <node id='4900759591' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038377' lon='-94.5389831' />
+  <node id='4900759592' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038396' lon='-94.5390716' />
+  <node id='4900759593' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1040044' lon='-94.5386869' />
+  <node id='4900759594' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.103996' lon='-94.5384676' />
+  <node id='4900759595' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1039321' lon='-94.5384717' />
+  <node id='4900759596' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1039404' lon='-94.538691' />
+  <node id='4900759597' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1039232' lon='-94.5387124' />
+  <node id='4900759598' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1039159' lon='-94.5385361' />
+  <node id='4900759599' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038582' lon='-94.53854' />
+  <node id='4900759600' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038655' lon='-94.5387164' />
+  <node id='4900759601' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038404' lon='-94.5387185' />
+  <node id='4900759602' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038342' lon='-94.5385368' />
+  <node id='4900759603' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1037759' lon='-94.5385401' />
+  <node id='4900759604' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1037822' lon='-94.5387218' />
+  <node id='4900759605' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1037535' lon='-94.5386977' />
+  <node id='4900759606' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1037483' lon='-94.5385442' />
+  <node id='4900759607' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1036879' lon='-94.5385475' />
+  <node id='4900759608' action='delete' timestamp='2017-06-07T02:53:05Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1036931' lon='-94.5387011' />
+  <node id='4900759685' action='delete' timestamp='2017-06-07T02:53:06Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038793' lon='-94.5379357' />
+  <node id='4900759688' action='delete' timestamp='2017-06-07T02:53:06Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1037628' lon='-94.5379408' />
+  <node id='4900759689' action='delete' timestamp='2017-06-07T02:53:06Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1039075' lon='-94.538145' />
+  <node id='4900759690' action='delete' timestamp='2017-06-07T02:53:06Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1039061' lon='-94.5380659' />
+  <node id='4900759691' action='delete' timestamp='2017-06-07T02:53:06Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1037833' lon='-94.5380695' />
+  <node id='4900759692' action='delete' timestamp='2017-06-07T02:53:06Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1037847' lon='-94.5381486' />
+  <node id='4900759693' action='delete' timestamp='2017-06-07T02:53:06Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038961' lon='-94.5380486' />
+  <node id='4900759694' action='delete' timestamp='2017-06-07T02:53:06Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1038951' lon='-94.5379715' />
+  <node id='4900759695' action='delete' timestamp='2017-06-07T02:53:06Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1037718' lon='-94.5379742' />
+  <node id='4900759696' action='delete' timestamp='2017-06-07T02:53:06Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993' lat='39.1037728' lon='-94.5380513' />
+  <node id='4903496821' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1043827' lon='-94.5387055' />
+  <node id='4903496822' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1043804' lon='-94.5385908' />
+  <node id='4903496823' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1042321' lon='-94.5385959' />
+  <node id='4903496824' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1042344' lon='-94.5387105' />
+  <node id='4903496825' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1043713' lon='-94.5385057' />
+  <node id='4903496826' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1043699' lon='-94.5384192' />
+  <node id='4903496827' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1042331' lon='-94.5384228' />
+  <node id='4903496828' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1042344' lon='-94.5385093' />
+  <node id='4903496829' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1043978' lon='-94.5390642' />
+  <node id='4903496830' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1043949' lon='-94.538973' />
+  <node id='4903496831' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1042446' lon='-94.5389808' />
+  <node id='4903496832' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1042474' lon='-94.539072' />
+  <node id='4903496833' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1044067' lon='-94.539187' />
+  <node id='4903496834' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1044048' lon='-94.5390985' />
+  <node id='4903496835' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1042529' lon='-94.539104' />
+  <node id='4903496836' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1042548' lon='-94.5391926' />
+  <node id='4903496837' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1044073' lon='-94.5393058' />
+  <node id='4903496838' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1044062' lon='-94.5392227' />
+  <node id='4903496839' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1042548' lon='-94.539226' />
+  <node id='4903496840' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1042559' lon='-94.5393091' />
+  <node id='4903496841' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1044456' lon='-94.5395482' />
+  <node id='4903496842' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1044441' lon='-94.5394877' />
+  <node id='4903496843' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.104398' lon='-94.5394896' />
+  <node id='4903496844' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1043972' lon='-94.5394609' />
+  <node id='4903496845' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1042644' lon='-94.5394663' />
+  <node id='4903496846' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1042666' lon='-94.5395555' />
+  <node id='4903496847' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1045052' lon='-94.5391919' />
+  <node id='4903496848' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1045046' lon='-94.5391389' />
+  <node id='4903496849' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.10444' lon='-94.5391401' />
+  <node id='4903496850' action='delete' timestamp='2017-06-08T08:56:30Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1044407' lon='-94.5391931' />
+  <node id='4903496963' action='delete' timestamp='2017-06-08T08:56:32Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1047673' lon='-94.5389921' />
+  <node id='4903496964' action='delete' timestamp='2017-06-08T08:56:32Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.104767' lon='-94.5389697' />
+  <node id='4903496965' action='delete' timestamp='2017-06-08T08:56:32Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.104643' lon='-94.5389725' />
+  <node id='4903496966' action='delete' timestamp='2017-06-08T08:56:32Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1046434' lon='-94.5389985' />
+  <node id='4903496967' action='delete' timestamp='2017-06-08T08:56:32Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1046005' lon='-94.5389995' />
+  <node id='4903496968' action='delete' timestamp='2017-06-08T08:56:32Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1046017' lon='-94.5390914' />
+  <node id='4903496969' timestamp='2017-06-08T08:56:32Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044' lat='39.1045572' lon='-94.5393299' />
+  <node id='4905092864' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1043528' lon='-94.538293' />
+  <node id='4905092865' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.104351' lon='-94.5382449' />
+  <node id='4905092866' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1043358' lon='-94.5382459' />
+  <node id='4905092867' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1043347' lon='-94.5382185' />
+  <node id='4905092868' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1042302' lon='-94.5382249' />
+  <node id='4905092869' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.104233' lon='-94.5383004' />
+  <node id='4905092870' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.104351' lon='-94.5382021' />
+  <node id='4905092871' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1043492' lon='-94.5381304' />
+  <node id='4905092872' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1042254' lon='-94.5381355' />
+  <node id='4905092873' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1042272' lon='-94.5382072' />
+  <node id='4905092874' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1043404' lon='-94.5381163' />
+  <node id='4905092875' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1042187' lon='-94.5381217' />
+  <node id='4905092876' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1042161' lon='-94.5380245' />
+  <node id='4905092877' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1043378' lon='-94.5380191' />
+  <node id='4905092878' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1043328' lon='-94.5379386' />
+  <node id='4905092881' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1042158' lon='-94.5379443' />
+  <node id='4905092912' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1047194' lon='-94.5382383' />
+  <node id='4905092913' action='delete' timestamp='2017-06-09T03:13:09Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1047203' lon='-94.5383321' />
+  <node id='4905092916' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1047791' lon='-94.5385177' />
+  <node id='4905092917' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1047814' lon='-94.5386397' />
+  <node id='4905092918' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.104638' lon='-94.5386723' />
+  <node id='4905092919' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1046327' lon='-94.5384666' />
+  <node id='4905092920' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1045566' lon='-94.5384698' />
+  <node id='4905092921' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1045619' lon='-94.5386756' />
+  <node id='4905092922' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1045066' lon='-94.5386466' />
+  <node id='4905092923' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1045044' lon='-94.5385702' />
+  <node id='4905092924' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1044633' lon='-94.5385721' />
+  <node id='4905092925' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1044654' lon='-94.5386486' />
+  <node id='4905092926' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.104786' lon='-94.538111' />
+  <node id='4905092927' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1047832' lon='-94.5380245' />
+  <node id='4905092928' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1046645' lon='-94.5380309' />
+  <node id='4905092929' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532' lat='39.1046674' lon='-94.5381174' />
+  <node id='4956687727' timestamp='2018-03-12T23:36:07Z' uid='1561092' user='sannkc' visible='true' version='2' changeset='57127547' lat='39.1045452' lon='-94.5388402' />
+  <node id='5630272864' timestamp='2018-05-20T10:53:33Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.1041565' lon='-94.5389163' />
+  <node id='5630272865' timestamp='2018-05-20T10:53:33Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.104042' lon='-94.5389216' />
+  <node id='5630272866' timestamp='2018-05-20T10:53:33Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.1040409' lon='-94.5388668'>
+    <tag k='error:circular' v='15' />
+    <tag k='highway' v='crossing' />
+  </node>
+  <node id='5630272867' timestamp='2018-05-20T10:53:33Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.10404' lon='-94.5388237' />
+  <node id='5630272868' timestamp='2018-05-20T10:53:33Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.10404' lon='-94.5387888' />
+  <node id='5630272874' timestamp='2018-05-20T10:53:33Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.1040428' lon='-94.5389457' />
+  <node id='5630272875' timestamp='2018-05-20T10:53:33Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.1040618' lon='-94.5389444' />
+  <node id='5630272876' timestamp='2018-05-20T10:53:33Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.1040938' lon='-94.5389427'>
+    <tag k='error:circular' v='15' />
+    <tag k='highway' v='crossing' />
+  </node>
+  <node id='5630272877' timestamp='2018-05-20T10:53:33Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.1041388' lon='-94.5389404' />
+  <node id='5630272878' timestamp='2018-05-20T10:53:33Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.1040556' lon='-94.5387875' />
+  <node id='5630272879' timestamp='2018-05-20T10:53:33Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.104088' lon='-94.5387858'>
+    <tag k='error:circular' v='15' />
+    <tag k='highway' v='crossing' />
+  </node>
+  <node id='5630272880' timestamp='2018-05-20T10:53:33Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.1041315' lon='-94.5387835' />
+  <node id='5630272881' timestamp='2018-05-20T10:53:33Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.104543' lon='-94.5387631' />
+  <node id='5630272893' timestamp='2018-05-20T10:53:34Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.1045471' lon='-94.5389177' />
+  <node id='5630272894' timestamp='2018-05-20T10:53:34Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.1041573' lon='-94.5389394' />
+  <node id='5630272895' timestamp='2018-05-20T10:53:34Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.1041553' lon='-94.5388607'>
+    <tag k='error:circular' v='15' />
+    <tag k='highway' v='crossing' />
+  </node>
+  <node id='5630272896' timestamp='2018-05-20T10:53:34Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.1041544' lon='-94.5388184' />
+  <node id='5630272897' timestamp='2018-05-20T10:53:34Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240' lat='39.1041544' lon='-94.5387824' />
+  <node id='6612815543' timestamp='2019-07-14T10:29:53Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='72228986' lat='39.1040566' lon='-94.5389935'>
+    <tag k='emergency' v='fire_hydrant' />
+    <tag k='error:circular' v='15' />
+    <tag k='fire_hydrant:type' v='pillar' />
+    <tag k='water_source' v='main' />
+  </node>
+  <way id='-253935330' visible='true' version='1'>
+    <nd ref='-253935144' />
+    <nd ref='4956687727' />
+    <nd ref='5630272895' />
+    <nd ref='191091793' />
+    <nd ref='5630272866' />
+    <nd ref='-253935142' />
+    <tag k='error:circular' v='15' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='Monroe Avenue' />
+    <tag k='source:datetime' v='2019-05-02T17:14:34Z' />
+    <tag k='surface' v='asphalt' />
+    <tag k='tiger:cfcc' v='A41' />
+    <tag k='tiger:county' v='Jackson, MO' />
+    <tag k='tiger:name_base' v='Monroe' />
+    <tag k='tiger:name_type' v='Ave' />
+    <tag k='tiger:reviewed' v='no' />
+    <tag k='tiger:zip_left' v='64124' />
+    <tag k='tiger:zip_right' v='64124' />
+  </way>
+  <way id='-253935331' visible='true' version='1'>
+    <nd ref='4903496969' />
+    <nd ref='5630272893' />
+    <nd ref='4956687727' />
+    <nd ref='5630272881' />
+    <nd ref='-253935146' />
+    <tag k='error:circular' v='15' />
+    <tag k='highway' v='service' />
+    <tag k='service' v='alley' />
+    <tag k='source:datetime' v='2018-05-20T10:53:47Z' />
+  </way>
+  <way id='-253935333' visible='true' version='1'>
+    <nd ref='5630272896' />
+    <nd ref='5630272897' />
+    <nd ref='-253935152' />
+    <tag k='error:circular' v='15' />
+    <tag k='footway' v='sidewalk' />
+    <tag k='highway' v='footway' />
+    <tag k='source:datetime' v='2018-05-20T10:53:39Z' />
+  </way>
+  <way id='-253935334' visible='true' version='1'>
+    <nd ref='-253935154' />
+    <nd ref='5630272893' />
+    <nd ref='5630272894' />
+    <nd ref='5630272877' />
+    <tag k='error:circular' v='15' />
+    <tag k='footway' v='sidewalk' />
+    <tag k='highway' v='footway' />
+    <tag k='source:datetime' v='2018-05-20T10:53:39Z' />
+  </way>
+  <way id='-253935335' visible='true' version='1'>
+    <nd ref='5630272880' />
+    <nd ref='5630272897' />
+    <nd ref='5630272881' />
+    <nd ref='-253935156' />
+    <tag k='error:circular' v='15' />
+    <tag k='footway' v='sidewalk' />
+    <tag k='highway' v='footway' />
+    <tag k='source:datetime' v='2018-05-20T10:53:39Z' />
+  </way>
+  <way id='-253935336' visible='true' version='1'>
+    <nd ref='-253935158' />
+    <nd ref='5630272874' />
+    <nd ref='5630272875' />
+    <tag k='error:circular' v='15' />
+    <tag k='footway' v='sidewalk' />
+    <tag k='highway' v='footway' />
+    <tag k='source:datetime' v='2018-05-20T10:53:39Z' />
+  </way>
+  <way id='-253935337' visible='true' version='1'>
+    <nd ref='5630272867' />
+    <nd ref='5630272868' />
+    <nd ref='-253935160' />
+    <tag k='error:circular' v='15' />
+    <tag k='footway' v='sidewalk' />
+    <tag k='highway' v='footway' />
+    <tag k='source:datetime' v='2018-05-20T10:53:39Z' />
+  </way>
+  <way id='-253935338' visible='true' version='1'>
+    <nd ref='-253935162' />
+    <nd ref='5630272874' />
+    <nd ref='5630272865' />
+    <tag k='error:circular' v='15' />
+    <tag k='footway' v='sidewalk' />
+    <tag k='highway' v='footway' />
+    <tag k='source:datetime' v='2018-05-20T10:53:38Z' />
+  </way>
+  <way id='-253935339' visible='true' version='1'>
+    <nd ref='-253935164' />
+    <nd ref='5630272894' />
+    <nd ref='5630272864' />
+    <tag k='error:circular' v='15' />
+    <tag k='footway' v='sidewalk' />
+    <tag k='highway' v='footway' />
+    <tag k='source:datetime' v='2018-05-20T10:53:38Z' />
+  </way>
+  <way id='-253935340' visible='true' version='1'>
+    <nd ref='-253935168' />
+    <nd ref='5630272876' />
+    <nd ref='191091793' />
+    <nd ref='5630272879' />
+    <nd ref='-253935166' />
+    <tag k='error:circular' v='15' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='East 7th Street' />
+    <tag k='name_1' v='East 7 Street' />
+    <tag k='source:datetime' v='2018-07-03T11:35:21Z' />
+    <tag k='tiger:cfcc' v='A41' />
+    <tag k='tiger:county' v='Jackson, MO' />
+    <tag k='tiger:name_base' v='7th' />
+    <tag k='tiger:name_base_1' v='7' />
+    <tag k='tiger:name_direction_prefix' v='E' />
+    <tag k='tiger:name_direction_prefix_1' v='E' />
+    <tag k='tiger:name_type' v='St' />
+    <tag k='tiger:name_type_1' v='St' />
+    <tag k='tiger:reviewed' v='no' />
+    <tag k='tiger:zip_left' v='64124' />
+    <tag k='tiger:zip_right' v='64124' />
+  </way>
+  <way id='498707692' action='delete' timestamp='2017-06-07T02:53:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993'>
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-07T02:53:10Z' />
+  </way>
+  <way id='498707693' action='delete' timestamp='2017-06-07T02:53:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993'>
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-07T02:53:10Z' />
+  </way>
+  <way id='498707694' action='delete' timestamp='2017-06-07T02:53:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993'>
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-07T02:53:10Z' />
+  </way>
+  <way id='498707695' action='delete' timestamp='2017-06-07T02:53:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993'>
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-07T02:53:10Z' />
+  </way>
+  <way id='498707696' action='delete' timestamp='2017-06-07T02:53:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993'>
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-07T02:53:10Z' />
+  </way>
+  <way id='498707697' action='delete' timestamp='2017-06-07T02:53:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993'>
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-07T02:53:10Z' />
+  </way>
+  <way id='498707698' action='delete' timestamp='2017-06-07T02:53:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993'>
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-07T02:53:10Z' />
+  </way>
+  <way id='498707699' action='delete' timestamp='2017-06-07T02:53:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993'>
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-07T02:53:10Z' />
+  </way>
+  <way id='498707700' action='delete' timestamp='2017-06-07T02:53:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993'>
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-07T02:53:10Z' />
+  </way>
+  <way id='498707718' action='delete' timestamp='2017-06-07T02:53:11Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993'>
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-07T02:53:11Z' />
+  </way>
+  <way id='498707719' action='delete' timestamp='2017-06-07T02:53:11Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49322993'>
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-07T02:53:11Z' />
+  </way>
+  <way id='499021843' action='delete' timestamp='2017-06-08T08:56:36Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044'>
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-08T08:56:36Z' />
+  </way>
+  <way id='499021844' action='delete' timestamp='2017-06-08T08:56:36Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044'>
+    <tag k='building' v='yes' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-08T08:56:36Z' />
+  </way>
+  <way id='499021845' action='delete' timestamp='2018-07-21T14:41:47Z' uid='3009398' user='StackKorora' visible='true' version='2' changeset='60932319'>
+    <tag k='addr:city' v='Kansas City' />
+    <tag k='addr:housenumber' v='3458' />
+    <tag k='addr:postcode' v='64124' />
+    <tag k='addr:state' v='MO' />
+    <tag k='addr:street' v='East 7th Street' />
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source' v='http://maps.kcmo.org/apps/parcelviewer/' />
+    <tag k='source:datetime' v='2018-07-21T14:41:47Z' />
+  </way>
+  <way id='499021846' action='delete' timestamp='2018-07-21T14:41:47Z' uid='3009398' user='StackKorora' visible='true' version='2' changeset='60932319'>
+    <tag k='addr:city' v='Kansas City' />
+    <tag k='addr:housenumber' v='3456' />
+    <tag k='addr:postcode' v='64124' />
+    <tag k='addr:state' v='MO' />
+    <tag k='addr:street' v='East 7th Street' />
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source' v='http://maps.kcmo.org/apps/parcelviewer/' />
+    <tag k='source:datetime' v='2018-07-21T14:41:47Z' />
+  </way>
+  <way id='499021847' action='delete' timestamp='2018-07-21T14:41:48Z' uid='3009398' user='StackKorora' visible='true' version='2' changeset='60932319'>
+    <tag k='addr:city' v='Kansas City' />
+    <tag k='addr:housenumber' v='3454' />
+    <tag k='addr:postcode' v='64124' />
+    <tag k='addr:state' v='MO' />
+    <tag k='addr:street' v='East 7th Street' />
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source' v='http://maps.kcmo.org/apps/parcelviewer/' />
+    <tag k='source:datetime' v='2018-07-21T14:41:48Z' />
+  </way>
+  <way id='499021848' action='delete' timestamp='2018-07-21T14:41:48Z' uid='3009398' user='StackKorora' visible='true' version='2' changeset='60932319'>
+    <tag k='addr:city' v='Kansas City' />
+    <tag k='addr:housenumber' v='3450' />
+    <tag k='addr:postcode' v='64124' />
+    <tag k='addr:state' v='MO' />
+    <tag k='addr:street' v='East 7th Street' />
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source' v='http://maps.kcmo.org/apps/parcelviewer/' />
+    <tag k='source:datetime' v='2018-07-21T14:41:48Z' />
+  </way>
+  <way id='499021849' action='delete' timestamp='2017-06-08T08:56:37Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49360044'>
+    <tag k='building' v='yes' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-08T08:56:37Z' />
+  </way>
+  <way id='499203446' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532'>
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-09T03:13:10Z' />
+  </way>
+  <way id='499203447' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532'>
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-09T03:13:10Z' />
+  </way>
+  <way id='499203448' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532'>
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-09T03:13:10Z' />
+  </way>
+  <way id='499203459' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532'>
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-09T03:13:10Z' />
+  </way>
+  <way id='499203460' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532'>
+    <tag k='building' v='yes' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-09T03:13:10Z' />
+  </way>
+  <way id='499203461' action='delete' timestamp='2017-06-09T03:13:10Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='49384532'>
+    <tag k='building' v='detached' />
+    <tag k='error:circular' v='15' />
+    <tag k='source:datetime' v='2017-06-09T03:13:10Z' />
+  </way>
+  <way id='589613548' timestamp='2018-05-20T10:53:38Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240'>
+    <nd ref='5630272865' />
+    <nd ref='5630272866' />
+    <nd ref='5630272867' />
+    <tag k='error:circular' v='15' />
+    <tag k='footway' v='crossing' />
+    <tag k='highway' v='footway' />
+    <tag k='source:datetime' v='2018-05-20T10:53:38Z' />
+  </way>
+  <way id='589613552' timestamp='2018-05-20T10:53:39Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240'>
+    <nd ref='5630272875' />
+    <nd ref='5630272876' />
+    <nd ref='5630272877' />
+    <tag k='error:circular' v='15' />
+    <tag k='footway' v='crossing' />
+    <tag k='highway' v='footway' />
+    <tag k='source:datetime' v='2018-05-20T10:53:39Z' />
+  </way>
+  <way id='589613553' timestamp='2018-05-20T10:53:39Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240'>
+    <nd ref='5630272868' />
+    <nd ref='5630272878' />
+    <tag k='error:circular' v='15' />
+    <tag k='footway' v='sidewalk' />
+    <tag k='highway' v='footway' />
+    <tag k='source:datetime' v='2018-05-20T10:53:39Z' />
+  </way>
+  <way id='589613554' timestamp='2018-05-20T10:53:39Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240'>
+    <nd ref='5630272878' />
+    <nd ref='5630272879' />
+    <nd ref='5630272880' />
+    <tag k='error:circular' v='15' />
+    <tag k='footway' v='crossing' />
+    <tag k='highway' v='footway' />
+    <tag k='source:datetime' v='2018-05-20T10:53:39Z' />
+  </way>
+  <way id='589613561' timestamp='2018-05-20T10:53:39Z' uid='1561092' user='sannkc' visible='true' version='1' changeset='59120240'>
+    <nd ref='5630272864' />
+    <nd ref='5630272895' />
+    <nd ref='5630272896' />
+    <tag k='error:circular' v='15' />
+    <tag k='footway' v='crossing' />
+    <tag k='highway' v='footway' />
+    <tag k='source:datetime' v='2018-05-20T10:53:39Z' />
+  </way>
+</osm>

--- a/test-files/cases/unifying/sidewalk-3895/README.txt
+++ b/test-files/cases/unifying/sidewalk-3895/README.txt
@@ -1,0 +1,4 @@
+This tests to make sure sidewalks don't conflate with roads when they are clearly not supposed to. Look at the intersection of East 7th Street
+and Monroe Avenue.
+
+Note the poorly snapped footway=crossing, which will be handled as part of #3901.


### PR DESCRIPTION
Made the tag similarity threshold required for road matching more strict when sidewalks are involved. The value may need additional tweaking. The more appropriate way to handle this would have been in the schema, but as noted in the code, due to the large amount of interrelations between highway types in the schema I couldn't get that to work. May be able to go back later and move the change to the schema instead.

Also discovered a related issue where `footway=crossing` features get snapped incorrectly and opened #3901 for it.