### PR TITLE
Repeated changeset create failures

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
@@ -41,7 +41,7 @@ public:
 
 protected:
   /** respond() function that responds once to the OSM API Capabilities request */
-  virtual bool respond(HttpConnection::HttpConnectionPtr& connection) override;
+  bool respond(HttpConnection::HttpConnectionPtr& connection) override;
 };
 
 class PermissionsTestServer : public HttpTestServer
@@ -52,7 +52,7 @@ public:
 
 protected:
   /** respond() function that responds once to the OSM API Permissions request */
-  virtual bool respond(HttpConnection::HttpConnectionPtr &connection) override;
+  bool respond(HttpConnection::HttpConnectionPtr &connection) override;
 };
 
 class RetryConflictsTestServer : public HttpTestServer
@@ -71,7 +71,7 @@ protected:
    *   - Changeset Upload - responding with an HTTP 405 error for the test
    *   - Changeset Close
    */
-  virtual bool respond(HttpConnection::HttpConnectionPtr& connection) override;
+  bool respond(HttpConnection::HttpConnectionPtr& connection) override;
 };
 
 class RetryVersionTestServer : public HttpTestServer
@@ -92,7 +92,7 @@ protected:
    *  - Changeset 1 Upload - respond with updated version
    *  - Changeset Close
    */
-  virtual bool respond(HttpConnection::HttpConnectionPtr &connection) override;
+  bool respond(HttpConnection::HttpConnectionPtr &connection) override;
 
 private:
   /** Flag set to false until the first changeset has failed once */
@@ -107,7 +107,7 @@ public:
 
 protected:
   /** respond() function that responds to a series of OSM API requests
-   *  to simulate a
+   *  to simulate a changeset upload.
    *  Requests, in order:
    *   - Capabilities
    *   - Permissions
@@ -116,7 +116,24 @@ protected:
    *   - Changeset Upload - responds with HTTP 200
    *   - Changeset Close
    */
-  virtual bool respond(HttpConnection::HttpConnectionPtr& connection) override;
+  bool respond(HttpConnection::HttpConnectionPtr& connection) override;
+};
+
+class ChangesetCreateFailureTestServer : public HttpTestServer
+{
+public:
+  /** Constructor */
+  ChangesetCreateFailureTestServer(int port) : HttpTestServer(port) { }
+
+protected:
+  /** respond() function that responds to a series of OSM API requests
+   *  to simulate a changeset create failure over and over.
+   *  Requests, in order:
+   *   - Capabilities
+   *   - Permissions
+   *   - Changeset Create Failure x6
+   */
+  bool respond(HttpConnection::HttpConnectionPtr &connection) override;
 };
 
 class OsmApiSampleRequestResponse

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -2109,6 +2109,31 @@ bool XmlChangeset::isMatch(const XmlChangeset& changeset)
   return isEqual;
 }
 
+void XmlChangeset::failRemainingChangeset()
+{
+  //  Fail all remaining nodes
+  failRemainingElements(_allNodes);
+  //  Fail all remaining ways
+  failRemainingElements(_allWays);
+  //  Fail all remaining relations
+  failRemainingElements(_allRelations);
+}
+
+void XmlChangeset::failRemainingElements(const ChangesetElementMap& elements)
+{
+  //  Iterate all elements
+  for (ChangesetElementMap::const_iterator it = elements.begin(); it != elements.end(); ++it)
+  {
+    ChangesetElementPtr element = it->second;
+    //  Anything that isn't finalized is now failed
+    if (element->getStatus() != ChangesetElement::Finalized)
+    {
+      element->setStatus(ChangesetElement::Failed);
+      ++_failedCount;
+    }
+  }
+}
+
 ChangesetInfo::ChangesetInfo()
   : _attemptedResolveChangesetIssues(false),
     _numRetries(0),

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -297,6 +297,10 @@ public:
    * @return true if they are equivalent
    */
   bool isMatch(const XmlChangeset& changeset);
+  /**
+   * @brief failRemainingChangeset Set all remaining elements to the failed state
+   */
+  void failRemainingChangeset();
 
 private:
   /**
@@ -489,6 +493,11 @@ private:
   void writeRelations(const ChangesetInfoPtr& changeset, QTextStream& ts, ChangesetType type, long changeset_id);
   void writeElements(const ChangesetInfoPtr& changeset, QTextStream& ts, ChangesetType type, long changeset_id,
                      ElementType::Type elementType, const ChangesetElementMap& elements);
+  /**
+   * @brief failRemainingElements Fail all non-finalized elements
+   * @param elements Map of elements to fail
+   */
+  void failRemainingElements(const ChangesetElementMap& elements);
 
   /** Sorted map of all nodes, original node ID and a pointer to the element object */
   ChangesetElementMap _allNodes;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -259,7 +259,7 @@ private:
    * @param response String response from the server to help in the splitting process
    * @return True if the changeset was split
    */
