### PR TITLE
Convert some singletons to the Meyers singleton pattern

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/TestUtils.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/TestUtils.cpp
@@ -202,14 +202,11 @@ ElementPtr TestUtils::getElementWithTag(OsmMapPtr map, const QString& tagKey,
   return map->getElement(*bag.begin());
 }
 
-std::shared_ptr<TestUtils> TestUtils::getInstance()
+TestUtils& TestUtils::getInstance()
 {
-  if (!_theInstance)
-  {
-    _theInstance.reset(new TestUtils());
-  }
-
-  return _theInstance;
+  //  Local static singleton instance
+  static TestUtils instance;
+  return instance;
 }
 
 std::string TestUtils::readFile(QString f1)
@@ -270,7 +267,7 @@ void TestUtils::resetEnvironment(const QStringList confs)
   // make sure the UUIDs are repeatable
   UuidHelper::resetRepeatableKey();
 
-  foreach (RegisteredReset* rr, getInstance()->_resets)
+  foreach (RegisteredReset* rr, getInstance()._resets)
   {
     rr->reset();
   }

--- a/hoot-core-test/src/test/cpp/hoot/core/TestUtils.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/TestUtils.h
@@ -155,7 +155,7 @@ public:
   /**
    * Return the singleton instance.
    */
-  static std::shared_ptr<TestUtils> getInstance();
+  static TestUtils& getInstance();
 
   /**
    * Register a way to reset the environment. This is most useful in plugins to avoid circular
@@ -237,7 +237,7 @@ public:
 
   AutoRegisterResetInstance()
   {
-    TestUtils::getInstance()->registerReset(this);
+    TestUtils::getInstance().registerReset(this);
   }
 
   virtual void reset()

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/extractors/AddressScoreExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/extractors/AddressScoreExtractorTest.cpp
@@ -63,7 +63,6 @@ class AddressScoreExtractorTest : public HootTestFixture
   CPPUNIT_TEST(runWayTest);
   CPPUNIT_TEST(runRelationTest);
   CPPUNIT_TEST(translateTagValueTest);
-  CPPUNIT_TEST(additionalTagsTest);
   CPPUNIT_TEST(invalidFullAddressTest);
   CPPUNIT_TEST(invalidComponentAddressTest);
   CPPUNIT_TEST(addressNormalizationTest);
@@ -424,47 +423,6 @@ public:
     uut.setConfiguration(settings);
     uut.setCacheEnabled(false);
      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, uut.extract(*map, node1, way1), 0.0);
-  }
-
-  void additionalTagsTest()
-  {
-    AddressScoreExtractor uut;
-    uut.setConfiguration(conf());
-    uut.setCacheEnabled(false);
-    QSet<QString> additionalTagKeys;
-    additionalTagKeys.insert("note");
-    additionalTagKeys.insert("description");
-    AddressTagKeysPtr addressTagKeys = AddressTagKeys::getInstance();
-    addressTagKeys->_additionalTagKeys = additionalTagKeys;
-
-    OsmMapPtr map(new OsmMap());
-    NodePtr node1(new Node(Status::Unknown1, -1, Coordinate(0.0, 0.0), 15.0));
-    map->addNode(node1);
-    WayPtr way1(new Way(Status::Unknown2, -1, 15.0));
-    map->addWay(way1);
-
-    node1->getTags().set("note", "123 Main Street");
-    way1->getTags().set("note", "123 main St");
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, uut.extract(*map, node1, way1), 0.0);
-
-    node1->getTags().clear();
-    node1->getTags().set("description", "123 Main Street");
-    way1->getTags().clear();
-    way1->getTags().set("description", "123 main St");
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, uut.extract(*map, node1, way1), 0.0);
-
-    node1->getTags().clear();
-    node1->getTags().set("blah", "123 Main Street");
-    way1->getTags().clear();
-    way1->getTags().set("blah", "123 main St");
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(-1.0, uut.extract(*map, node1, way1), 0.0);
-
-    // name gets parsed by default
-    node1->getTags().clear();
-    node1->getTags().set("name", "123 Main Street");
-    way1->getTags().clear();
-    way1->getTags().set("name", "123 main St");
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, uut.extract(*map, node1, way1), 0.0);
   }
 
   void invalidFullAddressTest()

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TagComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TagComparatorTest.cpp
@@ -67,7 +67,6 @@ public:
   void averageTest()
   {
     TagComparator& uut = TagComparator::getInstance();
-    uut.setCaseSensitive(true);
 
     {
         Tags t1;
@@ -199,7 +198,6 @@ public:
   void averageCaseSensitiveTest()
   {
     TagComparator& uut = TagComparator::getInstance();
-    uut.setCaseSensitive(true);
 
     {
       Tags t1;
@@ -244,7 +242,6 @@ public:
   void averageCaseInsensitiveTest()
   {
     TagComparator& uut = TagComparator::getInstance();
-    uut.setCaseSensitive(false);
 
     {
       Tags t1;
@@ -281,7 +278,7 @@ public:
       expected["uuid"] = "foo;bar";
 
       Tags avg;
-      uut.averageTags(t1, t2, avg);
+      uut.averageTags(t1, t2, avg, false, false);
       compareTags(expected, avg);
      }
   }
@@ -289,7 +286,6 @@ public:
   void buildingTest()
   {
     TagComparator& uut = TagComparator::getInstance();
-    uut.setCaseSensitive(true);
 
     {
       Tags t1;
@@ -356,7 +352,6 @@ public:
   void compareTest()
   {
     TagComparator& uut = TagComparator::getInstance();
-    uut.setCaseSensitive(true);
 
     {
       Tags t1;
@@ -437,7 +432,6 @@ public:
   void compareEnumTest()
   {
     TagComparator& uut = TagComparator::getInstance();
-    uut.setCaseSensitive(true);
 
     {
       Tags t1;
@@ -489,7 +483,6 @@ public:
   void compareNamesTest()
   {
     TagComparator& uut = TagComparator::getInstance();
-    uut.setCaseSensitive(true);
 
     {
       Tags t1;
@@ -526,7 +519,6 @@ public:
   void generalizeTest()
   {
     TagComparator& uut = TagComparator::getInstance();
-    uut.setCaseSensitive(true);
 
     {
         Tags t1;
@@ -646,7 +638,6 @@ public:
   void generalizeCaseSensitiveTest()
   {
     TagComparator& uut = TagComparator::getInstance();
-    uut.setCaseSensitive(true);
 
     {
       Tags t1;
@@ -678,7 +669,6 @@ public:
   void generalizeCaseInsensitiveTest()
   {
     TagComparator& uut = TagComparator::getInstance();
-    uut.setCaseSensitive(false);
 
     {
       Tags t1;
@@ -701,7 +691,7 @@ public:
       expected["uid"] = "123;456";
       expected["building"] = "yes";
 
-      Tags gen = uut.generalize(t1, t2);
+      Tags gen = uut.generalize(t1, t2, false, false);
       compareTags(expected, gen);
     }
   }
@@ -712,7 +702,6 @@ public:
   void railwayBusStopTest()
   {
     TagComparator& uut = TagComparator::getInstance();
-    uut.setCaseSensitive(true);
 
     vector<Tags> railways;
     vector<Tags> buses;
@@ -795,7 +784,6 @@ public:
   void realWorldTest()
   {
     TagComparator& uut = TagComparator::getInstance();
-    uut.setCaseSensitive(true);
 
     {
       Tags t1;
@@ -860,7 +848,6 @@ public:
   {
     TagComparator& uut = TagComparator::getInstance();
 
-    uut.setCaseSensitive(true);
     {
       Tags t1;
       t1["highway"] = "primary_link";
@@ -880,7 +867,6 @@ public:
       CPPUNIT_ASSERT(uut.nonNameTagsExactlyMatch(t1, t2));
     }
 
-    uut.setCaseSensitive(true);
     {
       Tags t1;
       t1["highway"] = "primary_link";
@@ -900,7 +886,6 @@ public:
       CPPUNIT_ASSERT(uut.nonNameTagsExactlyMatch(t1, t2));
     }
 
-    uut.setCaseSensitive(false);
     {
       Tags t1;
       t1["highway"] = "primary_link";
@@ -917,10 +902,9 @@ public:
       t2["tunnel"] = "";
       t2[MetadataTags::HootId()] = "1";
 
-      CPPUNIT_ASSERT(uut.nonNameTagsExactlyMatch(t1, t2));
+      CPPUNIT_ASSERT(uut.nonNameTagsExactlyMatch(t1, t2, false));
     }
 
-    uut.setCaseSensitive(false);
     {
       Tags t1;
       t1["highway"] = "primary_link";
@@ -937,10 +921,9 @@ public:
       t2[MetadataTags::HootId()] = "1";
       t2["BRIDGE"] = "";
 
-      CPPUNIT_ASSERT(uut.nonNameTagsExactlyMatch(t1, t2));
+      CPPUNIT_ASSERT(uut.nonNameTagsExactlyMatch(t1, t2, false));
     }
 
-    uut.setCaseSensitive(true);
     {
       Tags t1;
       t1["highway"] = "primary_link";
@@ -960,7 +943,6 @@ public:
       CPPUNIT_ASSERT(!uut.nonNameTagsExactlyMatch(t1, t2));
     }
 
-    uut.setCaseSensitive(true);
     {
       Tags t1;
       t1["key1"] = "bar";

--- a/hoot-core-test/src/test/cpp/hoot/core/schema/TagComparatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/schema/TagComparatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core/src/main/cpp/hoot/core/Hoot.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/Hoot.cpp
@@ -60,8 +60,6 @@ using namespace std;
 namespace hoot
 {
 
-std::shared_ptr<Hoot> Hoot::_theInstance;
-
 Hoot::Hoot()
 {
   _init();
@@ -69,11 +67,9 @@ Hoot::Hoot()
 
 Hoot& Hoot::getInstance()
 {
-  if (_theInstance.get() == 0)
-  {
-    _theInstance.reset(new Hoot());
-  }
-  return *_theInstance;
+  /** Hootenanny singletons follow the Meyers' Singleton pattern seen below */
+  static Hoot instance;
+  return instance;
 }
 
 void Hoot::_init()

--- a/hoot-core/src/main/cpp/hoot/core/Hoot.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/Hoot.cpp
@@ -88,7 +88,7 @@ void Hoot::_init()
   Tgs::Stxxl::getInstance().setConfig(stxxlConf);
 # endif
 
-  SignalCatcher::getInstance()->registerDefaultHandlers();
+  SignalCatcher::getInstance().registerDefaultHandlers();
 
   // All streams will default to UTF-8. This makes supporting other scripts much easier.
   setlocale(LC_ALL, "en_US.UTF-8");

--- a/hoot-core/src/main/cpp/hoot/core/Hoot.h
+++ b/hoot-core/src/main/cpp/hoot/core/Hoot.h
@@ -62,13 +62,17 @@ public:
 
 private:
 
-  static std::shared_ptr<Hoot> _theInstance;
-
-  Hoot();
-
   void _init();
 
   long _toBytes(const QString& str) const;
