### PR TITLE
Settings failure error

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -2268,8 +2268,9 @@ void XmlChangeset::failRemainingElements(const ChangesetElementMap& elements)
   for (ChangesetElementMap::const_iterator it = elements.begin(); it != elements.end(); ++it)
   {
     ChangesetElementPtr element = it->second;
-    //  Anything that isn't finalized is now failed
-    if (element->getStatus() != ChangesetElement::Finalized)
+    //  Anything that isn't finalized or failed is now failed
+    ChangesetElement::ElementStatus status = element->getStatus();
+    if (status != ChangesetElement::Finalized && status != ChangesetElement::Failed)
     {
       element->setStatus(ChangesetElement::Failed);
       ++_failedCount;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -241,6 +241,8 @@ private:
    * @param index Index into the thread status vector to report the status
    */
   void _changesetThreadFunc(int index);
+  /** Yield or sleep this thread */
+  void _yield(int milliseconds = 10);
   /**
    * @brief createNetworkRequest Create a network request object
    * @param requiresAuthentication Authentication flag set to true will cause OAuth credentials,

--- a/hoot-core/src/main/cpp/hoot/core/util/Settings.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/Settings.cpp
@@ -174,6 +174,8 @@ Settings::Settings() :
 _dynamicRegex("\\$\\{([\\w\\.]+)\\}"),
 _staticRegex("\\$\\(([\\w\\.]+)\\)")
 {
+  _dynamicRegex.optimize();
+  _staticRegex.optimize();
 }
 
 void Settings::prepend(const QString& key, const QStringList& values)
@@ -831,19 +833,31 @@ QString Settings::_replaceStaticVariables(QString value) const
   {
     done = true;
     int offset = 0;
-    if (_staticRegex.indexIn(value, offset) >= 0)
+    QRegularExpressionMatch match = _staticRegex.match(value, offset);
+    if (match.hasMatch())
     {
-      offset += _staticRegex.matchedLength();
-      QString varStr = _staticRegex.capturedTexts()[0];
-      QString subKey = _staticRegex.capturedTexts()[1];
-      QString expanded;
+      QString varStr = match.captured(0);
+      QString subKey = match.captured(1);
+      QString expanded = "";
       if (hasKey(subKey))
-      {
         expanded = getString(subKey);
-      }
       value.replace(varStr, expanded);
+      offset += expanded.length();
       done = false;
     }
+//    if (_staticRegex.indexIn(value, offset) >= 0)
+//    {
+//      offset += _staticRegex.matchedLength();
+//      QString varStr = _staticRegex.capturedTexts()[0];
+//      QString subKey = _staticRegex.capturedTexts()[1];
+//      QString expanded;
+//      if (hasKey(subKey))
+//      {
+//        expanded = getString(subKey);
+//      }
+//      value.replace(varStr, expanded);
+//      done = false;
+//    }
   }
 
   return value;
@@ -863,15 +877,25 @@ QString Settings::_replaceVariablesValue(QString value, std::set<QString> used) 
   {
     done = true;
     int offset = 0;
-    if (_dynamicRegex.indexIn(value, offset) >= 0)
+    QRegularExpressionMatch match = _dynamicRegex.match(value, offset);
+    if (match.hasMatch())
     {
-      QString varStr = _dynamicRegex.capturedTexts()[0];
-      QString subKey = _dynamicRegex.capturedTexts()[1];
+      QString varStr = match.captured(0);
+      QString subKey = match.captured(1);
       QString expanded = _replaceVariables(subKey, used);
       value.replace(varStr, expanded);
       offset += expanded.length();
       done = false;
     }
+//    if (_dynamicRegex.indexIn(value, offset) >= 0)
+//    {
+//      QString varStr = _dynamicRegex.capturedTexts()[0];
+//      QString subKey = _dynamicRegex.capturedTexts()[1];
+//      QString expanded = _replaceVariables(subKey, used);
+//      value.replace(varStr, expanded);
+//      offset += expanded.length();
+//      done = false;
+//    }
   }
 
   return value;

--- a/hoot-core/src/main/cpp/hoot/core/util/Settings.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/Settings.cpp
@@ -845,19 +845,6 @@ QString Settings::_replaceStaticVariables(QString value) const
       offset += expanded.length();
       done = false;
     }
-//    if (_staticRegex.indexIn(value, offset) >= 0)
-//    {
-//      offset += _staticRegex.matchedLength();
-//      QString varStr = _staticRegex.capturedTexts()[0];
-//      QString subKey = _staticRegex.capturedTexts()[1];
-//      QString expanded;
-//      if (hasKey(subKey))
-//      {
-//        expanded = getString(subKey);
-//      }
-//      value.replace(varStr, expanded);
-//      done = false;
-//    }
   }
 
   return value;
@@ -887,15 +874,6 @@ QString Settings::_replaceVariablesValue(QString value, std::set<QString> used) 
       offset += expanded.length();
       done = false;
     }
-//    if (_dynamicRegex.indexIn(value, offset) >= 0)
-//    {
-//      QString varStr = _dynamicRegex.capturedTexts()[0];
-//      QString subKey = _dynamicRegex.capturedTexts()[1];
-//      QString expanded = _replaceVariables(subKey, used);
-//      value.replace(varStr, expanded);
-//      offset += expanded.length();
-//      done = false;
-//    }
   }
 
   return value;

--- a/hoot-core/src/main/cpp/hoot/core/util/Settings.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Settings.h
@@ -30,7 +30,7 @@
 
 // Qt
 #include <QHash>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QString>
 #include <QStringList>
 #include <QVariant>
@@ -171,9 +171,9 @@ private:
   static std::shared_ptr<Settings> _theInstance;
   SettingsMap _settings;
   /// matches variables in the form ${My_Var_1}
-  QRegExp _dynamicRegex;
+  QRegularExpression _dynamicRegex;
   /// matches variables in the form $(My_Var_1)
-  QRegExp _staticRegex;
+  QRegularExpression _staticRegex;
 
   QString _markup(QString s) const
   {


### PR DESCRIPTION
Hoot failed with memory corruption and double free errors in the settings class.  Update the use of regular expression objects in Qt and waiting in the `OsmApiWriter` class.