### PR TITLE
Fail Nodes With Failed Ways

### DIFF
--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -255,7 +255,7 @@ $HOOT_HOME/scripts/chrome/driver-install.sh
 echo "### Configuring PostgreSQL..."
 $HOOT_HOME/scripts/database/ConfigurePostgresql.sh
 
-echo "### Createing databases..."
+echo "### Creating databases..."
 $HOOT_HOME/scripts/database/SetupHootDb.sh
 
 if ! mocha --version &>/dev/null; then

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetTest.cpp
@@ -284,15 +284,33 @@ public:
     id = 0;
     ids.clear();
     type = ElementType::Unknown;
+    type2 = ElementType::Unknown;
     hint = "Relation -2 requires the relations with id in 1707148,1707249,1707264,1707653,1707654,1707655,1707656,1707657,1707658,1707699,1707700, which either do not exist, or are not visible.";
-    found = changeset.matchesMultiRelationFailure(hint, id, ids, type);
-    std::vector<long> expected_ids { 1707148,1707249,1707264,1707653,1707654,1707655,1707656,1707657,1707658,1707699,1707700 };
+    found = changeset.matchesMultiElementFailure(hint, id, type, ids, type2);
+    std::vector<long> expected_relation_ids { 1707148,1707249,1707264,1707653,1707654,1707655,1707656,1707657,1707658,1707699,1707700 };
     CPPUNIT_ASSERT_EQUAL(true, found);
     CPPUNIT_ASSERT_EQUAL(-2L, id);
     CPPUNIT_ASSERT_EQUAL(ElementType::Relation, type);
-    CPPUNIT_ASSERT_EQUAL(11, (int)ids.size());
+    CPPUNIT_ASSERT_EQUAL(expected_relation_ids.size(), ids.size());
     for (int i = 0; i < (int)ids.size(); ++i)
-      CPPUNIT_ASSERT_EQUAL(expected_ids[i], ids[i]);
+      CPPUNIT_ASSERT_EQUAL(expected_relation_ids[i], ids[i]);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Relation, type2);
+
+    //  Test multi node failure with way ID
+    id = 0;
+    ids.clear();
+    type = ElementType::Unknown;
+    type2 = ElementType::Unknown;
+    hint = "Way -1 requires the nodes with id in 11,20, which either do not exist, or are not visible.";
+    found = changeset.matchesMultiElementFailure(hint, id, type, ids, type2);
+    std::vector<long> expected_node_ids { 11,20 };
+    CPPUNIT_ASSERT_EQUAL(true, found);
+    CPPUNIT_ASSERT_EQUAL(-1L, id);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Way, type);
+    CPPUNIT_ASSERT_EQUAL(expected_node_ids.size(), ids.size());
+    for (int i = 0; i < (int)ids.size(); ++i)
+      CPPUNIT_ASSERT_EQUAL(expected_node_ids[i], ids[i]);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Node, type2);
 
     //  Test relation failure with empty string
     id = 0;

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTest.cpp
@@ -56,6 +56,7 @@ class OsmApiWriterTest : public HootTestFixture
   CPPUNIT_TEST(runVersionConflictResolutionTest);
   CPPUNIT_TEST(runChangesetOutputTest);
   CPPUNIT_TEST(runChangesetCreateFailureTest);
+  CPPUNIT_TEST(runChangesetFailNodesWithWaysTest);
 #endif
   /* These tests are for local testing and require additional resources to complete */
 #ifdef RUN_LOCAL_OSM_API_SERVER
@@ -83,6 +84,7 @@ public:
   const int PORT_VERSION =      9803;
   const int PORT_DEBUG_OUTPUT = 9804;
   const int PORT_CREATE_FAIL =  9805;
+  const int PORT_FAIL_WAYS =    9806;
 
   OsmApiWriterTest()
     : HootTestFixture("test-files/io/OsmChangesetElementTest/",
@@ -467,6 +469,52 @@ public:
 
     //  Check the stats, 4 ways, 4 modifies, 4 errors
     checkStats(writer.getStats(), 0, 4, 0, 0, 4, 0, 4);
+#endif
+  }
+
+  void runChangesetFailNodesWithWaysTest()
+  {
+#ifdef RUN_LOCAL_TEST_SERVER
+    //  Suppress the OsmApiWriter errors by temporarily changing the log level
+    //  when the log level is Info or above because we expect the all of the errors.
+    //  Below Info is Debug and Trace, those are set because we want to see everything
+    Log::WarningLevel logLevel = Log::getInstance().getLevel();
+    if (Log::getInstance().getLevel() >= Log::Info)
+      Log::getInstance().setLevel(Log::Fatal);
+
+    //  Setup the test
+    QUrl osm;
+    osm.setUrl(LOCAL_TEST_API_URL.arg(PORT_FAIL_WAYS));
+    osm.setUserInfo(TEST_USER_INFO);
+
+    //  Kick off the changeset create failure test server
+    CreateWaysFailNodesTestServer server(PORT_FAIL_WAYS);
+    server.start();
+
+    QList<QString> changesets;
+    changesets.append(_inputPath + "ToyTestAFailure.osc");
+
+    OsmApiWriter writer(osm, changesets);
+    writer.setErrorPathname(_outputPath + "FailWayWithNodes-error.osc");
+
+    Settings s;
+    s.set(ConfigOptions::getChangesetApidbWritersMaxKey(), 1);
+    writer.setConfiguration(s);
+    writer.apply();
+
+    //  Wait for the test server to finish
+    server.shutdown();
+
+    Log::getInstance().setLevel(logLevel);
+
+    //  Make sure that the changes failed
+    CPPUNIT_ASSERT(writer.containsFailed());
+
+    //  Check the stats, 31 nodes, 2 ways, 33 creates, 2 errors
+    checkStats(writer.getStats(), 31, 2, 0, 33, 0, 0, 2);
+
+    HOOT_FILE_EQUALS(_inputPath + "FailWayWithNodes-error.osc",
+                     _outputPath + "FailWayWithNodes-error.osc");
 #endif
   }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