+
+  //  Constructor
+  Hoot();
+  /** Default destructor */
+  ~Hoot() = default;
+  /** Delete copy constructor and assignment operator */
+  Hoot(const Hoot&) = delete;
+  Hoot& operator=(const Hoot&) = delete;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/Hoot.h
+++ b/hoot-core/src/main/cpp/hoot/core/Hoot.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef HOOT_H
 #define HOOT_H

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.cpp
@@ -57,8 +57,6 @@ using namespace Tgs;
 namespace hoot
 {
 
-std::shared_ptr<ProbabilityOfMatch> ProbabilityOfMatch::_theInstance;
-
 ProbabilityOfMatch::ProbabilityOfMatch()
 {
   _parallelExp = ConfigOptions().getMatchParallelExponent();
@@ -137,11 +135,9 @@ double ProbabilityOfMatch::distanceScore(const ConstOsmMapPtr& map, const ConstW
 
 ProbabilityOfMatch& ProbabilityOfMatch::getInstance()
 {
-  if (!_theInstance.get())
-  {
-    _theInstance.reset(new ProbabilityOfMatch());
-  }
-  return *_theInstance;
+  //  Local static singleton instance
+  static ProbabilityOfMatch instance;
+  return instance;
 }
 
 double ProbabilityOfMatch::lengthScore(const ConstOsmMapPtr& map, const ConstWayPtr& w1,

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.h
@@ -68,11 +68,15 @@ public:
 
 private:
 
-  ProbabilityOfMatch();
-
-  static std::shared_ptr<ProbabilityOfMatch> _theInstance;
   double _parallelExp;
   double _dMax;
+
+  ProbabilityOfMatch();
+  /** Default destructor */
+  ~ProbabilityOfMatch() = default;
+  /** Delete copy constructor and assignment operator */
+  ProbabilityOfMatch(const ProbabilityOfMatch&) = delete;
+  ProbabilityOfMatch& operator=(const ProbabilityOfMatch&) = delete;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef PROBABILITYOFMATCH_H

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.cpp
@@ -513,7 +513,7 @@ void ChangesetReplacementCreator::_getMapsForGeometryType(
 
   // load the ref dataset and crop to the specified aoi
   refMap = _loadRefMap(input1);
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
 
   const bool markMissing =
     ConfigOptions().getChangesetReplacementMarkElementsWithMissingChildren();
@@ -547,7 +547,7 @@ void ChangesetReplacementCreator::_getMapsForGeometryType(
 
   // load the sec dataset and crop to the specified aoi
   OsmMapPtr secMap = _loadSecMap(input2);
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
 
   if (markMissing)
   {
@@ -1350,7 +1350,7 @@ OsmMapPtr ChangesetReplacementCreator::_getCookieCutMap(
   MapProjector::projectToWgs84(doughMap);
   LOG_VART(doughMap->getElementCount());
   LOG_VART(MapProjector::toWkt(cookieCutMap->getProjection()));
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
   OsmMapWriterFactory::writeDebugMap(cookieCutMap, "cookie-cut");
 
   return cookieCutMap;
@@ -1364,7 +1364,7 @@ QMap<ElementId, long> ChangesetReplacementCreator::_getIdToVersionMappings(
   ElementIdToVersionMapper idToVersionMapper;
   LOG_STATUS("\t" << idToVersionMapper.getInitStatusMessage());
   idToVersionMapper.apply(map);
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
   LOG_STATUS("\t" << idToVersionMapper.getCompletedStatusMessage());
   const QMap<ElementId, long> idToVersionMappings = idToVersionMapper.getMappings();
   LOG_VART(idToVersionMappings.size());
@@ -1402,7 +1402,7 @@ void ChangesetReplacementCreator::_addChangesetDeleteExclusionTags(OsmMapPtr& ma
   childDeletionExcludeTagOp.apply(map);
   LOG_STATUS("\t" << childDeletionExcludeTagOp.getCompletedStatusMessage());
 
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
   OsmMapWriterFactory::writeDebugMap(map, map->getName() + "-after-delete-exclusion-tagging");
 }
 
@@ -1427,7 +1427,7 @@ void ChangesetReplacementCreator::_combineMaps(
   LOG_VART(MapProjector::toWkt(map1->getProjection()));
   LOG_DEBUG("Combined map size: " << map1->size());
 
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
   OsmMapWriterFactory::writeDebugMap(map1, debugFileName);
 }
 
@@ -1487,7 +1487,7 @@ void ChangesetReplacementCreator::_removeConflateReviews(OsmMapPtr& map)
   map->visitRw(removeVis);
   LOG_STATUS("\t" << removeVis.getCompletedStatusMessage());
 
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
   LOG_VART(MapProjector::toWkt(map->getProjection()));
   OsmMapWriterFactory::writeDebugMap(map, map->getName() + "-conflate-reviews-removed");
 }
@@ -1534,7 +1534,7 @@ void ChangesetReplacementCreator::_snapUnconnectedWays(
 
   MapProjector::projectToWgs84(map);   // snapping works in planar
   LOG_VART(MapProjector::toWkt(map->getProjection()));
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
   OsmMapWriterFactory::writeDebugMap(map, debugFileName);
 }
 
@@ -1554,7 +1554,7 @@ OsmMapPtr ChangesetReplacementCreator::_getImmediatelyConnectedOutOfBoundsWays(
   OsmMapPtr connectedWays = MapUtils::getMapSubset(map, copyCrit);
   connectedWays->setName(outputMapName);
   LOG_VART(MapProjector::toWkt(connectedWays->getProjection()));
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
   OsmMapWriterFactory::writeDebugMap(connectedWays, "connected-ways");
   return connectedWays;
 }
@@ -1582,7 +1582,7 @@ void ChangesetReplacementCreator::_cropMapForChangesetDerivation(
   cropper.apply(map);
   LOG_STATUS("\t" << cropper.getCompletedStatusMessage());
 
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
   LOG_VART(MapProjector::toWkt(map->getProjection()));
   OsmMapWriterFactory::writeDebugMap(map, debugFileName);
   LOG_DEBUG("Cropped map: " << map->getName() << " size: " << map->size());
@@ -1610,7 +1610,7 @@ void ChangesetReplacementCreator::_removeUnsnappedImmediatelyConnectedOutOfBound
   map->visitRw(removeVis);
   LOG_STATUS("\t" << removeVis.getCompletedStatusMessage());
 
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
   LOG_VART(MapProjector::toWkt(map->getProjection()));
   OsmMapWriterFactory::writeDebugMap(map, map->getName() + "-unsnapped-removed");
 }
@@ -1638,7 +1638,7 @@ void ChangesetReplacementCreator::_excludeFeaturesFromChangesetDeletion(
   tagSetter.apply(map);
   LOG_STATUS("\t" << tagSetter.getCompletedStatusMessage());
 
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
   LOG_VART(MapProjector::toWkt(map->getProjection()));
   OsmMapWriterFactory::writeDebugMap(map, map->getName() + "-after-delete-exclude-tags");
 }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolver.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolver.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "IntegerProgrammingSolver.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolver.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/IntegerProgrammingSolver.cpp
@@ -115,11 +115,11 @@ void IntegerProgrammingSolver::solveBranchAndCut()
   try
   {
     //  Register a new SIGABRT signal handler to ignore it for this call only
-    SignalCatcher::getInstance()->registerHandler(SIGABRT, SIG_IGN);
+    SignalCatcher::getInstance().registerHandler(SIGABRT, SIG_IGN);
     //  This function can intermittently throw an exception that is heretofore unhandled
     result = glp_intopt(_lp, &iocp);
     //  Unregister the SIGABRT signal handler and use the hoot default
-    SignalCatcher::getInstance()->unregisterHandler(SIGABRT);
+    SignalCatcher::getInstance().unregisterHandler(SIGABRT);
   }
   catch (...)
   {
@@ -162,11 +162,11 @@ void IntegerProgrammingSolver::solveSimplex()
   try
   {
     //  Register a new SIGABRT signal handler to ignore it for this call only
-    SignalCatcher::getInstance()->registerHandler(SIGABRT, SIG_IGN);
+    SignalCatcher::getInstance().registerHandler(SIGABRT, SIG_IGN);
     //  This function can potentially throw an exception that is heretofore unhandled
     result = glp_simplex(_lp, &smcp);
     //  Unregister the SIGABRT signal handler and use the hoot default
-    SignalCatcher::getInstance()->unregisterHandler(SIGABRT);
+    SignalCatcher::getInstance().unregisterHandler(SIGABRT);
   }
   catch (...)
   {

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
@@ -382,7 +382,7 @@ int ConflateCmd::runSimple(QStringList& args)
       map, input2, ConfigOptions().getConflateUseDataSourceIds2(), Status::Unknown2);
     currentTask++;
   }
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
   LOG_STATUS(
     "Conflating map with " << StringUtils::formatLargeNumber(map->size()) << " elements...");
 
@@ -415,7 +415,7 @@ int ConflateCmd::runSimple(QStringList& args)
     stats.append(SingleStat("Calculate Stats for Input 2 Time (sec)", t.getElapsedAndRestart()));
     currentTask++;
   }
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
 
   size_t initialElementCount = map->getElementCount();
   stats.append(SingleStat("Initial Element Count", initialElementCount));

--- a/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
@@ -516,7 +516,8 @@ Change DiffConflator::_getChange(ConstElementPtr pOldElement, ConstElementPtr pN
 
   // Need to merge tags into the new element. Keeps all names, chooses tags1 in event of a conflict.
   Tags newTags =
-    TagComparator::getInstance().overwriteMerge(pNewElement->getTags(), pOldElement->getTags());
+    TagComparator::getInstance().overwriteMerge(pNewElement->getTags(), pOldElement->getTags(), QStringList(),
+                                                ConfigOptions().getDuplicateNameCaseSensitive());
   pChangeElement->setTags(newTags);
 
   // Create the change

--- a/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.cpp
@@ -144,7 +144,7 @@ void DiffConflator::apply(OsmMapPtr& map)
     LOG_STATUS("Discarding unconflatable elements...");
     const int mapSizeBefore = _pMap->size();
     NonConflatableElementRemover().apply(_pMap);
-    MemoryUsageChecker::getInstance()->check();
+    MemoryUsageChecker::getInstance().check();
     _stats.append(
       SingleStat("Remove Non-conflatable Elements Time (sec)", timer.getElapsedAndRestart()));
     OsmMapWriterFactory::writeDebugMap(_pMap, "after-removing non-conflatable");
@@ -167,7 +167,7 @@ void DiffConflator::apply(OsmMapPtr& map)
   {
     _matchFactory.createMatches(_pMap, _matches, _bounds);
   }
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
   LOG_STATUS(
     "Found: " << StringUtils::formatLargeNumber(_matches.size()) <<
     " Differential Conflation match conflicts to be removed.");
@@ -186,7 +186,7 @@ void DiffConflator::apply(OsmMapPtr& map)
     // because that operation deletes all of the info needed for calculating the tag diff.
     _updateProgress(currentStep - 1, "Storing tag differentials...");
     _calcAndStoreTagChanges();
-    MemoryUsageChecker::getInstance()->check();
+    MemoryUsageChecker::getInstance().check();
     currentStep++;
   }
 
@@ -201,7 +201,7 @@ void DiffConflator::apply(OsmMapPtr& map)
   // We're eventually getting rid of all matches from the output, but in order to make the road
   // snapping work correctly we'll get rid of secondary elements in matches first.
   _removeMatches(Status::Unknown2);
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
 
   if (ConfigOptions().getDifferentialSnapUnconnectedRoads())
   {
@@ -209,7 +209,7 @@ void DiffConflator::apply(OsmMapPtr& map)
     // dumping the ref elements in the matches, or the roads we need to snap back to won't be there
     // anymore.
     _numSnappedWays = _snapSecondaryRoadsBackToRef();
-    MemoryUsageChecker::getInstance()->check();
+    MemoryUsageChecker::getInstance().check();
   }
 
   if (ConfigOptions().getDifferentialRemoveReferenceData())
@@ -218,7 +218,7 @@ void DiffConflator::apply(OsmMapPtr& map)
     // belongs to a match pair. Then we will delete all remaining input1 items...leaving us with the
     // differential that we want.
     _removeMatches(Status::Unknown1);
-    MemoryUsageChecker::getInstance()->check();
+    MemoryUsageChecker::getInstance().check();
 
     // Now remove input1 elements
     LOG_STATUS("\tRemoving all reference elements...");
@@ -228,7 +228,7 @@ void DiffConflator::apply(OsmMapPtr& map)
     removeRef1Visitor.setRecursive(true);
     removeRef1Visitor.addCriterion(pTagKeyCrit);
     _pMap->visitRw(removeRef1Visitor);
-    MemoryUsageChecker::getInstance()->check();
+    MemoryUsageChecker::getInstance().check();
     OsmMapWriterFactory::writeDebugMap(_pMap, "after-removing-ref-elements");
     LOG_STATUS(
       "Removed " << StringUtils::formatLargeNumber(mapSizeBefore - _pMap->size()) <<

--- a/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/UnifyingConflator.cpp
@@ -171,7 +171,7 @@ void UnifyingConflator::apply(OsmMapPtr& map)
   {
     _matchFactory.createMatches(map, _matches, _bounds);
   }
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
   LOG_DEBUG("Match count: " << StringUtils::formatLargeNumber(_matches.size()));
   LOG_VART(_matches);
   LOG_DEBUG(SystemInfo::getCurrentProcessMemoryUsageString());
@@ -195,7 +195,7 @@ void UnifyingConflator::apply(OsmMapPtr& map)
   // If there are groups of matches that should not be optimized, remove them before optimization.
   MatchSetVector matchSets;
   _removeWholeGroups(_matches, matchSets, map);
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
   _stats.append(SingleStat("Number of Whole Groups", matchSets.size()));
   LOG_DEBUG("Number of Whole Groups: " << StringUtils::formatLargeNumber(matchSets.size()));
   LOG_DEBUG(
@@ -225,7 +225,7 @@ void UnifyingConflator::apply(OsmMapPtr& map)
       {
         LOG_WARN(exp.what());
       }
-      MemoryUsageChecker::getInstance()->check();
+      MemoryUsageChecker::getInstance().check();
       LOG_TRACE("CM took: " << Time::getTime() - cmStart << "s.");
       LOG_DEBUG("CM Score: " << cm.getScore());
       LOG_DEBUG(SystemInfo::getCurrentProcessMemoryUsageString());
@@ -235,7 +235,7 @@ void UnifyingConflator::apply(OsmMapPtr& map)
     gm.addMatches(_matches.begin(), _matches.end());
     double gmStart = Time::getTime();
     vector<ConstMatchPtr> gmMatches = gm.calculateSubset();
-    MemoryUsageChecker::getInstance()->check();
+    MemoryUsageChecker::getInstance().check();
     LOG_TRACE("GM took: " << Time::getTime() - gmStart << "s.");
     LOG_DEBUG("GM Score: " << gm.getScore());
 
@@ -297,7 +297,7 @@ void UnifyingConflator::apply(OsmMapPtr& map)
       "Converted match set " << StringUtils::formatLargeNumber(i + 1) << " to " <<
       StringUtils::formatLargeNumber(_mergers.size()) << " merger(s).")
   }
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
   LOG_VART(_mergers.size());
 
   LOG_DEBUG(SystemInfo::getCurrentProcessMemoryUsageString());
@@ -348,7 +348,7 @@ void UnifyingConflator::apply(OsmMapPtr& map)
 //        map, "after-merge-" + merger->getName() + "-#" + StringUtils::formatLargeNumber(i + 1));
 //    }
   }
-  MemoryUsageChecker::getInstance()->check();
+  MemoryUsageChecker::getInstance().check();
   OsmMapWriterFactory::writeDebugMap(map, "after-merging");
 
   LOG_DEBUG(SystemInfo::getCurrentProcessMemoryUsageString());

--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressNormalizer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressNormalizer.cpp
@@ -45,7 +45,7 @@ _numNormalized(0)
 
 void AddressNormalizer::normalizeAddresses(const ElementPtr& e)
 {
-  const QSet<QString> addressTagKeys = AddressTagKeys::getInstance()->getAddressTagKeys(*e);
+  const QSet<QString> addressTagKeys = AddressTagKeys::getInstance().getAddressTagKeys(*e);
   LOG_VART(addressTagKeys);
   for (QSet<QString>::const_iterator addressTagKeyItr = addressTagKeys.begin();
        addressTagKeyItr != addressTagKeys.end(); ++addressTagKeyItr)

--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressNormalizer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressNormalizer.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "AddressNormalizer.h"

--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressParser.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressParser.cpp
@@ -286,8 +286,8 @@ bool AddressParser::_isParseableAddressFromComponents(const Tags& tags, QString&
                                                       QString& street) const
 {
   // we only require a valid street address...no other higher order parts, like city, state, etc.
-  houseNum = AddressTagKeys::getInstance()->getAddressTagValue(tags, "house_number");
-  street = AddressTagKeys::getInstance()->getAddressTagValue(tags, "street").toLower();
+  houseNum = AddressTagKeys::getInstance().getAddressTagValue(tags, "house_number");
+  street = AddressTagKeys::getInstance().getAddressTagValue(tags, "street").toLower();
   if (!houseNum.isEmpty() && !street.isEmpty())
   {
     LOG_TRACE("Found address from components: " << houseNum << ", " << street << ".");
@@ -393,14 +393,14 @@ QSet<QString> AddressParser::_parseAddressFromComponents(const Tags& tags, QStri
     {
       QString parsedAddress = houseNum + " ";
       const QString streetPrefix =
-        AddressTagKeys::getInstance()->getAddressTagValue(tags, "street_prefix");
+        AddressTagKeys::getInstance().getAddressTagValue(tags, "street_prefix");
       if (!streetPrefix.isEmpty())
       {
         parsedAddress += streetPrefix + " ";
       }
       parsedAddress += street;
       const QString streetSuffix =
-        AddressTagKeys::getInstance()->getAddressTagValue(tags, "street_suffix");
+        AddressTagKeys::getInstance().getAddressTagValue(tags, "street_suffix");
       if (!streetSuffix.isEmpty())
       {
         parsedAddress += " " + streetPrefix;
@@ -422,7 +422,7 @@ QString AddressParser::_parseAddressFromAltTags(const Tags& tags, QString& house
 
   //let's always look in the name field; arguably, we could look in all of them instead of just
   //one...
-  QSet<QString> additionalTagKeys = AddressTagKeys::getInstance()->getAdditionalTagKeys();
+  QSet<QString> additionalTagKeys = AddressTagKeys::getInstance().getAdditionalTagKeys();
   additionalTagKeys = additionalTagKeys.unite(QSet<QString>::fromList(tags.getNameKeys()));
   LOG_VART(additionalTagKeys);
 
@@ -450,7 +450,7 @@ QSet<QString> AddressParser::_parseAddresses(const Element& element, QString& ho
 
   // look for a full address tag first
   QString fullAddress =
-    AddressTagKeys::getInstance()->getAddressTagValue(element.getTags(), "full_address");
+    AddressTagKeys::getInstance().getAddressTagValue(element.getTags(), "full_address");
   LOG_VART(fullAddress);
   if (fullAddress.isEmpty())
   {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressParser.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressParser.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "AddressParser.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressTagKeys.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressTagKeys.cpp
@@ -35,8 +35,6 @@
 namespace hoot
 {
 
-AddressTagKeysPtr AddressTagKeys::_theInstance;
-
 AddressTagKeys::AddressTagKeys()
 {
   ConfigOptions config = ConfigOptions(conf());
@@ -45,13 +43,11 @@ AddressTagKeys::AddressTagKeys()
   LOG_VART(_additionalTagKeys);
 }
 
-const AddressTagKeysPtr& AddressTagKeys::getInstance()
+AddressTagKeys& AddressTagKeys::getInstance()
 {
-  if (_theInstance.get() == 0)
-  {
-    _theInstance.reset(new AddressTagKeys());
-  }
-  return _theInstance;
+  //  Local static singleton instance
+  static AddressTagKeys instance;
+  return instance;
 }
 
 void AddressTagKeys::_readAddressTagKeys(const QString& configFile)
@@ -114,19 +110,15 @@ QSet<QString> AddressTagKeys::getAddressTagKeys(const Element& element) const
 
 QString AddressTagKeys::getAddressTagKey(const Tags& tags, const QString& addressTagType) const
 {
-  const QStringList tagKeys = _addressTypeToTagKeys.values(addressTagType);
-  for (int i = 0; i < tagKeys.size(); i++)
-  {
-    const QString tagKey = tagKeys.at(i);
-    if (tags.contains(tagKey))
-    {
-      return tagKey;
-    }
-  }
-  return "";
+  return _getAddressTag(tags, addressTagType, true);
 }
 
 QString AddressTagKeys::getAddressTagValue(const Tags& tags, const QString& addressTagType) const
+{
+  return _getAddressTag(tags, addressTagType, false);
+}
+
+QString AddressTagKeys::_getAddressTag(const Tags& tags, const QString& addressTagType, bool key) const
 {
   const QStringList tagKeys = _addressTypeToTagKeys.values(addressTagType);
   for (int i = 0; i < tagKeys.size(); i++)
@@ -134,7 +126,10 @@ QString AddressTagKeys::getAddressTagValue(const Tags& tags, const QString& addr
     const QString tagKey = tagKeys.at(i);
     if (tags.contains(tagKey))
     {
-      return tags.get(tagKey);
+      if (key)
+        return tagKey;
+      else
+        return tags.get(tagKey);
     }
   }
   return "";

--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressTagKeys.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressTagKeys.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "AddressTagKeys.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressTagKeys.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressTagKeys.h
@@ -48,7 +48,7 @@ class AddressTagKeys
 {
 public:
 
-  static const AddressTagKeysPtr& getInstance();
+  static AddressTagKeys& getInstance();
 
   /**
    * Returns the tag keys of all address tags on an element
@@ -83,21 +83,27 @@ public:
 
 private:
 
-  AddressTagKeys();
+  /*
+   * Reads tag keys used to identify tags as addresses
+   */
+  void _readAddressTagKeys(const QString& configFile);
+
+  QString _getAddressTag(const Tags& tags, const QString& addressTagType, bool key) const;
 
   friend class AddressScoreExtractorTest;
-
-  static AddressTagKeysPtr _theInstance;
 
   //extra tags to search for addresses in
   QSet<QString> _additionalTagKeys;
   //maps address tag types to valid address tag keys
   QMultiMap<QString, QString> _addressTypeToTagKeys;
 
-  /*
-   * Reads tag keys used to identify tags as addresses
-   */
-  void _readAddressTagKeys(const QString& configFile);
+  AddressTagKeys();
+  /**  Default destructor */
+  ~AddressTagKeys() = default;
+  /** Delete copy constructor and assignment operator */
+  AddressTagKeys(const AddressTagKeys&) = delete;
+  AddressTagKeys& operator=(const AddressTagKeys&) = delete;
+
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressTagKeys.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressTagKeys.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef ADDRESS_TAG_KEYS_H
 #define ADDRESS_TAG_KEYS_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/LibPostalInit.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/LibPostalInit.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "LibPostalInit.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/LibPostalInit.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/LibPostalInit.cpp
@@ -36,8 +36,6 @@
 namespace hoot
 {
 
-LibPostalInitPtr LibPostalInit::_theInstance;
-
 LibPostalInit::LibPostalInit()
 {
   // This init takes ~5 seconds normally.
@@ -57,13 +55,11 @@ LibPostalInit::~LibPostalInit()
   libpostal_teardown_language_classifier();
 }
 
-const LibPostalInitPtr& LibPostalInit::getInstance()
+LibPostalInit& LibPostalInit::getInstance()
 {
-  if (_theInstance.get() == 0)
-  {
-    _theInstance.reset(new LibPostalInit());
-  }
-  return _theInstance;
+  //  Local static singleton instance
+  static LibPostalInit instance;
+  return instance;
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/LibPostalInit.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/LibPostalInit.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef LIB_POSTAL_INIT_H
 #define LIB_POSTAL_INIT_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/LibPostalInit.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/LibPostalInit.h
@@ -44,17 +44,18 @@ class LibPostalInit
 {
 public:
 
-  ~LibPostalInit();
-
-  static const LibPostalInitPtr& getInstance();
+  static LibPostalInit& getInstance();
 
 private:
 
-  LibPostalInit();
-
-  static LibPostalInitPtr _theInstance;
-
   QString _dataDir;
+
+  LibPostalInit();
+  ~LibPostalInit();
+  /** Delete copy constructor and assignment operator */
+  LibPostalInit(const LibPostalInit&) = delete;
+  LibPostalInit& operator=(const LibPostalInit&) = delete;
+
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
@@ -253,7 +253,7 @@ public:
     }
     if (_numElementsVisited % _memoryCheckUpdateInterval == 0)
     {
-      MemoryUsageChecker::getInstance()->check();
+      MemoryUsageChecker::getInstance().check();
     }
   }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonTagIgnoreListReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonTagIgnoreListReader.cpp
@@ -34,8 +34,6 @@
 namespace hoot
 {
 
-std::shared_ptr<PoiPolygonTagIgnoreListReader> PoiPolygonTagIgnoreListReader::_theInstance;
-
 PoiPolygonTagIgnoreListReader::PoiPolygonTagIgnoreListReader()
 {
   LOG_DEBUG("Reading ignore lists...");
@@ -49,11 +47,9 @@ PoiPolygonTagIgnoreListReader::PoiPolygonTagIgnoreListReader()
 
 PoiPolygonTagIgnoreListReader& PoiPolygonTagIgnoreListReader::getInstance()
 {
-  if (!_theInstance.get())
-  {
-    _theInstance.reset(new PoiPolygonTagIgnoreListReader());
-  }
-  return *_theInstance;
+  //  Local static singleton instance
+  static PoiPolygonTagIgnoreListReader instance;
+  return instance;
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonTagIgnoreListReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonTagIgnoreListReader.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "PoiPolygonTagIgnoreListReader.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonTagIgnoreListReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonTagIgnoreListReader.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef POIPOLYGONTAGIGNORELISTREADER_H
 #define POIPOLYGONTAGIGNORELISTREADER_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonTagIgnoreListReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonTagIgnoreListReader.h
@@ -49,8 +49,11 @@ public:
 private:
 
   PoiPolygonTagIgnoreListReader();
-
-  static std::shared_ptr<PoiPolygonTagIgnoreListReader> _theInstance;
+  /** Default destructor */
+  ~PoiPolygonTagIgnoreListReader() = default;
+  /** Delete copy constructor and assignment operator */
+  PoiPolygonTagIgnoreListReader(const PoiPolygonTagIgnoreListReader&) = delete;
+  PoiPolygonTagIgnoreListReader& operator=(const PoiPolygonTagIgnoreListReader&) = delete;
 
   QStringList _poiTagIgnoreList;
   QStringList _polyTagIgnoreList;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
@@ -235,7 +235,7 @@ public:
     }
     if (_numElementsVisited % _memoryCheckUpdateInterval == 0)
     {
-      MemoryUsageChecker::getInstance()->check();
+      MemoryUsageChecker::getInstance().check();
     }
   }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/Node.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Node.cpp
@@ -43,9 +43,6 @@ using namespace std;
 namespace hoot
 {
 
-template<class Node>
-SharedPtrPool<Node> SharedPtrPool<Node>::_theInstance;
-
 Node::Node(Status s, long id, const Coordinate& c, Meters circularError) :
 Element(s)
 {

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.cpp
@@ -44,8 +44,6 @@ using namespace std;
 namespace hoot
 {
 
-std::shared_ptr<OgrUtilities> OgrUtilities::_theInstance;
-
 void OgrUtilities::loadDriverInfo()
 {
   //  Load the extension-based driver info
@@ -106,9 +104,9 @@ OgrUtilities::~OgrUtilities()
 
 OgrUtilities& OgrUtilities::getInstance()
 {
-  if (!_theInstance.get())
-      _theInstance.reset(new OgrUtilities());
-  return *_theInstance;
+  //  Local static singleton instance
+  static OgrUtilities instance;
+  return instance;
 }
 
 QSet<QString> OgrUtilities::getSupportedFormats(const bool readOnly)

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "OgrUtilities.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.h
@@ -71,8 +71,6 @@ class OgrUtilities
 {
 public:
 
-  virtual ~OgrUtilities();
-
   static OgrUtilities& getInstance();
 
   /**
@@ -115,10 +113,12 @@ public:
 
 private:
 
-  /**
-   * Use getInstance() instead of the constructor.
-   */
+  /** Use getInstance() instead of the constructor */
   OgrUtilities();
+  ~OgrUtilities();
+  /** Delete copy constructor and assignment operator */
+  OgrUtilities(const OgrUtilities&) = delete;
+  OgrUtilities& operator=(const OgrUtilities&) = delete;
 
   /**
    * @brief loadDriverInfo Loads a hard-coded set of GDAL driver information with file
@@ -126,7 +126,6 @@ private:
    */
   void loadDriverInfo();
 
-  static std::shared_ptr<OgrUtilities> _theInstance;
   std::vector<OgrDriverInfo> _drivers;
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef OGRUTILITIES_H
 #define OGRUTILITIES_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmChangeWriterFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmChangeWriterFactory.cpp
@@ -36,19 +36,11 @@ using namespace std;
 namespace hoot
 {
 
-std::shared_ptr<OsmChangeWriterFactory> OsmChangeWriterFactory::_theInstance;
-
-OsmChangeWriterFactory::OsmChangeWriterFactory()
-{
-}
-
 OsmChangeWriterFactory& OsmChangeWriterFactory::getInstance()
 {
-  if (!_theInstance.get())
-  {
-    _theInstance.reset(new OsmChangeWriterFactory());
-  }
-  return *_theInstance;
+  //  Local static singleton instance
+  static OsmChangeWriterFactory instance;
+  return instance;
 }
 
 std::shared_ptr<OsmChangeWriter> OsmChangeWriterFactory::createWriter(

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmChangeWriterFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmChangeWriterFactory.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "OsmChangeWriterFactory.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmChangeWriterFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmChangeWriterFactory.h
@@ -69,9 +69,12 @@ public:
 
 private:
 
-  OsmChangeWriterFactory();
-
-  static std::shared_ptr<OsmChangeWriterFactory> _theInstance;
+  /** Default constructor/destructor */
+  OsmChangeWriterFactory() = default;
+  ~OsmChangeWriterFactory() = default;
+  /** Delete copy constructor and assignment operator */
+  OsmChangeWriterFactory(const OsmChangeWriterFactory&) = delete;
+  OsmChangeWriterFactory& operator=(const OsmChangeWriterFactory&) = delete;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmChangeWriterFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmChangeWriterFactory.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef OSMCHANGEWRITERFACTORY_H
 #define OSMCHANGEWRITERFACTORY_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetFileWriterFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetFileWriterFactory.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "OsmChangesetFileWriterFactory.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetFileWriterFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetFileWriterFactory.cpp
@@ -36,19 +36,11 @@
 namespace hoot
 {
 
-std::shared_ptr<OsmChangesetFileWriterFactory> OsmChangesetFileWriterFactory::_theInstance;
-
-OsmChangesetFileWriterFactory::OsmChangesetFileWriterFactory()
-{
-}
-
 OsmChangesetFileWriterFactory& OsmChangesetFileWriterFactory::getInstance()
 {
-  if (!_theInstance.get())
-  {
-    _theInstance.reset(new OsmChangesetFileWriterFactory());
-  }
-  return *_theInstance;
+  //  Local static singleton instance
+  static OsmChangesetFileWriterFactory instance;
+  return instance;
 }
 
 std::shared_ptr<OsmChangesetFileWriter> OsmChangesetFileWriterFactory::createWriter(

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetFileWriterFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetFileWriterFactory.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef OSM_CHANGESET_FILE_WRITER_FACTORY_H
 #define OSM_CHANGESET_FILE_WRITER_FACTORY_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetFileWriterFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetFileWriterFactory.h
@@ -63,9 +63,12 @@ public:
 
 private:
 
-  OsmChangesetFileWriterFactory();
-
-  static std::shared_ptr<OsmChangesetFileWriterFactory> _theInstance;
+  /** Default constructor/destructor */
+  OsmChangesetFileWriterFactory() = default;
+  ~OsmChangesetFileWriterFactory() = default;
+  /** Delete copy constructor and assignment operator */
+  OsmChangesetFileWriterFactory(const OsmChangesetFileWriterFactory&) = delete;
+  OsmChangesetFileWriterFactory& operator=(const OsmChangesetFileWriterFactory&) = delete;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/language/ToEnglishDictionaryTranslator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/language/ToEnglishDictionaryTranslator.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "ToEnglishDictionaryTranslator.h"

--- a/hoot-core/src/main/cpp/hoot/core/language/ToEnglishDictionaryTranslator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/language/ToEnglishDictionaryTranslator.cpp
@@ -271,7 +271,7 @@ QString ToEnglishDictionaryTranslator::transliterateToLatin(const QString& input
   return result;
 }
 
-QString ToEnglishDictionaryTranslator::_transform(Transliterator* t, const QString& input) const
+QString ToEnglishDictionaryTranslator::_transform(const shared_ptr<Transliterator>& t, const QString& input) const
 {
   UnicodeString str((UChar*)input.constData(), input.size());
 

--- a/hoot-core/src/main/cpp/hoot/core/language/ToEnglishDictionaryTranslator.h
+++ b/hoot-core/src/main/cpp/hoot/core/language/ToEnglishDictionaryTranslator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef TO_ENGLISH_DICTIONARY_TRANSLATOR_H

--- a/hoot-core/src/main/cpp/hoot/core/language/ToEnglishDictionaryTranslator.h
+++ b/hoot-core/src/main/cpp/hoot/core/language/ToEnglishDictionaryTranslator.h
@@ -107,7 +107,7 @@ private:
   static QSet<QString> _streetTypes;
   QRegExp _whiteSpace;
 
-  QString _transform(icu::Transliterator* t, const QString& input) const;
+  QString _transform(const std::shared_ptr<icu::Transliterator>& t, const QString& input) const;
 
   static void _readStreetTypes();
 };

--- a/hoot-core/src/main/cpp/hoot/core/language/ToEnglishTranslateDictionary.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/language/ToEnglishTranslateDictionary.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "ToEnglishTranslateDictionary.h"

--- a/hoot-core/src/main/cpp/hoot/core/language/ToEnglishTranslateDictionary.h
+++ b/hoot-core/src/main/cpp/hoot/core/language/ToEnglishTranslateDictionary.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef TO_ENGLISH_TRANSLATE_DICTIONARY_H

--- a/hoot-core/src/main/cpp/hoot/core/language/ToEnglishTranslateDictionary.h
+++ b/hoot-core/src/main/cpp/hoot/core/language/ToEnglishTranslateDictionary.h
@@ -51,16 +51,14 @@ class ToEnglishTranslateDictionary
 {
 public:
 
-  ~ToEnglishTranslateDictionary();
-
   static ToEnglishTranslateDictionary& getInstance();
 
   const QMap<QString, QStringList>& getTable() { return _translations; }
 
   void load(const QString& path);
 
-  Transliterator* getTransliterator() const { return _transliterator; }
-  Transliterator* getTitler() const { return _titler; }
+  std::shared_ptr<Transliterator> getTransliterator() const { return _transliterator; }
+  std::shared_ptr<Transliterator> getTitler() const { return _titler; }
 
   bool getFromTransliterationCache(const QString& originalText, QString& transliteratedText);
   void insertIntoTransliterationCache(const QString& originalText, const QString& transliteratedText);
@@ -69,17 +67,21 @@ public:
 
 private:
 
-  ToEnglishTranslateDictionary();
-
-  static std::shared_ptr<ToEnglishTranslateDictionary> _theInstance;
+  void _loadTags(boost::property_tree::ptree& tree);
 
   QMap<QString, QStringList> _translations;
   std::shared_ptr<Tgs::LruCache<QString, QString>> _transliterationCache;
-  Transliterator* _transliterator;
-  Transliterator* _titler;
+  std::shared_ptr<Transliterator> _transliterator;
+  std::shared_ptr<Transliterator> _titler;
   bool _transliterationCachingEnabled;
 
-  void _loadTags(boost::property_tree::ptree& tree);
+  ToEnglishTranslateDictionary();
+  /** Default destructor */
+  ~ToEnglishTranslateDictionary() = default;
+  /** Delete copy constructor and assignment operator */
+  ToEnglishTranslateDictionary(const ToEnglishTranslateDictionary&) = delete;
+  ToEnglishTranslateDictionary& operator=(const ToEnglishTranslateDictionary&) = delete;
+
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/ops/DuplicateWayRemover.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/DuplicateWayRemover.cpp
@@ -134,7 +134,8 @@ void DuplicateWayRemover::apply(OsmMapPtr& map)
           if (_strictTagMatching)
           {
             nonNameTagsIdentical =
-              TagComparator::getInstance().nonNameTagsExactlyMatch(w->getTags(), w2->getTags());
+              TagComparator::getInstance().nonNameTagsExactlyMatch(w->getTags(), w2->getTags(),
+                                                                   ConfigOptions().getDuplicateNameCaseSensitive());
           }
 
           if (nonNameTagsIdentical || !_strictTagMatching)

--- a/hoot-core/src/main/cpp/hoot/core/ops/NamedOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/NamedOp.cpp
@@ -152,7 +152,7 @@ void NamedOp::apply(OsmMapPtr& map)
       throw HootException("Unexpected operation: " + s);
     }
 
-    MemoryUsageChecker::getInstance()->check();
+    MemoryUsageChecker::getInstance().check();
 
     LOG_DEBUG(
       "\tElement count after operation " << s << ": " <<

--- a/hoot-core/src/main/cpp/hoot/core/schema/AverageTagMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/AverageTagMerger.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "AverageTagMerger.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/AverageTagMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/AverageTagMerger.cpp
@@ -42,7 +42,7 @@ AverageTagMerger::AverageTagMerger()
 Tags AverageTagMerger::mergeTags(const Tags& t1, const Tags& t2, ElementType /*et*/) const
 {
   Tags result;
-  TagComparator::getInstance().averageTags(t1, 1.0, t2, 1.0, result, false);
+  TagComparator::getInstance().averageTags(t1, 1.0, t2, 1.0, result, false, _caseSensitive);
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/BuildingRelationMemberTagMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/BuildingRelationMemberTagMerger.cpp
@@ -78,7 +78,8 @@ Tags BuildingRelationMemberTagMerger::mergeTags(
   Tags constituentBuildingTagsCopy = constituentBuildingTags;
 
   Tags names;
-  TagComparator::getInstance().mergeNames(relationTagsCopy, constituentBuildingTagsCopy, names);
+  TagComparator::getInstance().mergeNames(relationTagsCopy, constituentBuildingTagsCopy, names,
+                                          QStringList(), _caseSensitive);
   mergedTags.set(names);
   LOG_VART(mergedTags);
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/GeneralizeTagMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/GeneralizeTagMerger.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "GeneralizeTagMerger.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/GeneralizeTagMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/GeneralizeTagMerger.cpp
@@ -41,7 +41,7 @@ GeneralizeTagMerger::GeneralizeTagMerger()
 
 Tags GeneralizeTagMerger::mergeTags(const Tags& t1, const Tags& t2, ElementType /*et*/) const
 {
-  return TagComparator::getInstance().generalize(t1, t2);
+  return TagComparator::getInstance().generalize(t1, t2, false, _caseSensitive);
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchemaLoaderFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchemaLoaderFactory.cpp
@@ -36,16 +36,11 @@ using namespace std;
 namespace hoot
 {
 
-std::shared_ptr<OsmSchemaLoaderFactory> OsmSchemaLoaderFactory::_theInstance;
-
 OsmSchemaLoaderFactory& OsmSchemaLoaderFactory::getInstance()
 {
-  if (_theInstance.get() == 0)
-  {
-    _theInstance.reset(new OsmSchemaLoaderFactory());
-  }
-
-  return *_theInstance;
+  //  Local static singleton instance
+  static OsmSchemaLoaderFactory instance;
+  return instance;
 }
 
 std::shared_ptr<OsmSchemaLoader> OsmSchemaLoaderFactory::createLoader(QString url)

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchemaLoaderFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchemaLoaderFactory.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "OsmSchemaLoaderFactory.h"

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchemaLoaderFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchemaLoaderFactory.h
@@ -50,9 +50,12 @@ public:
 
 private:
 
-  OsmSchemaLoaderFactory() {}
-
-  static std::shared_ptr<OsmSchemaLoaderFactory> _theInstance;
+  /** Default constructor/destructor */
+  OsmSchemaLoaderFactory() = default;
+  ~OsmSchemaLoaderFactory() = default;
+  /** Delete copy constructor and assignment operator */
+  OsmSchemaLoaderFactory(const OsmSchemaLoaderFactory&) = delete;
+  OsmSchemaLoaderFactory& operator=(const OsmSchemaLoaderFactory&) = delete;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchemaLoaderFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchemaLoaderFactory.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef OSMSCHEMALOADERFACTORY_H
 #define OSMSCHEMALOADERFACTORY_H

--- a/hoot-core/src/main/cpp/hoot/core/schema/OverwriteTagMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OverwriteTagMerger.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "OverwriteTagMerger.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/OverwriteTagMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OverwriteTagMerger.cpp
@@ -46,16 +46,17 @@ Tags OverwriteTagMerger::mergeTags(const Tags& t1, const Tags& t2, ElementType /
 {
   if (_swap)
   {
-    return TagComparator::getInstance().overwriteMerge(t2, t1, _overwriteExcludeTagKeys);
+    return TagComparator::getInstance().overwriteMerge(t2, t1, _overwriteExcludeTagKeys, _caseSensitive);
   }
   else
   {
-    return TagComparator::getInstance().overwriteMerge(t1, t2, _overwriteExcludeTagKeys);
+    return TagComparator::getInstance().overwriteMerge(t1, t2, _overwriteExcludeTagKeys, _caseSensitive);
   }
 }
 
 void OverwriteTagMerger::setConfiguration(const Settings& conf)
 {
+  TagMerger::setConfiguration(conf);
   ConfigOptions config = ConfigOptions(conf);
   setOverwriteExcludeTagKeys(config.getTagMergerOverwriteExclude());
 }

--- a/hoot-core/src/main/cpp/hoot/core/schema/OverwriteTagMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OverwriteTagMerger.h
@@ -29,7 +29,6 @@
 
 // Hoot
 #include <hoot/core/schema/TagMerger.h>
-#include <hoot/core/util/Configurable.h>
 
 namespace hoot
 {
@@ -38,7 +37,7 @@ namespace hoot
  * Combine all names in a fashion where no unique names will be lost and then favor t1 tags over
  * t2 tags. See TagComparator::overwriteMerge.
  */
-class OverwriteTagMerger : public TagMerger, public Configurable
+class OverwriteTagMerger : public TagMerger
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/PreserveTypesTagMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/PreserveTypesTagMerger.cpp
@@ -54,6 +54,7 @@ _skipTagKeys(skipTagKeys)
 
 void PreserveTypesTagMerger::setConfiguration(const Settings& conf)
 {
+  TagMerger::setConfiguration(conf);
   ConfigOptions config = ConfigOptions(conf);
   setOverwriteExcludeTagKeys(config.getTagMergerOverwriteExclude());
 }
@@ -79,10 +80,10 @@ Tags PreserveTypesTagMerger::mergeTags(const Tags& t1, const Tags& t2, ElementTy
 
   // handle name and text tags in the standard overwrite merge fashion
   //const QStringList excludeKeysAsList = QStringList::fromSet(_skipTagKeys);
-  TagComparator::getInstance().mergeNames(
-    tagsToOverwriteWith, tagsToBeOverwritten, result, _overwriteExcludeTagKeys);
-  TagComparator::getInstance().mergeText(
-    tagsToOverwriteWith, tagsToBeOverwritten, result, _overwriteExcludeTagKeys);
+  TagComparator::getInstance().mergeNames(tagsToOverwriteWith, tagsToBeOverwritten, result,
+                                          _overwriteExcludeTagKeys, _caseSensitive);
+  TagComparator::getInstance().mergeText(tagsToOverwriteWith, tagsToBeOverwritten, result,
+                                         _overwriteExcludeTagKeys, _caseSensitive);
   LOG_TRACE("Tags after name/text merging: " << result);
 
   // retain any previously set alt_types

--- a/hoot-core/src/main/cpp/hoot/core/schema/PreserveTypesTagMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/PreserveTypesTagMerger.h
@@ -29,7 +29,6 @@
 
 #include <hoot/core/schema/TagMerger.h>
 #include <hoot/core/schema/OsmSchema.h>
-#include <hoot/core/util/Configurable.h>
 
 namespace hoot
 {
@@ -40,7 +39,7 @@ namespace hoot
  * key are encountered. In the case where duplicated types have the same level of specificity, the
  * duplicated types are arbitrarily placed in an "alt_types" tag.
  */
-class PreserveTypesTagMerger : public TagMerger, public Configurable
+class PreserveTypesTagMerger : public TagMerger
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/ReplaceTagMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/ReplaceTagMerger.cpp
@@ -46,16 +46,17 @@ Tags ReplaceTagMerger::mergeTags(const Tags& t1, const Tags& t2, ElementType /*e
 {
   if (_swap)
   {
-    return TagComparator::getInstance().replaceMerge(t2, t1, _overwriteExcludeTagKeys);
+    return TagComparator::getInstance().replaceMerge(t2, t1, _overwriteExcludeTagKeys, _caseSensitive);
   }
   else
   {
-    return TagComparator::getInstance().replaceMerge(t1, t2, _overwriteExcludeTagKeys);
+    return TagComparator::getInstance().replaceMerge(t1, t2, _overwriteExcludeTagKeys, _caseSensitive);
   }
 }
 
 void ReplaceTagMerger::setConfiguration(const Settings& conf)
 {
+  TagMerger::setConfiguration(conf);
   ConfigOptions config = ConfigOptions(conf);
   setOverwriteExcludeTagKeys(config.getTagMergerOverwriteExclude());
 }

--- a/hoot-core/src/main/cpp/hoot/core/schema/ReplaceTagMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/ReplaceTagMerger.h
@@ -29,7 +29,6 @@
 
 // Hoot
 #include <hoot/core/schema/TagMerger.h>
-#include <hoot/core/util/Configurable.h>
 
 namespace hoot
 {
@@ -37,7 +36,7 @@ namespace hoot
 /**
  * Completely replaces tags in a feature
  */
-class ReplaceTagMerger : public TagMerger, public Configurable
+class ReplaceTagMerger : public TagMerger
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/ScriptSchemaTranslatorFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/ScriptSchemaTranslatorFactory.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "ScriptSchemaTranslatorFactory.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/ScriptSchemaTranslatorFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/ScriptSchemaTranslatorFactory.cpp
@@ -37,19 +37,11 @@ using namespace std;
 namespace hoot
 {
 
-std::shared_ptr<ScriptSchemaTranslatorFactory> ScriptSchemaTranslatorFactory::_theInstance;
-
-ScriptSchemaTranslatorFactory::ScriptSchemaTranslatorFactory()
-{
-}
-
 ScriptSchemaTranslatorFactory& ScriptSchemaTranslatorFactory::getInstance()
 {
-  if (!_theInstance.get())
-  {
-    _theInstance.reset(new ScriptSchemaTranslatorFactory());
-  }
-  return *_theInstance;
+  //  Local static singleton instance
+  static ScriptSchemaTranslatorFactory instance;
+  return instance;
 }
 
 bool CompareSt(ScriptSchemaTranslator* st1, ScriptSchemaTranslator* st2)

--- a/hoot-core/src/main/cpp/hoot/core/schema/ScriptSchemaTranslatorFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/ScriptSchemaTranslatorFactory.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef SCRIPT_SCHEMA_TRANSLATOR_FACTORY_H
 #define SCRIPT_SCHEMA_TRANSLATOR_FACTORY_H

--- a/hoot-core/src/main/cpp/hoot/core/schema/ScriptSchemaTranslatorFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/ScriptSchemaTranslatorFactory.h
@@ -58,13 +58,16 @@ public:
 
 private:
 
-  static std::shared_ptr<ScriptSchemaTranslatorFactory> _theInstance;
-
-  ScriptSchemaTranslatorFactory();
+  void _init();
 
   std::vector<std::string> _translators;
 
-  void _init();
+  /** Default constructor/destructor */
+  ScriptSchemaTranslatorFactory() = default;
+  ~ScriptSchemaTranslatorFactory() = default;
+  /** Delete copy constructor and assignment operator */
+  ScriptSchemaTranslatorFactory(const ScriptSchemaTranslatorFactory&) = delete;
+  ScriptSchemaTranslatorFactory& operator=(const ScriptSchemaTranslatorFactory&) = delete;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagComparator.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagComparator.h
@@ -52,14 +52,14 @@ public:
    * @param keepAllUnknownTags If this is set to true then all unknown tags will simply be
    *  concatenated using Tag lists.
    */
-  void averageTags(const Tags& t1, const Tags& t2, Tags& result, bool keepAllUnknownTags = false);
+  void averageTags(const Tags& t1, const Tags& t2, Tags& result, bool keepAllUnknownTags = false, bool caseSensitive = true);
 
   /**
    * @param keepAllUnknownTags If this is set to true then all unknown tags will simply be
    *  concatenated using Tag lists.
    */
   void averageTags(const Tags& t1, double w1, const Tags& t2, double w2, Tags& result,
-    bool keepAllUnknownTags = false);
+    bool keepAllUnknownTags = false, bool caseSensitive = true);
 
   void compareEnumeratedTags(Tags t1, Tags t2, double& score, double& weight);
 
@@ -81,7 +81,7 @@ public:
    * - Tags that share an ancestor are promoted to the first common ancestor
    * - If there are no conflicting tags the tag is kept
    */
-  Tags generalize(Tags t1, Tags t2, bool overwriteUnrecognizedTags = false);
+  Tags generalize(Tags t1, Tags t2, bool overwriteUnrecognizedTags = false, bool caseSensitive = true);
 
   static TagComparator& getInstance();
 
@@ -94,9 +94,11 @@ public:
    * @param t2 These names/tags get demoted to alt_name
    * @param result Tags w/names merged
    * @param overwriteExcludeTagKeys keys of tags which should not be overwritten in t2
+   * @param caseSensitive True for case sensitive merge names
    */
   void mergeNames(Tags& t1, Tags& t2, Tags& result,
-                  const QStringList& overwriteExcludeTagKeys = QStringList());
+                  const QStringList& overwriteExcludeTagKeys = QStringList(),
+                  bool caseSensitive = true);
 
   /**
    * Keep all names. If there is a conflict in tags between t1 and t2 then use the value in t1.
@@ -104,9 +106,10 @@ public:
    * @param t1 tags to keep
    * @param t2 tags to be overwritten
    * @param overwriteExcludeTagKeys optional keys of tags to exclude being overwritten in t2
+   * @param caseSensitive True for case sensitive merge names
    * @return merged tags
    */
-  Tags overwriteMerge(Tags t1, Tags t2, const QStringList& overwriteExcludeTagKeys = QStringList());
+  Tags overwriteMerge(Tags t1, Tags t2, const QStringList& overwriteExcludeTagKeys = QStringList(), bool caseSensitive = true);
 
   /**
    * Replace all tags in t2 with those from t1
@@ -114,10 +117,11 @@ public:
    * @param t1 Tags that replace
    * @param t2 Tags that are replaced
    * @param overwriteExcludeTagKeys keys of tags which should not be overwritten in t2
+   * @param caseSensitive True for case sensitive merge names
    * @return merged tags
    */
   Tags replaceMerge(const Tags& t1, const Tags& t2,
-                    const QStringList& overwriteExcludeTagKeys = QStringList());
+                    const QStringList& overwriteExcludeTagKeys = QStringList(), bool caseSensitive = true);
 
   /**
    * Determines whether two tag sets have identical non-name, non-metadata tags.  Case sensitivity
@@ -125,10 +129,11 @@ public:
    *
    * @param t1 first set of tags to compare
    * @param t2 second set of tags to compare
+   * @param caseSensitive True for case sensitive merge names
    * @return true if both tag sets have identical non-name, non-metadata contents (excluding
    * ordering); false otherwise
    */
-  bool nonNameTagsExactlyMatch(const Tags& t1, const Tags& t2);
+  bool nonNameTagsExactlyMatch(const Tags& t1, const Tags& t2, bool caseSensitive = true);
 
   /**
    * Merge tags of type text
@@ -137,19 +142,12 @@ public:
    * @param t2 second set of tags to merge
    * @param result merged tags
    * @param overwriteExcludeTagKeys keys of tags which should not be overwritten in t2
+   * @param caseSensitive True for case sensitive merge names
    */
   void mergeText(Tags& t1, Tags& t2, Tags& result,
-                 const QStringList& overwriteExcludeTagKeys = QStringList());
-
-  void setCaseSensitive(bool caseSensitive) { _caseSensitive = caseSensitive; }
+                 const QStringList& overwriteExcludeTagKeys = QStringList(), bool caseSensitive = true);
 
 private:
-
-  bool _caseSensitive;
-
-  static std::shared_ptr<TagComparator> _theInstance;
-
-  TagComparator();
 
   void _addDefaults(Tags& t);
 
@@ -178,7 +176,7 @@ private:
    * overwrite the t2 values. t1 & t2 will be cleared when this is done.
    */
   void _overwriteRemainingTags(Tags& t1, Tags& t2, Tags& result,
-                               const QStringList& overwriteExcludeTagKeys = QStringList());
+                               const QStringList& overwriteExcludeTagKeys = QStringList(), bool caseSensitive = true);
 
   void _overwriteUnrecognizedTags(Tags& t1, Tags& t2, Tags& result);
 
@@ -189,6 +187,13 @@ private:
   void _promoteToCommonAncestor(Tags& t1, Tags& t2, Tags& result);
 
   QSet<QString> _toSet(const Tags& t, const QString& k);
+
+  /** Default constructor/destructor */
+  TagComparator() = default;
+  ~TagComparator() = default;
+  /** Delete copy constructor and assignment operator */
+  TagComparator(const TagComparator&) = delete;
+  TagComparator& operator=(const TagComparator&) = delete;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagMerger.h
@@ -31,6 +31,8 @@
 #include <hoot/core/elements/ElementType.h>
 #include <hoot/core/elements/Tags.h>
 #include <hoot/core/info/ApiEntityInfo.h>
+#include <hoot/core/util/Configurable.h>
+#include <hoot/core/util/ConfigOptions.h>
 
 namespace hoot
 {
@@ -39,13 +41,13 @@ namespace hoot
  * Interface for merging two sets of tags into one set of tags. This is most useful when conflating
  * two different features into a single feature.
  */
-class TagMerger : public ApiEntityInfo
+class TagMerger : public ApiEntityInfo, public Configurable
 {
 public:
 
   static std::string className() { return "hoot::TagMerger"; }
 
-  TagMerger() {}
+  TagMerger() : _caseSensitive(ConfigOptions().getDuplicateNameCaseSensitive()) {}
   virtual ~TagMerger() {}
 
   /**
@@ -59,6 +61,16 @@ public:
   virtual Tags mergeTags(const Tags& t1, const Tags& t2, ElementType et) const = 0;
 
   virtual QString getClassName() const  = 0;
+
+  void setConfiguration(const Settings& conf) override
+  {
+    _caseSensitive = ConfigOptions(conf).getDuplicateNameCaseSensitive();
+  }
+
+protected:
+
+  bool _caseSensitive;
+
 };
 
 typedef std::shared_ptr<TagMerger> TagMergerPtr;

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagMergerFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagMergerFactory.cpp
@@ -35,24 +35,11 @@
 namespace hoot
 {
 
-std::shared_ptr<TagMergerFactory> TagMergerFactory::_theInstance;
-
-TagMergerFactory::TagMergerFactory()
-{
-}
-
-TagMergerFactory::~TagMergerFactory()
-{
-  reset();
-}
-
 TagMergerFactory& TagMergerFactory::getInstance()
 {
-  if (!_theInstance.get())
-  {
-    _theInstance.reset(new TagMergerFactory());
-  }
-  return *_theInstance;
+  //  Local static singleton instance
+  static TagMergerFactory instance;
+  return instance;
 }
 
 std::shared_ptr<TagMerger> TagMergerFactory::getDefaultPtr()

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagMergerFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagMergerFactory.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "TagMergerFactory.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagMergerFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagMergerFactory.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef TAGMERGERFACTORY_H
 #define TAGMERGERFACTORY_H

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagMergerFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagMergerFactory.h
@@ -48,8 +48,6 @@ class TagMergerFactory
 {
 public:
 
-  ~TagMergerFactory();
-
   static TagMergerFactory& getInstance();
 
   /**
@@ -76,12 +74,15 @@ public:
 
 private:
 
-  TagMergerFactory();
-
   QHash<QString, std::shared_ptr<TagMerger>> _mergers;
   std::shared_ptr<TagMerger> _default;
 
-  static std::shared_ptr<TagMergerFactory> _theInstance;
+  /** Default constructor/destructor */
+  TagMergerFactory() = default;
+  ~TagMergerFactory() = default;
+  /** Delete copy constructor and assignment operator */
+  TagMergerFactory(const TagMergerFactory&) = delete;
+  TagMergerFactory& operator=(const TagMergerFactory&) = delete;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/util/Factory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/Factory.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "Factory.h"

--- a/hoot-core/src/main/cpp/hoot/core/util/Factory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/Factory.cpp
@@ -39,16 +39,6 @@ using namespace std;
 namespace hoot
 {
 
-Factory* Factory::_theInstance = NULL;
-
-Factory::Factory()
-{
-}
-
-Factory::~Factory()
-{
-}
-
 boost::any Factory::constructObject(const std::string& name)
 {
   QMutexLocker locker(&_mutex);
@@ -64,11 +54,9 @@ boost::any Factory::constructObject(const std::string& name)
 
 Factory& Factory::getInstance()
 {
-  if (_theInstance == NULL)
-  {
-    _theInstance = new Factory();
-  }
-  return *_theInstance;
+  //  Local static singleton instance
+  static Factory instance;
+  return instance;
 }
 
 vector<std::string> Factory::getObjectNamesByBase(const std::string& baseName)

--- a/hoot-core/src/main/cpp/hoot/core/util/Factory.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Factory.h
@@ -102,8 +102,6 @@ class Factory
 {
 public:
 
-  virtual ~Factory();
-
   static Factory& getInstance();
 
   /**
@@ -175,13 +173,16 @@ public:
 
 private:
 
-  Factory();
-
-  static Factory* _theInstance;
-
   QMutex _mutex;
 
   std::map<std::string, std::shared_ptr<ObjectCreator>> _creators;
+
+  /** Default constructor/destructor */
+  Factory() = default;
+  ~Factory() = default;
+  /** Delete copy constructor and assignment operator */
+  Factory(const Factory&) = delete;
+  Factory& operator=(const Factory&) = delete;
 };
 
 template<class Base, class T>

--- a/hoot-core/src/main/cpp/hoot/core/util/Factory.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Factory.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef _HOOT_FACTORY_H

--- a/hoot-core/src/main/cpp/hoot/core/util/HootException.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/HootException.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "HootException.h"

--- a/hoot-core/src/main/cpp/hoot/core/util/HootException.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/HootException.cpp
@@ -42,15 +42,11 @@ HOOT_REGISTER_EXCEPTION(NeedsReviewException)
 HOOT_REGISTER_EXCEPTION(UnsupportedException)
 HOOT_REGISTER_EXCEPTION(NotImplementedException)
 
-HootExceptionThrower* HootExceptionThrower::_theInstance = 0;
-
 HootExceptionThrower& HootExceptionThrower::getInstance()
 {
-  if (_theInstance == 0)
-  {
-    _theInstance = new HootExceptionThrower();
-  }
-  return *_theInstance;
+  //  Local static singleton instance
+  static HootExceptionThrower instance;
+  return instance;
 }
 
 void HootExceptionThrower::rethrowPointer(HootException* e)

--- a/hoot-core/src/main/cpp/hoot/core/util/HootException.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/HootException.h
@@ -101,8 +101,6 @@ class HootExceptionThrower
 {
 public:
 
-  HootExceptionThrower() {}
-
   typedef void (*ThrowMethod)(HootException* e);
 
   static HootExceptionThrower& getInstance();
@@ -122,7 +120,13 @@ public:
 private:
 
   QVector<ThrowMethod> _throwMethods;
-  static HootExceptionThrower* _theInstance;
+
+  /** Default constructor/destructor */
+  HootExceptionThrower() = default;
+  ~HootExceptionThrower() = default;
+  /** Delete copy constructor and assignment operator */
+  HootExceptionThrower(const HootExceptionThrower&) = delete;
+  HootExceptionThrower& operator=(const HootExceptionThrower&) = delete;
 };
 
 #define HOOT_REGISTER_EXCEPTION(ClassName)      \

--- a/hoot-core/src/main/cpp/hoot/core/util/HootException.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/HootException.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef HOOTEXCEPTION_H

--- a/hoot-core/src/main/cpp/hoot/core/util/Log.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/Log.cpp
@@ -47,29 +47,24 @@ namespace hoot
 QString Log::LOG_WARN_LIMIT_REACHED_MESSAGE = "Reached the maximum number of allowed warning messages for this class set by the setting log.warn.message.limit.  Silencing additional warning messages for this class...";
 int Log::_warnMessageLimit = 0;
 
-std::shared_ptr<Log> Log::_theInstance = NULL;
+Log& Log::getInstance()
+{
+  //  Local static singleton instance
+  static Log instance;
+  return instance;
+}
 
 void myLoggerFunction(QtMsgType type, const QMessageLogContext& context, const QString& msg)
 {
   Log::WarningLevel l = Log::Fatal;
   switch(type)
   {
-  case QtDebugMsg:
-    l = Log::Debug;
-    break;
-  case QtWarningMsg:
-    l = Log::Warn;
-    break;
-  case QtCriticalMsg:
-    l = Log::Error;
-    break;
-  case QtFatalMsg:
-    l = Log::Fatal;
-    break;
-  case QtInfoMsg:
-    l = Log::Info;
+  case QtDebugMsg:      l = Log::Debug;   break;
+  case QtWarningMsg:    l = Log::Warn;    break;
+  case QtCriticalMsg:   l = Log::Error;   break;
+  case QtFatalMsg:      l = Log::Fatal;   break;
+  case QtInfoMsg:       l = Log::Info;    break;
   }
-
   Log::getInstance().log(l, msg, context.file, context.function, context.line);
 }
 
@@ -78,31 +73,21 @@ static void cplErrorHandler(CPLErr eErrClass, int err_no, const char *msg)
   Log::WarningLevel l = Log::Fatal;
   switch (eErrClass)
   {
-  case CE_None:
-    l = Log::None;
-    break;
-  case CE_Debug:
-    l = Log::Debug;
-    break;
-  case CE_Warning:
-    l = Log::Warn;
-    break;
-  case CE_Failure:
-    l = Log::Error;
-    break;
-  case CE_Fatal:
-    l = Log::Fatal;
-    break;
+  case CE_None:         l = Log::None;    break;
+  case CE_Debug:        l = Log::Debug;   break;
+  case CE_Warning:      l = Log::Warn;    break;
+  case CE_Failure:      l = Log::Error;   break;
+  case CE_Fatal:        l = Log::Fatal;   break;
   }
-
   stringstream ss;
   ss << "CPL Error #: " << err_no << " " << msg;
   Log::getInstance().log(l, ss.str());
 }
 
 Log::Log()
+  : _level(Log::Info),
+    _classFilterInitialized(false)
 {
-  _level = Log::Info;
   qInstallMessageHandler(myLoggerFunction);
   CPLSetErrorHandler(cplErrorHandler);
 }
@@ -110,9 +95,7 @@ Log::Log()
 int Log::getWarnMessageLimit()
 {
   if (_warnMessageLimit == 0)
-  {
     _warnMessageLimit = ConfigOptions().getLogWarnMessageLimit();
-  }
   return _warnMessageLimit;
 }
 
@@ -120,63 +103,38 @@ Log::WarningLevel Log::levelFromString(QString l)
 {
   l = l.toLower();
   if (l == "none")
-  {
     return None;
-  }
-  if (l == "trace")
-  {
+  else if (l == "trace")
     return Trace;
-  }
-  if (l == "debug")
-  {
+  else if (l == "debug")
     return Debug;
-  }
-  if (l == "info")
-  {
+  else if (l == "info")
     return Info;
-  }
-  if (l == "status")
-  {
+  else if (l == "status")
     return Status;
-  }
-  if (l == "warn")
-  {
+  else if (l == "warn")
     return Warn;
-  }
-  if (l == "error")
-  {
+  else if (l == "error")
     return Error;
-  }
-  if (l == "fatal")
-  {
+  else if (l == "fatal")
     return Fatal;
-  }
-
-  throw IllegalArgumentException("Unexpected log level string: " + l);
+  else
+    throw IllegalArgumentException("Unexpected log level string: " + l);
 }
 
 QString Log::levelToString(WarningLevel l)
 {
   switch(l)
   {
-  case None:
-    return "NONE";
-  case Trace:
-    return "TRACE";
-  case Debug:
-    return "DEBUG";
-  case Info:
-    return "INFO";
-  case Status:
-    return "STATUS";
-  case Warn:
-    return "WARN";
-  case Error:
-    return "ERROR";
-  case Fatal:
-    return "FATAL";
-  default:
-    return "UNK";
+  case None:      return "NONE";
+  case Trace:     return "TRACE";
+  case Debug:     return "DEBUG";
+  case Info:      return "INFO";
+  case Status:    return "STATUS";
+  case Warn:      return "WARN";
+  case Error:     return "ERROR";
+  case Fatal:     return "FATAL";
+  default:        return "UNK";
   }
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/util/Log.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/Log.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "Log.h"

--- a/hoot-core/src/main/cpp/hoot/core/util/Log.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Log.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef LOG_H

--- a/hoot-core/src/main/cpp/hoot/core/util/Log.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Log.h
@@ -98,16 +98,7 @@ public:
     Fatal = 5000
   };
 
-  static Log& getInstance()
-  {
-    if (_theInstance == NULL)
-    {
-      _theInstance.reset(new Log());
-      _theInstance->init();
-      _theInstance->setLevel(_theInstance->_level);
-    }
-    return *_theInstance;
-  }
+  static Log& getInstance();
 
   WarningLevel getLevel() const { return _level; }
 
@@ -145,14 +136,19 @@ public:
 
 private:
 
+  bool notFiltered(const std::string& prettyFunction);
+
   WarningLevel _level;
-  static std::shared_ptr<Log> _theInstance;
   static int _warnMessageLimit;
-  bool _classFilterInitialized = false;
+  bool _classFilterInitialized;
   QStringList _classFilter;
 
   Log();
-  bool notFiltered(const std::string& prettyFunction);
+  /** Default destructor */
+  ~Log() = default;
+  /** Delete copy constructor and assignment operator */
+  Log(const Log&) = delete;
+  Log& operator=(const Log&) = delete;
 };
 
 /**

--- a/hoot-core/src/main/cpp/hoot/core/util/MapProjector.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/MapProjector.cpp
@@ -53,8 +53,6 @@ namespace hoot
 
 int MapProjector::logWarnCount = 0;
 
-std::shared_ptr<MapProjector> MapProjector::_theInstance;
-
 class DisableCplErrors
 {
 public:
@@ -113,11 +111,9 @@ void ReprojectCoordinateFilter::project(Coordinate* c) const
 
 MapProjector& MapProjector::getInstance()
 {
-  if (!_theInstance.get())
-  {
-    _theInstance.reset(new MapProjector());
-  }
-  return *_theInstance;
+  //  Local static singleton instance
+  static MapProjector instance;
+  return instance;
 }
 
 bool MapProjector::_angleLessThan(const MapProjector::PlanarTestResult& p1,

--- a/hoot-core/src/main/cpp/hoot/core/util/MapProjector.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/MapProjector.h
@@ -173,8 +173,6 @@ private:
     double score;
   };
 
-  MapProjector() {}
-
   static std::shared_ptr<MapProjector> _theInstance;
 
   static bool _angleLessThan(const PlanarTestResult& p1, const PlanarTestResult& p2);
@@ -192,6 +190,13 @@ private:
   size_t _findBestScore(std::vector<PlanarTestResult>& results);
 
   static bool _scoreLessThan(const PlanarTestResult& p1, const PlanarTestResult& p2);
+
+  /** Default constructor/destructor */
+  MapProjector() = default;
+  ~MapProjector() = default;
+  /** Delete copy constructor and assignment operator */
+  MapProjector(const MapProjector&) = delete;
+  MapProjector& operator=(const MapProjector&) = delete;
 };
 
 class ReprojectCoordinateFilter : public geos::geom::CoordinateFilter

--- a/hoot-core/src/main/cpp/hoot/core/util/MapProjector.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/MapProjector.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef __MAP_PROJECTOR_H__
 #define __MAP_PROJECTOR_H__

--- a/hoot-core/src/main/cpp/hoot/core/util/MemoryUsageChecker.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/MemoryUsageChecker.h
@@ -28,15 +28,8 @@
 #ifndef MEMORY_USAGE_CHECKER_H
 #define MEMORY_USAGE_CHECKER_H
 
-// Hoot
-#include <hoot/core/util/Configurable.h>
-
 namespace hoot
 {
-
-class MemoryUsageChecker;
-
-typedef std::shared_ptr<MemoryUsageChecker> MemoryUsageCheckerPtr;
 
 /**
  * Utility for checking available memory (Singleton)
@@ -49,17 +42,12 @@ typedef std::shared_ptr<MemoryUsageChecker> MemoryUsageCheckerPtr;
  * logged based on what percentage the process memory is of that value instead of the total
  * available.
  */
-class MemoryUsageChecker : public Configurable
+class MemoryUsageChecker
 {
 
 public:
 
-  static const MemoryUsageCheckerPtr& getInstance();
-
-  /**
-   * @see Configurable
-   */
-  void setConfiguration(const Settings& conf);
+  static MemoryUsageChecker& getInstance();
 
   /**
    * Checks the available physical and virtual memory and logs a single message when it drops below
@@ -70,8 +58,11 @@ public:
 private:
 
   MemoryUsageChecker();
-
-  static MemoryUsageCheckerPtr _theInstance;
+  /** Default constructor/destructor */
+  ~MemoryUsageChecker() = default;
+  /** Delete copy constructor and assignment operator */
+  MemoryUsageChecker(const MemoryUsageChecker&) = delete;
+  MemoryUsageChecker& operator=(const MemoryUsageChecker&) = delete;
 
   bool _enabled;
   // memory usage percentage threshold above which a notification is logged

--- a/hoot-core/src/main/cpp/hoot/core/util/Settings.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/Settings.cpp
@@ -865,11 +865,11 @@ QString Settings::_replaceVariablesValue(QString value, std::set<QString> used) 
     int offset = 0;
     if (_dynamicRegex.indexIn(value, offset) >= 0)
     {
-      offset += _dynamicRegex.matchedLength();
       QString varStr = _dynamicRegex.capturedTexts()[0];
       QString subKey = _dynamicRegex.capturedTexts()[1];
       QString expanded = _replaceVariables(subKey, used);
       value.replace(varStr, expanded);
+      offset += expanded.length();
       done = false;
     }
   }

--- a/hoot-core/src/main/cpp/hoot/core/util/SharedPtrPool.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/SharedPtrPool.h
@@ -59,13 +59,21 @@ public:
       std::bind(&SharedPtrPool<T>::_destroy, this, std::placeholders::_1));
   }
 
-  static SharedPtrPool<T>& getInstance() { return _theInstance; }
+  static SharedPtrPool<T>& getInstance()
+  {
+    static SharedPtrPool<T> instance;
+    return instance;
+  }
 
 private:
 
-  SharedPtrPool() {}
+  /** Default constructor/destructor */
+  SharedPtrPool() = default;
+  ~SharedPtrPool() = default;
+  /** Delete copy constructor and assignment operator */
+  SharedPtrPool(const SharedPtrPool<T>&) = delete;
+  SharedPtrPool<T>& operator=(const SharedPtrPool<T>&) = delete;
 
-  static SharedPtrPool<T> _theInstance;
   boost::fast_pool_allocator<T> _pool;
 
   void _destroy(T* v)

--- a/hoot-core/src/main/cpp/hoot/core/util/SharedPtrPool.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/SharedPtrPool.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef SHAREDPTRPOOL_H
 #define SHAREDPTRPOOL_H

--- a/hoot-core/src/main/cpp/hoot/core/util/SignalCatcher.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/SignalCatcher.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "SignalCatcher.h"

--- a/hoot-core/src/main/cpp/hoot/core/util/SignalCatcher.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/SignalCatcher.cpp
@@ -39,18 +39,11 @@
 namespace hoot
 {
 
-std::shared_ptr<SignalCatcher> SignalCatcher::_instance;
-
-SignalCatcher::SignalCatcher()
-  : _defaultSet(false)
+SignalCatcher& SignalCatcher::getInstance()
 {
-}
-
-std::shared_ptr<SignalCatcher> SignalCatcher::getInstance()
-{
-  if (!SignalCatcher::_instance)
-    SignalCatcher::_instance.reset(new SignalCatcher());
-  return SignalCatcher::_instance;
+  //  Local static singleton instance
+  static SignalCatcher instance;
+  return instance;
 }
 
 void SignalCatcher::registerDefaultHandlers()

--- a/hoot-core/src/main/cpp/hoot/core/util/SignalCatcher.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/SignalCatcher.h
@@ -46,7 +46,7 @@ class SignalCatcher
 {
 public:
 
-  static std::shared_ptr<SignalCatcher> getInstance();
+  static SignalCatcher& getInstance();
 
   void registerDefaultHandlers();
 
@@ -58,16 +58,19 @@ public:
 
 private:
 
-  SignalCatcher();
+  /** Default constructor/destructor */
+  SignalCatcher() = default;
+  ~SignalCatcher() = default;
+  /** Delete copy constructor and assignment operator */
+  SignalCatcher(const SignalCatcher&) = delete;
+  SignalCatcher& operator=(const SignalCatcher&) = delete;
 
   static void default_handler(int sig);
   static void terminateHandler();
 
-  static std::shared_ptr<SignalCatcher> _instance;
-
   std::map<unsigned int, std::stack<__sighandler_t>> _handlers;
 
-  bool _defaultSet;
+  bool _defaultSet = false;
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/util/SignalCatcher.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/SignalCatcher.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef SIGNALCATCHER_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/poi-polygon/PoiPolygonMatchVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/poi-polygon/PoiPolygonMatchVisitor.cpp
@@ -224,7 +224,7 @@ void PoiPolygonMatchVisitor::visit(const ConstElementPtr& e)
   }
   if (_numElementsVisited % _memoryCheckUpdateInterval == 0)
   {
-    MemoryUsageChecker::getInstance()->check();
+    MemoryUsageChecker::getInstance().check();
   }
 }
 

--- a/hoot-js/src/main/cpp/hoot/js/JsRegistrar.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/JsRegistrar.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "JsRegistrar.h"
 

--- a/hoot-js/src/main/cpp/hoot/js/JsRegistrar.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/JsRegistrar.cpp
@@ -41,19 +41,11 @@ void Method(const FunctionCallbackInfo<Value>& args)
   args.GetReturnValue().Set(String::NewFromUtf8(current, "world"));
 }
 
-std::shared_ptr<JsRegistrar> JsRegistrar::_theInstance = NULL;
-
-JsRegistrar::JsRegistrar()
-{
-}
-
 JsRegistrar& JsRegistrar::getInstance()
 {
-  if (_theInstance == NULL)
-  {
-    _theInstance.reset(new JsRegistrar());
-  }
-  return *_theInstance;
+  //  Local static singleton instance
+  static JsRegistrar instance;
+  return instance;
 }
 
 void JsRegistrar::Init(Handle<Object> exports)

--- a/hoot-js/src/main/cpp/hoot/js/JsRegistrar.h
+++ b/hoot-js/src/main/cpp/hoot/js/JsRegistrar.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef JSREGISTRAR_H
 #define JSREGISTRAR_H

--- a/hoot-js/src/main/cpp/hoot/js/JsRegistrar.h
+++ b/hoot-js/src/main/cpp/hoot/js/JsRegistrar.h
@@ -56,9 +56,7 @@ class ClassInitializerTemplate : public ClassInitializer
 {
 public:
 
-  ClassInitializerTemplate()
-  {
-  }
+  ClassInitializerTemplate() { }
 
   virtual ~ClassInitializerTemplate() { }
 
@@ -86,9 +84,13 @@ public:
 private:
 
   std::vector<std::shared_ptr<ClassInitializer>> _initializers;
-  static std::shared_ptr<JsRegistrar> _theInstance;
 
-  JsRegistrar();
+  /** Default constructor/destructor */
+  JsRegistrar() = default;
+  ~JsRegistrar() = default;
+  /** Delete copy constructor and assignment operator */
+  JsRegistrar(const JsRegistrar&) = delete;
+  JsRegistrar& operator=(const JsRegistrar&) = delete;
 };
 
 template<class T>

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.cpp
@@ -581,7 +581,7 @@ public:
     }
     if (_numElementsVisited % _memoryCheckUpdateInterval == 0)
     {
-      MemoryUsageChecker::getInstance()->check();
+      MemoryUsageChecker::getInstance().check();
     }
   }
 

--- a/hoot-js/src/main/cpp/hoot/js/v8Engine.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/v8Engine.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "v8Engine.h"
 

--- a/hoot-js/src/main/cpp/hoot/js/v8Engine.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/v8Engine.cpp
@@ -32,8 +32,6 @@ using namespace v8;
 namespace hoot
 {
 
-std::shared_ptr<v8Engine> v8Engine::_theInstance;
-
 bool v8Engine::_needPlatform = false;
 
 v8Engine::v8Engine()
@@ -83,11 +81,9 @@ v8Engine::~v8Engine()
 
 v8Engine& v8Engine::getInstance()
 {
-  if (_theInstance.get() == 0)
-  {
-    _theInstance.reset(new v8Engine());
-  }
-  return *_theInstance;
+  //  Local static singleton instance
+  static v8Engine instance;
+  return instance;
 }
 
 Isolate* v8Engine::getIsolate()

--- a/hoot-js/src/main/cpp/hoot/js/v8Engine.h
+++ b/hoot-js/src/main/cpp/hoot/js/v8Engine.h
@@ -51,22 +51,20 @@ public:
    */
   void init() {}
 
-  ~v8Engine();
-
   static v8::Isolate* getIsolate();
 
   static void setPlatformInit(bool needsPlatform = true);
 
 private:
-  /** static pointer to the singleton instance */
-  static std::shared_ptr<v8Engine> _theInstance;
   /** static flag for platform initialization */
   static bool _needPlatform;
 
-  /**
-   * @brief v8Engine - private constructor
-   */
+  /** private constructor/destructor */
   v8Engine();
+  ~v8Engine();
+  /** Delete copy constructor and assignment operator */
+  v8Engine(const v8Engine&) = delete;
+  v8Engine& operator=(const v8Engine&) = delete;
 
   /** Creation parameters allocator for main isolate */
   std::shared_ptr<v8::ArrayBuffer::Allocator> _allocator;

--- a/hoot-js/src/main/cpp/hoot/js/v8Engine.h
+++ b/hoot-js/src/main/cpp/hoot/js/v8Engine.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef V8ENGINE_H
 #define V8ENGINE_H

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryUtilities.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryUtilities.cpp
@@ -42,8 +42,6 @@
 namespace hoot
 {
 
-std::shared_ptr<MultiaryUtilities> MultiaryUtilities::_theInstance;
-
 void MultiaryUtilities::conflate(OsmMapPtr map)
 {
   MatchFactory& matchFactory = MatchFactory::getInstance();
@@ -207,11 +205,9 @@ SearchBoundsCalculatorPtr MultiaryUtilities::getBoundsCalculator()
 
 MultiaryUtilities& MultiaryUtilities::getInstance()
 {
-  if (_theInstance.get() == 0)
-  {
-    _theInstance.reset(new MultiaryUtilities());
-  }
-  return *_theInstance;
+  //  Local static singleton instance
+  static MultiaryUtilities instance;
+  return instance;
 }
 
 }

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryUtilities.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryUtilities.h
@@ -147,9 +147,12 @@ public:
 
 private:
 
-  MultiaryUtilities() {}
-
-  static std::shared_ptr<MultiaryUtilities> _theInstance;
+  /** Default constructor/destructor */
+  MultiaryUtilities() = default;
+  ~MultiaryUtilities() = default;
+  /** Delete copy constructor and assignment operator */
+  MultiaryUtilities(const MultiaryUtilities&) = delete;
+  MultiaryUtilities& operator=(const MultiaryUtilities&) = delete;
 
   std::shared_ptr<SearchBoundsCalculator> _searchBoundsCalculator;
 };

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryUtilities.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryUtilities.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef MULTIARYUTILITIES_H
 #define MULTIARYUTILITIES_H

--- a/tgs/src/main/cpp/tgs/BigContainers/Stxxl.cpp
+++ b/tgs/src/main/cpp/tgs/BigContainers/Stxxl.cpp
@@ -44,24 +44,16 @@
 namespace Tgs
 {
 
-std::shared_ptr<Stxxl> Stxxl::_theInstance;
-
 Stxxl::Stxxl()
 {
   _init();
 }
 
-Stxxl::~Stxxl()
-{
-}
-
 Stxxl& Stxxl::getInstance()
 {
-  if (!_theInstance.get())
-  {
-    _theInstance.reset(new Stxxl());
-  }
-  return *_theInstance;
+  //  Local static singleton instance
+  static Stxxl instance;
+  return instance;
 }
 
 void Stxxl::_init()

--- a/tgs/src/main/cpp/tgs/BigContainers/Stxxl.cpp
+++ b/tgs/src/main/cpp/tgs/BigContainers/Stxxl.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "Stxxl.h"
 

--- a/tgs/src/main/cpp/tgs/BigContainers/Stxxl.h
+++ b/tgs/src/main/cpp/tgs/BigContainers/Stxxl.h
@@ -44,8 +44,6 @@ class Stxxl
 {
 public:
 
-  ~Stxxl();
-
   /**
    * Initializes the STXXL container.
    */
@@ -62,13 +60,17 @@ public:
 
 private:
 
-  static std::shared_ptr<Stxxl> _theInstance;
+  void _init();
+  QString _removeComments(QString s);
+
   QTemporaryFile _configFileTmp;
 
   Stxxl();
-
-  void _init();
-  QString _removeComments(QString s);
+  /** Default destructor */
+  ~Stxxl() = default;
+  /** Delete copy constructor and assignment operator */
+  Stxxl(const Stxxl&) = delete;
+  Stxxl& operator=(const Stxxl&) = delete;
 };
 
 }

--- a/tgs/src/main/cpp/tgs/BigContainers/Stxxl.h
+++ b/tgs/src/main/cpp/tgs/BigContainers/Stxxl.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef STXXL_H
 #define STXXL_H


### PR DESCRIPTION
A few of the singletons in hoot don't release memory and others are modified during testing that shouldn't be.  Use the Meyers singleton pattern to replace them.