-  bool _splitChangeset(const ChangesetInfoPtr& workInfo, const QString& response);
+  bool _splitChangeset(const ChangesetInfoPtr& workInfo, const QString& response = "");
   /**
    * @brief _writeDebugFile Write out the request or response file for debugging uploads
    * @param type "request" or "response" output file
@@ -274,8 +274,24 @@ private:
    * @return next ID
    */
   int _getNextApiId();
+  /**
+   * @brief _allThreadsFailed Check if all threads are in the failed state
+   * @return true if all threads are in the failed state
+   */
+  bool _allThreadsFailed();
+  /**
+   * @brief _hasFailedThread Check if any thread is in a failed state
+   * @return true if any thread is in a failed state
+   */
+  bool _hasFailedThread();
   /** Changeset processing thread pool */
   std::vector<std::thread> _threadPool;
+  /**
+   * @brief _pushChangesets Push one or more changesets on to the work queue
+   * @param changeset Required changeset info object
+   * @param changeset2 Optional changeset info object
+   */
+  void _pushChangesets(ChangesetInfoPtr changeset, ChangesetInfoPtr changeset2 = ChangesetInfoPtr());
   /** Queue for producer/consumer work model */
   std::queue<ChangesetInfoPtr> _workQueue;
   /** Mutex protecting work queue */
@@ -288,8 +304,15 @@ private:
   enum ThreadStatus
   {
     Idle,
-    Working
+    Working,
+    Failed
   };
+  /**
+   * @brief _updateThreadStatus Update the thread status
+   * @param thread_index Index of calling thread in _threadStatus vector
+   * @param status Status to update to
+   */
+  void _updateThreadStatus(int thread_index, ThreadStatus status);
   /** Vector of statuses for each running thread */
   std::vector<ThreadStatus> _threadStatus;
   /** Mutex protecting status vector */

--- a/hoot-core/src/main/cpp/hoot/core/util/HootNetworkUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/HootNetworkUtils.h
@@ -33,15 +33,16 @@ namespace hoot
 
 namespace HttpResponseCode
 {
-  const int HTTP_OK                    = 200;
-  const int HTTP_BAD_REQUEST           = 400;
-  const int HTTP_NOT_FOUND             = 404;
-  const int HTTP_METHOD_NOT_ALLOWED    = 405;
-  const int HTTP_CONFLICT              = 409;
-  const int HTTP_PRECONDITION_FAILED   = 412;
-  const int HTTP_INTERNAL_SERVER_ERROR = 500;
-  const int HTTP_BAD_GATEWAY           = 502;
-  const int HTTP_GATEWAY_TIMEOUT       = 504;
+  const int HTTP_OK                     = 200;
+  const int HTTP_BAD_REQUEST            = 400;
+  const int HTTP_UNAUTHORIZED           = 401;
+  const int HTTP_NOT_FOUND              = 404;
+  const int HTTP_METHOD_NOT_ALLOWED     = 405;
+  const int HTTP_CONFLICT               = 409;
+  const int HTTP_PRECONDITION_FAILED    = 412;
+  const int HTTP_INTERNAL_SERVER_ERROR  = 500;
+  const int HTTP_BAD_GATEWAY            = 502;
+  const int HTTP_GATEWAY_TIMEOUT        = 504;
 }
 
 class HootNetworkUtils

--- a/hoot-test/src/main/cpp/hoot/test/ProcessPool.cpp
+++ b/hoot-test/src/main/cpp/hoot/test/ProcessPool.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "ProcessPool.h"
 

--- a/hoot-test/src/main/cpp/hoot/test/ProcessPool.cpp
+++ b/hoot-test/src/main/cpp/hoot/test/ProcessPool.cpp
@@ -192,8 +192,11 @@ void ProcessThread::processJobs(JobQueue* queue)
               if (_proc->bytesAvailable() < 1)
                 _proc->waitForReadyRead(READ_TIMEOUT);
               next = QString(_proc->readLine()).trimmed();
-              if (next != HOOT_TEST_FINISHED)
+              if (next != HOOT_TEST_FINISHED && !next.isEmpty())
                 line.append(next.append("\n"));
+              //  If the process ends here before writing HOOT_TEST_FINISH, break out of the loop
+              if (_proc->state() != QProcess::Running)
+                break;
             }
           }
           output.append(line);


### PR DESCRIPTION
The API can fail to create a new changeset ID for numerous reasons, permission being one, and `changeset-apply` wasn't handling these failures correctly.  Also found and fixed an issue in the unit testing framework where parallel processes didn't shutdown correctly and left the main process running forever.

Closes #3936 