### PR TITLE
Don't allow commands to create an output dir for a URL target

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/DataConverterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/DataConverterTest.cpp
@@ -36,12 +36,15 @@
 #include <hoot/core/io/DataConverter.h>
 #include <hoot/core/util/ConfigOptions.h>
 
+// Qt
+#include <QFileInfo>
+
 namespace hoot
 {
 
 class DataConverterTest : public HootTestFixture
 {
-  //just testing input validation here, as the command line tests get the rest
+  // just testing input validation here, as the command line tests get the rest
   CPPUNIT_TEST_SUITE(DataConverterTest);
   CPPUNIT_TEST(runEmptyInputsTest);
   CPPUNIT_TEST(runEmptyOutputTest);
@@ -51,6 +54,7 @@ class DataConverterTest : public HootTestFixture
   CPPUNIT_TEST(runFeatureLimitNonOgrInputsTest);
   CPPUNIT_TEST(runTranslationFileDoesntExistTest);
   CPPUNIT_TEST(runInvalidTranslationFileFormatTest);
+  CPPUNIT_TEST(runUrlOutputTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -215,6 +219,18 @@ public:
 
     CPPUNIT_ASSERT(exceptionMsg.contains(
       "Invalid translation file format: test-files/DcGisRoads.osm"));
+  }
+
+  void runUrlOutputTest()
+  {
+    // just want to make sure an output dir isn't created for a url out
+
+    DataConverter uut;
+    const QString url = "osmapidb://user:password@postgres:5432";
+    LOG_VART(url);
+    uut._validateInput(QStringList("input1.osm"), url);
+    QFileInfo outputInfo("osmapidb:");
+    CPPUNIT_ASSERT(!outputInfo.exists());
   }
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetCreator.cpp
@@ -101,13 +101,9 @@ void ChangesetCreator::create(const QString& output, const QString& input1, cons
     "Creating changeset from inputs: " << input1 << " and " << input2 << " to output: " <<
     output << "...");
 
-  QFileInfo outputInfo(output);
-  LOG_VARD(outputInfo.dir().absolutePath());
-  const bool outputDirSuccess = QDir().mkpath(outputInfo.dir().absolutePath());
-  if (!outputDirSuccess)
-  {
-    throw IllegalArgumentException("Unable to create output path for: " + output);
-  }
+  // write the output dir now so we don't get a nasty surprise at the end of a long job that it
+  // can't be written
+  IoUtils::writeOutputDir(output);
 
   _singleInput = input2.trimmed().isEmpty();
   LOG_VARD(_singleInput);

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
@@ -223,12 +223,11 @@ int ConflateCmd::runSimple(QStringList& args)
   const QString input2 = args[1];
   QString output = args[2];
 
-  QFileInfo outputInfo(output);
-  LOG_VARD(outputInfo.dir().absolutePath());
-  const bool outputDirSuccess = QDir().mkpath(outputInfo.dir().absolutePath());
-  if (!outputDirSuccess)
+  if (!IoUtils::isUrl(output))
   {
-    throw IllegalArgumentException("Unable to create output path for: " + output);
+    // write the output dir now so we don't get a nasty surprise at the end of a long job that it
+    // can't be written
+    IoUtils::writeOutputDir(output);
   }
 
   QString osmApiDbUrl;

--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.cpp
@@ -321,12 +321,11 @@ void DataConverter::_validateInput(const QStringList& inputs, const QString& out
     throw HootException("Read limit may only be specified when converting OGR inputs.");
   }
 
-  QFileInfo outputInfo(output);
-  LOG_VARD(outputInfo.dir().absolutePath());
-  const bool outputDirSuccess = QDir().mkpath(outputInfo.dir().absolutePath());
-  if (!outputDirSuccess)
+  if (!IoUtils::isUrl(output))
   {
-    throw IllegalArgumentException("Unable to create output path for: " + output);
+    // write the output dir now so we don't get a nasty surprise at the end of a long job that it
+    // can't be written
+    IoUtils::writeOutputDir(output);
   }
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
@@ -118,6 +118,8 @@ public:
 
 private:
 
+  friend class DataConverterTest;
+
   QString _translation;
   QString _translationDirection;
   QStringList _shapeFileColumns;

--- a/hoot-core/src/main/cpp/hoot/core/io/IoUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/IoUtils.cpp
@@ -221,7 +221,7 @@ void IoUtils::cropToBounds(OsmMapPtr& map, const geos::geom::Envelope& bounds,
   LOG_VARD(StringUtils::formatLargeNumber(map->getElementCount()));
 }
 
-std::shared_ptr<ElementVisitorInputStream> getVisitorInputStream(
+std::shared_ptr<ElementVisitorInputStream> IoUtils::getVisitorInputStream(
   const QString& input, const QString& visitorClassName, const bool useDataSourceIds)
 {
   std::shared_ptr<PartialOsmMapReader> reader =
@@ -237,6 +237,24 @@ std::shared_ptr<ElementVisitorInputStream> getVisitorInputStream(
         std::dynamic_pointer_cast<ElementInputStream>(reader),
         ElementVisitorPtr(
           Factory::getInstance().constructObject<ElementVisitor>(visitorClassName.toStdString()))));
+}
+
+bool IoUtils::isUrl(const QString& str)
+{
+  // this works in the hoot world
+  return str.contains("://");
+}
+
+void IoUtils::writeOutputDir(const QString& dirName)
+{
+  QFileInfo outputInfo(dirName);
+  LOG_VART(outputInfo.dir().absolutePath());
+  const bool outputDirSuccess = QDir().mkpath(outputInfo.dir().absolutePath());
+  LOG_VART(outputDirSuccess);
+  if (!outputDirSuccess)
+  {
+    throw IllegalArgumentException("Unable to create output path for: " + dirName);
+  }
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/IoUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/IoUtils.h
@@ -134,6 +134,21 @@ public:
    */
   static std::shared_ptr<ElementVisitorInputStream> getVisitorInputStream(
     const QString& input, const QString& visitorClassName, const bool useDataSourceIds = false);
+
+  /**
+   * Determines if an input string is a URL by the hoot definition
+   *
+   * @param str string to examine
+   * @return true if the input is a hoot URL, false otherwise
+   */
+  static bool isUrl(const QString& str);
+
+  /**
+   * Writes an output directory
+   *
+   * @param dirName name of the directory to write
+   */
+  static void writeOutputDir(const QString& dirName);
 };
 
 }


### PR DESCRIPTION
Affected `convert` and `conflate` commands