@@ -233,6 +233,46 @@ bool ChangesetCreateFailureTestServer::respond(HttpConnection::HttpConnectionPtr
   return continue_processing && !get_interupt();
 }
 
+bool CreateWaysFailNodesTestServer::respond(HttpConnection::HttpConnectionPtr& connection)
+{
+  //  Stop processing by setting this to false
+  bool continue_processing = true;
+  //  Read the HTTP request headers
+  std::string headers = read_request_headers(connection);
+  //  Determine the response message's HTTP header
+  HttpResponsePtr response;
+  if (headers.find(OsmApiEndpoints::API_PATH_CAPABILITIES) != std::string::npos)
+    response.reset(new HttpResponse(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CAPABILITIES_RESPONSE));
+  else if (headers.find(OsmApiEndpoints::API_PATH_PERMISSIONS) != std::string::npos)
+    response.reset(new HttpResponse(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_PERMISSIONS_RESPONSE));
+  else if (headers.find(OsmApiEndpoints::API_PATH_CREATE_CHANGESET) != std::string::npos)
+    response.reset(new HttpResponse(HttpResponseCode::HTTP_OK, "1"));
+  else if (headers.find("POST") != std::string::npos)
+  {
+    //  Read the HTTP request body to figure out which response to send back
+    std::string body = read_request_body(headers, connection);
+    if (body.find("way id=\"-1\"") != std::string::npos)
+      response.reset(new HttpResponse(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CHANGESET_SUCCESS_1_RESPONSE));
+    else
+      response.reset(new HttpResponse(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CHANGESET_SUCCESS_2_RESPONSE));
+  }
+  else if (headers.find(QString(OsmApiEndpoints::API_PATH_CLOSE_CHANGESET).arg(1).toStdString()))
+  {
+    response.reset(new HttpResponse(HttpResponseCode::HTTP_OK));
+    continue_processing = false;
+  }
+  else
+  {
+    //  Error out here
+    response.reset(new HttpResponse(HttpResponseCode::HTTP_NOT_FOUND));
+    continue_processing = false;
+  }
+  //  Write out the response
+  write_response(connection, response->to_string());
+  //  Return true if we should continue listening and processing requests
+  return continue_processing && !get_interupt();
+}
+
 const char* OsmApiSampleRequestResponse::SAMPLE_CAPABILITIES_RESPONSE =
     "<?xml version='1.0' encoding='UTF-8'?>\n"
     "<osm version='0.6' generator='OpenStreetMap server'>\n"

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
@@ -252,9 +252,9 @@ bool CreateWaysFailNodesTestServer::respond(HttpConnection::HttpConnectionPtr& c
     //  Read the HTTP request body to figure out which response to send back
     std::string body = read_request_body(headers, connection);
     if (body.find("way id=\"-1\"") != std::string::npos)
-      response.reset(new HttpResponse(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CHANGESET_SUCCESS_1_RESPONSE));
+      response.reset(new HttpResponse(HttpResponseCode::HTTP_PRECONDITION_FAILED, OsmApiSampleRequestResponse::SAMPLE_CHANGESET_FAILURE_RESPONSE_1));
     else
-      response.reset(new HttpResponse(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CHANGESET_SUCCESS_2_RESPONSE));
+      response.reset(new HttpResponse(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CHANGESET_FAILURE_RESPONSE_2));
   }
   else if (headers.find(QString(OsmApiEndpoints::API_PATH_CLOSE_CHANGESET).arg(1).toStdString()))
   {
@@ -338,6 +338,7 @@ const char* OsmApiSampleRequestResponse::SAMPLE_CHANGESET_REQUEST =
     "  </modify>\n"
     "</osmChange>";
 const char* OsmApiSampleRequestResponse::SAMPLE_CHANGESET_1_RESPONSE =
+    "<?xml version='1.0' encoding='UTF-8'?>\n"
     "<diffResult generator='OpenStreetMap Server' version='0.6'>\n"
     "  <way old_id='1' new_id='1' new_version='2'/>\n"
     "  <way old_id='2' new_id='2' new_version='2'/>\n"
@@ -356,13 +357,52 @@ const char* OsmApiSampleRequestResponse::SAMPLE_ELEMENT_1_GET_RESPONSE =
     "  </way>\n"
     "</osm>";
 const char* OsmApiSampleRequestResponse::SAMPLE_CHANGESET_SUCCESS_1_RESPONSE =
+    "<?xml version='1.0' encoding='UTF-8'?>\n"
     "<diffResult generator='OpenStreetMap Server' version='0.6'>\n"
     "  <way old_id='1' new_id='1' new_version='2'/>\n"
     "  <way old_id='2' new_id='2' new_version='2'/>\n"
     "</diffResult>";
 const char* OsmApiSampleRequestResponse::SAMPLE_CHANGESET_SUCCESS_2_RESPONSE =
+    "<?xml version='1.0' encoding='UTF-8'?>\n"
     "<diffResult generator='OpenStreetMap Server' version='0.6'>\n"
     "  <way old_id='3' new_id='3' new_version='2'/>\n"
     "  <way old_id='4' new_id='4' new_version='2'/>\n"
+    "</diffResult>";
+const char* OsmApiSampleRequestResponse::SAMPLE_CHANGESET_FAILURE_RESPONSE_1 =
+    "Precondition failed: Way -1 requires the nodes with id in 111111111111, which either do not exist, or are not visible.";
+const char* OsmApiSampleRequestResponse::SAMPLE_CHANGESET_FAILURE_RESPONSE_2 =
+    "<?xml version='1.0' encoding='UTF-8'?>\n"
+    "<diffResult generator='OpenStreetMap Server' version='0.6'>\n"
+    " <node old_id='-2' new_id='1' new_version='1'/>\n"
+    " <node old_id='-3' new_id='2' new_version='1'/>\n"
+    " <node old_id='-4' new_id='3' new_version='1'/>\n"
+    " <node old_id='-5' new_id='4' new_version='1'/>\n"
+    " <node old_id='-6' new_id='5' new_version='1'/>\n"
+    " <node old_id='-7' new_id='6' new_version='1'/>\n"
+    " <node old_id='-8' new_id='7' new_version='1'/>\n"
+    " <node old_id='-9' new_id='8' new_version='1'/>\n"
+    " <node old_id='-10' new_id='9' new_version='1'/>\n"
+    " <node old_id='-11' new_id='10' new_version='1'/>\n"
+    " <node old_id='-12' new_id='11' new_version='1'/>\n"
+    " <node old_id='-13' new_id='12' new_version='1'/>\n"
+    " <node old_id='-14' new_id='13' new_version='1'/>\n"
+    " <node old_id='-15' new_id='14' new_version='1'/>\n"
+    " <node old_id='-16' new_id='15' new_version='1'/>\n"
+    " <node old_id='-17' new_id='16' new_version='1'/>\n"
+    " <node old_id='-18' new_id='17' new_version='1'/>\n"
+    " <node old_id='-19' new_id='18' new_version='1'/>\n"
+    " <node old_id='-20' new_id='19' new_version='1'/>\n"
+    " <node old_id='-21' new_id='20' new_version='1'/>\n"
+    " <node old_id='-22' new_id='21' new_version='1'/>\n"
+    " <node old_id='-23' new_id='22' new_version='1'/>\n"
+    " <node old_id='-24' new_id='23' new_version='1'/>\n"
+    " <node old_id='-25' new_id='24' new_version='1'/>\n"
+    " <node old_id='-26' new_id='25' new_version='1'/>\n"
+    " <node old_id='-27' new_id='26' new_version='1'/>\n"
+    " <node old_id='-28' new_id='27' new_version='1'/>\n"
+    " <node old_id='-29' new_id='28' new_version='1'/>\n"
+    " <node old_id='-30' new_id='29' new_version='1'/>\n"
+    " <node old_id='-31' new_id='30' new_version='1'/>\n"
+    " <way old_id='-2' new_id='1' new_version='1'/>\n"
     "</diffResult>";
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
@@ -178,6 +178,9 @@ public:
   /** Sample Changeset upload response bodies from '/api/0.6/changeset/1/upload' divided into two responses */
   static const char* SAMPLE_CHANGESET_SUCCESS_1_RESPONSE;
   static const char* SAMPLE_CHANGESET_SUCCESS_2_RESPONSE;
+  /** Sample Changeset upload response bodies for a failed response to '/api/0.6/changeset/1/upload' */
+  static const char* SAMPLE_CHANGESET_FAILURE_RESPONSE_1;
+  static const char* SAMPLE_CHANGESET_FAILURE_RESPONSE_2;
 };
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
@@ -136,6 +136,26 @@ protected:
   bool respond(HttpConnection::HttpConnectionPtr &connection) override;
 };
 
