### PR TITLE
HighwayRfClassifier memory leak

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/TestUtils.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/TestUtils.cpp
@@ -381,7 +381,7 @@ void TestUtils::runConflateOpReductionTest(
   CPPUNIT_ASSERT_EQUAL(17,  TestUtils::getConflateCmdSnapshotCleaningOps().size());
 
   MatchFactory::getInstance().reset();
-  MatchFactory::_setMatchCreators(matchCreators);
+  MatchFactory::getInstance()._setMatchCreators(matchCreators);
   // This is a snapshot of the ops in order to avoid any changes made to them result in requiring
   // this test's results to change over time. Clearly, any newly added ops could be being filtered
   // incorrectly, and we can update this list periodically if that's deemed important.

--- a/hoot-core-test/src/test/cpp/hoot/core/visitors/MatchCandidateCountVisitorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/visitors/MatchCandidateCountVisitorTest.cpp
@@ -80,7 +80,7 @@ public:
     QStringList matchCreators;
     matchCreators.append("hoot::BuildingMatchCreator");
     MatchFactory::getInstance().reset();
-    MatchFactory::_setMatchCreators(matchCreators);
+    MatchFactory::getInstance()._setMatchCreators(matchCreators);
 
     MatchCandidateCountVisitor uut(MatchFactory::getInstance().getCreators());
     map->visitRo(uut);
@@ -104,7 +104,7 @@ public:
     QStringList matchCreators;
     matchCreators.append("hoot::HighwayMatchCreator");
     MatchFactory::getInstance().reset();
-    MatchFactory::_setMatchCreators(matchCreators);
+    MatchFactory::getInstance()._setMatchCreators(matchCreators);
 
     MatchCandidateCountVisitor uut(MatchFactory::getInstance().getCreators());
     map->visitRo(uut);
@@ -130,7 +130,7 @@ public:
     matchCreators.append("hoot::HighwayMatchCreator");
     matchCreators.append("hoot::ScriptMatchCreator,Line.js");
     MatchFactory::getInstance().reset();
-    MatchFactory::_setMatchCreators(matchCreators);
+    MatchFactory::getInstance()._setMatchCreators(matchCreators);
 
     MatchCandidateCountVisitor uut(MatchFactory::getInstance().getCreators());
     map->visitRo(uut);
@@ -161,7 +161,7 @@ public:
     QStringList matchCreators;
     matchCreators.append("hoot::ScriptMatchCreator,Poi.js");
     MatchFactory::getInstance().reset();
-    MatchFactory::_setMatchCreators(matchCreators);
+    MatchFactory::getInstance()._setMatchCreators(matchCreators);
 
     MatchCandidateCountVisitor uut(MatchFactory::getInstance().getCreators());
     map->visitRo(uut);
@@ -187,7 +187,7 @@ public:
     matchCreators.append("hoot::ScriptMatchCreator,River.js");
     matchCreators.append("hoot::ScriptMatchCreator,Poi.js");
     MatchFactory::getInstance().reset();
-    MatchFactory::_setMatchCreators(matchCreators);
+    MatchFactory::getInstance()._setMatchCreators(matchCreators);
 
     MatchCandidateCountVisitor uut(MatchFactory::getInstance().getCreators());
     map->visitRo(uut);
@@ -213,7 +213,7 @@ public:
     QStringList matchCreators;
     matchCreators.append("hoot::ScriptMatchCreator,Poi.js");
     MatchFactory::getInstance().reset();
-    MatchFactory::_setMatchCreators(matchCreators);
+    MatchFactory::getInstance()._setMatchCreators(matchCreators);
 
     MatchCandidateCountVisitor uut(MatchFactory::getInstance().getCreators());
     map->visitRo(uut);
@@ -247,8 +247,8 @@ public:
     const QString poiTagFilter = "{ \"must\": [ { \"tag\": \"poi=yes\" } ] }";
 
     MatchFactory::getInstance().reset();
-    MatchFactory::_setTagFilter(poiTagFilter);
-    MatchFactory::_setMatchCreators(matchCreators);
+    MatchFactory::getInstance()._setTagFilter(poiTagFilter);
+    MatchFactory::getInstance()._setMatchCreators(matchCreators);
     uut.reset(new MatchCandidateCountVisitor(MatchFactory::getInstance().getCreators()));
     map->visitRo(*uut);
     CPPUNIT_ASSERT_EQUAL((int)2, (int)uut->getStat());
@@ -256,16 +256,16 @@ public:
     const QString restaurantTagFilter = "{ \"must\": [ { \"tag\": \"amenity=restaurant\" } ] }";
 
     MatchFactory::getInstance().reset();
-    MatchFactory::_setTagFilter(restaurantTagFilter);
-    MatchFactory::_setMatchCreators(matchCreators);
+    MatchFactory::getInstance()._setTagFilter(restaurantTagFilter);
+    MatchFactory::getInstance()._setMatchCreators(matchCreators);
     uut.reset(new MatchCandidateCountVisitor(MatchFactory::getInstance().getCreators()));
     node1->getTags().set("amenity", "restaurant");
     map->visitRo(*uut);
     CPPUNIT_ASSERT_EQUAL((int)1, (int)uut->getStat());
 
     MatchFactory::getInstance().reset();
-    MatchFactory::_setTagFilter(restaurantTagFilter);
-    MatchFactory::_setMatchCreators(matchCreators);
+    MatchFactory::getInstance()._setTagFilter(restaurantTagFilter);
+    MatchFactory::getInstance()._setMatchCreators(matchCreators);
     uut.reset(new MatchCandidateCountVisitor(MatchFactory::getInstance().getCreators()));
     node2->getTags().set("amenity", "restaurant");
     map->visitRo(*uut);
@@ -288,29 +288,29 @@ public:
     std::shared_ptr<MatchCandidateCountVisitor> uut;
 
     MatchFactory::getInstance().reset();
-    MatchFactory::_setTagFilter("");
-    MatchFactory::_setMatchCreators(matchCreators);
+    MatchFactory::getInstance()._setTagFilter("");
+    MatchFactory::getInstance()._setMatchCreators(matchCreators);
     uut.reset(new MatchCandidateCountVisitor(MatchFactory::getInstance().getCreators()));
     map->visitRo(*uut);
     CPPUNIT_ASSERT_EQUAL((int)39, (int)uut->getStat());
 
     MatchFactory::getInstance().reset();
-    MatchFactory::_setTagFilter("{ \"must\": [ { \"tag\": \"building=yes\" } ] }");
-    MatchFactory::_setMatchCreators(matchCreators);
+    MatchFactory::getInstance()._setTagFilter("{ \"must\": [ { \"tag\": \"building=yes\" } ] }");
+    MatchFactory::getInstance()._setMatchCreators(matchCreators);
     uut.reset(new MatchCandidateCountVisitor(MatchFactory::getInstance().getCreators()));
     map->visitRo(*uut);
     CPPUNIT_ASSERT_EQUAL((int)17, (int)uut->getStat());
 
     MatchFactory::getInstance().reset();
-    MatchFactory::_setTagFilter("{ \"must\": [ { \"tag\": \"poi=yes\" } ] }");
-    MatchFactory::_setMatchCreators(matchCreators);
+    MatchFactory::getInstance()._setTagFilter("{ \"must\": [ { \"tag\": \"poi=yes\" } ] }");
+    MatchFactory::getInstance()._setMatchCreators(matchCreators);
     uut.reset(new MatchCandidateCountVisitor(MatchFactory::getInstance().getCreators()));
     map->visitRo(*uut);
     CPPUNIT_ASSERT_EQUAL((int)21, (int)uut->getStat());
 
     MatchFactory::getInstance().reset();
-    MatchFactory::_setTagFilter("{ \"must\": [ { \"tag\": \"name=Starbucks\" } ] }");
-    MatchFactory::_setMatchCreators(matchCreators);
+    MatchFactory::getInstance()._setTagFilter("{ \"must\": [ { \"tag\": \"name=Starbucks\" } ] }");
+    MatchFactory::getInstance()._setMatchCreators(matchCreators);
     uut.reset(new MatchCandidateCountVisitor(MatchFactory::getInstance().getCreators()));
     map->visitRo(*uut);
     CPPUNIT_ASSERT_EQUAL((int)12, (int)uut->getStat());

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayClassifier.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayClassifier.h
@@ -39,6 +39,9 @@ class HighwayClassifier
 {
 public:
 
+  HighwayClassifier() = default;
+  virtual ~HighwayClassifier() = default;
+
   static std::string className() { return "hoot::HighwayClassifier"; }
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayClassifier.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayClassifier.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef HIGHWAYCLASSIFIER_H
 #define HIGHWAYCLASSIFIER_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayRfClassifier.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayRfClassifier.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef HIGHWAYRFCLASSIFIER_H
 #define HIGHWAYRFCLASSIFIER_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayRfClassifier.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayRfClassifier.h
@@ -46,6 +46,7 @@ public:
   static int logWarnCount;
 
   HighwayRfClassifier();
+  ~HighwayRfClassifier() = default;
 
   virtual MatchClassification classify(const ConstOsmMapPtr& map,
     ElementId eid1, ElementId eid2, const WaySublineMatchString& match) override;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.cpp
@@ -44,12 +44,6 @@ using namespace std;
 namespace hoot
 {
 
-std::shared_ptr<MatchFactory> MatchFactory::_theInstance;
-
-MatchFactory::~MatchFactory()
-{
-}
-
 MatchFactory::MatchFactory()
 {
   setConfiguration(conf());
@@ -149,7 +143,7 @@ void MatchFactory::registerCreator(const QString& c)
       mc->setCriterion(filter);
     }
 
-    _theInstance->registerCreator(mc);
+    registerCreator(mc);
 
     if (args.size() > 0)
     {
@@ -162,9 +156,12 @@ void MatchFactory::_setMatchCreators(QStringList matchCreatorsList)
 {
   LOG_DEBUG("MatchFactory creators: " << matchCreatorsList);
 
+  //  Setting the match creators replaces the previous creators
+  _creators.clear();
+
   for (int i = 0; i < matchCreatorsList.size(); i++)
   {
-    _theInstance->registerCreator(matchCreatorsList[i]);
+    registerCreator(matchCreatorsList[i]);
   }
 }
 
@@ -175,6 +172,7 @@ void MatchFactory::setConfiguration(const Settings& s)
 
 MatchFactory& MatchFactory::getInstance()
 {
+  static MatchFactory instance;
   if (ConfigOptions().getAutocorrectOptions())
   {
     /* TODO: remove this hack after UI issues are fixed; see OptionsValidator
@@ -192,17 +190,10 @@ MatchFactory& MatchFactory::getInstance()
   // well
   OptionsValidator::validateMatchers();
 
-  if (!_theInstance.get())
-  {
-    _theInstance.reset(new MatchFactory());
-  }
-
-  if (_theInstance->_creators.size() == 0)
-  {
-    //only get the match creators that are specified in the config
-    _setMatchCreators(ConfigOptions().getMatchCreators());
-  }
-  return *_theInstance;
+  //only get the match creators that are specified in the config
+  if (instance._creators.size() == 0)
+    instance._setMatchCreators(ConfigOptions().getMatchCreators());
+  return instance;
 }
 
 void MatchFactory::reset()

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchFactory.h
@@ -48,8 +48,6 @@ class MatchFactory : public Configurable
 {
 public:
 
-  ~MatchFactory();
-
   /**
    * Returns the default MatchFactory with the default creators registered.
    */
@@ -112,16 +110,15 @@ private:
   // allows for matching a subset of the input data
   QString _tagFilter;
 
-  static std::shared_ptr<MatchFactory> _theInstance;
-
   std::vector<std::shared_ptr<MatchCreator>> _creators;
 
   MatchFactory();
+  ~MatchFactory() = default;
 
   void _checkMatchCreatorBoundable(const std::shared_ptr<MatchCreator>& matchCreator,
                                    const geos::geom::Envelope& bounds) const;
-  static void _setMatchCreators(QStringList matchCreatorsList);
-  static void _setTagFilter(QString filter) { _theInstance->_tagFilter = filter; }
+  void _setMatchCreators(QStringList matchCreatorsList);
+  void _setTagFilter(QString filter) { _tagFilter = filter; }
 
   friend class MatchCandidateCountVisitorTest;
   friend class MatchCandidateCountVisitorRndTest;

--- a/tgs/src/main/cpp/tgs/RandomForest/BaseRandomForest.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/BaseRandomForest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "BaseRandomForest.h"
 

--- a/tgs/src/main/cpp/tgs/RandomForest/BaseRandomForest.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/BaseRandomForest.cpp
@@ -44,7 +44,10 @@ namespace Tgs
   {
   }
 
-  BaseRandomForest::~BaseRandomForest(){}
+  BaseRandomForest::~BaseRandomForest()
+  {
+    clear();
+  }
 
   void BaseRandomForest::clear()
   {

--- a/tgs/src/main/cpp/tgs/RandomForest/RandomForest.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/RandomForest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "RandomForest.h"
@@ -42,302 +42,289 @@ using namespace std;
 
 namespace Tgs
 {
-  RandomForest::RandomForest()
-  {
-    //Set the random seed
-    //clock_t t1 = clock();
-    //Tgs::Random::instance()->seed((unsigned int)t1);
-  }
 
-  RandomForest::~RandomForest()
+void RandomForest::trainBinary(const std::shared_ptr<DataFrame>& data, unsigned int numTrees,
+  unsigned int numFactors, std::string posClass, unsigned int nodeSize, double retrain,
+  bool balanced)
+{
+  try
   {
+    data->validateData();
 
-  }
+    _factorLabels = data->getFactorLabels();
+    _forest.clear();
+    _numSplitFactors = numFactors;
 
-  void RandomForest::trainBinary(const std::shared_ptr<DataFrame>& data, unsigned int numTrees,
-    unsigned int numFactors, std::string posClass, unsigned int nodeSize, double retrain,
-    bool balanced)
-  {
-    try
+    if (!data->empty())
     {
-      data->validateData();
+      _forest.reserve(numTrees);
 
-      _factorLabels = data->getFactorLabels();
-      _forest.clear();
-      _numSplitFactors = numFactors;
+      data->setBinaryClassLabels(posClass); //Set all non pos example to negative
 
-      if (!data->empty())
+      for (unsigned int i = 0; i < numTrees; i++)
       {
-        _forest.reserve(numTrees);
+        _forest.push_back(std::shared_ptr<RandomTree>(new RandomTree()));
+        _forest.back()->trainBinary(data, numFactors, posClass, nodeSize, true);
+        std::cout << "Trained Tree # " << i + 1 << " / " << numTrees << "     \r";
+        std::cout.flush();
+      }
+      std::cout << std::endl;
 
-        data->setBinaryClassLabels(posClass); //Set all non pos example to negative
+      //std::cout << "Mode Trained " << std::endl;
+      if (retrain >= 0 && retrain < 1.0)
+      {
+        std::cout << "Retraining model on top " << (retrain * 100) << "% of factors" << std::endl;
+        std::map<std::string, double> topFactors;
+        std::map<std::string, double>::iterator mapItr;
 
-        for (unsigned int i = 0; i < numTrees; i++)
+        getFactorImportance(data, topFactors);
+
+        std::vector<std::string> badFactors;
+
+        unsigned int cutOffIdx = topFactors.size() - (unsigned int)((double)topFactors.size() * retrain);
+
+        std::multimap<double, std::string> sortedFactors;
+        std::multimap<double, std::string>::iterator mMapItr;
+
+        //Create a map from lowest to highest of important mapped to factor type
+        for (mapItr = topFactors.begin(); mapItr != topFactors.end(); ++mapItr)
         {
-          _forest.push_back(std::shared_ptr<RandomTree>(new RandomTree()));
-          _forest.back()->trainBinary(data, numFactors, posClass, nodeSize, true);
-          std::cout << "Trained Tree # " << i + 1 << " / " << numTrees << "     \r";
-          std::cout.flush();
+          sortedFactors.insert(std::pair<double, std::string>(mapItr->second, mapItr->first));
         }
-        std::cout << std::endl;
 
-        //std::cout << "Mode Trained " << std::endl;
-        if (retrain >= 0 && retrain < 1.0)
+        unsigned int cutOffCtr = 0;
+
+        for (mMapItr = sortedFactors.begin(); mMapItr != sortedFactors.end(); ++mMapItr)
         {
-          std::cout << "Retraining model on top " << (retrain * 100) << "% of factors" << std::endl;
-          std::map<std::string, double> topFactors;
-          std::map<std::string, double>::iterator mapItr;
-
-          getFactorImportance(data, topFactors);
-
-          std::vector<std::string> badFactors;
-
-          unsigned int cutOffIdx = topFactors.size() - (unsigned int)((double)topFactors.size() * retrain);
-
-          std::multimap<double, std::string> sortedFactors;
-          std::multimap<double, std::string>::iterator mMapItr;
-
-          //Create a map from lowest to highest of important mapped to factor type
-          for (mapItr = topFactors.begin(); mapItr != topFactors.end(); ++mapItr)
+          if (cutOffCtr <  cutOffIdx)
           {
-            sortedFactors.insert(std::pair<double, std::string>(mapItr->second, mapItr->first));
+            badFactors.push_back(mMapItr->second);
+            cutOffCtr++;
           }
-
-          unsigned int cutOffCtr = 0;
-
-          for (mMapItr = sortedFactors.begin(); mMapItr != sortedFactors.end(); ++mMapItr)
+          else
           {
-            if (cutOffCtr <  cutOffIdx)
-            {
-              badFactors.push_back(mMapItr->second);
-              cutOffCtr++;
-            }
-            else
-            {
-              break;
-            }
-          }
-
-          for (unsigned int i = 0; i < badFactors.size(); i++)
-          {
-            data->deactivateFactor(badFactors[i]);
-          }
-
-          _forest.clear();
-
-          _forest.reserve(numTrees);
-
-          for (unsigned int i = 0; i < numTrees; i++)
-          {
-            _forest.push_back(std::shared_ptr<RandomTree>(new RandomTree()));
-            _forest.back()->trainBinary(data,
-              (unsigned int)sqrt((double)(topFactors.size() - cutOffIdx)), posClass, 1 , balanced);
+            break;
           }
         }
 
-        _forestCreated = true;
-        data->restoreClassLabels();  //Restore the original class labels
-      }
-      else
-      {
-        throw Exception(__LINE__, "Unable to operate on empty dataset");
-      }
-    }
-    catch(const Exception & e)
-    {
-      throw Exception(typeid(this).name(), __FUNCTION__, __LINE__, e);
-    }
-  }
-
-  void RandomForest::trainMulticlass(const std::shared_ptr<DataFrame>& data, unsigned int numTrees,
-    unsigned int numFactors, unsigned int nodeSize, double retrain, bool balanced)
-  {
-    try
-    {
-      data->validateData();
-
-      _factorLabels = data->getFactorLabels();
-      _forest.clear();
-      numFactors = min<size_t>(data->getActiveFactorCount(), numFactors);
-      _numSplitFactors = numFactors;
-      cout << _numSplitFactors;
-
-      if (!data->empty())
-      {
-        _forest.reserve(numTrees);
-        //  Reset the ids so that all forests are created alike
-        RandomTree::resetIds();
-
-        for (unsigned int i = 0; i < numTrees; i++)
+        for (unsigned int i = 0; i < badFactors.size(); i++)
         {
-          _forest.push_back(std::shared_ptr<RandomTree>(new RandomTree()));
-          _forest.back()->trainMulticlass(data, numFactors, nodeSize, true);
-          std::cout << "Trained Tree # " << i + 1 << " / " << numTrees << "     \r";
-          std::cout.flush();
-        }
-        std::cout << std::endl;
-
-        //std::cout << "Model Trained " << std::endl;
-        if (retrain >= 0 && retrain < 1.0)
-        {
-          std::cout << "Retraining model on top " << (retrain * 100) << "% of factors" << std::endl;
-          std::map<std::string, double> topFactors;
-          std::map<std::string, double>::iterator mapItr;
-
-          getFactorImportance(data, topFactors);
-
-          std::vector<std::string> badFactors;
-
-          unsigned int cutOffIdx =
-            topFactors.size() - (unsigned int)((double)topFactors.size() * retrain);
-
-          std::multimap<double, std::string> sortedFactors;
-          std::multimap<double, std::string>::iterator mMapItr;
-
-          //Create a map from lowest to highest of important mapped to factor type
-          for (mapItr = topFactors.begin(); mapItr != topFactors.end(); ++mapItr)
-          {
-            sortedFactors.insert(std::pair<double, std::string>(mapItr->second, mapItr->first));
-          }
-
-          unsigned int cutOffCtr = 0;
-
-          for (mMapItr = sortedFactors.begin(); mMapItr != sortedFactors.end(); ++mMapItr)
-          {
-            if (cutOffCtr <  cutOffIdx)
-            {
-              badFactors.push_back(mMapItr->second);
-              cutOffCtr++;
-            }
-            else
-            {
-              break;
-            }
-          }
-
-          for (unsigned int i = 0; i < badFactors.size(); i++)
-          {
-            data->deactivateFactor(badFactors[i]);
-          }
-
-          _forest.clear();
-
-          _forest.reserve(numTrees);
-
-          for (unsigned int i = 0; i < numTrees; i++)
-          {
-            _forest.push_back(std::shared_ptr<RandomTree>(new RandomTree()));
-            _forest.back()->trainMulticlass(data,
-              (unsigned int)sqrt((double)(topFactors.size() - cutOffIdx)), 1, balanced);
-          }
+          data->deactivateFactor(badFactors[i]);
         }
 
-        _forestCreated = true;
-      }
-      else
-      {
-        throw Exception(__LINE__, "Unable to operate on empty dataset");
-      }
-    }
-    catch(const Exception & e)
-    {
-      throw Exception(typeid(this).name(), __FUNCTION__, __LINE__, e);
-    }
-  }
+        _forest.clear();
 
-  void RandomForest::trainRoundRobin(const std::shared_ptr<DataFrame>& data, unsigned int numTrees,
-    unsigned int numFactors, std::string posClass, std::string negClass, unsigned int nodeSize,
-    double retrain, bool balanced)
-  {
-    try
-    {
-      data->validateData();
-
-      _factorLabels = data->getFactorLabels();
-      _forest.clear();
-      _numSplitFactors = numFactors;
-
-      if (!data->empty())
-      {
         _forest.reserve(numTrees);
 
         for (unsigned int i = 0; i < numTrees; i++)
         {
           _forest.push_back(std::shared_ptr<RandomTree>(new RandomTree()));
-          _forest.back()->trainRoundRobin(data, numFactors, posClass, negClass, nodeSize, true);
-          std::cout << "Trained Tree # " << i + 1 << " / " << numTrees << "     \r";
-          std::cout.flush();
+          _forest.back()->trainBinary(data,
+            (unsigned int)sqrt((double)(topFactors.size() - cutOffIdx)), posClass, 1 , balanced);
         }
-        std::cout << std::endl;
-
-       //std::cout << "Mode Trained " << std::endl;
-        if (retrain >= 0 && retrain < 1.0)
-        {
-          std::cout << "Retraining model on top " << (retrain * 100) << "% of factors" << std::endl;
-          std::map<std::string, double> topFactors;
-          std::map<std::string, double>::iterator mapItr;
-
-          getFactorImportance(data, topFactors);
-
-          std::vector<std::string> badFactors;
-
-          unsigned int cutOffIdx =
-            topFactors.size() - (unsigned int)((double)topFactors.size() * retrain);
-
-          std::multimap<double, std::string> sortedFactors;
-          std::multimap<double, std::string>::iterator mMapItr;
-
-          //Create a map from lowest to highest of important mapped to factor type
-          for (mapItr = topFactors.begin(); mapItr != topFactors.end(); ++mapItr)
-          {
-            sortedFactors.insert(std::pair<double, std::string>(mapItr->second, mapItr->first));
-          }
-
-          unsigned int cutOffCtr = 0;
-
-          for (mMapItr = sortedFactors.begin(); mMapItr != sortedFactors.end(); ++mMapItr)
-          {
-            if (cutOffCtr <  cutOffIdx)
-            {
-              badFactors.push_back(mMapItr->second);
-              cutOffCtr++;
-            }
-            else
-            {
-              break;
-            }
-          }
-
-          for (unsigned int i = 0; i < badFactors.size(); i++)
-          {
-            data->deactivateFactor(badFactors[i]);
-          }
-
-          _forest.clear();
-
-          _forest.reserve(numTrees);
-
-          for (unsigned int i = 0; i < numTrees; i++)
-          {
-            _forest.push_back(std::shared_ptr<RandomTree>(new RandomTree()));
-            _forest.back()->trainMulticlass(data,
-              (unsigned int)sqrt((double)(topFactors.size() - cutOffIdx)), 1, balanced);
-          }
-        }
-
-        _forestCreated = true;
       }
-      else
-      {
-        throw Exception(__LINE__, "Unable to operate on empty dataset");
-      }
+
+      _forestCreated = true;
+      data->restoreClassLabels();  //Restore the original class labels
     }
-    catch(const Exception & e)
+    else
     {
-      throw Exception(typeid(this).name(), __FUNCTION__, __LINE__, e);
+      throw Exception(__LINE__, "Unable to operate on empty dataset");
     }
   }
+  catch(const Exception & e)
+  {
+    throw Exception(typeid(this).name(), __FUNCTION__, __LINE__, e);
+  }
+}
+
+void RandomForest::trainMulticlass(const std::shared_ptr<DataFrame>& data, unsigned int numTrees,
+  unsigned int numFactors, unsigned int nodeSize, double retrain, bool balanced)
+{
+  try
+  {
+    data->validateData();
+
+    _factorLabels = data->getFactorLabels();
+    _forest.clear();
+    numFactors = min<size_t>(data->getActiveFactorCount(), numFactors);
+    _numSplitFactors = numFactors;
+    cout << _numSplitFactors;
+
+    if (!data->empty())
+    {
+      _forest.reserve(numTrees);
+      //  Reset the ids so that all forests are created alike
+      RandomTree::resetIds();
+
+      for (unsigned int i = 0; i < numTrees; i++)
+      {
+        _forest.push_back(std::shared_ptr<RandomTree>(new RandomTree()));
+        _forest.back()->trainMulticlass(data, numFactors, nodeSize, true);
+        std::cout << "Trained Tree # " << i + 1 << " / " << numTrees << "     \r";
+        std::cout.flush();
+      }
+      std::cout << std::endl;
+
+      //std::cout << "Model Trained " << std::endl;
+      if (retrain >= 0 && retrain < 1.0)
+      {
+        std::cout << "Retraining model on top " << (retrain * 100) << "% of factors" << std::endl;
+        std::map<std::string, double> topFactors;
+        std::map<std::string, double>::iterator mapItr;
+
+        getFactorImportance(data, topFactors);
+
+        std::vector<std::string> badFactors;
+
+        unsigned int cutOffIdx =
+          topFactors.size() - (unsigned int)((double)topFactors.size() * retrain);
+
+        std::multimap<double, std::string> sortedFactors;
+        std::multimap<double, std::string>::iterator mMapItr;
+
+        //Create a map from lowest to highest of important mapped to factor type
+        for (mapItr = topFactors.begin(); mapItr != topFactors.end(); ++mapItr)
+        {
+          sortedFactors.insert(std::pair<double, std::string>(mapItr->second, mapItr->first));
+        }
+
+        unsigned int cutOffCtr = 0;
+
+        for (mMapItr = sortedFactors.begin(); mMapItr != sortedFactors.end(); ++mMapItr)
+        {
+          if (cutOffCtr <  cutOffIdx)
+          {
+            badFactors.push_back(mMapItr->second);
+            cutOffCtr++;
+          }
+          else
+          {
+            break;
+          }
+        }
+
+        for (unsigned int i = 0; i < badFactors.size(); i++)
+        {
+          data->deactivateFactor(badFactors[i]);
+        }
+
+        _forest.clear();
+
+        _forest.reserve(numTrees);
+
+        for (unsigned int i = 0; i < numTrees; i++)
+        {
+          _forest.push_back(std::shared_ptr<RandomTree>(new RandomTree()));
+          _forest.back()->trainMulticlass(data,
+            (unsigned int)sqrt((double)(topFactors.size() - cutOffIdx)), 1, balanced);
+        }
+      }
+
+      _forestCreated = true;
+    }
+    else
+    {
+      throw Exception(__LINE__, "Unable to operate on empty dataset");
+    }
+  }
+  catch(const Exception & e)
+  {
+    throw Exception(typeid(this).name(), __FUNCTION__, __LINE__, e);
+  }
+}
+
+void RandomForest::trainRoundRobin(const std::shared_ptr<DataFrame>& data, unsigned int numTrees,
+  unsigned int numFactors, std::string posClass, std::string negClass, unsigned int nodeSize,
+  double retrain, bool balanced)
+{
+  try
+  {
+    data->validateData();
+
+    _factorLabels = data->getFactorLabels();
+    _forest.clear();
+    _numSplitFactors = numFactors;
+
+    if (!data->empty())
+    {
+      _forest.reserve(numTrees);
+
+      for (unsigned int i = 0; i < numTrees; i++)
+      {
+        _forest.push_back(std::shared_ptr<RandomTree>(new RandomTree()));
+        _forest.back()->trainRoundRobin(data, numFactors, posClass, negClass, nodeSize, true);
+        std::cout << "Trained Tree # " << i + 1 << " / " << numTrees << "     \r";
+        std::cout.flush();
+      }
+      std::cout << std::endl;
+
+     //std::cout << "Mode Trained " << std::endl;
+      if (retrain >= 0 && retrain < 1.0)
+      {
+        std::cout << "Retraining model on top " << (retrain * 100) << "% of factors" << std::endl;
+        std::map<std::string, double> topFactors;
+        std::map<std::string, double>::iterator mapItr;
+
+        getFactorImportance(data, topFactors);
+
+        std::vector<std::string> badFactors;
+
+        unsigned int cutOffIdx =
+          topFactors.size() - (unsigned int)((double)topFactors.size() * retrain);
+
+        std::multimap<double, std::string> sortedFactors;
+        std::multimap<double, std::string>::iterator mMapItr;
+
+        //Create a map from lowest to highest of important mapped to factor type
+        for (mapItr = topFactors.begin(); mapItr != topFactors.end(); ++mapItr)
+        {
+          sortedFactors.insert(std::pair<double, std::string>(mapItr->second, mapItr->first));
+        }
+
+        unsigned int cutOffCtr = 0;
+
+        for (mMapItr = sortedFactors.begin(); mMapItr != sortedFactors.end(); ++mMapItr)
+        {
+          if (cutOffCtr <  cutOffIdx)
+          {
+            badFactors.push_back(mMapItr->second);
+            cutOffCtr++;
+          }
+          else
+          {
+            break;
+          }
+        }
+
+        for (unsigned int i = 0; i < badFactors.size(); i++)
+        {
+          data->deactivateFactor(badFactors[i]);
+        }
+
+        _forest.clear();
+
+        _forest.reserve(numTrees);
+
+        for (unsigned int i = 0; i < numTrees; i++)
+        {
+          _forest.push_back(std::shared_ptr<RandomTree>(new RandomTree()));
+          _forest.back()->trainMulticlass(data,
+            (unsigned int)sqrt((double)(topFactors.size() - cutOffIdx)), 1, balanced);
+        }
+      }
+
+      _forestCreated = true;
+    }
+    else
+    {
+      throw Exception(__LINE__, "Unable to operate on empty dataset");
+    }
+  }
+  catch(const Exception & e)
+  {
+    throw Exception(typeid(this).name(), __FUNCTION__, __LINE__, e);
+  }
+}
+
 }  //End namespace
-
-
-

--- a/tgs/src/main/cpp/tgs/RandomForest/RandomForest.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/RandomForest.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef __RANDOM_FOREST_H__
@@ -43,73 +43,68 @@
 
 namespace Tgs
 {
+/**
+*  The RandomForest is an implementation of the Leo Breiman
+* Random Forest Classification algorithm
+*
+* For more information see:
+* http://oz.berkeley.edu/~breiman/RandomForests/
+*/
+class TGS_EXPORT RandomForest : public BaseRandomForest
+{
+public:
   /**
-  *  The RandomForest is an implementation of the Leo Breiman
-  * Random Forest Classification algorithm
-  *
-  * For more information see:
-  * http://oz.berkeley.edu/~breiman/RandomForests/
+  * Default Constructor/Destructor
   */
-  class TGS_EXPORT RandomForest : public BaseRandomForest
-  {
-  public:
-    /**
-    * Constructor
-    */
-    RandomForest();
+  RandomForest() = default;
+  ~RandomForest() = default;
 
-    /**
-    * Destructor
-    */
-    ~RandomForest();
+  /**
+  * Build the forest from a data set
+  *
+  * @param data the data set to train on
+  * @param numTrees the number of random trees to create
+  * @param numFactors the number of factors to randomly choose as candidates for node splitting
+  * @param posClass the name of the positive class
+  * @param nodeSize the minimum number of data vectors in a set to split a node
+  * @param retrain fraction of top factors to use in retraining model (1.0 means use all factors and no retraining)
+  * @param balanced true if the forest will be balanced
+  */
+  virtual void trainBinary(const std::shared_ptr<DataFrame>& data, unsigned int numTrees,
+    unsigned int numFactors, std::string posClass, unsigned int nodeSize = 1,
+    double retrain = 1.0, bool balanced = false) override;
 
-    /**
-    * Build the forest from a data set
-    *
-    * @param data the data set to train on 
-    * @param numTrees the number of random trees to create
-    * @param numFactors the number of factors to randomly choose as candidates for node splitting
-    * @param posClass the name of the positive class
-    * @param nodeSize the minimum number of data vectors in a set to split a node 
-    * @param retrain fraction of top factors to use in retraining model (1.0 means use all factors and no retraining)
-    * @param balanced true if the forest will be balanced
-    */
-    virtual void trainBinary(const std::shared_ptr<DataFrame>& data, unsigned int numTrees,
-      unsigned int numFactors, std::string posClass, unsigned int nodeSize = 1,
-      double retrain = 1.0, bool balanced = false) override;
+  /**
+  * Build the forest from a data set
+  *
+  * @param data the data set to train on
+  * @param numTrees the number of random trees to create
+  * @param numFactors the number of factors to randomly choose as candidates for node splitting
+  * @param nodeSize the minimum number of data vectors in a set to split a node
+  * @param retrain fraction of top factors to use in retraining model (1.0 means use all factors and no retraining)
+  * @param balanced true if the forest will be balanced
+  */
+  virtual void trainMulticlass(const std::shared_ptr<DataFrame>& data, unsigned int numTrees,
+    unsigned int numFactors, unsigned int nodeSize = 1, double retrain = 1.0,
+    bool balanced = false) override;
 
-    /**
-    * Build the forest from a data set
-    *
-    * @param data the data set to train on 
-    * @param numTrees the number of random trees to create
-    * @param numFactors the number of factors to randomly choose as candidates for node splitting
-    * @param nodeSize the minimum number of data vectors in a set to split a node 
-    * @param retrain fraction of top factors to use in retraining model (1.0 means use all factors and no retraining)
-    * @param balanced true if the forest will be balanced
-    */
-    virtual void trainMulticlass(const std::shared_ptr<DataFrame>& data, unsigned int numTrees,
-      unsigned int numFactors, unsigned int nodeSize = 1, double retrain = 1.0,
-      bool balanced = false) override;
+  /**
+  * Build the forest from a data set
+  *
+  * @param data the data set to train on
+  * @param numTrees the number of random trees to create
+  * @param numFactors the number of factors to randomly choose as candidates for node splitting
+  * @param posClass the name of the positive class
+  * @param negClass the name of the negative class
+  * @param nodeSize the minimum number of data vectors in a set to split a node
+  * @param retrain fraction of top factors to use in retraining model (1.0 means use all factors and no retraining)
+  * @param balanced true if the forest will be balanced
+  */
+  virtual void trainRoundRobin(const std::shared_ptr<DataFrame>& data, unsigned int numTrees,
+    unsigned int numFactors, std::string posClass, std::string negClass,
+    unsigned int nodeSize = 1, double retrain = 1.0, bool balanced = false) override;
 
-    /**
-    * Build the forest from a data set
-    *
-    * @param data the data set to train on 
-    * @param numTrees the number of random trees to create
-    * @param numFactors the number of factors to randomly choose as candidates for node splitting
-    * @param posClass the name of the positive class
-    * @param negClass the name of the negative class
-    * @param nodeSize the minimum number of data vectors in a set to split a node 
-    * @param retrain fraction of top factors to use in retraining model (1.0 means use all factors and no retraining)
-    * @param balanced true if the forest will be balanced
-    */
-    virtual void trainRoundRobin(const std::shared_ptr<DataFrame>& data, unsigned int numTrees,
-      unsigned int numFactors, std::string posClass, std::string negClass,
-      unsigned int nodeSize = 1, double retrain = 1.0, bool balanced = false) override;
+};
 
-  };
 }  //End namespace
 #endif
-
-


### PR DESCRIPTION
Update `MatchFactory` class to use the Meyer's Singleton pattern.  `HighwayClassifier` based classes can have a memory leak that is fixed with this change.

Found while investigating #4070 