### PR TITLE
Reduce changeset-apply errors

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetTest.cpp
@@ -43,7 +43,6 @@ class OsmApiChangesetTest : public HootTestFixture
   CPPUNIT_TEST(runXmlChangesetSplitTest);
   CPPUNIT_TEST(runXmlChangesetSplitWayTest);
   CPPUNIT_TEST(runXmlChangesetErrorFixTest);
-  CPPUNIT_TEST(runXmlChangesetFailureMatchesTest);
   CPPUNIT_TEST(runXmlChangesetSplitDeleteTest);
   CPPUNIT_TEST_SUITE_END();
 
@@ -205,128 +204,6 @@ public:
     QString error = changeset.getFailedChangesetString();
     QString expectedError = FileUtils::readFully(_inputPath + "ChangesetErrorFixErrors.osc");
     HOOT_STR_EQUALS(expectedError, error);
-  }
-
-  void runXmlChangesetFailureMatchesTest()
-  {
-    XmlChangeset changeset;
-
-    bool found = false;
-    long id = 0;
-    long id2 = 0;
-    std::vector<long> ids;
-    ElementType::Type type = ElementType::Unknown;
-    ElementType::Type type2 = ElementType::Unknown;
-    QString hint;
-
-    //  Test Placeholder failure with node in way
-    id = 0;
-    id2 = 0;
-    type = ElementType::Unknown;
-    type2 = ElementType::Unknown;
-    hint = "Placeholder node not found for reference -145213 in way -5687";
-    found = changeset.matchesPlaceholderFailure(hint, id, type, id2, type2);
-    CPPUNIT_ASSERT_EQUAL(true, found);
-    CPPUNIT_ASSERT_EQUAL(-145213L, id);
-    CPPUNIT_ASSERT_EQUAL(ElementType::Node, type);
-    CPPUNIT_ASSERT_EQUAL(-5687L, id2);
-    CPPUNIT_ASSERT_EQUAL(ElementType::Way, type2);
-
-    //  Test Placeholder failure with way in relation
-    id = 0;
-    id2 = 0;
-    type = ElementType::Unknown;
-    type2 = ElementType::Unknown;
-    hint = "Placeholder Way not found for reference -12257 in Relation -51";
-    found = changeset.matchesPlaceholderFailure(hint, id, type, id2, type2);
-    CPPUNIT_ASSERT_EQUAL(true, found);
-    CPPUNIT_ASSERT_EQUAL(-12257L, id);
-    CPPUNIT_ASSERT_EQUAL(ElementType::Way, type);
-    CPPUNIT_ASSERT_EQUAL(-51L, id2);
-    CPPUNIT_ASSERT_EQUAL(ElementType::Relation, type2);
-
-    //  Test Placeholder failure with empty string
-    id = 0;
-    id2 = 0;
-    type = ElementType::Unknown;
-    type2 = ElementType::Unknown;
-    hint = "";
-    found = changeset.matchesPlaceholderFailure(hint, id, type, id2, type2);
-    CPPUNIT_ASSERT_EQUAL(false, found);
-    CPPUNIT_ASSERT_EQUAL(0L, id);
-    CPPUNIT_ASSERT_EQUAL(ElementType::Unknown, type);
-    CPPUNIT_ASSERT_EQUAL(0L, id2);
-    CPPUNIT_ASSERT_EQUAL(ElementType::Unknown, type2);
-
-    //  Test relation failure with no relation ID
-    id = 0;
-    id2 = 0;
-    type = ElementType::Unknown;
-    hint = "Relation with id  cannot be saved due to Relation with id 1707699";
-    found = changeset.matchesRelationFailure(hint, id, id2, type);
-    CPPUNIT_ASSERT_EQUAL(true, found);
-    CPPUNIT_ASSERT_EQUAL(0L, id);
-    CPPUNIT_ASSERT_EQUAL(1707699L, id2);
-    CPPUNIT_ASSERT_EQUAL(ElementType::Relation, type);
-
-    //  Test relation failure with relation ID
-    id = 0;
-    id2 = 0;
-    type = ElementType::Unknown;
-    hint = "Relation with id 122 cannot be saved due to Way with id 7699";
-    found = changeset.matchesRelationFailure(hint, id, id2, type);
-    CPPUNIT_ASSERT_EQUAL(true, found);
-    CPPUNIT_ASSERT_EQUAL(122L, id);
-    CPPUNIT_ASSERT_EQUAL(7699L, id2);
-    CPPUNIT_ASSERT_EQUAL(ElementType::Way, type);
-
-    //  Test multi relation failure with relation ID
-    id = 0;
-    ids.clear();
-    type = ElementType::Unknown;
-    type2 = ElementType::Unknown;
-    hint = "Relation -2 requires the relations with id in 1707148,1707249,1707264,1707653,1707654,1707655,1707656,1707657,1707658,1707699,1707700, which either do not exist, or are not visible.";
-    found = changeset.matchesMultiElementFailure(hint, id, type, ids, type2);
-    std::vector<long> expected_relation_ids { 1707148,1707249,1707264,1707653,1707654,1707655,1707656,1707657,1707658,1707699,1707700 };
-    CPPUNIT_ASSERT_EQUAL(true, found);
-    CPPUNIT_ASSERT_EQUAL(-2L, id);
-    CPPUNIT_ASSERT_EQUAL(ElementType::Relation, type);
-    CPPUNIT_ASSERT_EQUAL(expected_relation_ids.size(), ids.size());
-    for (int i = 0; i < (int)ids.size(); ++i)
-      CPPUNIT_ASSERT_EQUAL(expected_relation_ids[i], ids[i]);
-    CPPUNIT_ASSERT_EQUAL(ElementType::Relation, type2);
-
-    //  Test multi node failure with way ID
-    id = 0;
-    ids.clear();
-    type = ElementType::Unknown;
-    type2 = ElementType::Unknown;
-    hint = "Way -1 requires the nodes with id in 11,20, which either do not exist, or are not visible.";
-    found = changeset.matchesMultiElementFailure(hint, id, type, ids, type2);
-    std::vector<long> expected_node_ids { 11,20 };
-    CPPUNIT_ASSERT_EQUAL(true, found);
-    CPPUNIT_ASSERT_EQUAL(-1L, id);
-    CPPUNIT_ASSERT_EQUAL(ElementType::Way, type);
-    CPPUNIT_ASSERT_EQUAL(expected_node_ids.size(), ids.size());
-    for (int i = 0; i < (int)ids.size(); ++i)
-      CPPUNIT_ASSERT_EQUAL(expected_node_ids[i], ids[i]);
-    CPPUNIT_ASSERT_EQUAL(ElementType::Node, type2);
-
-    //  Test relation failure with empty string
-    id = 0;
-    id2 = 0;
-    type = ElementType::Unknown;
-    hint = "";
-    found = changeset.matchesRelationFailure(hint, id, id2, type);
-    CPPUNIT_ASSERT_EQUAL(false, found);
-    CPPUNIT_ASSERT_EQUAL(0L, id);
-    CPPUNIT_ASSERT_EQUAL(0L, id2);
-    CPPUNIT_ASSERT_EQUAL(ElementType::Unknown, type);
-
-    //  Test changeset closed
-    hint = "Changeset conflict: The changeset 49514404 was closed at 2020-01-23 20:11:10 UTC";
-    found = changeset.matchesChangesetClosedFailure(hint);
-    CPPUNIT_ASSERT_EQUAL(true, found);
   }
 
   void runXmlChangesetSplitDeleteTest()

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiMatchFailureTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiMatchFailureTest.cpp
@@ -1,0 +1,189 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2020 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+//  Hoot
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/io/OsmApiMatchFailure.h>
+#include <hoot/core/util/FileUtils.h>
+
+namespace hoot
+{
+
+class OsmApiMatchFailureTest : public HootTestFixture
+{
+  CPPUNIT_TEST_SUITE(OsmApiMatchFailureTest);
+  CPPUNIT_TEST(runXmlChangesetFailureMatchesTest);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  OsmApiMatchFailureTest() = default;
+
+  void runXmlChangesetFailureMatchesTest()
+  {
+    OsmApiMatchFailure failureCheck;
+
+    bool found = false;
+    long id = 0;
+    long id2 = 0;
+    std::vector<long> ids;
+    ElementType::Type type = ElementType::Unknown;
+    ElementType::Type type2 = ElementType::Unknown;
+    QString hint;
+
+    //  Test Placeholder failure with node in way
+    id = 0;
+    id2 = 0;
+    type = ElementType::Unknown;
+    type2 = ElementType::Unknown;
+    hint = "Placeholder node not found for reference -145213 in way -5687";
+    found = failureCheck.matchesPlaceholderFailure(hint, id, type, id2, type2);
+    CPPUNIT_ASSERT_EQUAL(true, found);
+    CPPUNIT_ASSERT_EQUAL(-145213L, id);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Node, type);
+    CPPUNIT_ASSERT_EQUAL(-5687L, id2);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Way, type2);
+
+    //  Test Placeholder failure with way in relation
+    id = 0;
+    id2 = 0;
+    type = ElementType::Unknown;
+    type2 = ElementType::Unknown;
+    hint = "Placeholder Way not found for reference -12257 in Relation -51";
+    found = failureCheck.matchesPlaceholderFailure(hint, id, type, id2, type2);
+    CPPUNIT_ASSERT_EQUAL(true, found);
+    CPPUNIT_ASSERT_EQUAL(-12257L, id);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Way, type);
+    CPPUNIT_ASSERT_EQUAL(-51L, id2);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Relation, type2);
+
+    //  Test Placeholder failure with empty string
+    id = 0;
+    id2 = 0;
+    type = ElementType::Unknown;
+    type2 = ElementType::Unknown;
+    hint = "";
+    found = failureCheck.matchesPlaceholderFailure(hint, id, type, id2, type2);
+    CPPUNIT_ASSERT_EQUAL(false, found);
+    CPPUNIT_ASSERT_EQUAL(0L, id);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Unknown, type);
+    CPPUNIT_ASSERT_EQUAL(0L, id2);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Unknown, type2);
+
+    //  Test relation failure with no relation ID
+    id = 0;
+    id2 = 0;
+    type = ElementType::Unknown;
+    hint = "Relation with id  cannot be saved due to Relation with id 1707699";
+    found = failureCheck.matchesRelationFailure(hint, id, id2, type);
+    CPPUNIT_ASSERT_EQUAL(true, found);
+    CPPUNIT_ASSERT_EQUAL(0L, id);
+    CPPUNIT_ASSERT_EQUAL(1707699L, id2);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Relation, type);
+
+    //  Test relation failure with relation ID
+    id = 0;
+    id2 = 0;
+    type = ElementType::Unknown;
+    hint = "Relation with id 122 cannot be saved due to Way with id 7699";
+    found = failureCheck.matchesRelationFailure(hint, id, id2, type);
+    CPPUNIT_ASSERT_EQUAL(true, found);
+    CPPUNIT_ASSERT_EQUAL(122L, id);
+    CPPUNIT_ASSERT_EQUAL(7699L, id2);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Way, type);
+
+    //  Test multi relation failure with relation ID
+    id = 0;
+    ids.clear();
+    type = ElementType::Unknown;
+    type2 = ElementType::Unknown;
+    hint = "Relation -2 requires the relations with id in 1707148,1707249,1707264,1707653,1707654,1707655,1707656,1707657,1707658,1707699,1707700, which either do not exist, or are not visible.";
+    found = failureCheck.matchesMultiElementFailure(hint, id, type, ids, type2);
+    std::vector<long> expected_relation_ids { 1707148, 1707249, 1707264, 1707653, 1707654, 1707655, 1707656, 1707657, 1707658, 1707699, 1707700 };
+    CPPUNIT_ASSERT_EQUAL(true, found);
+    CPPUNIT_ASSERT_EQUAL(-2L, id);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Relation, type);
+    CPPUNIT_ASSERT_EQUAL(expected_relation_ids.size(), ids.size());
+    for (int i = 0; i < (int)ids.size(); ++i)
+      CPPUNIT_ASSERT_EQUAL(expected_relation_ids[i], ids[i]);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Relation, type2);
+
+    //  Test multi node failure with way ID
+    id = 0;
+    ids.clear();
+    type = ElementType::Unknown;
+    type2 = ElementType::Unknown;
+    hint = "Way -1 requires the nodes with id in 11,20, which either do not exist, or are not visible.";
+    found = failureCheck.matchesMultiElementFailure(hint, id, type, ids, type2);
+    std::vector<long> expected_node_ids { 11, 20 };
+    CPPUNIT_ASSERT_EQUAL(true, found);
+    CPPUNIT_ASSERT_EQUAL(-1L, id);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Way, type);
+    CPPUNIT_ASSERT_EQUAL(expected_node_ids.size(), ids.size());
+    for (int i = 0; i < (int)ids.size(); ++i)
+      CPPUNIT_ASSERT_EQUAL(expected_node_ids[i], ids[i]);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Node, type2);
+
+    //  Test multi way failure with node ID
+    id = 0;
+    ids.clear();
+    type = ElementType::Unknown;
+    type2 = ElementType::Unknown;
+    hint = "Precondition failed: Node 1671 is still used by ways 308,880,884,1071.";
+    found = failureCheck.matchesChangesetDeletePreconditionFailure(hint, id, type, ids, type2);
+    std::vector<long> expected_way_ids { 308, 880, 884, 1071 };
+    CPPUNIT_ASSERT_EQUAL(true, found);
+    CPPUNIT_ASSERT_EQUAL(1671L, id);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Node, type);
+    CPPUNIT_ASSERT_EQUAL(expected_way_ids.size(), ids.size());
+    for (int i = 0; i < (int)ids.size(); ++i)
+      CPPUNIT_ASSERT_EQUAL(expected_way_ids[i], ids[i]);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Way, type2);
+
+    //  Test relation failure with empty string
+    id = 0;
+    id2 = 0;
+    type = ElementType::Unknown;
+    hint = "";
+    found = failureCheck.matchesRelationFailure(hint, id, id2, type);
+    CPPUNIT_ASSERT_EQUAL(false, found);
+    CPPUNIT_ASSERT_EQUAL(0L, id);
+    CPPUNIT_ASSERT_EQUAL(0L, id2);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Unknown, type);
+
+    //  Test changeset closed
+    hint = "Changeset conflict: The changeset 49514404 was closed at 2020-01-23 20:11:10 UTC";
+    found = failureCheck.matchesChangesetClosedFailure(hint);
+    CPPUNIT_ASSERT_EQUAL(true, found);
+  }
+
+};
+
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(OsmApiMatchFailureTest, "quick");
+//CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(OsmApiMatchFailureTest, "current");
+
+}