+class CreateWaysFailNodesTestServer : public HttpTestServer
+{
+public:
+  /** Constructor */
+  CreateWaysFailNodesTestServer(int port) : HttpTestServer(port) { }
+
+protected:
+  /** respond() function that responds to a series of OSM API requests
+   *  to simulate a changeset create failure over and over.
+   *  Requests, in order:
+   *   - Capabilities
+   *   - Permissions
+   *   - Changeset Create
+   *   - Changeset Upload Failure - responds with HTTP
+   *   - Changeset Upload - responds with HTTP 200
+   *   - Changeset Close
+   */
+  bool respond(HttpConnection::HttpConnectionPtr &connection) override;
+};
+
 class OsmApiSampleRequestResponse
 {
 public:

--- a/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.cpp
@@ -104,7 +104,7 @@ void HttpTestServer::wait()
   _thread->join();
 }
 
-void HttpTestServer::shutdown()
+void HttpTestServer::stop()
 {
   //  Interupt the threads
   _interupt = true;
@@ -113,7 +113,13 @@ void HttpTestServer::shutdown()
   //  Cancel the acceptor
   _acceptor->cancel();
   _acceptor.reset();
-  //   Wait for the server to stop
+}
+
+void HttpTestServer::shutdown()
+{
+  //  Stop the server
+  stop();
+  //  Wait for the server to shutdown
   wait();
 }
 
