### PR TITLE
Multiple version failures can grind changeset-upload to a halt

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
@@ -149,8 +149,28 @@ protected:
    *   - Capabilities
    *   - Permissions
    *   - Changeset Create
-   *   - Changeset Upload Failure - responds with HTTP
+   *   - Changeset Upload Failure - responds with HTTP 412
    *   - Changeset Upload - responds with HTTP 200
+   *   - Changeset Close
+   */
+  bool respond(HttpConnection::HttpConnectionPtr &connection) override;
+};
+
+class VersionFailureTestServer : public HttpTestServer
+{
+public:
+  /** Constructor */
+  VersionFailureTestServer(int port) : HttpTestServer(port) { }
+
+protected:
+  /** respond() function that responds to a series of OSM API requests
+   *  to simulate an element version failure over and over.
+   *  Requests, in order:
+   *   - Capabilities
+   *   - Permissions
+   *   - Changeset Create
+   *   - Changeset Upload Version Failure - responds with HTTP 409
+   *   - Element Get - responds with HTTP 200
    *   - Changeset Close
    */
   bool respond(HttpConnection::HttpConnectionPtr &connection) override;
@@ -181,6 +201,12 @@ public:
   /** Sample Changeset upload response bodies for a failed response to '/api/0.6/changeset/1/upload' */
   static const char* SAMPLE_CHANGESET_FAILURE_RESPONSE_1;
   static const char* SAMPLE_CHANGESET_FAILURE_RESPONSE_2;
+  /** Sample Changeset upload request */
+  static const char* SAMPLE_CHANGESET_VERSION_FAILURE_CHANGESET;
+  /** Sample Changeset upload conflict response body for a version conflict response to '/api/0.6/changeset/1/upload' */
+  static const char* SAMPLE_CHANGESET_VERSION_FAILURE_RESPONSE;
+  /** Sample Element GET response body for version conflict resolution */
+  static const char* SAMPLE_CHANGESET_VERSION_FAILURE_GET_RESPONSE;
 };
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.cpp
@@ -109,7 +109,8 @@ void HttpTestServer::stop()
   //  Interupt the threads
   _interupt = true;
   //  Close the acceptor
-  _acceptor->close();
+  boost::system::error_code ec;
+  _acceptor->close(ec);
   //  Stop the IO service
   _io_service.stop();
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -2387,9 +2387,8 @@ void ChangesetInfo::retryFailure()
 {
   //  Increment the failure retry count
   _numFailureRetries++;
-  //  Once the failure retry count reaches MAX_FAILURE_RETRIES set the attempted resolved flag
-  if (_numFailureRetries > MAX_FAILURE_RETRIES)
-    _attemptedResolveChangesetIssues = true;
+  //  A retry was attempted, set the attempted flag
+  _attemptedResolveChangesetIssues = true;
 }
 
 bool ChangesetInfo::canRetryVersion()

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -2297,7 +2297,8 @@ QString XmlChangeset::getRemainingFilename()
 
 ChangesetInfo::ChangesetInfo()
   : _attemptedResolveChangesetIssues(false),
-    _numRetries(0),
+    _numFailureRetries(0),
+    _numVersionRetries(0),
     _last(false),
     _isError(false)
 {
@@ -2307,7 +2308,7 @@ void ChangesetInfo::add(ElementType::Type element_type, XmlChangeset::ChangesetT
 {
   _changeset[element_type][changeset_type].insert(id);
   //  Changes in the changeset cause the retries to start over
-  _numRetries = 0;
+  _numFailureRetries = 0;
 }
 
 void ChangesetInfo::remove(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type, long id)
@@ -2316,7 +2317,7 @@ void ChangesetInfo::remove(ElementType::Type element_type, XmlChangeset::Changes
   if (selectedSet.find(id) != selectedSet.end())
     selectedSet.erase(id);
   //  Changes in the changeset cause the retries to start over
-  _numRetries = 0;
+  _numFailureRetries = 0;
 }
 
 long ChangesetInfo::getFirst(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type)
@@ -2331,7 +2332,7 @@ void ChangesetInfo::clear()
     for (int j = 0; j < (int)XmlChangeset::TypeMax; ++j)
       _changeset[i][j].clear();
   }
-  _numRetries = 0;
+  _numFailureRetries = 0;
 }
 
 bool ChangesetInfo::contains(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type, long id)
