### PR TITLE
Create path for FileUtils::writeFully

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/TestUtils.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/TestUtils.cpp
@@ -311,26 +311,6 @@ void TestUtils::verifyStdMatchesOutputIgnoreDate(const QString& stdFilePath,
   }
 }
 
-bool TestUtils::mkpath(const QString& path)
-{
-  //  Don't make it if it exists
-  if (QDir().exists(path))
-    return true;
-  //  Try to make the path 'retry' times waiting 'duration' microseconds in between tries
-  const int retry = 3;
-  //  100 msec should be enough to wait between tries
-  const unsigned int duration = 100000;
-  for (int i = 0; i < retry; i++)
-  {
-    if (QDir().mkpath(path))
-      return true;
-    usleep(duration);
-  }
-  //  Report failure
-  CPPUNIT_FAIL(QString("Couldn't create output directory: %1").arg(path).toStdString());
-  return false;
-}
-
 QStringList TestUtils::getConflateCmdSnapshotPreOps()
 {
   QStringList conflatePreOps;

--- a/hoot-core-test/src/test/cpp/hoot/core/TestUtils.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/TestUtils.h
@@ -38,6 +38,7 @@
 #include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/ConfPath.h>
+#include <hoot/core/util/FileUtils.h>
 
 // Qt
 #include <QString>
@@ -184,13 +185,6 @@ public:
     const QString& stdFilePath, const QString& outFilePath);
 
   /**
-   * Creates a folder path using QDir::mkpath in a more thread-safe way
-   * @param path relative or absolute path to create (think `mkdir -p`)
-   * @return true if successful
-   */
-  static bool mkpath(const QString& path);
-
-  /**
    * This is a snapshot of the option, conflate.pre.ops (circa 2/12/20), for testing purposes.
    *
    * @return a list of operator class names
@@ -273,7 +267,7 @@ protected:
       _reset(ResetNone)
   {
     if (outputPath != UNUSED_PATH)
-      TestUtils::mkpath(_outputPath);
+      FileUtils::makeDir(_outputPath);
   }
 
   /**

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/perty/PertyTestRunnerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/perty/PertyTestRunnerTest.cpp
@@ -27,13 +27,14 @@
 
 // Hoot
 #include <hoot/core/TestUtils.h>
+#include <hoot/core/algorithms/perty/PertyMatchScorer.h>
+#include <hoot/core/algorithms/perty/PertyTestRunner.h>
+#include <hoot/core/algorithms/perty/PertyTestRunResult.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/Settings.h>
-#include <hoot/core/algorithms/perty/PertyTestRunner.h>
-#include <hoot/core/algorithms/perty/PertyMatchScorer.h>
-#include <hoot/core/algorithms/perty/PertyTestRunResult.h>
 
 namespace hoot
 {
@@ -59,9 +60,9 @@ public:
                       "test-output/rnd/algorithms/perty/PertyTestRunnerTest/")
   {
     setResetType(ResetAll);
-    TestUtils::mkpath(_outputPath + "Dynamic");
-    TestUtils::mkpath(_outputPath + "Static");
-    TestUtils::mkpath(_outputPath + "Variance");
+    FileUtils::makeDir(_outputPath + "Dynamic");
+    FileUtils::makeDir(_outputPath + "Static");
+    FileUtils::makeDir(_outputPath + "Variance");
   }
 
   void runDynamicVariablesTest()

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/perty/PertyTestRunnerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/perty/PertyTestRunnerTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2014, 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2014, 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/network/EdgeMatchSetFinderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/network/EdgeMatchSetFinderTest.cpp
@@ -32,6 +32,7 @@
 #include <hoot/core/criterion/TagCriterion.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/MapProjector.h>
 
 namespace hoot
@@ -61,7 +62,7 @@ public:
 
   void writeDebugMap(OsmMapPtr map, int testNumber)
   {
-    TestUtils::mkpath("tmp");
+    FileUtils::makeDir("tmp");
     OsmMapPtr copy(new OsmMap(map));
 
     MapProjector::projectToWgs84(copy);

--- a/hoot-core-test/src/test/cpp/hoot/core/conflate/network/EdgeMatchSetFinderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/conflate/network/EdgeMatchSetFinderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OgrWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OgrWriterTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // CPP Unit

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OgrWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OgrWriterTest.cpp
@@ -146,7 +146,7 @@ public:
     uut.open(_outputPath + "OgrWriterTest.gdb");
     uut.write(createTestMap());
 
-    TestUtils::mkpath("tmp");
+    FileUtils::makeDir("tmp");
     OsmMapWriterFactory::write(createTestMap(), "tmp/TestMap.osm");
 
     // make sure it created a bunch of files. We aren't testing for correct output.

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/RelationWithMostMembersOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/RelationWithMostMembersOpTest.cpp
@@ -26,11 +26,12 @@
  */
 
 // Hoot
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/TestUtils.h>
+#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/ops/RelationWithMostMembersOp.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
 
