### PR TITLE
Jenkins Configure Test failing with race condition

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTest.cpp
@@ -453,7 +453,6 @@ public:
 
     Settings s;
     s.set(ConfigOptions::getChangesetApidbWritersMaxKey(), 1);
-    s.set(ConfigOptions::getChangesetApidbSizeMaxKey(), 2);
     writer.setConfiguration(s);
     writer.apply();
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
@@ -132,6 +132,7 @@ bool RetryVersionTestServer::respond(HttpConnection::HttpConnectionPtr &connecti
   //  Upload changeset 1
   else if (headers.find(QString(OsmApiEndpoints::API_PATH_UPLOAD_CHANGESET).arg(1).toStdString()) != std::string::npos)
   {
+    std::lock_guard<std::mutex> lock(_errorMutex);
     //  The first time through, the 'version' of element 1 should fail.
     if (!_has_error)
     {
@@ -216,9 +217,9 @@ bool ChangesetCreateFailureTestServer::respond(HttpConnection::HttpConnectionPtr
     response.reset(new HttpResponse(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_PERMISSIONS_RESPONSE));
   else if (headers.find(OsmApiEndpoints::API_PATH_CREATE_CHANGESET) != std::string::npos)
   {
-    static int count = 0;
+    std::lock_guard<std::mutex> lock(_responseMutex);
     response.reset(new HttpResponse(HttpResponseCode::HTTP_UNAUTHORIZED, "User is not authorized"));
-    if (++count >= 3)
+    if (++_responseCount >= 3)
       continue_processing = false;
   }
   else

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
@@ -30,6 +30,8 @@
 
 #include <hoot/core/util/HttpTestServer.h>
 
+#include <mutex>
+
 namespace hoot
 {
 
@@ -97,6 +99,7 @@ protected:
 private:
   /** Flag set to false until the first changeset has failed once */
   bool _has_error;
+  std::mutex _errorMutex;
 };
 
 class ChangesetOutputTestServer : public HttpTestServer
@@ -134,6 +137,10 @@ protected:
    *   - Changeset Create Failure x6
    */
   bool respond(HttpConnection::HttpConnectionPtr &connection) override;
+private:
+  /** Number of invalid changeset create responses sent */
+  int _responseCount = 0;
+  std::mutex _responseMutex;
 };
 
 class OsmApiSampleRequestResponse


### PR DESCRIPTION
Use mutex to fix race condition in HTTP test servers