### PR TITLE
Some datasets get into an infinite loop at 99% complete

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -108,7 +108,7 @@ public:
    * @brief isDone Checks if all elements are either finalized or failed
    * @return true if there aren't any elements left to receive updates from
    */
-  bool isDone() { return (long)(_allNodes.size() + _allWays.size() + _allRelations.size()) == _processedCount + _failedCount; }
+  bool isDone() { return (long)(_allNodes.size() + _allWays.size() + _allRelations.size()) <= _processedCount + _failedCount; }
   /** Elements in a changeset can be in three sections, create, modify, and delete.  Max is used for iterating */
   enum ChangesetType : int
   {

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -394,6 +394,8 @@ private:
   int _apiId;
   /** Mutex for API ID counter */
   std::mutex _apiIdMutex;
+  /** Flag to tell threads that they can exit when idle */
+  bool _threadsCanExit;
   /** For white box testing */
   friend class OsmApiWriterTest;
   /** Default constructor for testing purposes only */


### PR DESCRIPTION
This particular failure was because a relation failed to be created and that relation was a member of another relation that was failing to be added to a changeset and failing to be recognized as unable to send.  Now when an element fails to be created, an parent element must also fail at the same time.