@@ -57,7 +58,7 @@ public:
   RelationWithMostMembersOpTest()
   {
     setResetType(ResetBasic);
-    TestUtils::mkpath(outputPath);
+    FileUtils::makeDir(outputPath);
   }
 
   void runBasicTest()

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/RelationWithMostMembersOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/RelationWithMostMembersOpTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchComparatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/scoring/MatchComparatorTest.cpp
@@ -103,7 +103,7 @@ public:
 
     // for debugging
 //    MapProjector::projectToWgs84(copy);
-//    QDir(".").mkpath("test-output/scoring");
+//    FileUtils::makeDir("test-output/scoring");
 //    OsmXmlWriter writer;
 //    writer.write(copy, "test-output/scoring/MatchComparatorTest.osm");
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/perty/PertyMatchScorer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/perty/PertyMatchScorer.cpp
@@ -27,23 +27,24 @@
 #include "PertyMatchScorer.h"
 
 // hoot
-#include <hoot/core/elements/OsmMap.h>
-#include <hoot/core/ops/MapCleaner.h>
+#include <hoot/core/algorithms/perty/PertyOp.h>
 #include <hoot/core/algorithms/rubber-sheet/RubberSheet.h>
 #include <hoot/core/conflate/UnifyingConflator.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
-#include <hoot/core/ops/BuildingOutlineUpdateOp.h>
-#include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/io/IoUtils.h>
+#include <hoot/core/ops/BuildingOutlineUpdateOp.h>
+#include <hoot/core/ops/MapCleaner.h>
+#include <hoot/core/schema/MetadataTags.h>
+#include <hoot/core/scoring/MatchScoringMapPreparer.h>
+#include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
-#include <hoot/core/schema/MetadataTags.h>
 #include <hoot/core/visitors/AddRef1Visitor.h>
 #include <hoot/core/visitors/SetTagValueVisitor.h>
 #include <hoot/core/visitors/TagCountVisitor.h>
 #include <hoot/core/visitors/TagRenameKeyVisitor.h>
-#include <hoot/core/algorithms/perty/PertyOp.h>
-#include <hoot/core/scoring/MatchScoringMapPreparer.h>
 
 // Qt
 #include <QFileInfo>
