### PR TITLE
Prevent review relations with zero or only null members from breaking AddHilbertReviewSortOrderOp

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/ops/AddHilbertReviewSortOrderOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/AddHilbertReviewSortOrderOp.cpp
@@ -43,6 +43,8 @@ using namespace std;
 namespace hoot
 {
 
+int AddHilbertReviewSortOrderOp::logWarnCount = 0;
+
 HOOT_FACTORY_REGISTER(OsmMapOperation, AddHilbertReviewSortOrderOp)
 
 bool reviewLess(const pair<ElementId, int64_t>& p1, const pair<ElementId, int64_t>& p2)
@@ -101,8 +103,19 @@ void AddHilbertReviewSortOrderOp::apply(OsmMapPtr& map)
       }
       else
       {
-        throw HootException(
-          "No review elements returned for relation with ID: " + r->getElementId().toString());
+        // don't think this really needs to be an exceptional situation
+//        throw HootException(
+//          "No review elements returned for relation with ID: " + r->getElementId().toString());
+        LOG_WARN("No review elements returned for relation with ID: " << r->getElementId());
+        if (logWarnCount < Log::getWarnMessageLimit())
+        {
+          LOG_WARN("No review elements returned for relation with ID: " << r->getElementId());
+        }
+        else if (logWarnCount == Log::getWarnMessageLimit())
+        {
+          LOG_WARN(className() << ": " << Log::LOG_WARN_LIMIT_REACHED_MESSAGE);
+        }
+        logWarnCount++;
       }
     }
   }

--- a/hoot-core/src/main/cpp/hoot/core/ops/AddHilbertReviewSortOrderOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/AddHilbertReviewSortOrderOp.h
@@ -41,6 +41,8 @@ public:
 
   static std::string className() { return "hoot::AddHilbertReviewSortOrderOp"; }
 
+  static int logWarnCount;
+
   AddHilbertReviewSortOrderOp() = default;
   virtual ~AddHilbertReviewSortOrderOp() = default;
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidReviewRelationsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidReviewRelationsVisitor.cpp
@@ -56,11 +56,31 @@ void RemoveInvalidReviewRelationsVisitor::visit(const ElementPtr& e)
       {
         invalidRelation = true;
       }
-      //in case the review member count tag didn't get added for some reason, go ahead and at least
-      //remove empty relations
+      // in case the review member count tag didn't get added for some reason, go ahead and at least
+      // remove empty relations
       else if (!hasMemberCountTag && r->getMembers().size() == 0)
       {
         invalidRelation = true;
+      }
+      else
+      {
+        // In the cut and replace workflow (ChangesetReplacementCreator), there's a possibility that
+        // we could have a relation with all references to members not actually in the data. If all
+        // the members don't exist, let's drop the review.
+        int nullMemberCount = 0;
+        const std::vector<RelationData::Entry> relationMembers = r->getMembers();
+        for (size_t i = 0; i < relationMembers.size(); i++)
+        {
+          ConstElementPtr member = _map->getElement(relationMembers[i].getElementId());
+          if (!member)
+          {
+            nullMemberCount++;
+          }
+        }
+        if (nullMemberCount == (int)relationMembers.size())
+        {
+          invalidRelation = true;
+        }
       }
 
       if (invalidRelation)


### PR DESCRIPTION
In the cut and replace workflow there may be review relations with references to elements that don't exist in the data. This fix is a continuation of #4093.