@@ -132,7 +138,9 @@ void HttpTestServer::run_server(int port)
   catch (std::exception& e)
   {
     LOG_ERROR(e.what());
-    shutdown();
+    //  Stop the server here, do not `shutdown`
+    //  Joining the thread inside of the thread causes resource deadlocks
+    stop();
   }
 }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.cpp
@@ -108,10 +108,12 @@ void HttpTestServer::shutdown()
 {
   //  Interupt the threads
   _interupt = true;
+  //  Stop the IO service
+  _io_service.stop();
   //  Cancel the acceptor
   _acceptor->cancel();
-  //  Stop the IO service and wait for the server to stop
-  _io_service.stop();
+  _acceptor.reset();
+  //   Wait for the server to stop
   wait();
 }
 

--- a/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.h
@@ -140,6 +140,8 @@ protected:
   void write_response(HttpConnection::HttpConnectionPtr& connection, const std::string& response);
   /** Get the value of the interupt flag */
   bool get_interupt() { return _interupt; }
+  /** Shutdown the thread but don't wait on it */
+  void stop();
 
 private:
   /** Function that starts the server listening and accepting connections */

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.h
@@ -479,7 +479,8 @@ inline const ConstWayPtr OsmMap::getWay(long id) const
 
 inline const ConstWayPtr OsmMap::getWay(ElementId eid) const
 {
-  assert(eid.getType() == ElementType::Way);
+  if (eid.getType() != ElementType::Way)
+    return _nullWay;
   return getWay(eid.getId());
 }
 