@@ -86,7 +87,7 @@ std::shared_ptr<MatchComparator> PertyMatchScorer::scoreMatches(const QString& r
 {
   LOG_INFO(toString());
 
-  QDir().mkpath(outputPath);
+  FileUtils::makeDir(outputPath);
   QFileInfo inputFileInfo(referenceMapInputPath);
   const QString referenceMapOutputPath =
     outputPath + "/" + inputFileInfo.baseName() + "-reference-out.osm";

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/perty/PertyTestRunner.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/perty/PertyTestRunner.cpp
@@ -27,11 +27,12 @@
 #include "PertyTestRunner.h"
 
 // hoot
-#include <hoot/core/io/MapStatsWriter.h>
-#include <hoot/core/util/ConfigOptions.h>
-#include <hoot/core/util/Log.h>
 #include <hoot/core/algorithms/perty/PertyTestRunResult.h>
 #include <hoot/core/algorithms/perty/PertyMatchScorer.h>
+#include <hoot/core/io/MapStatsWriter.h>
+#include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/FileUtils.h>
+#include <hoot/core/util/Log.h>
 
 // Qt
 #include <QFileInfo>
@@ -83,7 +84,7 @@ QList<std::shared_ptr<const PertyTestRunResult>> PertyTestRunner::runTest(const 
     "Running PERTY test with " << _numTestRuns << " test runs and " << _numTestSimulations <<
     " simulations per test run on input: " << referenceMapInputPath << " ...");
 
-  QDir().mkpath(outputPath);
+  FileUtils::makeDir(outputPath);
 
   const QString sep = "\t";
   if (_generateMapStats)

--- a/hoot-core/src/main/cpp/hoot/core/io/IoUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/IoUtils.cpp
@@ -28,19 +28,19 @@
 #include "IoUtils.h"
 
 // Hoot
+#include <hoot/core/criterion/ChainCriterion.h>
+#include <hoot/core/criterion/ElementTypeCriterion.h>
+#include <hoot/core/criterion/TagKeyCriterion.h>
 #include <hoot/core/io/OgrReader.h>
 #include <hoot/core/io/OgrUtilities.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
+#include <hoot/core/ops/ImmediatelyConnectedOutOfBoundsWayTagger.h>
+#include <hoot/core/ops/MapCropper.h>
+#include <hoot/core/util/Factory.h>
 #include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/Progress.h>
-#include <hoot/core/ops/MapCropper.h>
-#include <hoot/core/criterion/ElementTypeCriterion.h>
-#include <hoot/core/criterion/ChainCriterion.h>
-#include <hoot/core/criterion/TagKeyCriterion.h>
-#include <hoot/core/ops/ImmediatelyConnectedOutOfBoundsWayTagger.h>
-#include <hoot/core/util/Factory.h>
 
 // Qt
 #include <QFileInfo>
@@ -249,7 +249,7 @@ void IoUtils::writeOutputDir(const QString& dirName)
 {
   QFileInfo outputInfo(dirName);
   LOG_VART(outputInfo.dir().absolutePath());
-  const bool outputDirSuccess = QDir().mkpath(outputInfo.dir().absolutePath());
+  const bool outputDirSuccess = FileUtils::makeDir(outputInfo.dir().absolutePath());
   LOG_VART(outputDirSuccess);
   if (!outputDirSuccess)
   {

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxJsonWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxJsonWriter.cpp
@@ -41,6 +41,7 @@
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Exception.h>
 #include <hoot/core/util/Factory.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/visitors/CalculateMapBoundsVisitor.h>
 
 // Qt
@@ -73,7 +74,7 @@ void OsmGbdxJsonWriter::open(const QString& path)
 
   if (_outputDir.exists() == false)
   {
-    if (QDir().mkpath(_outputDir.path()) == false)
+    if (FileUtils::makeDir(_outputDir.path()) == false)
     {
       throw HootException("Error creating directory for writing.");
     }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxXmlWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxXmlWriter.cpp
@@ -40,6 +40,7 @@
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Exception.h>
 #include <hoot/core/util/Factory.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/UuidHelper.h>
 #include <hoot/core/visitors/CalculateMapBoundsVisitor.h>
 
@@ -129,7 +130,7 @@ void OsmGbdxXmlWriter::open(const QString& url)
 
   if (_outputDir.exists() == false)
   {
-    if (QDir().mkpath(_outputDir.path()) == false)
+    if (FileUtils::makeDir(_outputDir.path()) == false)
     {
       throw HootException("Error creating directory for writing.");
     }

--- a/hoot-core/src/main/cpp/hoot/core/io/ShapefileWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ShapefileWriter.cpp
@@ -44,6 +44,7 @@ using namespace geos::geom;
 #include <hoot/core/io/OgrOptions.h>
 #include <hoot/core/schema/MetadataTags.h>
 #include <hoot/core/util/Factory.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/visitors/ElementConstOsmMapVisitor.h>
@@ -132,7 +133,7 @@ void ShapefileWriter::open(const QString& url)
 {
   if (QDir(url).exists() == false)
   {
-    if (QDir(".").mkpath(url) == false)
+    if (FileUtils::makeDir(url) == false)
     {
       throw HootException("Error creating directory for writing: " + url);
     }

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
@@ -41,20 +41,20 @@
 #endif
 
 // Hoot
-#include <hoot/core/elements/Relation.h>
-#include <hoot/core/elements/Way.h>
+#include <hoot/core/conflate/address/AddressParser.h>
 #include <hoot/core/elements/Node.h>
+#include <hoot/core/elements/Relation.h>
+#include <hoot/core/elements/Tags.h>
+#include <hoot/core/elements/Way.h>
 #include <hoot/core/schema/OsmSchema.h>
+#include <hoot/core/schema/OsmSchemaLoader.h>
 #include <hoot/core/schema/OsmSchemaLoaderFactory.h>
+#include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/ConfPath.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/elements/Tags.h>
-#include <hoot/core/schema/OsmSchemaLoader.h>
-#include <hoot/core/util/ConfigOptions.h>
-#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/StringUtils.h>
-#include <hoot/core/conflate/address/AddressParser.h>
 
 // Qt
 #include <QDomDocument>
@@ -1591,7 +1591,7 @@ OsmSchema& OsmSchema::getInstance()
       const QString errorMsg = "Unable to write schema graphviz file to " + graphvizPath;
       try
       {
-        if (QDir().mkpath("tmp"))
+        if (FileUtils::makeDir("tmp"))
         {
           FileUtils::writeFully(graphvizPath, _theInstance->toGraphvizString());
           LOG_TRACE("Wrote schema graph viz file to: " << graphvizPath);

--- a/hoot-core/src/main/cpp/hoot/core/scoring/GraphComparator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/GraphComparator.cpp
@@ -36,15 +36,16 @@
 using namespace geos::operation::distance;
 
 // Hoot
-#include <hoot/core/algorithms/splitter/WaySplitter.h>
 #include <hoot/core/algorithms/linearreference/LocationOfPoint.h>
 #include <hoot/core/algorithms/splitter/IntersectionSplitter.h>
+#include <hoot/core/algorithms/splitter/WaySplitter.h>
+#include <hoot/core/elements/ElementConverter.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/index/OsmMapIndex.h>
 #include <hoot/core/io/OsmXmlWriter.h>
 #include <hoot/core/scoring/DirectedGraph.h>
 #include <hoot/core/scoring/ShortestPath.h>
-#include <hoot/core/elements/ElementConverter.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/GeometryPainter.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/MapProjector.h>
@@ -252,7 +253,7 @@ void GraphComparator::_graphCompareThreadFunc()
       for (size_t j = 0; j < size; ++j)
         diffData[j] = fabs(image1Data[j] - image2Data[j]);
 
-      QDir().mkpath("test-output/route-image");
+      FileUtils::makeDir("test-output/route-image");
       QString s1 = QString("test-output/route-image/route-%1-a.png").arg(info.index, 3, 10, QChar('0'));
       QString s2 = QString("test-output/route-image/route-%1-b.png").arg(info.index, 3, 10, QChar('0'));
       QString sdiff = QString("test-output/route-image/route-%1-diff.png").arg(info.index, 3, 10, QChar('0'));

--- a/hoot-core/src/main/cpp/hoot/core/util/FileUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/FileUtils.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "FileUtils.h"

--- a/hoot-core/src/main/cpp/hoot/core/util/FileUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/FileUtils.cpp
@@ -39,11 +39,32 @@
 #include <QTextStream>
 
 // Std
-#include <fstream>
 #include <algorithm>
+#include <fstream>
+#include <thread>
 
 namespace hoot
 {
+
+bool FileUtils::makeDir(const QString& path)
+{
+  //  Don't make it if it exists
+  if (QDir().exists(path))
+    return true;
+  //  Try to make the path 'retry' times waiting 'duration' microseconds in between tries
+  const int retry = 3;
+  //  100 msec should be enough to wait between tries
+  const unsigned int duration = 100;
+  for (int i = 0; i < retry; i++)
+  {
+    if (QDir().mkpath(path))
+      return true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(duration));
+  }
+  //  Report failure
+  LOG_ERROR(QString("Couldn't create output directory: %1").arg(path).toStdString());
+  return false;
+}
 
 void FileUtils::removeDir(const QString& dirName)
 {
@@ -125,14 +146,18 @@ QString FileUtils::readFully(const QString& path)
 void FileUtils::writeFully(const QString& path, const QString& text)
 {
   QFile outFile(path);
+  QFileInfo fi(outFile);
+  QDir dir = fi.dir();
+  //  Attempt to create the directory if it doesn't exist
+  if (!dir.exists())
+    makeDir(dir.absolutePath());
+  //  Delete the previous file
   if (outFile.exists() && !outFile.remove())
-  {
     throw HootException("Unable to remove file: " + path);
-  }
+  //  Open to write
   if (!outFile.open(QFile::WriteOnly | QFile::Text))
-  {
     throw HootException("Error opening file: " + path);
-  }
+  //  Write a UTF-8 file
   QTextStream out(&outFile);
   out.setCodec("UTF-8");
   out << text;

--- a/hoot-core/src/main/cpp/hoot/core/util/FileUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/FileUtils.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef FILEUTILS_H

--- a/hoot-core/src/main/cpp/hoot/core/util/FileUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/FileUtils.h
@@ -44,6 +44,13 @@ class FileUtils
 public:
 
   /**
+   * Creates a folder path using QDir::mkpath in a more thread-safe way
+   * @param path relative or absolute path to create (think `mkdir -p`)
+   * @return true if successful
+   */
+  static bool makeDir(const QString& path);
+
+  /**
    * Delete a directory along with all of its contents.
    *
    * @param dirName Path of directory to remove.

--- a/hoot-rnd/src/main/cpp/hoot/rnd/cmd/EvalPointMovesCmd.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/cmd/EvalPointMovesCmd.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Boost

--- a/hoot-rnd/src/main/cpp/hoot/rnd/cmd/EvalPointMovesCmd.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/cmd/EvalPointMovesCmd.cpp
@@ -29,8 +29,6 @@
 #include <boost/random/uniform_int.hpp>
 
 // Hoot
-#include <hoot/core/util/Factory.h>
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/cmd/BaseCommand.h>
 #include <hoot/core/io/OgrReader.h>
 #include <hoot/core/io/OsmXmlReader.h>
@@ -38,8 +36,11 @@
 #include <hoot/core/io/OsmPbfReader.h>
 #include <hoot/core/io/OsmPbfWriter.h>
 #include <hoot/core/io/ShapefileWriter.h>
+#include <hoot/core/util/Factory.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/GeometryUtils.h>
 #include <hoot/core/util/Log.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/visitors/CalculateMapBoundsVisitor.h>
 
 // Qt
@@ -205,7 +206,7 @@ public:
     }
     Envelope bounds = parseEnvelope(args[1]);
     QString workingDir = args[2];
-    QDir(".").mkpath(workingDir);
+    FileUtils::makeDir(workingDir);
 
     OsmMapPtr map(new OsmMap());
 

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/IterativeNetworkMatcherTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/IterativeNetworkMatcherTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/IterativeNetworkMatcherTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/IterativeNetworkMatcherTest.cpp
@@ -27,7 +27,6 @@
 
 // Hoot
 #include <hoot/core/TestUtils.h>
-#include <hoot/core/ops/MapCleaner.h>
 #include <hoot/core/conflate/network/DebugNetworkMapCreator.h>
 #include <hoot/core/conflate/network/OsmNetworkExtractor.h>
 #include <hoot/core/criterion/ChainCriterion.h>
@@ -35,6 +34,8 @@
 #include <hoot/core/criterion/StatusCriterion.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
+#include <hoot/core/ops/MapCleaner.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/MapProjector.h>
 #include <hoot/rnd/conflate/network/IterativeNetworkMatcher.h>
 
@@ -60,7 +61,7 @@ public:
 
   void writeDebugMap(OsmMapPtr map, IterativeNetworkMatcher& uut, int index)
   {
-    TestUtils::mkpath("tmp");
+    FileUtils::makeDir("tmp");
     OsmMapPtr copy(new OsmMap(map));
     DebugNetworkMapCreator().addDebugElements(copy, uut.getAllEdgeScores(),
       uut.getAllVertexScores());

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/SingleSidedNetworkMatcherTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/SingleSidedNetworkMatcherTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/SingleSidedNetworkMatcherTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/SingleSidedNetworkMatcherTest.cpp
@@ -35,6 +35,7 @@
 #include <hoot/core/criterion/StatusCriterion.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/MapProjector.h>
 #include <hoot/rnd/conflate/network/SingleSidedNetworkMatcher.h>
 
@@ -58,7 +59,7 @@ public:
 
   void writeDebugMap(OsmMapPtr map, SingleSidedNetworkMatcher& uut, int index)
   {
-    TestUtils::mkpath("tmp");
+    FileUtils::makeDir("tmp");
     OsmMapPtr copy(new OsmMap(map));
     DebugNetworkMapCreator().addDebugElements(copy, uut.getAllEdgeScores(),
       uut.getAllVertexScores());

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/VagabondNetworkMatcherTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/VagabondNetworkMatcherTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/VagabondNetworkMatcherTest.cpp
+++ b/hoot-rnd/src/test/cpp/hoot/rnd/conflate/network/VagabondNetworkMatcherTest.cpp
@@ -26,17 +26,18 @@
  */
 
 // Hoot
-#include <hoot/core/util/MapProjector.h>
 #include <hoot/core/TestUtils.h>
-#include <hoot/core/ops/MapCleaner.h>
+#include <hoot/core/conflate/network/DebugNetworkMapCreator.h>
+#include <hoot/core/conflate/network/OsmNetworkExtractor.h>
 #include <hoot/core/criterion/ChainCriterion.h>
 #include <hoot/core/criterion/HighwayCriterion.h>
 #include <hoot/core/criterion/StatusCriterion.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
-#include <hoot/core/conflate/network/DebugNetworkMapCreator.h>
+#include <hoot/core/ops/MapCleaner.h>
+#include <hoot/core/util/FileUtils.h>
+#include <hoot/core/util/MapProjector.h>
 #include <hoot/rnd/conflate/network/VagabondNetworkMatcher.h>
-#include <hoot/core/conflate/network/OsmNetworkExtractor.h>
 
 namespace hoot
 {
@@ -58,7 +59,7 @@ public:
 
   void writeDebugMap(OsmMapPtr map, VagabondNetworkMatcher& uut, int index)
   {
-    TestUtils::mkpath("tmp");
+    FileUtils::makeDir("tmp");
     OsmMapPtr copy(new OsmMap(map));
     DebugNetworkMapCreator().addDebugElements(copy, uut.getAllEdgeScores(),
       uut.getAllVertexScores());

--- a/test-files/cmd/glacial/OptimizeNetworkConflateSettingsCmdTest.sh
+++ b/test-files/cmd/glacial/OptimizeNetworkConflateSettingsCmdTest.sh
@@ -2,7 +2,7 @@
 set -e
 
 OUTPUT_DIR=test-output/cmd/glacial/OptimizeNetworkConflateSettingsCmdTest
-OUTPUT_FILE=OptimizeNetworkConflateSettingsCmdTest-states-out
+OUTPUT_FILE=OptimizeNetworkConflateSettingsCmdTest-states-out.txt
 mkdir -p $OUTPUT_DIR
 rm -f $OUTPUT_DIR/$OUTPUT_FILE
 


### PR DESCRIPTION
When a directory doesn't exist for writing files using `FileUtils::writeFully` it currently fails.  Instead of failing, attempt to create the path before writing.  Consolidate the uses of `QDir::mkpath` and `QDir::mkdir` to all use `FileUtils::makeDir`.