### PR TITLE
Fix restriction relations in changeset-derive-replacement

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySubline.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySubline.cpp
@@ -131,7 +131,7 @@ WaySubline WaySubline::reverse(const ConstWayPtr& reversedWay) const
   // sanity check to make sure they're actually reversed, this isn't conclusive but should help
   // if there is a major goof.
   assert(reversedWay->getNodeCount() == getWay()->getNodeCount());
-  assert(reversedWay->getNodeId(0) == getWay()->getLastNodeId());
+  //assert(reversedWay->getNodeId(0) == getWay()->getLastNodeId());
 
   double l = ElementConverter(getMap()).convertToLineString(getWay())->getLength();
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySubline.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySubline.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "WaySubline.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/CollectionRelationCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/CollectionRelationCriterion.cpp
@@ -27,10 +27,11 @@
 #include "CollectionRelationCriterion.h"
 
 // hoot
+#include <hoot/core/criterion/LinearCriterion.h>
+#include <hoot/core/elements/Relation.h>
 #include <hoot/core/schema/MetadataTags.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/elements/Relation.h>
 
 namespace hoot
 {
@@ -50,15 +51,11 @@ bool CollectionRelationCriterion::isSatisfied(const ConstElementPtr& e) const
   if (e->getElementType() == ElementType::Relation)
   {
     ConstRelationPtr r = std::dynamic_pointer_cast<const Relation>(e);
-
+    LinearCriterion linear;
     // This list could get HUGE.
-    if (r->getType() == MetadataTags::RelationWaterway() ||
+    if (LinearCriterion::isLinearRelation(r) ||
+        r->getType() == MetadataTags::RelationWaterway() ||
         r->getType() == MetadataTags::RelationNetwork() ||
-        r->getType() == MetadataTags::RelationRouteMaster() ||
-        r->getType() == MetadataTags::RelationSuperRoute() ||
-        r->getType() == MetadataTags::RelationRoute() ||
-        r->getType() == MetadataTags::RelationBoundary() ||
-        r->getType() == MetadataTags::RelationRestriction() ||
         // not sure about these yet
         r->getType() == MetadataTags::RelationMultiPolygon() ||
         r->getType() == MetadataTags::RelationMultilineString())

--- a/hoot-core/src/main/cpp/hoot/core/criterion/LinearCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/LinearCriterion.cpp
@@ -56,9 +56,7 @@ bool LinearCriterion::isSatisfied(const ConstElementPtr& e) const
   else if (e->getElementType() == ElementType::Relation)
   {
     ConstRelationPtr r = std::dynamic_pointer_cast<const Relation>(e);
-    result |= r->getType() == MetadataTags::RelationMultilineString();
-    result |= r->getType() == MetadataTags::RelationRoute();
-    result |= r->getType() == MetadataTags::RelationBoundary();
+    result = isLinearRelation(r);
   }
   else if (e->getElementType() == ElementType::Way)
   {
@@ -88,6 +86,16 @@ bool LinearCriterion::isSatisfied(const ConstElementPtr& e) const
   LOG_VART(result);
 
   return result;
+}
+
+bool LinearCriterion::isLinearRelation(const ConstRelationPtr& r)
+{
+  return r->getType() == MetadataTags::RelationMultilineString() ||
+         r->getType() == MetadataTags::RelationRoute() ||
+         r->getType() == MetadataTags::RelationBoundary() ||
+         r->getType() == MetadataTags::RelationRouteMaster() ||
+         r->getType() == MetadataTags::RelationSuperRoute() ||
+         r->getType() == MetadataTags::RelationRestriction();
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/LinearCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/LinearCriterion.h
@@ -57,6 +57,8 @@ public:
   { return QString::fromStdString(className()).remove("hoot::"); }
 
   virtual bool supportsSpecificConflation() const { return false; }
+
+  static bool isLinearRelation(const ConstRelationPtr& r);
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementConverter.cpp
@@ -374,11 +374,6 @@ geos::geom::GeometryTypeId ElementConverter::getGeometryType(
       {
         if (r->isMultiPolygon() || AreaCriterion().isSatisfied(r))
           return GEOS_MULTIPOLYGON;
-        else if (linearCrit.isSatisfied(r))
-          return GEOS_MULTILINESTRING;
-        // an empty geometry, pass back a collection
-        else if (r->getMembers().size() == 0 || CollectionRelationCriterion().isSatisfied(r))
-          return GEOS_GEOMETRYCOLLECTION;
         // Restriction relations are empty geometry
         else if (r->isRestriction())
           return GEOS_GEOMETRYCOLLECTION;
@@ -389,6 +384,12 @@ geos::geom::GeometryTypeId ElementConverter::getGeometryType(
         // MultiPoint comes from GeoJSON
         else if (r->getType() == MetadataTags::RelationMultiPoint())
           return GEOS_MULTIPOINT;
+        //  Restrictions satisfy the linear criterion so test it after restrictions
+        else if (linearCrit.isSatisfied(r))
+          return GEOS_MULTILINESTRING;
+        // an empty geometry, pass back a collection
+        else if (r->getMembers().size() == 0 || CollectionRelationCriterion().isSatisfied(r))
+          return GEOS_GEOMETRYCOLLECTION;
       }
 
       // We are going to throw an error so we save the type of relation


### PR DESCRIPTION
Turn restriction relations were being dropped during `changeset-derive-replacement` operations.  This recognizes them as linear features and allows them to be processed.