### PR TITLE
Small runtime perf improvement tweaks

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoiner.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoiner.cpp
@@ -329,10 +329,6 @@ bool WayJoiner::_joinWays(const WayPtr& parent, const WayPtr& child)
   if (!parent || !child)
     return false;
 
-  //  Don't join area ways
-  AreaCriterion areaCrit;
-  if (areaCrit.isSatisfied(parent) || areaCrit.isSatisfied(child))
-    return false;
   //  Check if the two ways are able to be joined back up
   vector<long> child_nodes = child->getNodeIds();
   vector<long> parent_nodes = parent->getNodeIds();
@@ -346,6 +342,11 @@ bool WayJoiner::_joinWays(const WayPtr& parent, const WayPtr& child)
   else if (child_nodes[child_nodes.size() - 1] == parent_nodes[0])
     parentFirst = false;
   else
+    return false;
+  // Don't join area ways; moved this to here, as its a little more expensive than the calcs done
+  // above
+  AreaCriterion areaCrit;
+  if (areaCrit.isSatisfied(parent) || areaCrit.isSatisfied(child))
     return false;
   //  Remove the split parent id
   child->resetPid();

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoiner.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoiner.h
@@ -99,6 +99,7 @@ protected:
   bool _leavePid;
   /** Pointer to the map to work on */
   OsmMapPtr _map;
+
   int _numJoined;
   int _numProcessed;
   int _totalWays;

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoinerAdvanced.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoinerAdvanced.cpp
@@ -43,6 +43,7 @@
 #include <hoot/core/schema/TagMergerFactory.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/StringUtils.h>
 
 #include <unordered_set>
 #include <vector>
@@ -84,6 +85,7 @@ void WayJoinerAdvanced::_joinParentChild()
   LOG_INFO("\tJoining parent ways to children...");
 
   WayMap ways = _map->getWays();
+  _totalWays = ways.size();
   vector<long> ids;
   //  Find all ways that have a split parent id
   for (WayMap::const_iterator it = ways.begin(); it != ways.end(); ++it)
@@ -141,6 +143,13 @@ void WayJoinerAdvanced::_joinParentChild()
       //  Join this way to the parent
       _callingMethod = "_joinParentChild";
       _joinWays(parent, way);
+    }
+
+    if (_numProcessed % (_taskStatusUpdateInterval / 10) == 0)
+    {
+      PROGRESS_INFO(
+        "\tRejoined " << StringUtils::formatLargeNumber(_numJoined) << " pairs of ways / " <<
+        StringUtils::formatLargeNumber(_totalWays) << " total ways.");
     }
   }
 }
@@ -264,6 +273,13 @@ void WayJoinerAdvanced::_joinAtNode()
             }
           }
         }
+      }
+
+      if (_numProcessed % (_taskStatusUpdateInterval / 10) == 0)
+      {
+        PROGRESS_INFO(
+          "\tRejoined " << StringUtils::formatLargeNumber(_numJoined) << " pairs of ways / " <<
+          StringUtils::formatLargeNumber(_totalWays) << " total ways.");
       }
     }
     numIterations++;
@@ -423,6 +439,8 @@ void WayJoinerAdvanced::_rejoinSiblings(deque<long>& way_ids)
 
 bool WayJoinerAdvanced::_joinWays(const WayPtr& parent, const WayPtr& child)
 {
+  _numProcessed++;
+
   if (!parent || !child)
     return false;
 
@@ -673,6 +691,13 @@ void WayJoinerAdvanced::_joinUnsplitWaysAtNode()
           }
         }
       }
+    }
+
+    if (_numProcessed % (_taskStatusUpdateInterval / 10) == 0)
+    {
+      PROGRESS_INFO(
+        "\tRejoined " << StringUtils::formatLargeNumber(_numJoined) << " pairs of ways / " <<
+        StringUtils::formatLargeNumber(_totalWays) << " total ways.");
     }
   }
   LOG_TRACE(

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoinerAdvanced.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoinerAdvanced.h
@@ -37,10 +37,8 @@ namespace hoot
 {
 
 /**
- * An experimental way joiner implemented to work with Attribute Conflation and a possible
- * replacement for WayJoinerBasic.
- *
- * @todo update progress logging
+ * An way joiner with extended features implemented to work with Attribute Conflation. Eventually
+ * some of the logic could be moved up to WayJoinerBasic.
  */
 class WayJoinerAdvanced : public WayJoiner
 {


### PR DESCRIPTION
* This combined with the previous related PR yielded ~27% default way joining performance improvement for the #3892 data. To be fair, timing from Vagrant is always suspect between runs, so it could be less.
* Also implemented progress logging for `WayJoinerAdvanced`.