@@ -498,7 +499,8 @@ inline const WayPtr OsmMap::getWay(long id)
 
 inline const WayPtr OsmMap::getWay(ElementId eid)
 {
-  assert(eid.getType() == ElementType::Way);
+  if (eid.getType() != ElementType::Way)
+    return _nullWay;
   return getWay(eid.getId());
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -231,18 +231,19 @@ public:
   static bool matchesRelationFailure(const QString& hint, long& element_id,
                                      long& member_id, ElementType::Type& member_type);
   /**
-   * @brief matchesMultiRelationFailure Checks the return from the API to see if it is similar to the following error message:
+   * @brief matchesMultiElementFailure Checks the return from the API to see if it is similar to the following error message:
    *        "Relation with id -2 requires the relations with id in 1707148,1707249, which either do not exist, or are not visible."
    * @param hint Error message from OSM API
    * @param element_id ID of the element that failed
+   * @param element_type Type of the element that failed
    * @param member_ids IDs of the member elements that caused the element to fail
-   * @param member_type Type of the member element that caused the element to fail
+   * @param member_type Type of the member elements that caused the element to fail
    * @return True if the message matches and was parsed
    */
-  static bool matchesMultiRelationFailure(const QString& hint, long& element_id,
-                                          std::vector<long>& member_ids, ElementType::Type& member_type);
+  static bool matchesMultiElementFailure(const QString& hint, long& element_id, ElementType::Type& element_type,
+                                         std::vector<long>& member_ids, ElementType::Type& member_type);
   /**
-   * @brief matchesChangesetPreconditionFailure Checks the return from the API to see if it is similar to the following error message:
+   * @brief matchesChangesetDeletePreconditionFailure Checks the return from the API to see if it is similar to the following error message:
    *        "Precondition failed: Node 55 is still used by ways 123"
    * @param hint Error message from OSM API
    * @param member_id ID of the member element that caused the element to fail
@@ -251,9 +252,9 @@ public:
    * @param element_type Type of the element that failed
    * @return True if the message matches and was parsed
    */
-  static bool matchesChangesetPreconditionFailure(const QString& hint,
-                                                  long& member_id, ElementType::Type& member_type,
-                                                  long& element_id, ElementType::Type& element_type);
+  static bool matchesChangesetDeletePreconditionFailure(const QString& hint,
+                                                        long& member_id, ElementType::Type& member_type,
+                                                        long& element_id, ElementType::Type& element_type);
   /**
    * @brief matchesChangesetConflictVersionMismatchFailure Checks the return from the API to see if it is similar to the following error message:
    *        "Changeset conflict: Version mismatch: Provided 2, server had: 1 of Node 4869875616"
@@ -292,6 +293,10 @@ public:
    */
   bool calculateRemainingChangeset(ChangesetInfoPtr &changeset);
   /**
+   * @brief updateRemainingChangeset
+   */
+  void updateRemainingChangeset();
+  /**
    * @brief isMatch Function to compare two changesets
    * @param changeset Changeset object to compare this changeset against
    * @return true if they are equivalent
@@ -301,6 +306,11 @@ public:
    * @brief failRemainingChangeset Set all remaining elements to the failed state
    */
   void failRemainingChangeset();
+  /**
+   * @brief failChangeset Set all elements' status to failed that are in the changeset
+   * @param changeset ChangesetInfo pointer of elements that all failed
+   */
+  void failChangeset(const ChangesetInfoPtr& changeset);
 
 private:
   /**
@@ -475,11 +485,6 @@ private:
   void replaceWayId(long old_id, long new_id);
   void replaceRelationId(long old_id, long new_id);
   /**
-   * @brief failChangeset Set all elements' status to failed that are in the changeset
-   * @param changeset ChangesetInfo pointer of elements that all failed
-   */
-  void failChangeset(const ChangesetInfoPtr& changeset);
-  /**
    * @brief failNode/Way/Relation Set element's status to failed and up the failed count
    * @param id ID of the node/way/relation to fail
    * @param beforeSend True if it was set to failed before sending
@@ -504,6 +509,11 @@ private:
    * @param elements Map of elements to fail
    */
   void failRemainingElements(const ChangesetElementMap& elements);
+  /**
+   * @brief getRemainingFilename Get the filename for the "remaining" elements
+   * @return _errorPathname with "error" replaced by "remaining"
+   */
+  QString getRemainingFilename();
 
   /** Sorted map of all nodes, original node ID and a pointer to the element object */
   ChangesetElementMap _allNodes;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
@@ -51,7 +51,8 @@ namespace hoot
 {
 
 OsmApiWriter::OsmApiWriter(const QUrl &url, const QString &changeset)
-  : _description(ConfigOptions().getChangesetDescription()),
+  : _startFlag(false),
+    _description(ConfigOptions().getChangesetDescription()),
     _source(ConfigOptions().getChangesetSource()),
     _hashtags(ConfigOptions().getChangesetHashtags()),
     _maxWriters(ConfigOptions().getChangesetApidbWritersMax()),
@@ -75,7 +76,8 @@ OsmApiWriter::OsmApiWriter(const QUrl &url, const QString &changeset)
 }
 
 OsmApiWriter::OsmApiWriter(const QUrl& url, const QList<QString>& changesets)
-  : _changesets(changesets),
+  : _startFlag(false),
+    _changesets(changesets),
     _description(ConfigOptions().getChangesetDescription()),
     _source(ConfigOptions().getChangesetSource()),
     _hashtags(ConfigOptions().getChangesetHashtags()),
@@ -140,12 +142,12 @@ bool OsmApiWriter::apply()
   _changeset.fixMalformedInput();
   //  Start the writer threads
   LOG_INFO("Starting " << _maxWriters << " processing threads.");
+  _threadIdle.reserve(_maxWriters);
   for (int i = 0; i < _maxWriters; ++i)
   {
     _threadStatus.push_back(ThreadStatus::Working);
     _threadPool.push_back(thread(&OsmApiWriter::_changesetThreadFunc, this, i));
   }
-  _threadIdle.reserve(_maxWriters);
   //  Setup the progress indicators
   long total = _changeset.getTotalElementCount();
   float progress = 0.0f;
@@ -203,13 +205,15 @@ bool OsmApiWriter::apply()
       else
       {
         //  Allow time for the worker threads to complete some work
-        this_thread::sleep_for(chrono::milliseconds(10));
+        this_thread::yield();
       }
     }
     else
     {
+      //  Indicate to the worker threads that there is work to be done
+      _startWork();
       //  Allow time for the worker threads to complete some work
-      this_thread::sleep_for(chrono::milliseconds(10));
+      this_thread::yield();
     }
     //  Show the progress
     if (_showProgress)
@@ -223,6 +227,8 @@ bool OsmApiWriter::apply()
       }
     }
   }
+  //  Indicate to the worker threads that there is work to be done, if they haven't started already
+  _startWork();
   //  Wait for the threads to shutdown
   for (int i = 0; i < _maxWriters; ++i)
     _threadPool[i].join();
@@ -232,8 +238,8 @@ bool OsmApiWriter::apply()
     LOG_ERROR("Multiple bad changeset ID errors in a row, is the API functioning correctly?");
     _changeset.failRemainingChangeset();
   }
