### PR TITLE
ParallelBoundedApiReader error processing and Qt race conditions

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/Hoot.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/Hoot.cpp
@@ -44,6 +44,7 @@
 
 // Qt
 #include <QLibrary>
+#include <QNetworkSession>
 
 // System
 #include <memory>
@@ -124,6 +125,12 @@ void Hoot::_init()
 # endif
 
   Log::getInstance().setLevel(Log::Info);
+  //  Registering these metatypes here removes warning messages
+  //  in threads that use QNetworkAccessManager whose initialization
+  //  routine isn't thread safe
+  qRegisterMetaType<QPair<QByteArray, QByteArray>>();
+  qRegisterMetaType<QList<QPair<QByteArray,QByteArray>>>();
+  qRegisterMetaType<QSharedPointer<QNetworkSession>>();
 }
 
 void Hoot::loadLibrary(const QString& name)

--- a/hoot-core/src/main/cpp/hoot/core/io/HootNetworkRequest.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootNetworkRequest.cpp
@@ -170,6 +170,9 @@ bool HootNetworkRequest::_networkRequest(const QUrl& url,
       _error.replace(request.url().toString(), tempUrl.toString(QUrl::RemoveUserInfo), Qt::CaseInsensitive);
     //  Replace the IP address in the error string with <host-ip>
     HootNetworkRequest::removeIpFromUrlString(_error, request.url());
+    //  Negate the connection error as the status
+    if (_status == 0)
+      _status = -1 * (int)reply->error();
     return false;
   }
 
@@ -214,7 +217,7 @@ int HootNetworkRequest::_getHttpResponseCode(QNetworkReply* reply)
     if (status.isValid())
       return status.toInt();
   }
-  return -1;
+  return 0;
 }
 
 void HootNetworkRequest::_setOAuthHeader(QNetworkAccessManager::Operation http_op, QNetworkRequest& request)

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #ifndef PARALLEL_BOUNDED_API_READER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
@@ -164,6 +164,8 @@ protected:
   int _threadCount;
   /** Processing thread pool */
   std::vector<std::thread> _threads;
+  /** Mutex guarding error processing code */
+  std::mutex _errorMutex;
   /** Set to true if there was a fatal error in the query */
   bool _fatalError;
   /** Flag set to true if the bounding box is to be output in the x1,y1,x2,y2 format and

--- a/hoot-core/src/main/cpp/hoot/core/util/HootNetworkUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/HootNetworkUtils.h
@@ -44,6 +44,7 @@ namespace HttpResponseCode
   const int HTTP_BAD_GATEWAY            = 502;
   const int HTTP_SERVICE_UNAVAILABLE    = 503;
   const int HTTP_GATEWAY_TIMEOUT        = 504;
+  const int HTTP_BANDWIDTH_EXCEEDED     = 509;
 }
 
 class HootNetworkUtils


### PR DESCRIPTION
Refs #4113

While working on cut & replace errors cropped up in the `ParallelBoundedApiReader` class and weren't being handled correctly.  Mostly unrelated to the actual errors in cut & replace.