--- a/hoot-core/src/main/cpp/hoot/core/io/HootNetworkRequest.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootNetworkRequest.cpp
@@ -245,4 +245,17 @@ void HootNetworkRequest::removeIpFromUrlString(QString& endpointUrl, const QUrl&
     endpointUrl.replace(url.host(), "<host-ip>");
 }
 
+void HootNetworkRequest::logConnectionError()
+{
+  if (_status < 0)
+  {
+    //  Negative status error messages are connection errors from the socket and not from the HTTP server
+    LOG_ERROR("Connection Error: " << getErrorString() << " (" << (_status * -1) << ")");
+  }
+  else
+  {
+    LOG_ERROR("Unexpected Error: HTTP " << _status << " : " << getErrorString());
+  }
+}
+
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/HootNetworkRequest.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootNetworkRequest.h
@@ -133,6 +133,11 @@ public:
    */
   static void removeIpFromUrlString(QString& endpointUrl, const QUrl& url);
 
+  /**
+   * @brief logConnectionError Log an error with the connection based on the reponse error, not an HTTP error code
+   */
+  void logConnectionError();
+
 private:
   /**
    * @brief _networkRequest Function to make the actual request

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -1281,141 +1281,6 @@ bool XmlChangeset::calculateChangeset(ChangesetInfoPtr& changeset)
   return changeset->size() > 0;
 }
 
-bool XmlChangeset::matchesPlaceholderFailure(const QString& hint,
-                                             long& member_id, ElementType::Type& member_type,
-                                             long& element_id, ElementType::Type& element_type)
-{
-  //  Placeholder node not found for reference -145213 in way -5687
-  //  Placeholder Way not found for reference -12257 in Relation -51
-  QRegularExpression reg("Placeholder (node|way|relation) not found for reference (-?[0-9]+) in (node|way|relation) (-?[0-9]+)",
-                         QRegularExpression::CaseInsensitiveOption);
-  QRegularExpressionMatch match = reg.match(hint);
-  if (match.hasMatch())
-  {
-    //  Get the node/way/relation type and id that caused the failure
-    member_type = ElementType::fromString(match.captured(1).toLower());
-    bool success = false;
-    member_id = match.captured(2).toLong(&success);
-    if (!success)
-      return success;
-    //  Get the node/way/relation type and id that failed
-    element_type = ElementType::fromString(match.captured(3));
-    element_id = match.captured(4).toLong(&success);
-    return success;
-  }
-  return false;
-}
-
-bool XmlChangeset::matchesRelationFailure(const QString& hint, long& element_id, long& member_id, ElementType::Type& member_type)
-{
-  //  Relation with id  cannot be saved due to Relation with id 1707699
-  QRegularExpression reg("Relation with id (-?[0-9]+)? cannot be saved due to (nodes|way|relation) with id (-?[0-9]+)",
-                         QRegularExpression::CaseInsensitiveOption);
-  QRegularExpressionMatch match = reg.match(hint);
-  if (match.hasMatch())
-  {
-    QString error = match.captured(1);
-    if (error != "")
-      element_id = error.toLong();
-    //  Get the node/way/relation type and id that failed
-    member_type = ElementType::fromString(match.captured(2));
-    bool success = false;
-    member_id = match.captured(3).toLong(&success);
-    return success;
-  }
-  return false;
-}
-
-bool XmlChangeset::matchesMultiElementFailure(const QString& hint,
-                                              long& element_id,
-                                              ElementType::Type& element_type,
-                                              std::vector<long>& member_ids,
-                                              ElementType::Type& member_type)
-{
-  //  Relation with id -2 requires the relations with id in 1707148,1707249, which either do not exist, or are not visible.
-  QRegularExpression reg("(Relation|Way) (-?[0-9]+) requires the (nodes|ways|relations) with id in ((-?[0-9]+,)+) (.*)", //-?[0-9]+,).*", //+ which either do not exist, or are not visible.",
-                         QRegularExpression::CaseInsensitiveOption);
-  QRegularExpressionMatch match = reg.match(hint);
-  if (match.hasMatch())
-  {
-    element_type = ElementType::fromString(match.captured(1));
-    QString error = match.captured(2);
-    if (error != "")
-      element_id = error.toLong();
-    //  Get the node/way/relation type (remove the 's') and id that failed
-    member_type = ElementType::fromString(match.captured(3).left(match.captured(3).length() - 1));
-    bool success = false;
-    QStringList ids = match.captured(4).split(",", QString::SkipEmptyParts);
-    for (int i = 0; i < ids.size(); ++i)
-    {
-      long id = ids[i].toLong(&success);
-      if (success)
-        member_ids.push_back(id);
-    }
-    return success;
-  }
-  return false;
-}
-
-bool XmlChangeset::matchesChangesetDeletePreconditionFailure(
-    const QString& hint,
-    long& member_id, ElementType::Type& member_type,
-    long& element_id, ElementType::Type& element_type)
-{
-  //  Precondition failed: Node 55 is still used by ways 123
-  QRegularExpression reg(
-        "Precondition failed: (Node|Way|Relation) (-?[0-9]+) is still used by (node|way|relation)s (-?[0-9]+)",
-        QRegularExpression::CaseInsensitiveOption);
-  QRegularExpressionMatch match = reg.match(hint);
-  if (match.hasMatch())
-  {
-    bool success = false;
-    member_type = ElementType::fromString(match.captured(1).toLower());
-    member_id = match.captured(2).toLong(&success);
-    if (!success)
-      return success;
-    element_type = ElementType::fromString(match.captured(3).toLower());
-    element_id = match.captured(4).toLong(&success);
-    return success;
-  }
-  return false;
-}
-
-bool XmlChangeset::matchesChangesetConflictVersionMismatchFailure(const QString& hint,
-                                                                  long& element_id, ElementType::Type& element_type,
-                                                                  long& version_old, long& version_new)
-{
-  //  Changeset conflict: Version mismatch: Provided 2, server had: 1 of Node 4869875616
-  QRegularExpression reg(
-        "Changeset conflict: Version mismatch: Provided ([0-9]+), server had: ([0-9]+) of (Node|Way|Relation) ([0-9]+)",
-        QRegularExpression::CaseInsensitiveOption);
-  QRegularExpressionMatch match = reg.match(hint);
-  if (match.hasMatch())
-  {
-    bool success = false;
-    version_old = match.captured(1).toLong(&success);
-    if (!success)
-      return success;
-    version_new = match.captured(2).toLong(&success);
-    if (!success)
-      return success;
-    element_type = ElementType::fromString(match.captured(3).toLower());
-    element_id = match.captured(4).toLong(&success);
-    return success;
-  }
-  return false;
-}
-
-bool XmlChangeset::matchesChangesetClosedFailure(const QString& hint)
-{
-  //  Changeset conflict: The changeset 49514098 was closed at 2020-01-08 16:28:56 UTC
-  QRegularExpression reg(
-        ".*The changeset ([0-9]+) was closed.*",
-        QRegularExpression::CaseInsensitiveOption);
-  QRegularExpressionMatch match = reg.match(hint);
-  return match.hasMatch();
-}
-
 bool XmlChangeset::writeErrorFile()
 {
   //  Validate the pathname
@@ -1455,7 +1320,7 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(const ChangesetInfoPtr& changeset,
     ElementType::Type element_type = ElementType::Unknown;
     //  See if the hint is something like:
     //   Placeholder node not found for reference -145213 in way -5687
-    if (matchesPlaceholderFailure(splitHint, member_id, member_type, element_id, element_type))
+    if (_failureCheck.matchesPlaceholderFailure(splitHint, member_id, member_type, element_id, element_type))
     {
       //  Use the type and id to split the changeset
       for (int current_type = ChangesetType::TypeCreate; current_type != ChangesetType::TypeMax; ++current_type)
@@ -1468,14 +1333,15 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(const ChangesetInfoPtr& changeset,
             //  Add the way to the split and remove from the changeset
             if (current_type == ChangesetType::TypeCreate)
             {
+              //  Move all nodes to be created with this way to the split
               moveWay(changeset, split, (ChangesetType)current_type, way, true);
-              split->setError();
             }
             else
             {
               split->add(element_type, (ChangesetType)current_type, way->id());
               changeset->remove(element_type, (ChangesetType)current_type, way->id());
             }
+            split->setError();
             return split;
           }
           else if (element_type == ElementType::Relation)
@@ -1484,6 +1350,8 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(const ChangesetInfoPtr& changeset,
             //  Add the relation to the split and remove from the changeset
             split->add(element_type, (ChangesetType)current_type, relation->id());
             changeset->remove(element_type, (ChangesetType)current_type, relation->id());
+            //  If one element doesn't exist, fail the relation
+            split->setError();
             return split;
           }
         }
@@ -1491,7 +1359,7 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(const ChangesetInfoPtr& changeset,
     }
     //  See if the hint is something like:
     //   Relation with id  cannot be saved due to Relation with id 1707699
-    else if (matchesRelationFailure(splitHint, element_id, member_id, member_type))
+    else if (_failureCheck.matchesRelationFailure(splitHint, element_id, member_id, member_type))
     {
       if (element_id != 0)
       {
@@ -1531,7 +1399,7 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(const ChangesetInfoPtr& changeset,
     }
     //  See if the hint is something like:
     //   Relation with id -2 requires the relations with id in 1707148,1707249, which either do not exist, or are not visible.
-    else if (matchesMultiElementFailure(splitHint, element_id, element_type, member_ids, member_type))
+    else if (_failureCheck.matchesMultiElementFailure(splitHint, element_id, element_type, member_ids, member_type))
     {
       //  If there is a relation id, move just that relation to the split
       for (int current_type = ChangesetType::TypeCreate; current_type != ChangesetType::TypeMax; ++current_type)
@@ -1567,39 +1435,62 @@ ChangesetInfoPtr XmlChangeset::splitChangeset(const ChangesetInfoPtr& changeset,
       }
     }
     //  See if the hint is something like:
-    //   Changeset precondition failed: Precondition failed: Node 5 is still used by ways 67
-    else if (matchesChangesetDeletePreconditionFailure(splitHint, member_id, member_type, element_id, element_type))
+    //   Changeset precondition failed: Precondition failed: Node 5 is still used by ways 67,91
+    else if (_failureCheck.matchesChangesetDeletePreconditionFailure(splitHint, element_id, element_type, member_ids, member_type))
     {
-      //  In this case the node 5 cannot be deleted because way 67 is still using it.  Way 67 must be modified or deleted first
-      //  here we figure out how to make that happen
+      //  In this case the node 5 cannot be deleted because ways 67 and 91 are still using it.  Ways 67 and 91
+      //  must be modified or deleted first here we figure out how to make that happen
       for (int current_type = ChangesetType::TypeCreate; current_type != ChangesetType::TypeMax; ++current_type)
       {
-        if (changeset->contains(member_type, (ChangesetType)current_type, member_id))
+        if (changeset->contains(element_type, (ChangesetType)current_type, element_id))
         {
           //  Remove the offending change from this changeset
-          split->add(member_type, (ChangesetType)current_type, member_id);
-          changeset->remove(member_type, (ChangesetType)current_type, member_id);
+          split->add(element_type, (ChangesetType)current_type, element_id);
+          changeset->remove(element_type, (ChangesetType)current_type, element_id);
           //  Try to add the blocking element to the split changeset
           for (int blocking_type = ChangesetType::TypeCreate; blocking_type != ChangesetType::TypeMax; ++blocking_type)
           {
-            if (element_type == ElementType::Way)
+            if (member_type == ElementType::Way)
             {
-              //  Add the way to the split so that they can be processed together
-              if (_allWays.find(element_id) != _allWays.end())
+              for (size_t i = 0; i < member_ids.size(); ++i)
               {
-                ChangesetWay* way = dynamic_cast<ChangesetWay*>(_allWays[element_id].get());
-                addWay(split, (ChangesetType)blocking_type, way);
+                //  Add the way to the split so that they can be processed together
+                if (_allWays.find(member_ids[i]) != _allWays.end())
+                {
+                  ChangesetWay* way = dynamic_cast<ChangesetWay*>(_allWays[member_ids[i]].get());
+                  moveWay(changeset, split, (ChangesetType)blocking_type, way);
+                }
               }
             }
-            else if (element_type == ElementType::Relation)
+            else if (member_type == ElementType::Relation)
             {
-              //  Add the relation to the split so that they can be processed together
-              if (_allRelations.find(element_id) != _allRelations.end())
+              for (size_t i = 0; i < member_ids.size(); ++i)
               {
-                ChangesetRelation* relation = dynamic_cast<ChangesetRelation*>(_allRelations[element_id].get());
-                addRelation(split, (ChangesetType)blocking_type, relation);
+                //  Add the relation to the split so that they can be processed together
+                if (_allRelations.find(member_ids[i]) != _allRelations.end())
+                {
+                  ChangesetRelation* relation = dynamic_cast<ChangesetRelation*>(_allRelations[member_ids[i]].get());
+                  moveRelation(changeset, split, (ChangesetType)blocking_type, relation);
+                }
               }
             }
+          }
+          //  Don't send the element again if the blocking elements aren't in the split
+          if (split->size() != member_ids.size() + 1) //  +1 includes element reported
+          {
+            if (split->size() != 1)
+            {
+              //  When some of the containing elements but not all are present,
+              //  move the element to a new changeset info object to fail it
+              ChangesetInfoPtr failing(new ChangesetInfo());
+              failing->add(element_type, (ChangesetType)current_type, element_id);
+              split->remove(element_type, (ChangesetType)current_type, element_id);
+              //  Fail only the element, but not the other elements in split
+              failing->setError();
+              failChangeset(failing);
+            }
+            else
+              split->setError();
           }
           //  Split out the offending element and the associated blocking element if possible
           return split;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -44,6 +44,7 @@
 
 //  Hoot
 #include <hoot/core/io/OsmApiChangesetElement.h>
+#include <hoot/core/io/OsmApiMatchFailure.h>
 #include <hoot/core/util/DefaultIdGenerator.h>
 
 namespace hoot
@@ -207,75 +208,6 @@ public:
    */
   long getProcessedCount()      { return _processedCount; }
   /**
-   * @brief matchesPlaceholderFailure Checks the return from the API to see if it is similar to the following error message:
-   *        "Placeholder node not found for reference -145213 in way -5687"
-   * @param hint Error message from OSM API
-   * @param member_id ID of the member element that caused the element to fail
-   * @param member_type Type of the member element that caused the element to fail
-   * @param element_id ID of the element that failed
-   * @param element_type Type of the element that failed
-   * @return True if the message matches and was parsed
-   */
-  static bool matchesPlaceholderFailure(const QString& hint,
-                                        long& member_id, ElementType::Type& member_type,
-                                        long& element_id, ElementType::Type& element_type);
-  /**
-   * @brief matchesRelationFailure Checks the return from the API to see if it is similar to the following error message:
-   *        "Relation with id  cannot be saved due to Relation with id 1707699"
-   * @param hint Error message from OSM API
-   * @param element_id ID of the element that failed
-   * @param member_id ID of the member element that caused the element to fail
-   * @param member_type Type of the member element that caused the element to fail
-   * @return True if the message matches and was parsed
-   */
-  static bool matchesRelationFailure(const QString& hint, long& element_id,
-                                     long& member_id, ElementType::Type& member_type);
-  /**
-   * @brief matchesMultiElementFailure Checks the return from the API to see if it is similar to the following error message:
-   *        "Relation with id -2 requires the relations with id in 1707148,1707249, which either do not exist, or are not visible."
-   * @param hint Error message from OSM API
-   * @param element_id ID of the element that failed
-   * @param element_type Type of the element that failed
-   * @param member_ids IDs of the member elements that caused the element to fail
-   * @param member_type Type of the member elements that caused the element to fail
-   * @return True if the message matches and was parsed
-   */
-  static bool matchesMultiElementFailure(const QString& hint, long& element_id, ElementType::Type& element_type,
-                                         std::vector<long>& member_ids, ElementType::Type& member_type);
-  /**
-   * @brief matchesChangesetDeletePreconditionFailure Checks the return from the API to see if it is similar to the following error message:
-   *        "Precondition failed: Node 55 is still used by ways 123"
-   * @param hint Error message from OSM API
-   * @param member_id ID of the member element that caused the element to fail
-   * @param member_type Type of the member element that caused the element to fail
-   * @param element_id ID of the element that failed
-   * @param element_type Type of the element that failed
-   * @return True if the message matches and was parsed
-   */
-  static bool matchesChangesetDeletePreconditionFailure(const QString& hint,
-                                                        long& member_id, ElementType::Type& member_type,
-                                                        long& element_id, ElementType::Type& element_type);
-  /**
-   * @brief matchesChangesetConflictVersionMismatchFailure Checks the return from the API to see if it is similar to the following error message:
-   *        "Changeset conflict: Version mismatch: Provided 2, server had: 1 of Node 4869875616"
-   * @param hint Error message from OSM API
-   * @param member_id ID of the member element that caused the element to fail
-   * @param member_type Type of the member element that caused the element to fail
-   * @param element_id ID of the element that failed
-   * @param element_type Type of the element that failed
-   * @return True if the message matches and was parsed
-   */
-  static bool matchesChangesetConflictVersionMismatchFailure(const QString& hint,
-                                                             long& element_id, ElementType::Type& element_type,
-                                                             long& version_old, long& version_new);
-  /**
-   * @brief matchesChangesetClosed FailureChecks the return from the API to see if it is similar to the following error message:
-   *        "Changeset conflict: The changeset 49514098 was closed at 2020-01-08 16:28:56 UTC"
-   * @param hint Error message from OSM API
-   * @return True if the message matches
-   */
-  static bool matchesChangesetClosedFailure(const QString& hint);
-  /**
    * @brief setErrorPathname Record the pathname of the error changeset
    * @param path Pathname
    */
