### PR TITLE
3896 - Add auto-retry for Alpha Shape generation when initial alpha too small

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/alpha-shape/AlphaShapeGeneratorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/alpha-shape/AlphaShapeGeneratorTest.cpp
@@ -47,6 +47,7 @@ namespace hoot
 class AlphaShapeGeneratorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(AlphaShapeGeneratorTest);
+  // TODO: need test for auto alpha retry when initial value is too small
   CPPUNIT_TEST(runBasicTest);
   CPPUNIT_TEST(runBufferTest);
   CPPUNIT_TEST(runNegativeBufferTest);
@@ -117,6 +118,5 @@ public:
 };
 
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(AlphaShapeGeneratorTest, "slow");
-//CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(AlphaShapeGeneratorTest, "current");
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/alpha-shape/AlphaShapeGeneratorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/alpha-shape/AlphaShapeGeneratorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShape.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShape.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "AlphaShape.h"

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShape.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShape.cpp
@@ -363,11 +363,18 @@ std::shared_ptr<Geometry> AlphaShape::toGeometry()
   // if the result is an empty geometry.
   if (tmp.size() == 0)
   {
-    throw IllegalArgumentException(
-      "Longest face edge of size: " + QString::number(_longestFaceEdge) +
-      " larger than alpha value of: " + QString::number(_alpha) + ". Try an alpha value of " +
-      QString::number(_longestFaceEdge) + " or larger.");
-    //return std::shared_ptr<Geometry>(GeometryFactory::getDefaultInstance()->createEmptyGeometry());
+    if (_longestFaceEdge > _alpha)
+    {
+      throw IllegalArgumentException(
+        "Longest face edge of size: " + QString::number(_longestFaceEdge) +
+        " larger than alpha value of: " + QString::number(_alpha) + ". Try an alpha value of " +
+        QString::number(_longestFaceEdge) + " or larger.");
+    }
+    else
+    {
+      // don't know how to handle it
+      return std::shared_ptr<Geometry>(GeometryFactory::getDefaultInstance()->createEmptyGeometry());
+    }
   }
 
   LOG_DEBUG("Joining faces...");

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShape.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShape.h
@@ -80,14 +80,16 @@ public:
 
   std::shared_ptr<OsmMap> toOsmMap();
 
+  double getLongestFaceEdge() const { return _longestFaceEdge; }
+
 private:
 
   double _alpha;
 
+  mutable double _longestFaceEdge;
+
   std::shared_ptr<Tgs::DelaunayTriangulation> _pDelauneyTriangles;
   std::set<std::pair<double, double>> _outsidePoint;
-
-  std::shared_ptr<hoot::Way> _addFaceAsWay(const Tgs::Face* face, const std::shared_ptr<OsmMap>& map);
 
   std::shared_ptr<geos::geom::Polygon> _convertFaceToPolygon(const Tgs::Face& face) const;
 
@@ -112,7 +114,8 @@ private:
 
   bool _isTooLong(const Tgs::Edge& e) const;
 
-  std::shared_ptr<geos::geom::Geometry> _validateGeometry(const std::shared_ptr<geos::geom::Geometry>& g);
+  std::shared_ptr<geos::geom::Geometry> _validateGeometry(
+    const std::shared_ptr<geos::geom::Geometry>& g);
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShape.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShape.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef __ALPHASHAPE_H__

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShapeGenerator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShapeGenerator.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "AlphaShapeGenerator.h"

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShapeGenerator.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShapeGenerator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef ALPHASHAPEGENERATOR_H

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShapeGenerator.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShapeGenerator.h
@@ -55,10 +55,13 @@ public:
 
   std::shared_ptr<geos::geom::Geometry> generateGeometry(OsmMapPtr inputMap);
 
+  void setRetryOnTooSmallInitialAlpha(bool retry) { _retryOnTooSmallInitialAlpha = retry; }
+
 private:
 
   double _alpha;
   double _buffer;
+  bool _retryOnTooSmallInitialAlpha;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetCreator.cpp
@@ -55,6 +55,10 @@
 //GEOS
 #include <geos/geom/Envelope.h>
 
