### PR TITLE
Fix changeset-derive-replacement crash

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetDeriveReplacementCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetDeriveReplacementCmd.cpp
@@ -63,12 +63,7 @@ public:
 
   virtual int runSimple(QStringList& args) override
   {
-    const QString boundsStr = args[2].trimmed();
-    conf().set(ConfigOptions::getConvertBoundingBoxKey(), boundsStr);
-    BoundedCommand::runSimple(args);
-
     // process optional params
-
     bool fullReplacement = false;
     if (args.contains("--full-replacement"))
     {
@@ -231,16 +226,18 @@ public:
     LOG_VARD(args.size());
     LOG_VARD(args);
 
-    // param error checking
-
-    if (args.size() < 4 || args.size() > 5)
+    QString boundsStr = "";
+    if (args.size() >= 3)
     {
-      std::cout << getHelp() << std::endl << std::endl;
-      throw HootException(QString("%1 takes four or five parameters.").arg(getName()));
+      boundsStr = args[2].trimmed();
+      conf().set(ConfigOptions::getConvertBoundingBoxKey(), boundsStr);
+      BoundedCommand::runSimple(args);
     }
 
-    // process non-optional params
+    // param error checking
+    checkParameterCount(args.size());
 
+    // process non-optional params
     const QString input1 = args[0].trimmed();
     LOG_VARD(input1);
     const QString input2 = args[1].trimmed();
@@ -280,6 +277,15 @@ public:
     changesetCreator.create(input1, input2, bounds, output);
 
     return 0;
+  }
+
+  void checkParameterCount(int count)
+  {
+    if (count != 4 && count != 5)
+    {
+      std::cout << getHelp() << std::endl << std::endl;
+      throw HootException(QString("%1 takes four or five parameters.").arg(getName()));
+    }
   }
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/index/OsmMapIndex.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/index/OsmMapIndex.cpp
@@ -482,7 +482,7 @@ set<ElementId> OsmMapIndex::getParents(ElementId eid) const
       LOG_INFO("Child element: " << eid);
       LOG_INFO("Missing relation: " << *it);
       LOG_INFO("Child element: " << _map.getElement(eid)->toString());
-      // TODO: throw exception here or continue to next iteration?
+      continue;
     }
     // the map should contain all the relations returned by the index.
     assert(_map.containsRelation(*it));


### PR DESCRIPTION
Certain datasets cause a crash in `changeset-derive-replacement`.  I was unable to track down where the node in the relation isn't update when the relation is deleted but this will fix the crash.