### PR TITLE
CircleCI Image Updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   archive-create:
     working_directory: '/rpmbuild/hootenanny'
     docker:
-      - image: hootenanny/rpmbuild-hoot-release@sha256:aae16380c2f96744b658c383a6c40f1623285cd680666f908f5f7e96e79c0776
+      - image: hootenanny/rpmbuild-hoot-release@sha256:dd8d865531c034aa66daf763dc7068f0a08745f5d63a7766ad69e0b5fd8cf10b
     steps:
       - checkout
       - run:
@@ -27,7 +27,7 @@ jobs:
   archive-upload:
     working_directory: '/rpmbuild/hootenanny'
     docker:
-      - image: hootenanny/rpmbuild-repo@sha256:27c86924043bae5d291bbc203702d2b2ed9f6970d9647462ecb8c73df5e012b4
+      - image: hootenanny/rpmbuild-repo@sha256:8717a75726db4a38977977f08344510bd15515aba4e344fd51f96f39b4f9fa75
         user: rpmbuild
     steps:
       - attach_workspace:
@@ -39,7 +39,7 @@ jobs:
   copyright:
     working_directory: '/rpmbuild/hootenanny'
     docker:
-      - image: hootenanny/rpmbuild-generic@sha256:9e64e3c20f8a5781ab61e0eec855d658c511c558d36eb41c4f2a45ad881bae93
+      - image: hootenanny/rpmbuild-generic@sha256:5c563f129e7802029cf6ecc1f3cd50668c53fcca532895fce615de9f4337c951
         user: rpmbuild
         environment:
           HOOT_HOME: '/rpmbuild/hootenanny'


### PR DESCRIPTION
Updates the images used in CircleCI to the latest versions that have the latest package updates, including `rpmbuild-hoot-release` with NodeJS 8.9.3-2 via ngageoint/hootenanny-rpms#298.