+// Qt
+#include <QFileInfo>
+#include <QDir>
+
 namespace hoot
 {
 
@@ -92,6 +96,14 @@ void ChangesetCreator::create(const QString& output, const QString& input1, cons
   LOG_DEBUG(
     "Creating changeset from inputs: " << input1 << " and " << input2 << " to output: " <<
     output << "...");
+
+  QFileInfo outputInfo(output);
+  LOG_VARD(outputInfo.dir().absolutePath());
+  const bool outputDirSuccess = QDir().mkpath(outputInfo.dir().absolutePath());
+  if (!outputDirSuccess)
+  {
+    throw IllegalArgumentException("Unable to create output path for: " + output);
+  }
 
   _singleInput = input2.trimmed().isEmpty();
   LOG_VARD(_singleInput);

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.cpp
@@ -448,7 +448,7 @@ void ChangesetReplacementCreator::_getMapsForGeometryType(
 
   // Cut the secondary data out of the reference data.
 
-  OsmMapPtr cookieCutRefMap = _getCookieCutMap(refMap, secMap);
+  OsmMapPtr cookieCutRefMap = _getCookieCutMap(refMap, secMap, geometryType);
 
   // At one point it was necessary to re-number the relations in the sec map, as they could have ID
   // overlap with those in the cookie cut ref map at this point. It seemed that this was due to the
@@ -827,7 +827,8 @@ void ChangesetReplacementCreator::_filterFeatures(
   OsmMapWriterFactory::writeDebugMap(map, debugFileName);
 }
 
-OsmMapPtr ChangesetReplacementCreator::_getCookieCutMap(OsmMapPtr doughMap, OsmMapPtr cutterMap)
+OsmMapPtr ChangesetReplacementCreator::_getCookieCutMap(
+  OsmMapPtr doughMap, OsmMapPtr cutterMap, const GeometryTypeCriterion::GeometryType& geometryType)
 {
   // could use some refactoring here after the addition of _fullReplacement
 
@@ -926,8 +927,9 @@ OsmMapPtr ChangesetReplacementCreator::_getCookieCutMap(OsmMapPtr doughMap, OsmM
     if (e.getWhat().contains("Alpha Shape area is zero"))
     {
       LOG_ERROR(
-        "No cut shape generated from secondary data. Is your secondary data empty or have you " <<
-        "filtered it to be empty? error: " << e.getWhat());
+        "No cut shape generated from secondary data when processing geometry type: " <<
+        GeometryTypeCriterion::typeToString(geometryType) << ". Is your secondary data empty " <<
+        "or have you filtered it to be empty? error: " << e.getWhat());
     }
     // rethrow the original exception
     throw;

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.cpp
@@ -904,7 +904,7 @@ OsmMapPtr ChangesetReplacementCreator::_getCookieCutMap(OsmMapPtr doughMap, OsmM
   else
   {
     // Generate a cutter shape based on the cropped secondary map.
-    LOG_DEBUG("Using cuter map as cutter shape map...");
+    LOG_DEBUG("Using cutter map as cutter shape map...");
     cutterMapToUse = cutterMap;
   }
   LOG_VART(cutterMapToUse->getElementCount());
@@ -912,6 +912,8 @@ OsmMapPtr ChangesetReplacementCreator::_getCookieCutMap(OsmMapPtr doughMap, OsmM
 
   LOG_INFO("Generating cutter shape map from: " << cutterMapToUse->getName() << "...");
 
+  LOG_VART(cookieCutterAlpha);
+  LOG_VART(cookieCutterAlphaShapeBuffer);
   OsmMapPtr cutterShapeOutlineMap;
   try
   {

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.h
@@ -234,7 +234,8 @@ private:
    */
   void _addChangesetDeleteExclusionTags(OsmMapPtr& map);
 
-  OsmMapPtr _getCookieCutMap(OsmMapPtr doughMap, OsmMapPtr cutterMap);
+  OsmMapPtr _getCookieCutMap(OsmMapPtr doughMap, OsmMapPtr cutterMap,
+                             const GeometryTypeCriterion::GeometryType& geometryType);
 
   /*
    * Copies all ways that are tagged with MetadataTags::HootConnectedWayOutsideBounds() out of a map

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonAlphaShapeDistanceExtractor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonAlphaShapeDistanceExtractor.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "PoiPolygonAlphaShapeDistanceExtractor.h"
 
@@ -66,8 +66,9 @@ double PoiPolygonAlphaShapeDistanceExtractor::extract(const OsmMap& map,
     OsmMapPtr polyMap(new OsmMap());
     ElementPtr polyTemp(poly->clone());
     polyMap->addElement(polyTemp);
-    std::shared_ptr<Geometry> polyAlphaShape =
-      AlphaShapeGenerator(1000.0, 0.0).generateGeometry(polyMap);
+    AlphaShapeGenerator alphaShapeGenerator(1000.0, 0.0);
+    alphaShapeGenerator.setRetryOnTooSmallInitialAlpha(false);
+    std::shared_ptr<Geometry> polyAlphaShape = alphaShapeGenerator.generateGeometry(polyMap);
     // Oddly, even if the area is zero calc'ing the distance can have a positive effect. This may
     // be worth looking into at some point, but going with it for now.
     /*if (polyAlphaShape->getArea() == 0.0)


### PR DESCRIPTION
After this change, `AlphaShapeGenerator` will try a second time to generate an alpha shape if the generation fails the first time when the alpha value is too small. It will do this only if any alpha shape edge face size is larger than the initial alpha value and use the largest face size for the alpha value.