@@ -311,6 +243,8 @@ public:
    * @param changeset ChangesetInfo pointer of elements that all failed
    */
   void failChangeset(const ChangesetInfoPtr& changeset);
+
+  const OsmApiMatchFailure& getFailureCheck() const { return _failureCheck; }
 
 private:
   /**
@@ -552,6 +486,8 @@ private:
   /** Full pathname of the error file changeset, if any errors occur */
   QString _errorPathname;
   std::mutex _errorMutex;
+  /** OSM API error matching object */
+  OsmApiMatchFailure _failureCheck;
 };
 
 /** Atomic subset of IDs that are sent to the OSM API, header only class */

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiMatchFailure.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiMatchFailure.cpp
@@ -1,0 +1,196 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2020 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+#include "OsmApiMatchFailure.h"
+
+namespace hoot
+{
+
+OsmApiMatchFailure::OsmApiMatchFailure()
+  :
+    //  Placeholder node not found for reference -145213 in way -5687
+    //  Placeholder Way not found for reference -12257 in Relation -51
+    _placeholderFailure(
+      "Placeholder (node|way|relation) not found for reference (-?[0-9]+) in (node|way|relation) (-?[0-9]+)",
+      QRegularExpression::CaseInsensitiveOption),
+    //  Relation with id  cannot be saved due to Relation with id 1707699
+    _relationFailure(
+      "Relation with id (-?[0-9]+)? cannot be saved due to (nodes|way|relation) with id (-?[0-9]+)",
+      QRegularExpression::CaseInsensitiveOption),
+    //  Relation with id -2 requires the relations with id in 1707148,1707249, which either do not exist, or are not visible.
+    _multiElementFailure(
+      "(Relation|Way) (-?[0-9]+) requires the (nodes|ways|relations) with id in ((-?[0-9]+,)+) (.*)",
+      QRegularExpression::CaseInsensitiveOption),
+    //  Precondition failed: Node 55 is still used by ways 123
+    _deletePreconditionFailure(
+      "Precondition failed: (Node|Way|Relation) (-?[0-9]+) is still used by (node|way|relation)s ((-?[0-9]+,?)+)",
+      QRegularExpression::CaseInsensitiveOption),
+    //  Changeset conflict: Version mismatch: Provided 2, server had: 1 of Node 4869875616
+    _conflictVersionFailure(
+      "Changeset conflict: Version mismatch: Provided ([0-9]+), server had: ([0-9]+) of (Node|Way|Relation) ([0-9]+)",
+      QRegularExpression::CaseInsensitiveOption),
+    //  Changeset conflict: The changeset 49514098 was closed at 2020-01-08 16:28:56 UTC
+    _changesetClosedFailure(
+      ".*The changeset ([0-9]+) was closed.*",
+      QRegularExpression::CaseInsensitiveOption)
+{
+  _placeholderFailure.optimize();
+  _relationFailure.optimize();
+  _multiElementFailure.optimize();
+  _deletePreconditionFailure.optimize();
+  _conflictVersionFailure.optimize();
+  _changesetClosedFailure.optimize();
+}
+
+bool OsmApiMatchFailure::matchesPlaceholderFailure(const QString& hint,
+                                                   long& member_id, ElementType::Type& member_type,
+                                                   long& element_id, ElementType::Type& element_type) const
+{
+  //  Placeholder node not found for reference -145213 in way -5687
+  //  Placeholder Way not found for reference -12257 in Relation -51
+  QRegularExpressionMatch match = _placeholderFailure.match(hint);
+  if (match.hasMatch())
+  {
+    //  Get the node/way/relation type and id that caused the failure
+    member_type = ElementType::fromString(match.captured(1).toLower());
+    bool success = false;
+    member_id = match.captured(2).toLong(&success);
+    if (!success)
+      return success;
+    //  Get the node/way/relation type and id that failed
+    element_type = ElementType::fromString(match.captured(3));
+    element_id = match.captured(4).toLong(&success);
+    return success;
+  }
+  return false;
+}
+
+bool OsmApiMatchFailure::matchesRelationFailure(const QString& hint,
+                                                long& element_id,
+                                                long& member_id, ElementType::Type& member_type) const
+{
+  //  Relation with id  cannot be saved due to Relation with id 1707699
+  QRegularExpressionMatch match = _relationFailure.match(hint);
+  if (match.hasMatch())
+  {
+    QString error = match.captured(1);
+    if (error != "")
+      element_id = error.toLong();
+    //  Get the node/way/relation type and id that failed
+    member_type = ElementType::fromString(match.captured(2));
+    bool success = false;
+    member_id = match.captured(3).toLong(&success);
+    return success;
+  }
+  return false;
+}
+
+bool OsmApiMatchFailure::matchesMultiElementFailure(const QString& hint,
+                                                    long& element_id,
+                                                    ElementType::Type& element_type,
+                                                    std::vector<long>& member_ids,
+                                                    ElementType::Type& member_type) const
+{
+  //  Relation with id -2 requires the relations with id in 1707148,1707249, which either do not exist, or are not visible.
+  QRegularExpressionMatch match = _multiElementFailure.match(hint);
+  if (match.hasMatch())
+  {
+    element_type = ElementType::fromString(match.captured(1));
+    QString error = match.captured(2);
+    if (error != "")
+      element_id = error.toLong();
+    //  Get the node/way/relation type (remove the 's') and id that failed
+    member_type = ElementType::fromString(match.captured(3).left(match.captured(3).length() - 1));
+    bool success = false;
+    QStringList ids = match.captured(4).split(",", QString::SkipEmptyParts);
+    for (int i = 0; i < ids.size(); ++i)
+    {
+      long id = ids[i].toLong(&success);
+      if (success)
+        member_ids.push_back(id);
+    }
+    return success;
+  }
+  return false;
+}
+
+bool OsmApiMatchFailure::matchesChangesetDeletePreconditionFailure(const QString& hint,
+                                                             long& element_id, ElementType::Type& element_type,
+                                                             std::vector<long>& member_ids, ElementType::Type& member_type) const
+{
+  //  Precondition failed: Node 55 is still used by ways 123
+  QRegularExpressionMatch match = _deletePreconditionFailure.match(hint);
+  if (match.hasMatch())
+  {
+    bool success = false;
+    element_type = ElementType::fromString(match.captured(1).toLower());
+    element_id = match.captured(2).toLong(&success);
+    if (!success)
+      return success;
+    member_type = ElementType::fromString(match.captured(3).toLower());
+    QStringList ids = match.captured(4).split(",", QString::SkipEmptyParts);
+    for (int i = 0; i < ids.size(); ++i)
+    {
+      long id = ids[i].toLong(&success);
+      if (success)
+        member_ids.push_back(id);
+    }
+    return success;
+  }
+  return false;
+}
+
+bool OsmApiMatchFailure::matchesChangesetConflictVersionMismatchFailure(const QString& hint,
+                                                                  long& element_id, ElementType::Type& element_type,
+                                                                  long& version_old, long& version_new) const
+{
+  //  Changeset conflict: Version mismatch: Provided 2, server had: 1 of Node 4869875616
+  QRegularExpressionMatch match = _conflictVersionFailure.match(hint);
+  if (match.hasMatch())
+  {
+    bool success = false;
+    version_old = match.captured(1).toLong(&success);
+    if (!success)
+      return success;
+    version_new = match.captured(2).toLong(&success);
+    if (!success)
+      return success;
+    element_type = ElementType::fromString(match.captured(3).toLower());
+    element_id = match.captured(4).toLong(&success);
+    return success;
+  }
+  return false;
+}
+
+bool OsmApiMatchFailure::matchesChangesetClosedFailure(const QString& hint) const
+{
+  //  Changeset conflict: The changeset 49514098 was closed at 2020-01-08 16:28:56 UTC
+  QRegularExpressionMatch match = _changesetClosedFailure.match(hint);
+  return match.hasMatch();
+}
+
+}

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiMatchFailure.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiMatchFailure.h
@@ -1,0 +1,130 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2020 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+#ifndef OSM_API_MATCH_FAILURE_H
+#define OSM_API_MATCH_FAILURE_H
+
+//  Qt
+#include <QString>
+
+//  Standard
+#include <vector>
+
+//  Hoot
+#include <hoot/core/io/OsmApiChangesetElement.h>
+
+namespace hoot
+{
+
+class OsmApiMatchFailure
+{
+public:
+  /** Constructor */
+  OsmApiMatchFailure();
+  /**
+   * @brief matchesPlaceholderFailure Checks the return from the API to see if it is similar to the following error message:
+   *        "Placeholder node not found for reference -145213 in way -5687"
+   * @param hint Error message from OSM API
+   * @param member_id ID of the member element that caused the element to fail
+   * @param member_type Type of the member element that caused the element to fail
+   * @param element_id ID of the element that failed
+   * @param element_type Type of the element that failed
+   * @return True if the message matches and was parsed
+   */
+  bool matchesPlaceholderFailure(const QString& hint,
+                                        long& member_id, ElementType::Type& member_type,
+                                        long& element_id, ElementType::Type& element_type) const;
+  /**
+   * @brief matchesRelationFailure Checks the return from the API to see if it is similar to the following error message:
+   *        "Relation with id  cannot be saved due to Relation with id 1707699"
+   * @param hint Error message from OSM API
+   * @param element_id ID of the element that failed
+   * @param member_id ID of the member element that caused the element to fail
+   * @param member_type Type of the member element that caused the element to fail
+   * @return True if the message matches and was parsed
+   */
+  bool matchesRelationFailure(const QString& hint, long& element_id,
+                                     long& member_id, ElementType::Type& member_type) const;
+  /**
+   * @brief matchesMultiElementFailure Checks the return from the API to see if it is similar to the following error message:
+   *        "Relation with id -2 requires the relations with id in 1707148,1707249, which either do not exist, or are not visible."
+   * @param hint Error message from OSM API
+   * @param element_id ID of the element that failed
+   * @param element_type Type of the element that failed
+   * @param member_ids IDs of the member elements that caused the element to fail
+   * @param member_type Type of the member elements that caused the element to fail
+   * @return True if the message matches and was parsed
+   */
+  bool matchesMultiElementFailure(const QString& hint, long& element_id, ElementType::Type& element_type,
+                                         std::vector<long>& member_ids, ElementType::Type& member_type) const;
+  /**
+   * @brief matchesChangesetDeletePreconditionFailure Checks the return from the API to see if it is similar to the following error message:
+   *        "Precondition failed: Node 55 is still used by ways 123"
+   * @param hint Error message from OSM API
+   * @param element_id ID of the element that failed
+   * @param element_type Type of the element that failed
+   * @param member_ids IDs of the member elements that caused the element to fail
+   * @param member_type Type of the member elements that caused the element to fail
+   * @return True if the message matches and was parsed
+   */
+  bool matchesChangesetDeletePreconditionFailure(const QString& hint,
+                                                 long& element_id, ElementType::Type& element_type,
+                                                 std::vector<long>& member_ids, ElementType::Type& member_type) const;
+  /**
+   * @brief matchesChangesetConflictVersionMismatchFailure Checks the return from the API to see if it is similar to the following error message:
+   *        "Changeset conflict: Version mismatch: Provided 2, server had: 1 of Node 4869875616"
+   * @param hint Error message from OSM API
+   * @param member_id ID of the member element that caused the element to fail
+   * @param member_type Type of the member element that caused the element to fail
+   * @param element_id ID of the element that failed
+   * @param element_type Type of the element that failed
+   * @return True if the message matches and was parsed
+   */
+  bool matchesChangesetConflictVersionMismatchFailure(const QString& hint,
+                                                      long& element_id, ElementType::Type& element_type,
+                                                      long& version_old, long& version_new) const;
+  /**
+   * @brief matchesChangesetClosed FailureChecks the return from the API to see if it is similar to the following error message:
+   *        "Changeset conflict: The changeset 49514098 was closed at 2020-01-08 16:28:56 UTC"
+   * @param hint Error message from OSM API
+   * @return True if the message matches
+   */
+  bool matchesChangesetClosedFailure(const QString& hint) const;
+
+private:
+  /** Precompiled regular expressions */
+  QRegularExpression _placeholderFailure;
+  QRegularExpression _relationFailure;
+  QRegularExpression _multiElementFailure;
+  QRegularExpression _deletePreconditionFailure;
+  QRegularExpression _conflictVersionFailure;
+  QRegularExpression _changesetClosedFailure;
+};
+
+}
+
+#endif  //  OSM_API_MATCH_FAILURE_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
@@ -487,7 +487,7 @@ void OsmApiWriter::_changesetThreadFunc(int index)
           break;
         default:
           //  This is a big problem, report it and try again