-
-  LOG_INFO("Upload progress: 100%");
+  //  Final write for the error file
+  _changeset.writeErrorFile();
   //  Keep some stats
   _stats.append(SingleStat("API Upload Time (sec)", timer.getElapsedAndRestart()));
   _stats.append(SingleStat("Total OSM Changesets Uploaded", _changesetCount));
@@ -258,6 +264,8 @@ void OsmApiWriter::_changesetThreadFunc(int index)
   long changesetSize = 0;
   bool stop_thread = false;
   int changeset_failures = 0;
+  //  Before working, wait for the signal
+  _waitForStart();
   //  Iterate until all elements are sent and updated
   while (!_changeset.isDone() && !stop_thread)
   {
@@ -299,7 +307,7 @@ void OsmApiWriter::_changesetThreadFunc(int index)
           //  Reset the network request object and sleep it off
           request = createNetworkRequest(true);
           LOG_DEBUG("Bad changeset ID. Resetting network request object.");
-          this_thread::sleep_for(chrono::milliseconds(100));
+          this_thread::yield();
         }
         //  Try a new create changeset request
         continue;
@@ -338,6 +346,9 @@ void OsmApiWriter::_changesetThreadFunc(int index)
         _changesetMutex.unlock();
         //  Update the size of the current changeset that is open
         changesetSize += workInfo->size();
+        //  Remove the "remaining" file if the remaining was successful
+        if (workInfo->getLast())
+          _changeset.updateRemainingChangeset();
         //  When the current changeset is nearing the 50k max (or the specified max), close the changeset
         //  otherwise keep it open and go again
         if (changesetSize > _maxChangesetSize - (int)(_maxPushSize * 1.5))
@@ -426,7 +437,7 @@ void OsmApiWriter::_changesetThreadFunc(int index)
             //  push it back on the queue and give the API a break
             _pushChangesets(workInfo);
             //  Sleep the thread
-            this_thread::sleep_for(chrono::milliseconds(10));
+            this_thread::sleep_for(chrono::milliseconds(100));
           }
           break;
         default:
@@ -446,7 +457,7 @@ void OsmApiWriter::_changesetThreadFunc(int index)
     }
     else
     {
-      if (!_changeset.hasElementsToSend() && !_changeset.isDone() && queueSize == 0)
+      if (_changeset.hasElementsToSend() && !_changeset.isDone() && queueSize == 0)
       {
         //  This is a bad state where the producer thread says all elements are sent and
         //  waits for all threads to join but the changeset isn't "done".
@@ -464,34 +475,32 @@ void OsmApiWriter::_changesetThreadFunc(int index)
           id = -1;
         }
         _threadStatusMutex.unlock();
-        if (_threadsAreIdle())
+        //  In this case there are elements that have been sent and not reported back
+        //  BUT there are no threads that are waiting for them either.  Every thread
+        //  except the "first" worker thread will exit here.  The first worker thread
+        //  will wait for the producer thread to calculate the remaining changeset and
+        //  push in on the queue.  It then loops around and picks up the remaining
+        //  changeset and processes it.
+        if (_threadsAreIdle() && index != 0)
         {
-          //  In this case there are elements that have been sent and not reported back
-          //  BUT there are no threads that are waiting for them either.  Every thread
-          //  except the "first" worker thread will exit here.  The first worker thread
-          //  Tries to calculate the remaining changeset and push in on the queue.  It then
-          //  loops around and picks up the remaining changeset to process.  Next time around
-          //  calculateRemainingChangeset() fails and this thread is stopped.
-          if (index != 0)
-            stop_thread = true;
-          else if (_changeset.calculateRemainingChangeset(workInfo))
-            _pushChangesets(workInfo);
-          else
-            stop_thread = true;
+          stop_thread = true;
+          _updateThreadStatus(index, ThreadStatus::Completed);
         }
       }
       else
       {
         //  Set the status to idle
         _updateThreadStatus(index, ThreadStatus::Idle);
-        //  Sleep the thread
-        this_thread::sleep_for(chrono::milliseconds(10));
+        //  Yield the thread
+        this_thread::yield();
       }
     }
   }
   //  Close the changeset if one is still open
   if (id != -1)
     _closeChangeset(request, id);
+  //  Update the thread to complete
+  _updateThreadStatus(index, ThreadStatus::Completed);
 }
 
 void OsmApiWriter::setConfiguration(const Settings& conf)