@@ -2377,17 +2378,30 @@ void ChangesetInfo::setAttemptedResolveChangesetIssues(bool attempted)
   _attemptedResolveChangesetIssues = attempted;
 }
 
-bool ChangesetInfo::canRetry()
+bool ChangesetInfo::canRetryFailure()
 {
-  return _numRetries < MAX_RETRIES;
+  return _numFailureRetries < MAX_FAILURE_RETRIES;
 }
 
-void ChangesetInfo::retry()
+void ChangesetInfo::retryFailure()
 {
-  //  Increment the retry count
-  _numRetries++;
-  //  Once the retry count reaches MAX_RETRIES set the attempted resolved flag
-  _attemptedResolveChangesetIssues = true;
+  //  Increment the failure retry count
+  _numFailureRetries++;
+  //  Once the failure retry count reaches MAX_FAILURE_RETRIES set the attempted resolved flag
+  if (_numFailureRetries > MAX_FAILURE_RETRIES)
+    _attemptedResolveChangesetIssues = true;
 }
+
+bool ChangesetInfo::canRetryVersion()
+{
+  return _numVersionRetries < MAX_VERSION_RETRIES;
+}
+
+void ChangesetInfo::retryVersion()
+{
+  //  Increment the version retry count
+  _numVersionRetries++;
+}
+
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -628,8 +628,11 @@ public:
   bool getAttemptedResolveChangesetIssues();
   void setAttemptedResolveChangesetIssues(bool attempted);
   /** Set/get _numRetries member */
-  bool canRetry();
-  void retry();
+  bool canRetryFailure();
+  void retryFailure();
+  /** Set/get _versionRetries member */
+  bool canRetryVersion();
+  void retryVersion();
   /** Set/get _last member for final error checking */
   void setLast() { _last = true; }
   bool getLast() { return _last; }
@@ -642,9 +645,12 @@ private:
   std::array<std::array<container, XmlChangeset::TypeMax>, ElementType::Unknown> _changeset;
   /** Flag set after attempt to resolve changeset issues has completed. */
   bool _attemptedResolveChangesetIssues;
-  /** Number of times this exact changeset has been retried unsuccessfully */
-  int _numRetries;
-  const int MAX_RETRIES = 5;
+  /** Number of times this exact changeset has been retried from failures unsuccessfully */
+  int _numFailureRetries;
+  const int MAX_FAILURE_RETRIES = 5;
+  /** Number of times this exact changeset has had version errors */
+  int _numVersionRetries;
+  const int MAX_VERSION_RETRIES = 25;
   /** Flag set when this is the last changeset because of error */
   bool _last;
   /** When `true` this entire changeset consists of elements that cannot be pushed without an error.

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -402,6 +402,8 @@ private:
   std::mutex _apiIdMutex;
   /** Flag to tell threads that they can exit when idle */
   bool _threadsCanExit;
+  /** Error message for why the process failed */
+  QString _errorMessage;
   /** For white box testing */
   friend class OsmApiWriterTest;
   /** Default constructor for testing purposes only */

--- a/test-files/io/OsmChangesetElementTest/VersionFailure-error.osc
+++ b/test-files/io/OsmChangesetElementTest/VersionFailure-error.osc
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<modify>
+		<way id="1" version="51" timestamp="" changeset="0">
+			<nd ref="1"/>
+			<nd ref="2"/>
+			<nd ref="3"/>
+			<tag k="amenity" v="restaurant"/>
+			<tag k="name" v="Pizza Shop"/>
+			<tag k="building" v="yes"/>
+		</way>
+	</modify>
+</osmChange>


### PR DESCRIPTION
Closes #4110 

Version failures are mitigated by requesting the offending element and updating version/tag information.  This takes quite some time.  Since the OSM API only returns one error, this process happens for each conflicting element.  If there are a lot of them Hootenanny tries for a while and then fails reporting to the user that their data is out of date.