-          LOG_ERROR("Changeset upload responded with HTTP status response: " << request->getHttpStatus());
+          request->logConnectionError();
           //  Fall through
         case HttpResponseCode::HTTP_METHOD_NOT_ALLOWED:
         case HttpResponseCode::HTTP_UNAUTHORIZED:
@@ -793,7 +793,7 @@ void OsmApiWriter::_closeChangeset(HootNetworkRequestPtr request, long id)
       _changesetCountMutex.unlock();
       break;
     default:
-      LOG_WARN("Uknown HTTP response code: " << request->getHttpStatus());
+      request->logConnectionError();
       break;
     }
   }
@@ -864,7 +864,7 @@ OsmApiWriter::OsmApiFailureInfoPtr OsmApiWriter::_uploadChangeset(HootNetworkReq
       LOG_WARN("Changeset precondition failed: " << info->response);
       break;
     default:
-      LOG_WARN("Uknown HTTP response code: " << info->status);
+      request->logConnectionError();
       break;
     }
   }
@@ -883,7 +883,7 @@ bool OsmApiWriter::_fixConflict(HootNetworkRequestPtr request, ChangesetInfoPtr 
   long version_old = 0;
   long version_new = 0;
   //  Match the error and parse the error information
-  if (_changeset.matchesChangesetConflictVersionMismatchFailure(conflictExplanation, element_id, element_type, version_old, version_new))
+  if (_changeset.getFailureCheck().matchesChangesetConflictVersionMismatchFailure(conflictExplanation, element_id, element_type, version_old, version_new))
   {
     //  Increment the retry version count
     changeset->retryVersion();
@@ -911,7 +911,7 @@ bool OsmApiWriter::_fixConflict(HootNetworkRequestPtr request, ChangesetInfoPtr 
 
 bool OsmApiWriter::_changesetClosed(const QString &conflictExplanation)
 {
-  return _changeset.matchesChangesetClosedFailure(conflictExplanation);
+  return _changeset.getFailureCheck().matchesChangesetClosedFailure(conflictExplanation);
 }
 
 bool OsmApiWriter::_resolveIssues(HootNetworkRequestPtr request, ChangesetInfoPtr changeset)

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
@@ -246,15 +246,7 @@ void ParallelBoundedApiReader::_process()
         break;
       default:
         _errorMutex.lock();
-        if (status < 0)
-        {
-          //  Negative status error messages are connection errors from the socket and not from the HTTP server
-          LOG_ERROR("Connection Error: " << request.getErrorString() << " (" << (status * -1) << ")");
-        }
-        else
-        {
-          LOG_ERROR("Unexpected Error: HTTP " << status << " : " << request.getErrorString());
-        }
+        request.logConnectionError();
         _fatalError = true;
         _errorMutex.unlock();
         break;


### PR DESCRIPTION
Reduced error message count for `changeset-apply` by not sending things we know we cannot resolve more than once.  Also reorganized some of the error code for `changeset-apply`.