@@ -957,9 +966,19 @@ bool OsmApiWriter::_splitChangeset(const ChangesetInfoPtr& workInfo, const QStri
   _changesetMutex.unlock();
   if (split->size() > 0)
   {
-    //  Push both of the changesets onto the queue
-    _pushChangesets(split, workInfo);
-    return true;
+    //  Fail the split changeset if the error flag is set
+    if (split->getError())
+    {
+      _changeset.failChangeset(split);
+      _pushChangesets(workInfo);
+      return true;
+    }
+    else
+    {
+      //  Push both of the changesets onto the queue
+      _pushChangesets(workInfo, split);
+      return true;
+    }
   }
   //  Nothing was split out, return false
   return false;
@@ -992,6 +1011,19 @@ void OsmApiWriter::_pushChangesets(ChangesetInfoPtr changeset, ChangesetInfoPtr 
     _workQueue.push(changeset);
   if (changeset2)
     _workQueue.push(changeset2);
+}
+
+void OsmApiWriter::_startWork()
+{
+  std::lock_guard<std::mutex> lock(_startMutex);
+  _startFlag = true;
+  _start.notify_all();
+}
+
+void OsmApiWriter::_waitForStart()
+{
+  std::unique_lock<std::mutex> lock(_startMutex);
+  _start.wait(lock, [this]{ return _startFlag; });
 }
 
 void OsmApiWriter::_updateThreadStatus(int thread_index, ThreadStatus status)

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -41,6 +41,7 @@
 #include <tgs/System/Timer.h>
 
 //  Standard
+#include <condition_variable>
 #include <mutex>
 #include <queue>
 #include <thread>
@@ -300,11 +301,26 @@ private:
   XmlChangeset _changeset;
   /** Mutex protecting large changeset */
   std::mutex _changesetMutex;
+  /**
+   * @brief _startWork Tell the worker threads to begin processing work
+   */
+  void _startWork();
+  /**
+   * @brief _waitForStart Wait for the producer to signal to the consumers to begin work
+   */
+  void _waitForStart();
+  /** Mutex protecting start flag */
+  std::mutex _startMutex;
+  /** Condition variable to notify worker threads */
+  std::condition_variable _start;
+  /** Flag to tell worker threads to start processing */
+  bool _startFlag;
   /** Status of each working thread, working or idle */
   enum ThreadStatus
   {
     Idle,
     Working,
+    Completed,
     Failed
   };
   /**

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -321,8 +321,15 @@ private:
     Idle,
     Working,
     Completed,
-    Failed
+    Failed,
+    Unknown
   };
+  /**
+   * @brief _getThreadStatus Safely get the status of the thread
+   * @param thread_index Index of calling thread in _threadStatus vector
+   * @return  Status of the thread
+   */
+  ThreadStatus _getThreadStatus(int thread_index);
   /**
    * @brief _updateThreadStatus Update the thread status
    * @param thread_index Index of calling thread in _threadStatus vector

--- a/test-files/cmd/quick/ServiceDbListMapsCmdTest.sh
+++ b/test-files/cmd/quick/ServiceDbListMapsCmdTest.sh
@@ -13,3 +13,7 @@ hoot convert --warn $CONFIG -D api.db.email=$EMAIL -D hootapi.db.writer.create.u
 
 # list the maps (not dealing with public maps here; see ServiceHootApiDbTest)
 hoot db-list-maps --warn $CONFIG -D api.db.email=$EMAIL $HOOT_DB_URL
+
+# clean-up the databases
+hoot db-delete-map --warn $CONFIG -D api.db.email=$EMAIL $HOOT_DB_URL/DbListMapsCmdTest1
+hoot db-delete-map --warn $CONFIG -D api.db.email=$EMAIL $HOOT_DB_URL/DbListMapsCmdTest2

--- a/test-files/io/OsmChangesetElementTest/ChangesetOutput-Response-1.osc
+++ b/test-files/io/OsmChangesetElementTest/ChangesetOutput-Response-1.osc
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <diffResult generator='OpenStreetMap Server' version='0.6'>
   <way old_id='1' new_id='1' new_version='2'/>
   <way old_id='2' new_id='2' new_version='2'/>

--- a/test-files/io/OsmChangesetElementTest/ChangesetOutput-Response-2.osc
+++ b/test-files/io/OsmChangesetElementTest/ChangesetOutput-Response-2.osc
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <diffResult generator='OpenStreetMap Server' version='0.6'>
   <way old_id='3' new_id='3' new_version='2'/>
   <way old_id='4' new_id='4' new_version='2'/>

--- a/test-files/io/OsmChangesetElementTest/FailWayWithNodes-error.osc
+++ b/test-files/io/OsmChangesetElementTest/FailWayWithNodes-error.osc
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<create>
+		<node id="-1" version="0" lat="38.8549524185660573" lon="-104.8987388916486054" timestamp="" changeset="0"/>
+		<way id="-1" version="0" timestamp="" changeset="0">
+			<nd ref="111111111111"/>
+			<nd ref="-1"/>
+			<nd ref="6"/>
+			<tag k="note" v="1"/>
+			<tag k="highway" v="road"/>
+		</way>
+	</create>
+</osmChange>

--- a/test-files/io/OsmChangesetElementTest/ToyTestAFailure.osc
+++ b/test-files/io/OsmChangesetElementTest/ToyTestAFailure.osc
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+    <create>
+        <node id="-1" version="0" lat="38.8549524185660573" lon="-104.8987388916486054" timestamp=""/>
+        <node id="-2" version="0" lat="38.8540541370891077" lon="-104.9024316099691276" timestamp=""/>
+        <node id="-3" version="0" lat="38.8541298962059614" lon="-104.9023065312240703" timestamp=""/>
+        <node id="-4" version="0" lat="38.8543319201230304" lon="-104.9017876860593788" timestamp=""/>
+        <node id="-5" version="0" lat="38.8548207434768855" lon="-104.9008079025564655" timestamp=""/>
+        <node id="-6" version="0" lat="38.8549289695954272" lon="-104.9005253172435630" timestamp=""/>
+        <node id="-7" version="0" lat="38.8549614373988845" lon="-104.8997124086258452" timestamp=""/>
+        <node id="-8" version="0" lat="38.8545785045938388" lon="-104.8997171368440888" timestamp=""/>
+        <node id="-9" version="0" lat="38.8542618470630714" lon="-104.8997171368440888" timestamp=""/>
+        <node id="-10" version="0" lat="38.8541670018907581" lon="-104.8997069874790355" timestamp=""/>
+        <node id="-11" version="0" lat="38.8539525522998730" lon="-104.8996840393162842" timestamp=""/>
+        <node id="-12" version="0" lat="38.8536248456666229" lon="-104.8996934957527998" timestamp=""/>
+        <node id="-13" version="0" lat="38.8532583477841484" lon="-104.8997542928851772" timestamp=""/>
+        <node id="-14" version="0" lat="38.8532424272016641" lon="-104.8996868263970015" timestamp=""/>
+        <node id="-15" version="0" lat="38.8533001490996028" lon="-104.8994528828182951" timestamp=""/>
+        <node id="-16" version="0" lat="38.8533470481072030" lon="-104.8993671807151884" timestamp=""/>
+        <node id="-17" version="0" lat="38.8535166057996975" lon="-104.8992698972467963" timestamp=""/>
+        <node id="-18" version="0" lat="38.8535689160700528" lon="-104.8990568001256065" timestamp=""/>
+        <node id="-19" version="0" lat="38.8535508780501431" lon="-104.8988321216391171" timestamp=""/>
+        <node id="-20" version="0" lat="38.8536194225014810" lon="-104.8987070428940598" timestamp=""/>
+        <node id="-21" version="0" lat="38.8537204352567329" lon="-104.8987232568054679" timestamp=""/>
+        <node id="-22" version="0" lat="38.8539585361836473" lon="-104.8989155074691695" timestamp=""/>
+        <node id="-23" version="0" lat="38.8541335037809361" lon="-104.8988900284655159" timestamp=""/>
+        <node id="-24" version="0" lat="38.8541767946664436" lon="-104.8987070428940598" timestamp=""/>
+        <node id="-25" version="0" lat="38.8542327120211866" lon="-104.8983109602013855" timestamp=""/>
+        <node id="-26" version="0" lat="38.8544293243065937" lon="-104.8980654352573794" timestamp=""/>
+        <node id="-27" version="0" lat="38.8546042907457476" lon="-104.8977759011253141" timestamp=""/>
+        <node id="-28" version="0" lat="38.8547197322843374" lon="-104.8973219116062410" timestamp=""/>
+        <node id="-29" version="0" lat="38.8548604264061623" lon="-104.8968586569948798" timestamp=""/>
+        <node id="-30" version="0" lat="38.8549019130812496" lon="-104.8964394115716487" timestamp=""/>
+        <node id="-31" version="0" lat="38.8549073243849037" lon="-104.8961823052623856" timestamp=""/>
+        <way id="-1" version="0" timestamp="">
+            <!-- This node will fail -->
+            <nd ref="111111111111"/>
+            <nd ref="-1"/>
+            <nd ref="-7"/>
+            <tag k="note" v="1"/>
+            <tag k="highway" v="road"/>
+        </way>
+        <way id="-2" version="0" timestamp="">
+            <nd ref="-2"/>
+            <nd ref="-3"/>
+            <nd ref="-4"/>
+            <nd ref="-5"/>
+            <nd ref="-6"/>
+            <nd ref="-7"/>
+            <nd ref="-8"/>
+            <nd ref="-9"/>
+            <nd ref="-10"/>
+            <nd ref="-11"/>
+            <nd ref="-12"/>
+            <nd ref="-13"/>
+            <nd ref="-14"/>
+            <nd ref="-15"/>
+            <nd ref="-16"/>
+            <nd ref="-17"/>
+            <nd ref="-18"/>
+            <nd ref="-19"/>
+            <nd ref="-20"/>
+            <nd ref="-21"/>
+            <nd ref="-22"/>
+            <nd ref="-23"/>
+            <nd ref="-24"/>
+            <nd ref="-25"/>
+            <nd ref="-26"/>
+            <nd ref="-27"/>
+            <nd ref="-28"/>
+            <nd ref="-29"/>
+            <nd ref="-30"/>
+            <nd ref="-31"/>
+            <tag k="note" v="0"/>
+            <tag k="highway" v="road"/>
+        </way>
+    </create>
+</osmChange>


### PR DESCRIPTION
When a way is to be created along with new nodes that make it up and it fails, previously the nodes were pushed to the API and there were orphaned nodes.  This holds back those nodes and puts them in the error file along with the offending way so that they are all together and no nodes are orphaned in the API database.

Closes #3970 