### PR TITLE
Make POI/Polygon string comparer configurable and change default implementation

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -3598,6 +3598,13 @@ controlled by the Hootenanny schema.
 
 The source tag key to be used in conjunction with poi.polygon.disable.same.source.conflation.
 
+=== poi.polygon.string.comparer
+
+* Data Type: string
+* Default Value: `hoot::MeanWordSetDistance`
+
+TODO
+
 === poi.polygon.tag.merger
 
 * Data Type: string

--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -3601,9 +3601,10 @@ The source tag key to be used in conjunction with poi.polygon.disable.same.sourc
 === poi.polygon.string.comparer
 
 * Data Type: string
-* Default Value: `hoot::MeanWordSetDistance`
+* Default Value: `hoot::KskipBigramDistance`
 
-TODO
+String comparison algorithm to use for name comparison with POI/Polygon conflation. Must be an
+implementation of `StringDistance`.
 
 === poi.polygon.tag.merger
 

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonNameScoreExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonNameScoreExtractorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonNameScoreExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonNameScoreExtractorTest.cpp
@@ -50,6 +50,7 @@ class PoiPolygonNameScoreExtractorTest : public HootTestFixture
   CPPUNIT_TEST_SUITE(PoiPolygonNameScoreExtractorTest);
   CPPUNIT_TEST(scoreTest);
   CPPUNIT_TEST(translateTest);
+  //CPPUNIT_TEST(miscTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -57,6 +58,7 @@ public:
   void scoreTest()
   {
     PoiPolygonNameScoreExtractor uut;
+    uut.setConfiguration(conf());
     OsmMapPtr map(new OsmMap());
 
     NodePtr node1(new Node(Status::Unknown1, -1, Coordinate(0.0, 0.0), 15.0));
@@ -96,6 +98,25 @@ public:
     uut.setConfiguration(settings);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.203, uut.extract(*map, node1, way1), 0.001);
   }
+
+  // for misc name debug testing only
+//  void miscTest()
+//  {
+//    //conf().set(ConfigOptions::getPoiPolygonStringComparerKey(), "hoot::KskipBigramDistance");
+//    PoiPolygonNameScoreExtractor uut;
+//    uut.setConfiguration(conf());
+//    OsmMapPtr map(new OsmMap());
+//    NodePtr node1(new Node(Status::Unknown1, -1, Coordinate(0.0, 0.0), 15.0));
+//    WayPtr way1(new Way(Status::Unknown2, -1, 15.0));
+
+//    node1->getTags().set("name", "54 Mint");
+//    way1->getTags().set("name", "San Francisco Mint");
+//    LOG_VARW(uut.extract(*map, node1, way1));
+
+//    node1->getTags().set("name", "Rincon hill Dog Park");
+//    way1->getTags().set("name", "Rincon Hill");
+//    LOG_VARW(uut.extract(*map, node1, way1));
+//  }
 };
 
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(PoiPolygonNameScoreExtractorTest, "quick");

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonNameScoreExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonNameScoreExtractorTest.cpp
@@ -50,7 +50,6 @@ class PoiPolygonNameScoreExtractorTest : public HootTestFixture
   CPPUNIT_TEST_SUITE(PoiPolygonNameScoreExtractorTest);
   CPPUNIT_TEST(scoreTest);
   CPPUNIT_TEST(translateTest);
-  //CPPUNIT_TEST(miscTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonNameScoreExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonNameScoreExtractorTest.cpp
@@ -68,7 +68,7 @@ public:
 
     WayPtr way2(new Way(Status::Unknown2, -1, 15.0));
     way2->getTags().set("name", "dfghdgf");
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.10669, uut.extract(*map, node1, way2), 0.001);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, uut.extract(*map, node1, way2), 0.001);
   }
 
   void translateTest()
@@ -85,8 +85,8 @@ public:
         PoiPolygonNameScoreExtractor::_translator);
     dictTranslator->setTokenizeInput(false);
 
-    //ToEnglishDictionaryTranslator has some support for acronyms in the same manner that it
-    //supports to English translations.
+    // ToEnglishDictionaryTranslator has some support for acronyms in the same manner that it
+    // supports to English translations.
     NodePtr node1(new Node(Status::Unknown1, -1, Coordinate(0.0, 0.0), 15.0));
     node1->getTags().set("name", "Kentucky Fried Chicken");
     WayPtr way1(new Way(Status::Unknown2, -1, 15.0));
@@ -95,7 +95,7 @@ public:
 
     settings.set("poi.polygon.name.translate.to.english", "false");
     uut.setConfiguration(settings);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.203, uut.extract(*map, node1, way1), 0.001);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, uut.extract(*map, node1, way1), 0.001);
   }
 
   // for misc name debug testing only

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonTypeScoreExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonTypeScoreExtractorTest.cpp
@@ -48,6 +48,7 @@ class PoiPolygonTypeScoreExtractorTest : public HootTestFixture
   CPPUNIT_TEST_SUITE(PoiPolygonTypeScoreExtractorTest);
   CPPUNIT_TEST(runTest);
   CPPUNIT_TEST(translateTagValueTest);
+  //CPPUNIT_TEST(miscTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -101,6 +102,22 @@ public:
     uut.setConfiguration(settings);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, uut.extract(*map, node1, way1), 0.0);
   }
+
+  // for misc type debug testing only
+//  void miscTest()
+//  {
+//    OsmMapPtr map(new OsmMap());
+//    PoiPolygonInfoCachePtr infoCache(new PoiPolygonInfoCache(map));
+//    infoCache->setConfiguration(conf());
+//    PoiPolygonTypeScoreExtractor uut(infoCache);
+//    uut.setConfiguration(conf());
+//    NodePtr node1(new Node(Status::Unknown1, -1, Coordinate(0.0, 0.0), 15.0));
+//    WayPtr way1(new Way(Status::Unknown2, -1, 15.0));
+
+//    node1->getTags().set("amenity", "arts_centre");
+//    way1->getTags().set("amenity", "fountain");
+//    LOG_VARW(uut.extract(*map, node1, way1));
+//  }
 };
 
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(PoiPolygonTypeScoreExtractorTest, "quick");

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonTypeScoreExtractorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonTypeScoreExtractorTest.cpp
@@ -48,7 +48,6 @@ class PoiPolygonTypeScoreExtractorTest : public HootTestFixture
   CPPUNIT_TEST_SUITE(PoiPolygonTypeScoreExtractorTest);
   CPPUNIT_TEST(runTest);
   CPPUNIT_TEST(translateTagValueTest);
-  //CPPUNIT_TEST(miscTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonNameScoreExtractor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonNameScoreExtractor.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "PoiPolygonNameScoreExtractor.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonNameScoreExtractor.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonNameScoreExtractor.h
@@ -85,6 +85,7 @@ private:
 
   double _nameScoreThreshold;
   double _levDist;
+  StringDistancePtr _stringComp;
 
   //when enabled, will attempt to translate address tags to English
   bool _translateTagValuesToEnglish;

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/string/MeanWordSetDistance.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/string/MeanWordSetDistance.h
@@ -50,7 +50,7 @@ public:
   /**
    * @param portion The portion parameter passed off to ScoreMatrix.
    */
-  MeanWordSetDistance(StringDistancePtr d, double portion=1.0);
+  MeanWordSetDistance(StringDistancePtr d, double portion = 1.0);
   MeanWordSetDistance();
   virtual ~MeanWordSetDistance() = default;
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/string/MinSumWordSetDistance.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/string/MinSumWordSetDistance.cpp
@@ -40,9 +40,9 @@ namespace hoot
 
 HOOT_FACTORY_REGISTER(StringDistance, MinSumWordSetDistance)
 
-MinSumWordSetDistance::MinSumWordSetDistance(StringDistance* d)
+MinSumWordSetDistance::MinSumWordSetDistance(StringDistancePtr d) :
+_d(d)
 {
-  _d.reset(d);
 }
 
 double MinSumWordSetDistance::compare(const QString& s1, const QString& s2) const

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/string/MinSumWordSetDistance.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/string/MinSumWordSetDistance.h
@@ -45,7 +45,7 @@ public:
   /**
    * @param d Takes ownership of d.
    */
-  MinSumWordSetDistance(StringDistance* d);
+  MinSumWordSetDistance(StringDistancePtr d);
 
   MinSumWordSetDistance() = default;
   virtual ~MinSumWordSetDistance() = default;

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/string/StringDistanceConsumer.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/string/StringDistanceConsumer.h
@@ -46,7 +46,6 @@ public:
   virtual void setStringDistance(const StringDistancePtr& sd) = 0;
 };
 
-
 }
 
 #endif // STRINGDISTANCECONSUMER_H

--- a/test-files/cases/reference/unifying/poi-polygon/poi-polygon-auto-merge-10/Expected.osm
+++ b/test-files/cases/reference/unifying/poi-polygon/poi-polygon-auto-merge-10/Expected.osm
@@ -55,7 +55,7 @@
         <member type="way" ref="-85799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="0"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (7m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (7m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.153846/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -66,7 +66,7 @@
         <member type="way" ref="-85917" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="1"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (15m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (15m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.0714286/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>

--- a/test-files/cases/reference/unifying/poi-polygon/poi-polygon-auto-merge-3/Expected.osm
+++ b/test-files/cases/reference/unifying/poi-polygon/poi-polygon-auto-merge-3/Expected.osm
@@ -38,7 +38,7 @@
         <member type="way" ref="-85799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="0"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (9m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (9m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.0714286/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -49,7 +49,7 @@
         <member type="way" ref="-85799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="1"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (15m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (15m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.153846/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>

--- a/test-files/cases/reference/unifying/poi-polygon/poi-polygon-auto-merge-4/Expected.osm
+++ b/test-files/cases/reference/unifying/poi-polygon/poi-polygon-auto-merge-4/Expected.osm
@@ -38,7 +38,7 @@
         <member type="way" ref="-85799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="0"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (9m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (9m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.0714286/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -49,7 +49,7 @@
         <member type="way" ref="-85799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="1"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (15m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (15m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.153846/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>

--- a/test-files/cases/reference/unifying/poi-polygon/poi-polygon-auto-merge-5/Expected.osm
+++ b/test-files/cases/reference/unifying/poi-polygon/poi-polygon-auto-merge-5/Expected.osm
@@ -35,7 +35,7 @@
         <member type="way" ref="-85799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="0"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (8m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (8m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.153846/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>

--- a/test-files/cases/reference/unifying/poi-polygon/poi-polygon-auto-merge-6/Expected.osm
+++ b/test-files/cases/reference/unifying/poi-polygon/poi-polygon-auto-merge-6/Expected.osm
@@ -36,7 +36,7 @@
         <member type="way" ref="-85799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="0"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (8m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (8m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.153846/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>

--- a/test-files/cases/reference/unifying/poi-polygon/poi-polygon-auto-merge-9/Expected.osm
+++ b/test-files/cases/reference/unifying/poi-polygon/poi-polygon-auto-merge-9/Expected.osm
@@ -55,7 +55,7 @@
         <member type="way" ref="-85799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="0"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (7m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (7m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.153846/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -66,7 +66,7 @@
         <member type="way" ref="-85917" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="1"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (15m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (15m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.0714286/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>

--- a/test-files/cases/reference/unifying/poi-polygon/poi-polygon-keep-closest-match-only-10/Expected.osm
+++ b/test-files/cases/reference/unifying/poi-polygon/poi-polygon-keep-closest-match-only-10/Expected.osm
@@ -55,7 +55,7 @@
         <member type="way" ref="-85799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="0"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (7m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (7m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.153846/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>

--- a/test-files/cases/reference/unifying/poi-polygon/poi-polygon-keep-closest-match-only-3/Expected.osm
+++ b/test-files/cases/reference/unifying/poi-polygon/poi-polygon-keep-closest-match-only-3/Expected.osm
@@ -38,7 +38,7 @@
         <member type="way" ref="-85799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="0"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (9m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (9m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.0714286/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -49,7 +49,7 @@
         <member type="way" ref="-85799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="1"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (15m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (15m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.153846/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>

--- a/test-files/cases/reference/unifying/poi-polygon/poi-polygon-keep-closest-match-only-4/Expected.osm
+++ b/test-files/cases/reference/unifying/poi-polygon/poi-polygon-keep-closest-match-only-4/Expected.osm
@@ -38,7 +38,7 @@
         <member type="way" ref="-85799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="0"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (9m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (9m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.0714286/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>

--- a/test-files/cases/reference/unifying/poi-polygon/poi-polygon-keep-closest-match-only-5/Expected.osm
+++ b/test-files/cases/reference/unifying/poi-polygon/poi-polygon-keep-closest-match-only-5/Expected.osm
@@ -35,7 +35,7 @@
         <member type="way" ref="-85799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="0"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (8m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (8m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.153846/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>

--- a/test-files/cases/reference/unifying/poi-polygon/poi-polygon-keep-closest-match-only-9/Expected.osm
+++ b/test-files/cases/reference/unifying/poi-polygon/poi-polygon-keep-closest-match-only-9/Expected.osm
@@ -55,7 +55,7 @@
         <member type="way" ref="-85799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="0"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (7m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.555743/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (7m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.153846/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -66,7 +66,7 @@
         <member type="way" ref="-85917" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="1"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (15m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.348633/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (15m; score: 2/2), type: yes (score: 0.8/1), name: no (score: 0.0714286/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>

--- a/test-files/cases/reference/unifying/poi-polygon/poi-polygon-street-num-1/Expected.osm
+++ b/test-files/cases/reference/unifying/poi-polygon/poi-polygon-street-num-1/Expected.osm
@@ -158,7 +158,7 @@
         <member type="way" ref="-104044802" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="0"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (1m; score: 2/2), type: no (score: 0.14406/1), name: no (score: 0.0985552/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 41.2132m."/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (1m; score: 2/2), type: no (score: 0.14406/1), name: no (score: 0.0327869/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 41.2132m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>

--- a/test-files/cmd/glacial/PoiPolygonConflateCombinedTest/output1.osm
+++ b/test-files/cmd/glacial/PoiPolygonConflateCombinedTest/output1.osm
@@ -221,12 +221,6 @@
     <node visible="true" id="-4703" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7641891493961026" lon="-122.4201371787444259"/>
     <node visible="true" id="-4702" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7641247800976814" lon="-122.4201313053116422"/>
     <node visible="true" id="-4701" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7640604044559538" lon="-122.4201254395568839"/>
-    <node visible="true" id="-4700" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7649533402675104" lon="-122.4335864761653454"/>
-    <node visible="true" id="-4699" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7649595297470384" lon="-122.4334842015991711"/>
-    <node visible="true" id="-4698" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7649619601256745" lon="-122.4334440625481477"/>
-    <node visible="true" id="-4697" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7649698871745372" lon="-122.4333130471325433"/>
-    <node visible="true" id="-4696" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7648808872435495" lon="-122.4333045096773418"/>
-    <node visible="true" id="-4695" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7648643403644115" lon="-122.4335780010396206"/>
     <node visible="true" id="-4694" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7644111796706099" lon="-122.4102345811686092"/>
     <node visible="true" id="-4693" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7655046162117145" lon="-122.4103383140635231"/>
     <node visible="true" id="-4692" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7656056705426835" lon="-122.4086721412707277"/>
@@ -334,18 +328,6 @@
         <tag k="addr:postcode" v="94110"/>
         <tag k="addr:city" v="San Francisco"/>
         <tag k="REF2" v="none"/>
-        <tag k="error:circular" v="15"/>
-    </node>
-    <node visible="true" id="-4677" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7695999999999970" lon="-122.4344999999999999">
-        <tag k="wheelchair" v="yes"/>
-        <tag k="amenity" v="arts_centre"/>
-        <tag k="addr:state" v="CA"/>
-        <tag k="address" v="50 Scott St"/>
-        <tag k="name" v="Harvey Milk Photo Center"/>
-        <tag k="addr:postcode" v="94117"/>
-        <tag k="addr:city" v="San Francisco"/>
-        <tag k="phone" v="(415) 554-9522"/>
-        <tag k="REF2" v="00a471"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-4676" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7695999999999827" lon="-122.4333999999999918">
@@ -7358,19 +7340,6 @@
         <tag k="REF1" v="0005ae"/>
         <tag k="error:circular" v="15"/>
     </node>
-    <way visible="true" id="-802" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-4700"/>
-        <nd ref="-4699"/>
-        <nd ref="-4698"/>
-        <nd ref="-4697"/>
-        <nd ref="-4696"/>
-        <nd ref="-4695"/>
-        <nd ref="-4700"/>
-        <tag k="area" v="yes"/>
-        <tag k="name" v="Noe &amp; Beaver Mini Park"/>
-        <tag k="REF2" v="none"/>
-        <tag k="error:circular" v="15"/>
-    </way>
     <way visible="true" id="-801" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-4708"/>
         <nd ref="-4707"/>
@@ -7434,11 +7403,20 @@
         <nd ref="-3945"/>
         <nd ref="-4667"/>
         <nd ref="-4666"/>
+        <tag k="hoot:poipolygon:poismerged" v="1"/>
+        <tag k="wheelchair" v="yes"/>
         <tag k="amenity" v="community_centre"/>
+        <tag k="addr:state" v="CA"/>
         <tag k="name" v="Harvey Milk Recreational Arts Center"/>
+        <tag k="address" v="50 Scott St"/>
+        <tag k="addr:postcode" v="94117"/>
+        <tag k="alt_name" v="Harvey Milk Photo Center"/>
         <tag k="building" v="yes"/>
+        <tag k="addr:city" v="San Francisco"/>
+        <tag k="phone" v="(415) 554-9522"/>
         <tag k="REF1" v="00a471"/>
         <tag k="toilets" v="yes"/>
+        <tag k="REF2" v="00a471"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-794" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -9153,11 +9131,14 @@
         <nd ref="-3863"/>
         <nd ref="-3904"/>
         <nd ref="-3854"/>
-        <tag k="ele" v="45"/>
+        <tag k="area" v="yes"/>
         <tag k="name" v="Noe-Beaver Mini-Park"/>
+        <tag k="ele" v="45"/>
+        <tag k="alt_name" v="Noe &amp; Beaver Mini Park"/>
         <tag k="leisure" v="park"/>
         <tag k="gnis:state_id" v="06"/>
         <tag k="REF1" v="005aa3"/>
+        <tag k="REF2" v="none"/>
         <tag k="gnis:feature_id" v="1655714"/>
         <tag k="gnis:county_id" v="075"/>
         <tag k="gnis:created" v="11/01/1994"/>
@@ -18329,12 +18310,23 @@
         <tag k="access" v="customers"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <relation visible="true" id="-592" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-593" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-1960" role="reviewee"/>
         <member type="way" ref="-443" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="171"/>
+        <tag k="hoot:review:sort_order" v="170"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-592" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4237" role="reviewee"/>
+        <member type="way" ref="-310" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI to Polygon"/>
+        <tag k="hoot:review:sort_order" v="340"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (28m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -18342,32 +18334,32 @@
     </relation>
     <relation visible="true" id="-591" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4237" role="reviewee"/>
-        <member type="way" ref="-310" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="343"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (28m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-590" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4237" role="reviewee"/>
         <member type="way" ref="-416" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="344"/>
+        <tag k="hoot:review:sort_order" v="341"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-589" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-590" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4452" role="reviewee"/>
         <member type="way" ref="-413" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="339"/>
+        <tag k="hoot:review:sort_order" v="336"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-589" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4218" role="reviewee"/>
+        <member type="node" ref="-4720" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI"/>
+        <tag k="hoot:review:sort_order" v="355"/>
+        <tag k="hoot:review:note" v="Overlapping matches"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -18375,9 +18367,9 @@
     </relation>
     <relation visible="true" id="-588" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4218" role="reviewee"/>
-        <member type="node" ref="-4720" role="reviewee"/>
+        <member type="node" ref="-4754" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="358"/>
+        <tag k="hoot:review:sort_order" v="381"/>
         <tag k="hoot:review:note" v="Overlapping matches"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -18385,10 +18377,10 @@
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-587" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4218" role="reviewee"/>
-        <member type="node" ref="-4754" role="reviewee"/>
+        <member type="node" ref="-4234" role="reviewee"/>
+        <member type="node" ref="-4725" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="384"/>
+        <tag k="hoot:review:sort_order" v="47"/>
         <tag k="hoot:review:note" v="Overlapping matches"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -18397,9 +18389,9 @@
     </relation>
     <relation visible="true" id="-586" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4234" role="reviewee"/>
-        <member type="node" ref="-4725" role="reviewee"/>
+        <member type="node" ref="-4756" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="48"/>
+        <tag k="hoot:review:sort_order" v="56"/>
         <tag k="hoot:review:note" v="Overlapping matches"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -18407,10 +18399,10 @@
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-585" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4234" role="reviewee"/>
-        <member type="node" ref="-4756" role="reviewee"/>
+        <member type="node" ref="-4212" role="reviewee"/>
+        <member type="node" ref="-4722" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="57"/>
+        <tag k="hoot:review:sort_order" v="154"/>
         <tag k="hoot:review:note" v="Overlapping matches"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -18419,9 +18411,9 @@
     </relation>
     <relation visible="true" id="-584" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4212" role="reviewee"/>
-        <member type="node" ref="-4722" role="reviewee"/>
+        <member type="node" ref="-4743" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="155"/>
+        <tag k="hoot:review:sort_order" v="176"/>
         <tag k="hoot:review:note" v="Overlapping matches"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -18430,9 +18422,9 @@
     </relation>
     <relation visible="true" id="-583" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4212" role="reviewee"/>
-        <member type="node" ref="-4743" role="reviewee"/>
+        <member type="node" ref="-4759" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="177"/>
+        <tag k="hoot:review:sort_order" v="178"/>
         <tag k="hoot:review:note" v="Overlapping matches"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -18440,51 +18432,7 @@
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-582" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4212" role="reviewee"/>
-        <member type="node" ref="-4759" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="179"/>
-        <tag k="hoot:review:note" v="Overlapping matches"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-581" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4213" role="reviewee"/>
-        <member type="node" ref="-4722" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="157"/>
-        <tag k="hoot:review:note" v="Overlapping matches"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-580" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4213" role="reviewee"/>
-        <member type="node" ref="-4743" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="173"/>
-        <tag k="hoot:review:note" v="Overlapping matches"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-579" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4213" role="reviewee"/>
-        <member type="node" ref="-4759" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="250"/>
-        <tag k="hoot:review:note" v="Overlapping matches"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-578" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4313" role="reviewee"/>
         <member type="node" ref="-4722" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
         <tag k="hoot:review:sort_order" v="156"/>
@@ -18494,11 +18442,55 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-577" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-581" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4213" role="reviewee"/>
+        <member type="node" ref="-4743" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI"/>
+        <tag k="hoot:review:sort_order" v="172"/>
+        <tag k="hoot:review:note" v="Overlapping matches"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-580" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4213" role="reviewee"/>
+        <member type="node" ref="-4759" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI"/>
+        <tag k="hoot:review:sort_order" v="249"/>
+        <tag k="hoot:review:note" v="Overlapping matches"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-579" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4313" role="reviewee"/>
+        <member type="node" ref="-4722" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI"/>
+        <tag k="hoot:review:sort_order" v="155"/>
+        <tag k="hoot:review:note" v="Overlapping matches"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-578" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4313" role="reviewee"/>
         <member type="node" ref="-4743" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="174"/>
+        <tag k="hoot:review:sort_order" v="173"/>
+        <tag k="hoot:review:note" v="Overlapping matches"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-577" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4313" role="reviewee"/>
+        <member type="node" ref="-4759" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI"/>
+        <tag k="hoot:review:sort_order" v="181"/>
         <tag k="hoot:review:note" v="Overlapping matches"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -18506,21 +18498,21 @@
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-576" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4313" role="reviewee"/>
-        <member type="node" ref="-4759" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="182"/>
-        <tag k="hoot:review:note" v="Overlapping matches"/>
+        <member type="way" ref="-728" role="reviewee"/>
+        <member type="way" ref="-799" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI to Polygon;Area"/>
+        <tag k="hoot:review:sort_order" v="537"/>
+        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-575" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4679" role="reviewee"/>
         <member type="way" ref="-728" role="reviewee"/>
-        <member type="way" ref="-799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon;Area"/>
-        <tag k="hoot:review:sort_order" v="540"/>
+        <tag k="hoot:review:sort_order" v="538"/>
         <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -18528,10 +18520,10 @@
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-574" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4679" role="reviewee"/>
+        <member type="node" ref="-4681" role="reviewee"/>
         <member type="way" ref="-728" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon;Area"/>
-        <tag k="hoot:review:sort_order" v="541"/>
+        <tag k="hoot:review:sort_order" v="539"/>
         <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -18539,10 +18531,10 @@
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-573" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4681" role="reviewee"/>
-        <member type="way" ref="-728" role="reviewee"/>
+        <member type="way" ref="-725" role="reviewee"/>
+        <member type="way" ref="-801" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon;Area"/>
-        <tag k="hoot:review:sort_order" v="542"/>
+        <tag k="hoot:review:sort_order" v="101"/>
         <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -18550,30 +18542,8 @@
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-572" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-667" role="reviewee"/>
-        <member type="way" ref="-802" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon;Area"/>
-        <tag k="hoot:review:sort_order" v="8"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-571" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4684" role="reviewee"/>
-        <member type="way" ref="-802" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon;Area"/>
-        <tag k="hoot:review:sort_order" v="9"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-570" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4683" role="reviewee"/>
         <member type="way" ref="-725" role="reviewee"/>
-        <member type="way" ref="-801" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon;Area"/>
         <tag k="hoot:review:sort_order" v="102"/>
         <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
@@ -18582,8 +18552,8 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-569" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4678" role="reviewee"/>
+    <relation visible="true" id="-571" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4685" role="reviewee"/>
         <member type="way" ref="-725" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon;Area"/>
         <tag k="hoot:review:sort_order" v="103"/>
@@ -18593,31 +18563,31 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-568" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4683" role="reviewee"/>
-        <member type="way" ref="-725" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon;Area"/>
-        <tag k="hoot:review:sort_order" v="104"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-567" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4685" role="reviewee"/>
-        <member type="way" ref="-725" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon;Area"/>
-        <tag k="hoot:review:sort_order" v="105"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-566" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-570" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="way" ref="-785" role="reviewee"/>
         <member type="way" ref="-798" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI to Polygon;Area"/>
+        <tag k="hoot:review:sort_order" v="327"/>
+        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-569" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4676" role="reviewee"/>
+        <member type="way" ref="-785" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI to Polygon;Area"/>
+        <tag k="hoot:review:sort_order" v="328"/>
+        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-568" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4687" role="reviewee"/>
+        <member type="way" ref="-785" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon;Area"/>
         <tag k="hoot:review:sort_order" v="329"/>
         <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
@@ -18626,64 +18596,20 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-565" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4676" role="reviewee"/>
-        <member type="way" ref="-785" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon;Area"/>
-        <tag k="hoot:review:sort_order" v="330"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-564" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4687" role="reviewee"/>
-        <member type="way" ref="-785" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon;Area"/>
-        <tag k="hoot:review:sort_order" v="331"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-563" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4688" role="reviewee"/>
-        <member type="way" ref="-798" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon;Area"/>
-        <tag k="hoot:review:sort_order" v="332"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-562" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4677" role="reviewee"/>
-        <member type="way" ref="-795" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="326"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-561" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4730" role="reviewee"/>
-        <member type="way" ref="-795" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="327"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-560" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-567" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-384" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI to Polygon"/>
+        <tag k="hoot:review:sort_order" v="86"/>
+        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-566" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-2390" role="reviewee"/>
+        <member type="way" ref="-410" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="87"/>
         <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
@@ -18692,364 +18618,397 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-559" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-2390" role="reviewee"/>
-        <member type="way" ref="-410" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="88"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-558" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-565" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="262"/>
+        <tag k="hoot:review:sort_order" v="261"/>
         <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-557" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-564" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="274"/>
+        <tag k="hoot:review:sort_order" v="273"/>
         <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-556" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-563" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-183" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="480"/>
+        <tag k="hoot:review:sort_order" v="477"/>
         <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-555" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-562" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-190" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="481"/>
+        <tag k="hoot:review:sort_order" v="478"/>
         <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-554" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-561" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4451" role="reviewee"/>
         <member type="node" ref="-4452" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="341"/>
+        <tag k="hoot:review:sort_order" v="338"/>
         <tag k="hoot:review:note" v="Somewhat similar (71m) - similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-553" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-560" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-1808" role="reviewee"/>
         <member type="node" ref="-4728" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="369"/>
+        <tag k="hoot:review:sort_order" v="366"/>
         <tag k="hoot:review:note" v="Somewhat similar (27m) - similar names and generic type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-552" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-559" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-2371" role="reviewee"/>
         <member type="node" ref="-1960" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="154"/>
+        <tag k="hoot:review:sort_order" v="153"/>
         <tag k="hoot:review:note" v="Somewhat similar (120m) - similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-551" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-558" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-2402" role="reviewee"/>
         <member type="node" ref="-4726" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="144"/>
+        <tag k="hoot:review:sort_order" v="143"/>
         <tag k="hoot:review:note" v="Somewhat similar (490m) - similar names and generic type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-550" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-557" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-2472" role="reviewee"/>
         <member type="node" ref="-1960" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="170"/>
+        <tag k="hoot:review:sort_order" v="169"/>
         <tag k="hoot:review:note" v="Somewhat similar (110m) - similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-549" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-556" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-3990" role="reviewee"/>
         <member type="node" ref="-4679" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="539"/>
+        <tag k="hoot:review:sort_order" v="536"/>
         <tag k="hoot:review:note" v="Somewhat similar (69m) - very close together, similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-548" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-555" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-3990" role="reviewee"/>
         <member type="node" ref="-4681" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="538"/>
+        <tag k="hoot:review:sort_order" v="535"/>
         <tag k="hoot:review:note" v="Somewhat similar (3.6m) - very close together, similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-547" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-554" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4225" role="reviewee"/>
         <member type="node" ref="-4745" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="54"/>
+        <tag k="hoot:review:sort_order" v="53"/>
         <tag k="hoot:review:note" v="Somewhat similar (120m) - similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-546" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-553" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4234" role="reviewee"/>
         <member type="node" ref="-4745" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="51"/>
+        <tag k="hoot:review:sort_order" v="50"/>
         <tag k="hoot:review:note" v="Somewhat similar (140m) - similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-545" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-552" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4235" role="reviewee"/>
         <member type="node" ref="-4725" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="50"/>
+        <tag k="hoot:review:sort_order" v="49"/>
         <tag k="hoot:review:note" v="Somewhat similar (96m) - similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-544" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-551" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4235" role="reviewee"/>
         <member type="node" ref="-4745" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="55"/>
+        <tag k="hoot:review:sort_order" v="54"/>
         <tag k="hoot:review:note" v="Somewhat similar (39m) - very close together, similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-543" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-550" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4235" role="reviewee"/>
         <member type="node" ref="-4756" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="49"/>
+        <tag k="hoot:review:sort_order" v="48"/>
         <tag k="hoot:review:note" v="Somewhat similar (100m) - similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-542" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-549" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4237" role="reviewee"/>
         <member type="node" ref="-4741" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="342"/>
+        <tag k="hoot:review:sort_order" v="339"/>
         <tag k="hoot:review:note" v="Somewhat similar (130m) - similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-541" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-548" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4326" role="reviewee"/>
         <member type="node" ref="-4452" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="536"/>
+        <tag k="hoot:review:sort_order" v="533"/>
         <tag k="hoot:review:note" v="Somewhat similar (170m) - similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-540" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-547" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4327" role="reviewee"/>
         <member type="node" ref="-4452" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="537"/>
+        <tag k="hoot:review:sort_order" v="534"/>
         <tag k="hoot:review:note" v="Somewhat similar (70m) - similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-539" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-546" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4428" role="reviewee"/>
         <member type="node" ref="-4682" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="382"/>
+        <tag k="hoot:review:sort_order" v="379"/>
         <tag k="hoot:review:note" v="Somewhat similar (390m) - similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-538" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-545" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4428" role="reviewee"/>
         <member type="node" ref="-4683" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="111"/>
+        <tag k="hoot:review:sort_order" v="110"/>
         <tag k="hoot:review:note" v="Somewhat similar (10m) - very close together, similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-537" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-544" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4428" role="reviewee"/>
         <member type="node" ref="-4685" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="106"/>
+        <tag k="hoot:review:sort_order" v="104"/>
         <tag k="hoot:review:note" v="Somewhat similar (19m) - very close together, similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-536" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-543" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4429" role="reviewee"/>
         <member type="node" ref="-4682" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="381"/>
+        <tag k="hoot:review:sort_order" v="378"/>
         <tag k="hoot:review:note" v="Somewhat similar (390m) - similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-535" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-542" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4429" role="reviewee"/>
         <member type="node" ref="-4683" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="107"/>
+        <tag k="hoot:review:sort_order" v="105"/>
         <tag k="hoot:review:note" v="Somewhat similar (17m) - very close together, similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-534" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-541" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4429" role="reviewee"/>
         <member type="node" ref="-4685" role="reviewee"/>
         <tag k="hoot:review:type" v="POI"/>
-        <tag k="hoot:review:sort_order" v="101"/>
+        <tag k="hoot:review:sort_order" v="100"/>
         <tag k="hoot:review:note" v="Somewhat similar (8.6m) - very close together, similar POI type"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-533" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-540" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4438" role="reviewee"/>
         <member type="way" ref="-357" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="380"/>
+        <tag k="hoot:review:sort_order" v="377"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-529" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4677" role="reviewee"/>
-        <member type="way" ref="-798" role="reviewee"/>
+    <relation visible="true" id="-535" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4678" role="reviewee"/>
+        <member type="way" ref="-725" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="333"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.205039/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="106"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.367347/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-534" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4678" role="reviewee"/>
+        <member type="way" ref="-801" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI to Polygon"/>
+        <tag k="hoot:review:sort_order" v="107"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.346154/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-530" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4684" role="reviewee"/>
+        <member type="way" ref="-667" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI to Polygon"/>
+        <tag k="hoot:review:sort_order" v="8"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.510204/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-528" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4678" role="reviewee"/>
-        <member type="way" ref="-801" role="reviewee"/>
+        <member type="node" ref="-4688" role="reviewee"/>
+        <member type="way" ref="-798" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="108"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.791227/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="330"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.6/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-525" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-527" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4719" role="reviewee"/>
         <member type="way" ref="-139" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="518"/>
+        <tag k="hoot:review:sort_order" v="515"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-524" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-526" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4722" role="reviewee"/>
         <member type="way" ref="-774" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="153"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0.317916/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="152"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0.2125/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-522" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-524" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4728" role="reviewee"/>
         <member type="way" ref="-343" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="370"/>
+        <tag k="hoot:review:sort_order" v="367"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-521" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-523" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4729" role="reviewee"/>
         <member type="way" ref="-523" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="357"/>
+        <tag k="hoot:review:sort_order" v="354"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (30m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-522" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4730" role="reviewee"/>
+        <member type="way" ref="-785" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI to Polygon"/>
+        <tag k="hoot:review:sort_order" v="331"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.0434783/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-521" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4730" role="reviewee"/>
+        <member type="way" ref="-795" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI to Polygon"/>
+        <tag k="hoot:review:sort_order" v="325"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.526316/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19057,32 +19016,32 @@
     </relation>
     <relation visible="true" id="-520" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4730" role="reviewee"/>
-        <member type="way" ref="-785" role="reviewee"/>
+        <member type="way" ref="-798" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="334"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.141345/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="332"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.0434783/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-519" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4730" role="reviewee"/>
-        <member type="way" ref="-798" role="reviewee"/>
+        <member type="node" ref="-4732" role="reviewee"/>
+        <member type="way" ref="-594" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="335"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.141345/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="345"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-518" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4732" role="reviewee"/>
-        <member type="way" ref="-594" role="reviewee"/>
+        <member type="node" ref="-4735" role="reviewee"/>
+        <member type="way" ref="-283" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="348"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="365"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19090,20 +19049,20 @@
     </relation>
     <relation visible="true" id="-517" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4735" role="reviewee"/>
-        <member type="way" ref="-283" role="reviewee"/>
+        <member type="way" ref="-288" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="368"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="364"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-516" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4735" role="reviewee"/>
-        <member type="way" ref="-288" role="reviewee"/>
+    <relation visible="true" id="-515" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4737" role="reviewee"/>
+        <member type="way" ref="-715" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="367"/>
+        <tag k="hoot:review:sort_order" v="346"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19111,10 +19070,10 @@
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-514" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4737" role="reviewee"/>
-        <member type="way" ref="-715" role="reviewee"/>
+        <member type="node" ref="-4738" role="reviewee"/>
+        <member type="way" ref="-585" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="349"/>
+        <tag k="hoot:review:sort_order" v="335"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19122,10 +19081,10 @@
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-513" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4738" role="reviewee"/>
-        <member type="way" ref="-585" role="reviewee"/>
+        <member type="node" ref="-4740" role="reviewee"/>
+        <member type="way" ref="-490" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="338"/>
+        <tag k="hoot:review:sort_order" v="426"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19133,11 +19092,11 @@
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-512" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4740" role="reviewee"/>
-        <member type="way" ref="-490" role="reviewee"/>
+        <member type="node" ref="-4741" role="reviewee"/>
+        <member type="way" ref="-515" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="429"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="357"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (16m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19145,10 +19104,10 @@
     </relation>
     <relation visible="true" id="-511" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4741" role="reviewee"/>
-        <member type="way" ref="-515" role="reviewee"/>
+        <member type="way" ref="-516" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="360"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (16m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="129"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (17m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19156,10 +19115,10 @@
     </relation>
     <relation visible="true" id="-510" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4741" role="reviewee"/>
-        <member type="way" ref="-516" role="reviewee"/>
+        <member type="way" ref="-517" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="130"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (17m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="131"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (20m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19167,10 +19126,10 @@
     </relation>
     <relation visible="true" id="-509" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4741" role="reviewee"/>
-        <member type="way" ref="-517" role="reviewee"/>
+        <member type="way" ref="-518" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="132"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (20m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (22m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19178,10 +19137,10 @@
     </relation>
     <relation visible="true" id="-508" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4741" role="reviewee"/>
-        <member type="way" ref="-518" role="reviewee"/>
+        <member type="way" ref="-519" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="133"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (22m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="359"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (31m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19189,10 +19148,10 @@
     </relation>
     <relation visible="true" id="-507" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4741" role="reviewee"/>
-        <member type="way" ref="-519" role="reviewee"/>
+        <member type="way" ref="-520" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="362"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (31m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="358"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (15m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19200,43 +19159,43 @@
     </relation>
     <relation visible="true" id="-506" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4741" role="reviewee"/>
-        <member type="way" ref="-520" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="361"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (15m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-505" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4741" role="reviewee"/>
         <member type="way" ref="-521" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="131"/>
+        <tag k="hoot:review:sort_order" v="130"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (18m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-502" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-503" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4744" role="reviewee"/>
         <member type="way" ref="-108" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="547"/>
+        <tag k="hoot:review:sort_order" v="545"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-501" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-502" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4745" role="reviewee"/>
         <member type="way" ref="-729" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="56"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (136m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.476796/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="55"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (136m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.243902/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-501" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4750" role="reviewee"/>
+        <member type="way" ref="-785" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI to Polygon"/>
+        <tag k="hoot:review:sort_order" v="333"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.027027/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19244,10 +19203,10 @@
     </relation>
     <relation visible="true" id="-500" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4750" role="reviewee"/>
-        <member type="way" ref="-785" role="reviewee"/>
+        <member type="way" ref="-795" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="336"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.0785515/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="326"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.203125/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19255,21 +19214,21 @@
     </relation>
     <relation visible="true" id="-499" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4750" role="reviewee"/>
-        <member type="way" ref="-795" role="reviewee"/>
+        <member type="way" ref="-798" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="328"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.578552/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="334"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.027027/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-498" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4750" role="reviewee"/>
-        <member type="way" ref="-798" role="reviewee"/>
+        <member type="node" ref="-4752" role="reviewee"/>
+        <member type="way" ref="-799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="337"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.0785515/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="540"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.681818/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19279,7 +19238,7 @@
         <member type="node" ref="-4753" role="reviewee"/>
         <member type="way" ref="-589" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="347"/>
+        <tag k="hoot:review:sort_order" v="344"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19290,7 +19249,7 @@
         <member type="node" ref="-1808" role="reviewee"/>
         <member type="way" ref="-343" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="371"/>
+        <tag k="hoot:review:sort_order" v="368"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19301,7 +19260,7 @@
         <member type="node" ref="-1808" role="reviewee"/>
         <member type="way" ref="-536" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="379"/>
+        <tag k="hoot:review:sort_order" v="376"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19312,7 +19271,7 @@
         <member type="node" ref="-1808" role="reviewee"/>
         <member type="way" ref="-540" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="378"/>
+        <tag k="hoot:review:sort_order" v="375"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19323,7 +19282,7 @@
         <member type="node" ref="-1906" role="reviewee"/>
         <member type="way" ref="-292" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="383"/>
+        <tag k="hoot:review:sort_order" v="380"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19334,8 +19293,8 @@
         <member type="node" ref="-1906" role="reviewee"/>
         <member type="way" ref="-347" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="385"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (79m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.304934/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="382"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (79m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.196721/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19345,7 +19304,7 @@
         <member type="node" ref="-1909" role="reviewee"/>
         <member type="way" ref="-263" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="532"/>
+        <tag k="hoot:review:sort_order" v="529"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19356,7 +19315,7 @@
         <member type="node" ref="-1935" role="reviewee"/>
         <member type="way" ref="-219" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="533"/>
+        <tag k="hoot:review:sort_order" v="530"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (1m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19367,7 +19326,7 @@
         <member type="node" ref="-1938" role="reviewee"/>
         <member type="way" ref="-764" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="458"/>
+        <tag k="hoot:review:sort_order" v="455"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19378,7 +19337,7 @@
         <member type="node" ref="-1939" role="reviewee"/>
         <member type="way" ref="-764" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="459"/>
+        <tag k="hoot:review:sort_order" v="456"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19389,7 +19348,7 @@
         <member type="node" ref="-1942" role="reviewee"/>
         <member type="way" ref="-485" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="426"/>
+        <tag k="hoot:review:sort_order" v="423"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19400,7 +19359,7 @@
         <member type="node" ref="-1947" role="reviewee"/>
         <member type="way" ref="-555" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="425"/>
+        <tag k="hoot:review:sort_order" v="422"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19411,7 +19370,7 @@
         <member type="node" ref="-1957" role="reviewee"/>
         <member type="way" ref="-104" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="535"/>
+        <tag k="hoot:review:sort_order" v="532"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19422,7 +19381,7 @@
         <member type="node" ref="-1959" role="reviewee"/>
         <member type="way" ref="-77" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="546"/>
+        <tag k="hoot:review:sort_order" v="544"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19433,7 +19392,7 @@
         <member type="node" ref="-1966" role="reviewee"/>
         <member type="way" ref="-529" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="354"/>
+        <tag k="hoot:review:sort_order" v="351"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (2m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19444,7 +19403,7 @@
         <member type="node" ref="-1966" role="reviewee"/>
         <member type="way" ref="-530" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="353"/>
+        <tag k="hoot:review:sort_order" v="350"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19455,7 +19414,7 @@
         <member type="node" ref="-1967" role="reviewee"/>
         <member type="way" ref="-223" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="351"/>
+        <tag k="hoot:review:sort_order" v="348"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19466,7 +19425,7 @@
         <member type="node" ref="-1968" role="reviewee"/>
         <member type="way" ref="-18" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="134"/>
+        <tag k="hoot:review:sort_order" v="133"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19477,7 +19436,7 @@
         <member type="node" ref="-2102" role="reviewee"/>
         <member type="way" ref="-781" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="427"/>
+        <tag k="hoot:review:sort_order" v="424"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (110m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19488,7 +19447,7 @@
         <member type="node" ref="-2158" role="reviewee"/>
         <member type="way" ref="-415" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="129"/>
+        <tag k="hoot:review:sort_order" v="128"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19499,7 +19458,7 @@
         <member type="node" ref="-2279" role="reviewee"/>
         <member type="way" ref="-453" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="71"/>
+        <tag k="hoot:review:sort_order" v="70"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19510,7 +19469,7 @@
         <member type="node" ref="-2280" role="reviewee"/>
         <member type="way" ref="-411" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="47"/>
+        <tag k="hoot:review:sort_order" v="46"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19521,8 +19480,8 @@
         <member type="node" ref="-2280" role="reviewee"/>
         <member type="way" ref="-670" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="46"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (57m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.17734/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="45"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (57m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.0645161/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19543,8 +19502,8 @@
         <member type="node" ref="-2382" role="reviewee"/>
         <member type="way" ref="-541" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="372"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.323624/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="369"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.0888889/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19554,7 +19513,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-16" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="79"/>
+        <tag k="hoot:review:sort_order" v="78"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (90m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19565,7 +19524,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-17" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="77"/>
+        <tag k="hoot:review:sort_order" v="76"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (98m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19576,7 +19535,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-18" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="76"/>
+        <tag k="hoot:review:sort_order" v="75"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (105m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19587,7 +19546,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-367" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="85"/>
+        <tag k="hoot:review:sort_order" v="84"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (32m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19598,7 +19557,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-368" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="84"/>
+        <tag k="hoot:review:sort_order" v="83"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (31m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19609,7 +19568,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-369" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="124"/>
+        <tag k="hoot:review:sort_order" v="123"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (55m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19620,7 +19579,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-370" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="125"/>
+        <tag k="hoot:review:sort_order" v="124"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (63m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19631,7 +19590,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-371" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="126"/>
+        <tag k="hoot:review:sort_order" v="125"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (70m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19642,7 +19601,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-372" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="82"/>
+        <tag k="hoot:review:sort_order" v="81"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (31m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19653,7 +19612,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-373" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="83"/>
+        <tag k="hoot:review:sort_order" v="82"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (31m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19664,7 +19623,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-374" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="81"/>
+        <tag k="hoot:review:sort_order" v="80"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (33m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19675,7 +19634,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-375" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="112"/>
+        <tag k="hoot:review:sort_order" v="111"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (89m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19686,7 +19645,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-376" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="113"/>
+        <tag k="hoot:review:sort_order" v="112"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (100m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19697,7 +19656,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-377" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="115"/>
+        <tag k="hoot:review:sort_order" v="114"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (86m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19708,7 +19667,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-378" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="121"/>
+        <tag k="hoot:review:sort_order" v="120"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (78m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19719,7 +19678,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-379" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="122"/>
+        <tag k="hoot:review:sort_order" v="121"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (72m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19730,7 +19689,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-380" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="123"/>
+        <tag k="hoot:review:sort_order" v="122"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (60m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19741,7 +19700,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-381" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="119"/>
+        <tag k="hoot:review:sort_order" v="118"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (52m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19752,7 +19711,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-382" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="120"/>
+        <tag k="hoot:review:sort_order" v="119"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (45m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19763,7 +19722,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-383" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="86"/>
+        <tag k="hoot:review:sort_order" v="85"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (23m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19774,7 +19733,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-385" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="89"/>
+        <tag k="hoot:review:sort_order" v="88"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (6m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19785,7 +19744,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-386" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="70"/>
+        <tag k="hoot:review:sort_order" v="69"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (111m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19796,7 +19755,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-387" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="68"/>
+        <tag k="hoot:review:sort_order" v="67"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (114m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19807,7 +19766,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-388" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="69"/>
+        <tag k="hoot:review:sort_order" v="68"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (115m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19818,7 +19777,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-389" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="65"/>
+        <tag k="hoot:review:sort_order" v="64"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19829,7 +19788,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-390" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="66"/>
+        <tag k="hoot:review:sort_order" v="65"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (124m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19840,7 +19799,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-391" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="67"/>
+        <tag k="hoot:review:sort_order" v="66"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (130m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19851,7 +19810,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-392" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="63"/>
+        <tag k="hoot:review:sort_order" v="62"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (133m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19862,7 +19821,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-393" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="64"/>
+        <tag k="hoot:review:sort_order" v="63"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (142m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19873,7 +19832,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-394" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="62"/>
+        <tag k="hoot:review:sort_order" v="61"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (146m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19884,7 +19843,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-415" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="114"/>
+        <tag k="hoot:review:sort_order" v="113"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (99m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19895,7 +19854,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-418" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="98"/>
+        <tag k="hoot:review:sort_order" v="97"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (127m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19906,7 +19865,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-419" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="97"/>
+        <tag k="hoot:review:sort_order" v="96"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (136m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19917,7 +19876,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-480" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="90"/>
+        <tag k="hoot:review:sort_order" v="89"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (140m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19928,7 +19887,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-481" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="93"/>
+        <tag k="hoot:review:sort_order" v="92"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (139m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19939,7 +19898,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-482" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="94"/>
+        <tag k="hoot:review:sort_order" v="93"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (139m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19950,7 +19909,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-483" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="95"/>
+        <tag k="hoot:review:sort_order" v="94"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (135m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19961,7 +19920,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-497" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="99"/>
+        <tag k="hoot:review:sort_order" v="98"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (139m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19972,7 +19931,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-498" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="100"/>
+        <tag k="hoot:review:sort_order" v="99"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (136m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19983,7 +19942,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-499" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="91"/>
+        <tag k="hoot:review:sort_order" v="90"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (134m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19994,7 +19953,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-506" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="92"/>
+        <tag k="hoot:review:sort_order" v="91"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (136m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20005,7 +19964,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-522" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="96"/>
+        <tag k="hoot:review:sort_order" v="95"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (146m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20016,7 +19975,7 @@
         <member type="node" ref="-2404" role="reviewee"/>
         <member type="way" ref="-775" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="534"/>
+        <tag k="hoot:review:sort_order" v="531"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20027,7 +19986,7 @@
         <member type="node" ref="-2405" role="reviewee"/>
         <member type="way" ref="-558" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="460"/>
+        <tag k="hoot:review:sort_order" v="457"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20038,7 +19997,7 @@
         <member type="node" ref="-2405" role="reviewee"/>
         <member type="way" ref="-562" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="461"/>
+        <tag k="hoot:review:sort_order" v="458"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20049,7 +20008,7 @@
         <member type="node" ref="-2456" role="reviewee"/>
         <member type="way" ref="-18" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="135"/>
+        <tag k="hoot:review:sort_order" v="134"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20060,7 +20019,7 @@
         <member type="node" ref="-2464" role="reviewee"/>
         <member type="way" ref="-418" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="373"/>
+        <tag k="hoot:review:sort_order" v="370"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20071,7 +20030,7 @@
         <member type="node" ref="-2464" role="reviewee"/>
         <member type="way" ref="-419" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="375"/>
+        <tag k="hoot:review:sort_order" v="372"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20082,7 +20041,7 @@
         <member type="node" ref="-2464" role="reviewee"/>
         <member type="way" ref="-522" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="374"/>
+        <tag k="hoot:review:sort_order" v="371"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (5m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20093,8 +20052,8 @@
         <member type="node" ref="-2465" role="reviewee"/>
         <member type="way" ref="-408" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="149"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0.392/1), name: no (score: 0.17734/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="148"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0.392/1), name: no (score: 0.0285714/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -20104,7 +20063,7 @@
         <member type="node" ref="-2473" role="reviewee"/>
         <member type="way" ref="-461" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="53"/>
+        <tag k="hoot:review:sort_order" v="52"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (1m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20115,8 +20074,8 @@
         <member type="node" ref="-2552" role="reviewee"/>
         <member type="way" ref="-670" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="45"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (88m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.17734/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="44"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (88m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -20126,7 +20085,7 @@
         <member type="node" ref="-2587" role="reviewee"/>
         <member type="way" ref="-439" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="345"/>
+        <tag k="hoot:review:sort_order" v="342"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20137,8 +20096,8 @@
         <member type="node" ref="-3095" role="reviewee"/>
         <member type="way" ref="-347" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="356"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (126m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.101532/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="353"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (126m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.0212766/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -20148,7 +20107,7 @@
         <member type="node" ref="-3095" role="reviewee"/>
         <member type="way" ref="-528" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="531"/>
+        <tag k="hoot:review:sort_order" v="528"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20159,7 +20118,7 @@
         <member type="node" ref="-3095" role="reviewee"/>
         <member type="way" ref="-529" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="355"/>
+        <tag k="hoot:review:sort_order" v="352"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20170,7 +20129,7 @@
         <member type="node" ref="-3210" role="reviewee"/>
         <member type="way" ref="-568" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="432"/>
+        <tag k="hoot:review:sort_order" v="429"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20181,7 +20140,7 @@
         <member type="node" ref="-3211" role="reviewee"/>
         <member type="way" ref="-550" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="377"/>
+        <tag k="hoot:review:sort_order" v="374"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20192,7 +20151,7 @@
         <member type="node" ref="-3212" role="reviewee"/>
         <member type="way" ref="-568" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="433"/>
+        <tag k="hoot:review:sort_order" v="430"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20203,7 +20162,7 @@
         <member type="node" ref="-3213" role="reviewee"/>
         <member type="way" ref="-543" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="437"/>
+        <tag k="hoot:review:sort_order" v="434"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20214,7 +20173,7 @@
         <member type="node" ref="-3213" role="reviewee"/>
         <member type="way" ref="-546" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="439"/>
+        <tag k="hoot:review:sort_order" v="436"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20225,7 +20184,7 @@
         <member type="node" ref="-3213" role="reviewee"/>
         <member type="way" ref="-552" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="435"/>
+        <tag k="hoot:review:sort_order" v="432"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20236,7 +20195,7 @@
         <member type="node" ref="-3214" role="reviewee"/>
         <member type="way" ref="-360" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="420"/>
+        <tag k="hoot:review:sort_order" v="417"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (121m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20247,7 +20206,7 @@
         <member type="node" ref="-3214" role="reviewee"/>
         <member type="way" ref="-544" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="430"/>
+        <tag k="hoot:review:sort_order" v="427"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20258,7 +20217,7 @@
         <member type="node" ref="-3214" role="reviewee"/>
         <member type="way" ref="-547" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="431"/>
+        <tag k="hoot:review:sort_order" v="428"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20269,7 +20228,7 @@
         <member type="node" ref="-3309" role="reviewee"/>
         <member type="way" ref="-573" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="61"/>
+        <tag k="hoot:review:sort_order" v="60"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20280,7 +20239,7 @@
         <member type="node" ref="-3309" role="reviewee"/>
         <member type="way" ref="-575" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="60"/>
+        <tag k="hoot:review:sort_order" v="59"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20291,7 +20250,7 @@
         <member type="node" ref="-3310" role="reviewee"/>
         <member type="way" ref="-715" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="350"/>
+        <tag k="hoot:review:sort_order" v="347"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20302,7 +20261,7 @@
         <member type="node" ref="-3336" role="reviewee"/>
         <member type="way" ref="-579" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="141"/>
+        <tag k="hoot:review:sort_order" v="140"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20313,7 +20272,7 @@
         <member type="node" ref="-3337" role="reviewee"/>
         <member type="way" ref="-577" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="140"/>
+        <tag k="hoot:review:sort_order" v="139"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20324,7 +20283,7 @@
         <member type="node" ref="-3338" role="reviewee"/>
         <member type="way" ref="-442" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="161"/>
+        <tag k="hoot:review:sort_order" v="160"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (133m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20335,7 +20294,7 @@
         <member type="node" ref="-3338" role="reviewee"/>
         <member type="way" ref="-443" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="159"/>
+        <tag k="hoot:review:sort_order" v="158"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (102m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20346,7 +20305,7 @@
         <member type="node" ref="-3338" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="241"/>
+        <tag k="hoot:review:sort_order" v="240"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (119m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20357,7 +20316,7 @@
         <member type="node" ref="-3338" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="187"/>
+        <tag k="hoot:review:sort_order" v="186"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (107m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20368,7 +20327,7 @@
         <member type="node" ref="-3338" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="183"/>
+        <tag k="hoot:review:sort_order" v="182"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (94m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20379,7 +20338,7 @@
         <member type="node" ref="-3338" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="235"/>
+        <tag k="hoot:review:sort_order" v="234"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (129m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20390,7 +20349,7 @@
         <member type="node" ref="-3338" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="175"/>
+        <tag k="hoot:review:sort_order" v="174"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (75m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20401,7 +20360,7 @@
         <member type="node" ref="-3339" role="reviewee"/>
         <member type="way" ref="-442" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="162"/>
+        <tag k="hoot:review:sort_order" v="161"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (143m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20412,7 +20371,7 @@
         <member type="node" ref="-3339" role="reviewee"/>
         <member type="way" ref="-443" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="164"/>
+        <tag k="hoot:review:sort_order" v="163"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (113m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20423,7 +20382,7 @@
         <member type="node" ref="-3339" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="242"/>
+        <tag k="hoot:review:sort_order" v="241"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (118m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20434,7 +20393,7 @@
         <member type="node" ref="-3339" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="188"/>
+        <tag k="hoot:review:sort_order" v="187"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (107m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20445,7 +20404,7 @@
         <member type="node" ref="-3339" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="184"/>
+        <tag k="hoot:review:sort_order" v="183"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (95m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20456,7 +20415,7 @@
         <member type="node" ref="-3339" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="236"/>
+        <tag k="hoot:review:sort_order" v="235"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (128m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20467,7 +20426,7 @@
         <member type="node" ref="-3339" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="180"/>
+        <tag k="hoot:review:sort_order" v="179"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (79m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20478,7 +20437,7 @@
         <member type="node" ref="-3339" role="reviewee"/>
         <member type="way" ref="-658" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="297"/>
+        <tag k="hoot:review:sort_order" v="296"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (20m; score: 2/2), type: yes (score: 0.9/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20489,7 +20448,7 @@
         <member type="node" ref="-3340" role="reviewee"/>
         <member type="way" ref="-443" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="165"/>
+        <tag k="hoot:review:sort_order" v="164"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (119m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20500,7 +20459,7 @@
         <member type="node" ref="-3340" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="243"/>
+        <tag k="hoot:review:sort_order" v="242"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (115m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20511,7 +20470,7 @@
         <member type="node" ref="-3340" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="189"/>
+        <tag k="hoot:review:sort_order" v="188"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (105m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20522,7 +20481,7 @@
         <member type="node" ref="-3340" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="185"/>
+        <tag k="hoot:review:sort_order" v="184"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (94m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20533,7 +20492,7 @@
         <member type="node" ref="-3340" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="233"/>
+        <tag k="hoot:review:sort_order" v="232"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (125m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20544,7 +20503,7 @@
         <member type="node" ref="-3340" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="181"/>
+        <tag k="hoot:review:sort_order" v="180"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (79m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20555,8 +20514,8 @@
         <member type="node" ref="-3340" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="289"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (142m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.194692/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="288"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (142m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0188679/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -20566,7 +20525,7 @@
         <member type="node" ref="-3341" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="239"/>
+        <tag k="hoot:review:sort_order" v="238"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20577,7 +20536,7 @@
         <member type="node" ref="-3341" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="199"/>
+        <tag k="hoot:review:sort_order" v="198"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (109m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20588,7 +20547,7 @@
         <member type="node" ref="-3341" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="197"/>
+        <tag k="hoot:review:sort_order" v="196"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (101m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20599,7 +20558,7 @@
         <member type="node" ref="-3341" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="234"/>
+        <tag k="hoot:review:sort_order" v="233"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (123m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20610,7 +20569,7 @@
         <member type="node" ref="-3341" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="194"/>
+        <tag k="hoot:review:sort_order" v="193"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (95m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20621,8 +20580,8 @@
         <member type="node" ref="-3341" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="290"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (124m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.290242/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="289"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (124m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.129032/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -20632,7 +20591,7 @@
         <member type="node" ref="-3342" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="240"/>
+        <tag k="hoot:review:sort_order" v="239"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20643,7 +20602,7 @@
         <member type="node" ref="-3342" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="200"/>
+        <tag k="hoot:review:sort_order" v="199"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (110m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20654,7 +20613,7 @@
         <member type="node" ref="-3342" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="198"/>
+        <tag k="hoot:review:sort_order" v="197"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (103m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20665,7 +20624,7 @@
         <member type="node" ref="-3342" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="222"/>
+        <tag k="hoot:review:sort_order" v="221"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (123m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20676,7 +20635,7 @@
         <member type="node" ref="-3342" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="195"/>
+        <tag k="hoot:review:sort_order" v="194"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (98m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20687,8 +20646,8 @@
         <member type="node" ref="-3342" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="291"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (120m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.326844/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="290"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (120m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0344828/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -20698,7 +20657,7 @@
         <member type="node" ref="-3343" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="210"/>
+        <tag k="hoot:review:sort_order" v="209"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (118m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20709,7 +20668,7 @@
         <member type="node" ref="-3343" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="201"/>
+        <tag k="hoot:review:sort_order" v="200"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (113m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20720,7 +20679,7 @@
         <member type="node" ref="-3343" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="202"/>
+        <tag k="hoot:review:sort_order" v="201"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (107m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20731,7 +20690,7 @@
         <member type="node" ref="-3343" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="223"/>
+        <tag k="hoot:review:sort_order" v="222"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (124m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20742,7 +20701,7 @@
         <member type="node" ref="-3343" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="196"/>
+        <tag k="hoot:review:sort_order" v="195"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (104m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20753,8 +20712,8 @@
         <member type="node" ref="-3343" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="292"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.147284/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="291"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -20764,8 +20723,8 @@
         <member type="node" ref="-3344" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="286"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.127387/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="285"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0434783/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -20775,7 +20734,7 @@
         <member type="node" ref="-3345" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="216"/>
+        <tag k="hoot:review:sort_order" v="215"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (119m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20786,7 +20745,7 @@
         <member type="node" ref="-3345" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="212"/>
+        <tag k="hoot:review:sort_order" v="211"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (120m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20797,7 +20756,7 @@
         <member type="node" ref="-3345" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="213"/>
+        <tag k="hoot:review:sort_order" v="212"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (119m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20808,7 +20767,7 @@
         <member type="node" ref="-3345" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="220"/>
+        <tag k="hoot:review:sort_order" v="219"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (120m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20819,7 +20778,7 @@
         <member type="node" ref="-3345" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="206"/>
+        <tag k="hoot:review:sort_order" v="205"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (122m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20830,7 +20789,7 @@
         <member type="node" ref="-3345" role="reviewee"/>
         <member type="way" ref="-659" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="302"/>
+        <tag k="hoot:review:sort_order" v="301"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20841,7 +20800,7 @@
         <member type="node" ref="-3345" role="reviewee"/>
         <member type="way" ref="-672" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="205"/>
+        <tag k="hoot:review:sort_order" v="204"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (90m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20852,7 +20811,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-443" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="168"/>
+        <tag k="hoot:review:sort_order" v="167"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (142m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20863,7 +20822,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-459" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="228"/>
+        <tag k="hoot:review:sort_order" v="227"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (135m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20874,7 +20833,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-460" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="229"/>
+        <tag k="hoot:review:sort_order" v="228"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (138m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20885,7 +20844,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="237"/>
+        <tag k="hoot:review:sort_order" v="236"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (94m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20896,7 +20855,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="244"/>
+        <tag k="hoot:review:sort_order" v="243"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (87m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20907,7 +20866,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="248"/>
+        <tag k="hoot:review:sort_order" v="247"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (79m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20918,7 +20877,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="226"/>
+        <tag k="hoot:review:sort_order" v="225"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (102m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20929,7 +20888,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="190"/>
+        <tag k="hoot:review:sort_order" v="189"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (75m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20940,7 +20899,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-659" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="296"/>
+        <tag k="hoot:review:sort_order" v="295"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (76m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20951,7 +20910,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-672" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="203"/>
+        <tag k="hoot:review:sort_order" v="202"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (27m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20962,7 +20921,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-443" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="169"/>
+        <tag k="hoot:review:sort_order" v="168"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (134m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20973,7 +20932,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-459" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="230"/>
+        <tag k="hoot:review:sort_order" v="229"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (134m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20984,7 +20943,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-460" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="231"/>
+        <tag k="hoot:review:sort_order" v="230"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (137m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20995,7 +20954,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="247"/>
+        <tag k="hoot:review:sort_order" v="246"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (94m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21006,7 +20965,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="245"/>
+        <tag k="hoot:review:sort_order" v="244"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (86m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21017,7 +20976,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="249"/>
+        <tag k="hoot:review:sort_order" v="248"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (77m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21028,7 +20987,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="227"/>
+        <tag k="hoot:review:sort_order" v="226"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (102m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21039,7 +20998,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="191"/>
+        <tag k="hoot:review:sort_order" v="190"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (70m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21050,7 +21009,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-659" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="299"/>
+        <tag k="hoot:review:sort_order" v="298"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (74m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21061,7 +21020,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-672" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="178"/>
+        <tag k="hoot:review:sort_order" v="177"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (21m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21072,7 +21031,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-421" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="310"/>
+        <tag k="hoot:review:sort_order" v="309"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (59m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21083,7 +21042,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-422" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="308"/>
+        <tag k="hoot:review:sort_order" v="307"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (62m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21094,7 +21053,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-423" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="306"/>
+        <tag k="hoot:review:sort_order" v="305"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (42m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21105,7 +21064,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-424" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="305"/>
+        <tag k="hoot:review:sort_order" v="304"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (30m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21116,7 +21075,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-426" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="320"/>
+        <tag k="hoot:review:sort_order" v="319"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (127m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21127,7 +21086,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-428" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="319"/>
+        <tag k="hoot:review:sort_order" v="318"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (134m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21138,7 +21097,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-429" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="309"/>
+        <tag k="hoot:review:sort_order" v="308"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (49m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21149,7 +21108,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-432" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="307"/>
+        <tag k="hoot:review:sort_order" v="306"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (37m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21160,7 +21119,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-433" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="322"/>
+        <tag k="hoot:review:sort_order" v="321"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (78m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21171,7 +21130,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-435" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="321"/>
+        <tag k="hoot:review:sort_order" v="320"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (113m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21182,7 +21141,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-737" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="324"/>
+        <tag k="hoot:review:sort_order" v="323"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (128m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21205,7 +21164,7 @@
         <member type="way" ref="-411" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="4"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (37m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.127387/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (37m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21215,7 +21174,7 @@
         <member type="node" ref="-3384" role="reviewee"/>
         <member type="way" ref="-425" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="32"/>
+        <tag k="hoot:review:sort_order" v="31"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (103m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21226,7 +21185,7 @@
         <member type="node" ref="-3384" role="reviewee"/>
         <member type="way" ref="-426" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="20"/>
+        <tag k="hoot:review:sort_order" v="19"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (140m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21237,7 +21196,7 @@
         <member type="node" ref="-3384" role="reviewee"/>
         <member type="way" ref="-427" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="33"/>
+        <tag k="hoot:review:sort_order" v="32"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (110m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21248,7 +21207,7 @@
         <member type="node" ref="-3384" role="reviewee"/>
         <member type="way" ref="-428" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="35"/>
+        <tag k="hoot:review:sort_order" v="34"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (126m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21259,7 +21218,7 @@
         <member type="node" ref="-3384" role="reviewee"/>
         <member type="way" ref="-430" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="40"/>
+        <tag k="hoot:review:sort_order" v="39"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (52m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21270,7 +21229,7 @@
         <member type="node" ref="-3384" role="reviewee"/>
         <member type="way" ref="-431" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="36"/>
+        <tag k="hoot:review:sort_order" v="35"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (94m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21281,7 +21240,7 @@
         <member type="node" ref="-3384" role="reviewee"/>
         <member type="way" ref="-434" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="34"/>
+        <tag k="hoot:review:sort_order" v="33"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (118m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21292,7 +21251,7 @@
         <member type="node" ref="-3384" role="reviewee"/>
         <member type="way" ref="-436" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="10"/>
+        <tag k="hoot:review:sort_order" v="9"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (86m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21304,7 +21263,7 @@
         <member type="way" ref="-411" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="1"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (46m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.127387/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (46m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21314,7 +21273,7 @@
         <member type="node" ref="-3385" role="reviewee"/>
         <member type="way" ref="-425" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="11"/>
+        <tag k="hoot:review:sort_order" v="10"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (107m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21325,7 +21284,7 @@
         <member type="node" ref="-3385" role="reviewee"/>
         <member type="way" ref="-426" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="21"/>
+        <tag k="hoot:review:sort_order" v="20"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (144m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21336,7 +21295,7 @@
         <member type="node" ref="-3385" role="reviewee"/>
         <member type="way" ref="-427" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="26"/>
+        <tag k="hoot:review:sort_order" v="25"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (114m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21347,7 +21306,7 @@
         <member type="node" ref="-3385" role="reviewee"/>
         <member type="way" ref="-428" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="22"/>
+        <tag k="hoot:review:sort_order" v="21"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (129m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21358,7 +21317,7 @@
         <member type="node" ref="-3385" role="reviewee"/>
         <member type="way" ref="-430" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="37"/>
+        <tag k="hoot:review:sort_order" v="36"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (61m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21369,7 +21328,7 @@
         <member type="node" ref="-3385" role="reviewee"/>
         <member type="way" ref="-431" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="12"/>
+        <tag k="hoot:review:sort_order" v="11"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (99m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21380,7 +21339,7 @@
         <member type="node" ref="-3385" role="reviewee"/>
         <member type="way" ref="-434" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="27"/>
+        <tag k="hoot:review:sort_order" v="26"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (121m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21391,7 +21350,7 @@
         <member type="node" ref="-3385" role="reviewee"/>
         <member type="way" ref="-436" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="13"/>
+        <tag k="hoot:review:sort_order" v="12"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (91m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21403,7 +21362,7 @@
         <member type="way" ref="-411" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="2"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (50m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.203063/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (50m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21413,7 +21372,7 @@
         <member type="node" ref="-3386" role="reviewee"/>
         <member type="way" ref="-425" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="14"/>
+        <tag k="hoot:review:sort_order" v="13"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (108m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21424,7 +21383,7 @@
         <member type="node" ref="-3386" role="reviewee"/>
         <member type="way" ref="-426" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="23"/>
+        <tag k="hoot:review:sort_order" v="22"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (145m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21435,7 +21394,7 @@
         <member type="node" ref="-3386" role="reviewee"/>
         <member type="way" ref="-427" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="28"/>
+        <tag k="hoot:review:sort_order" v="27"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (115m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21446,7 +21405,7 @@
         <member type="node" ref="-3386" role="reviewee"/>
         <member type="way" ref="-428" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="24"/>
+        <tag k="hoot:review:sort_order" v="23"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (130m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21457,7 +21416,7 @@
         <member type="node" ref="-3386" role="reviewee"/>
         <member type="way" ref="-430" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="38"/>
+        <tag k="hoot:review:sort_order" v="37"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (64m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21468,7 +21427,7 @@
         <member type="node" ref="-3386" role="reviewee"/>
         <member type="way" ref="-431" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="15"/>
+        <tag k="hoot:review:sort_order" v="14"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (100m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21479,7 +21438,7 @@
         <member type="node" ref="-3386" role="reviewee"/>
         <member type="way" ref="-434" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="29"/>
+        <tag k="hoot:review:sort_order" v="28"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (123m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21490,7 +21449,7 @@
         <member type="node" ref="-3386" role="reviewee"/>
         <member type="way" ref="-436" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="16"/>
+        <tag k="hoot:review:sort_order" v="15"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (93m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21512,7 +21471,7 @@
         <member type="node" ref="-3387" role="reviewee"/>
         <member type="way" ref="-425" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="17"/>
+        <tag k="hoot:review:sort_order" v="16"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (111m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21523,7 +21482,7 @@
         <member type="node" ref="-3387" role="reviewee"/>
         <member type="way" ref="-427" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="30"/>
+        <tag k="hoot:review:sort_order" v="29"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (118m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21534,7 +21493,7 @@
         <member type="node" ref="-3387" role="reviewee"/>
         <member type="way" ref="-428" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="25"/>
+        <tag k="hoot:review:sort_order" v="24"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (132m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21545,7 +21504,7 @@
         <member type="node" ref="-3387" role="reviewee"/>
         <member type="way" ref="-430" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="39"/>
+        <tag k="hoot:review:sort_order" v="38"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (69m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21556,7 +21515,7 @@
         <member type="node" ref="-3387" role="reviewee"/>
         <member type="way" ref="-431" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="18"/>
+        <tag k="hoot:review:sort_order" v="17"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (103m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21567,7 +21526,7 @@
         <member type="node" ref="-3387" role="reviewee"/>
         <member type="way" ref="-434" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="31"/>
+        <tag k="hoot:review:sort_order" v="30"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (125m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21578,7 +21537,7 @@
         <member type="node" ref="-3387" role="reviewee"/>
         <member type="way" ref="-436" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="19"/>
+        <tag k="hoot:review:sort_order" v="18"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (96m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21590,7 +21549,7 @@
         <member type="way" ref="-670" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="5"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (53m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.0636936/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (53m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.0322581/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21600,7 +21559,7 @@
         <member type="node" ref="-3746" role="reviewee"/>
         <member type="way" ref="-381" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="116"/>
+        <tag k="hoot:review:sort_order" v="115"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21611,7 +21570,7 @@
         <member type="node" ref="-3746" role="reviewee"/>
         <member type="way" ref="-382" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="117"/>
+        <tag k="hoot:review:sort_order" v="116"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21622,7 +21581,7 @@
         <member type="node" ref="-3746" role="reviewee"/>
         <member type="way" ref="-383" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="118"/>
+        <tag k="hoot:review:sort_order" v="117"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21633,7 +21592,7 @@
         <member type="node" ref="-3756" role="reviewee"/>
         <member type="way" ref="-413" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="340"/>
+        <tag k="hoot:review:sort_order" v="337"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (2m; score: 2/2), type: no (score: 0.2/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21644,7 +21603,7 @@
         <member type="node" ref="-3767" role="reviewee"/>
         <member type="way" ref="-333" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="143"/>
+        <tag k="hoot:review:sort_order" v="142"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (1m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21655,7 +21614,7 @@
         <member type="node" ref="-3768" role="reviewee"/>
         <member type="way" ref="-8" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="456"/>
+        <tag k="hoot:review:sort_order" v="453"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (2m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21666,7 +21625,7 @@
         <member type="node" ref="-3768" role="reviewee"/>
         <member type="way" ref="-9" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="457"/>
+        <tag k="hoot:review:sort_order" v="454"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21677,7 +21636,7 @@
         <member type="node" ref="-3769" role="reviewee"/>
         <member type="way" ref="-408" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="150"/>
+        <tag k="hoot:review:sort_order" v="149"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (2m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21688,8 +21647,8 @@
         <member type="node" ref="-3799" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="287"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (104m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.180083/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="286"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (104m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0263158/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21699,7 +21658,7 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-441" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="158"/>
+        <tag k="hoot:review:sort_order" v="157"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (146m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21710,7 +21669,7 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-442" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="163"/>
+        <tag k="hoot:review:sort_order" v="162"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (127m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21721,7 +21680,7 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-443" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="160"/>
+        <tag k="hoot:review:sort_order" v="159"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (96m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21732,7 +21691,7 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="246"/>
+        <tag k="hoot:review:sort_order" v="245"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (122m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21743,7 +21702,7 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="192"/>
+        <tag k="hoot:review:sort_order" v="191"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (110m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21754,7 +21713,7 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="186"/>
+        <tag k="hoot:review:sort_order" v="185"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (96m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21765,7 +21724,7 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="238"/>
+        <tag k="hoot:review:sort_order" v="237"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (133m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21776,7 +21735,7 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="176"/>
+        <tag k="hoot:review:sort_order" v="175"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (75m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21787,8 +21746,8 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-653" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="298"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (28m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0457527/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="297"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (28m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21798,8 +21757,8 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-656" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="300"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (37m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.215194/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="299"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (37m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0392157/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21809,8 +21768,8 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-658" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="166"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0.56/1), name: no (score: 0.0799137/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="165"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0.56/1), name: no (score: 0.0222222/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21820,7 +21779,7 @@
         <member type="node" ref="-3951" role="reviewee"/>
         <member type="way" ref="-18" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="136"/>
+        <tag k="hoot:review:sort_order" v="135"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (1m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21831,7 +21790,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-456" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="270"/>
+        <tag k="hoot:review:sort_order" v="269"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (142m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21842,7 +21801,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-457" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="276"/>
+        <tag k="hoot:review:sort_order" v="275"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (111m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21853,7 +21812,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-458" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="277"/>
+        <tag k="hoot:review:sort_order" v="276"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (103m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21864,7 +21823,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-459" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="278"/>
+        <tag k="hoot:review:sort_order" v="277"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (91m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21875,7 +21834,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-460" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="279"/>
+        <tag k="hoot:review:sort_order" v="278"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (86m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21886,7 +21845,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-461" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="271"/>
+        <tag k="hoot:review:sort_order" v="270"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (134m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21897,7 +21856,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="281"/>
+        <tag k="hoot:review:sort_order" v="280"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (57m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21908,7 +21867,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="282"/>
+        <tag k="hoot:review:sort_order" v="281"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (67m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21919,7 +21878,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="225"/>
+        <tag k="hoot:review:sort_order" v="224"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (80m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21930,7 +21889,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="280"/>
+        <tag k="hoot:review:sort_order" v="279"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (44m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21941,7 +21900,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="224"/>
+        <tag k="hoot:review:sort_order" v="223"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (93m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21952,8 +21911,8 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="284"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0.5/1), name: no (score: 0.275848/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="283"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0.5/1), name: no (score: 0.0192308/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21963,7 +21922,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-672" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="211"/>
+        <tag k="hoot:review:sort_order" v="210"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21974,7 +21933,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-456" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="268"/>
+        <tag k="hoot:review:sort_order" v="267"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (112m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21985,7 +21944,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-457" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="266"/>
+        <tag k="hoot:review:sort_order" v="265"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (60m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21996,7 +21955,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-458" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="264"/>
+        <tag k="hoot:review:sort_order" v="263"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (53m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22007,7 +21966,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-459" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="272"/>
+        <tag k="hoot:review:sort_order" v="271"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (40m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22018,7 +21977,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-460" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="273"/>
+        <tag k="hoot:review:sort_order" v="272"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (39m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22029,7 +21988,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-461" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="267"/>
+        <tag k="hoot:review:sort_order" v="266"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (90m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22040,7 +21999,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-462" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="269"/>
+        <tag k="hoot:review:sort_order" v="268"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (109m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22051,7 +22010,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="260"/>
+        <tag k="hoot:review:sort_order" v="259"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (8m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22062,7 +22021,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="255"/>
+        <tag k="hoot:review:sort_order" v="254"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (25m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22073,7 +22032,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="253"/>
+        <tag k="hoot:review:sort_order" v="252"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (40m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22084,7 +22043,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-672" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="193"/>
+        <tag k="hoot:review:sort_order" v="192"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (81m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22095,7 +22054,7 @@
         <member type="node" ref="-3958" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="263"/>
+        <tag k="hoot:review:sort_order" v="262"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22106,7 +22065,7 @@
         <member type="node" ref="-3958" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="275"/>
+        <tag k="hoot:review:sort_order" v="274"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22117,7 +22076,7 @@
         <member type="node" ref="-3958" role="reviewee"/>
         <member type="way" ref="-662" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="285"/>
+        <tag k="hoot:review:sort_order" v="284"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (139m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22128,7 +22087,7 @@
         <member type="node" ref="-3958" role="reviewee"/>
         <member type="way" ref="-671" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="217"/>
+        <tag k="hoot:review:sort_order" v="216"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (41m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22139,8 +22098,8 @@
         <member type="node" ref="-3959" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="288"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (97m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.17734/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="287"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (97m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.03125/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22150,8 +22109,8 @@
         <member type="node" ref="-3959" role="reviewee"/>
         <member type="way" ref="-658" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="295"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (67m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0799137/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="294"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (67m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0263158/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22161,8 +22120,8 @@
         <member type="node" ref="-3959" role="reviewee"/>
         <member type="way" ref="-663" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="215"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (74m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.17734/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="214"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (74m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0227273/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22172,7 +22131,7 @@
         <member type="node" ref="-3959" role="reviewee"/>
         <member type="way" ref="-666" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="218"/>
+        <tag k="hoot:review:sort_order" v="217"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (82m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22183,7 +22142,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-443" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="167"/>
+        <tag k="hoot:review:sort_order" v="166"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (133m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22194,7 +22153,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-457" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="256"/>
+        <tag k="hoot:review:sort_order" v="255"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (114m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22205,7 +22164,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-458" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="257"/>
+        <tag k="hoot:review:sort_order" v="256"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (110m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22216,7 +22175,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-459" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="258"/>
+        <tag k="hoot:review:sort_order" v="257"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (98m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22227,7 +22186,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-460" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="259"/>
+        <tag k="hoot:review:sort_order" v="258"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (102m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22238,7 +22197,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-461" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="265"/>
+        <tag k="hoot:review:sort_order" v="264"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (146m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22249,7 +22208,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="232"/>
+        <tag k="hoot:review:sort_order" v="231"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (60m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22260,7 +22219,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="254"/>
+        <tag k="hoot:review:sort_order" v="253"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (50m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22271,7 +22230,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="251"/>
+        <tag k="hoot:review:sort_order" v="250"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (39m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22282,7 +22241,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="261"/>
+        <tag k="hoot:review:sort_order" v="260"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (70m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22293,7 +22252,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="252"/>
+        <tag k="hoot:review:sort_order" v="251"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (35m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22304,8 +22263,8 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="219"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (104m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.203063/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="218"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (104m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0227273/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22315,7 +22274,7 @@
         <member type="node" ref="-3962" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="283"/>
+        <tag k="hoot:review:sort_order" v="282"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (64m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22326,8 +22285,8 @@
         <member type="node" ref="-3962" role="reviewee"/>
         <member type="way" ref="-658" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="204"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (98m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.17734/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="203"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (98m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0384615/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22337,7 +22296,7 @@
         <member type="node" ref="-3967" role="reviewee"/>
         <member type="way" ref="-132" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="352"/>
+        <tag k="hoot:review:sort_order" v="349"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22348,7 +22307,7 @@
         <member type="node" ref="-3971" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="214"/>
+        <tag k="hoot:review:sort_order" v="213"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (130m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22359,7 +22318,7 @@
         <member type="node" ref="-3971" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="207"/>
+        <tag k="hoot:review:sort_order" v="206"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (129m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22370,7 +22329,7 @@
         <member type="node" ref="-3971" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="209"/>
+        <tag k="hoot:review:sort_order" v="208"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (126m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22381,7 +22340,7 @@
         <member type="node" ref="-3971" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="221"/>
+        <tag k="hoot:review:sort_order" v="220"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (134m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22392,7 +22351,7 @@
         <member type="node" ref="-3971" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="208"/>
+        <tag k="hoot:review:sort_order" v="207"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (126m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22403,8 +22362,8 @@
         <member type="node" ref="-3973" role="reviewee"/>
         <member type="way" ref="-650" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="303"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.343703/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="302"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.126214/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22414,8 +22373,8 @@
         <member type="node" ref="-3973" role="reviewee"/>
         <member type="way" ref="-651" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="301"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (106m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.383548/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="300"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (106m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.282609/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22425,8 +22384,8 @@
         <member type="node" ref="-3973" role="reviewee"/>
         <member type="way" ref="-663" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="293"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (77m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.156355/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="292"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (77m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0777778/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22436,8 +22395,8 @@
         <member type="node" ref="-3973" role="reviewee"/>
         <member type="way" ref="-666" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="294"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (89m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.274604/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="293"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (89m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.113636/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22447,8 +22406,8 @@
         <member type="node" ref="-3976" role="reviewee"/>
         <member type="way" ref="-650" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="146"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (129m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.198771/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="145"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (129m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.119403/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22458,7 +22417,7 @@
         <member type="node" ref="-3976" role="reviewee"/>
         <member type="way" ref="-654" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="147"/>
+        <tag k="hoot:review:sort_order" v="146"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22469,8 +22428,8 @@
         <member type="node" ref="-3976" role="reviewee"/>
         <member type="way" ref="-734" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="145"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (104m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.198771/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="144"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (104m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.119403/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22480,8 +22439,8 @@
         <member type="node" ref="-3985" role="reviewee"/>
         <member type="way" ref="-408" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="152"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (35m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.236767/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="151"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (35m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22491,7 +22450,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-421" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="312"/>
+        <tag k="hoot:review:sort_order" v="311"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (50m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22502,7 +22461,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-422" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="311"/>
+        <tag k="hoot:review:sort_order" v="310"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (56m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22513,7 +22472,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-423" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="314"/>
+        <tag k="hoot:review:sort_order" v="313"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (33m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22524,7 +22483,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-424" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="304"/>
+        <tag k="hoot:review:sort_order" v="303"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (18m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22535,7 +22494,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-426" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="316"/>
+        <tag k="hoot:review:sort_order" v="315"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (123m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22546,7 +22505,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-428" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="317"/>
+        <tag k="hoot:review:sort_order" v="316"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (130m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22557,7 +22516,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-429" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="313"/>
+        <tag k="hoot:review:sort_order" v="312"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (42m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22568,7 +22527,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-432" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="315"/>
+        <tag k="hoot:review:sort_order" v="314"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (27m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22579,7 +22538,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-433" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="323"/>
+        <tag k="hoot:review:sort_order" v="322"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (73m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22601,7 +22560,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-435" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="318"/>
+        <tag k="hoot:review:sort_order" v="317"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (109m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22612,7 +22571,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-737" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="325"/>
+        <tag k="hoot:review:sort_order" v="324"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (142m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22623,7 +22582,7 @@
         <member type="node" ref="-3989" role="reviewee"/>
         <member type="way" ref="-545" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="440"/>
+        <tag k="hoot:review:sort_order" v="437"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22634,7 +22593,7 @@
         <member type="node" ref="-3990" role="reviewee"/>
         <member type="way" ref="-799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="543"/>
+        <tag k="hoot:review:sort_order" v="541"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22645,7 +22604,7 @@
         <member type="node" ref="-4009" role="reviewee"/>
         <member type="way" ref="-543" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="438"/>
+        <tag k="hoot:review:sort_order" v="435"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22656,7 +22615,7 @@
         <member type="node" ref="-4009" role="reviewee"/>
         <member type="way" ref="-552" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="436"/>
+        <tag k="hoot:review:sort_order" v="433"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22667,7 +22626,7 @@
         <member type="node" ref="-4009" role="reviewee"/>
         <member type="way" ref="-568" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="434"/>
+        <tag k="hoot:review:sort_order" v="431"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22678,7 +22637,7 @@
         <member type="node" ref="-4010" role="reviewee"/>
         <member type="way" ref="-18" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="137"/>
+        <tag k="hoot:review:sort_order" v="136"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22689,7 +22648,7 @@
         <member type="node" ref="-4011" role="reviewee"/>
         <member type="way" ref="-533" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="376"/>
+        <tag k="hoot:review:sort_order" v="373"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22700,7 +22659,7 @@
         <member type="node" ref="-4012" role="reviewee"/>
         <member type="way" ref="-227" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="530"/>
+        <tag k="hoot:review:sort_order" v="527"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22711,7 +22670,7 @@
         <member type="node" ref="-4025" role="reviewee"/>
         <member type="way" ref="-654" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="148"/>
+        <tag k="hoot:review:sort_order" v="147"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22722,7 +22681,7 @@
         <member type="node" ref="-4046" role="reviewee"/>
         <member type="way" ref="-28" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="550"/>
+        <tag k="hoot:review:sort_order" v="548"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22733,7 +22692,7 @@
         <member type="node" ref="-4046" role="reviewee"/>
         <member type="way" ref="-45" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="551"/>
+        <tag k="hoot:review:sort_order" v="549"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (2m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22744,7 +22703,7 @@
         <member type="node" ref="-4048" role="reviewee"/>
         <member type="way" ref="-430" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="41"/>
+        <tag k="hoot:review:sort_order" v="40"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (1m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22755,8 +22714,8 @@
         <member type="node" ref="-4049" role="reviewee"/>
         <member type="way" ref="-670" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="44"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (138m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.174317/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="43"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (138m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.03125/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22766,7 +22725,7 @@
         <member type="node" ref="-4050" role="reviewee"/>
         <member type="way" ref="-670" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="43"/>
+        <tag k="hoot:review:sort_order" v="42"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (119m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22777,8 +22736,8 @@
         <member type="node" ref="-4052" role="reviewee"/>
         <member type="way" ref="-670" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="42"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (75m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.225313/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="41"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (75m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.12/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22788,7 +22747,7 @@
         <member type="node" ref="-4060" role="reviewee"/>
         <member type="way" ref="-525" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="58"/>
+        <tag k="hoot:review:sort_order" v="57"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22799,8 +22758,8 @@
         <member type="node" ref="-4065" role="reviewee"/>
         <member type="way" ref="-408" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="151"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.106693/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="150"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.0344828/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22810,7 +22769,7 @@
         <member type="node" ref="-4068" role="reviewee"/>
         <member type="way" ref="-501" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="73"/>
+        <tag k="hoot:review:sort_order" v="72"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22821,7 +22780,7 @@
         <member type="node" ref="-4069" role="reviewee"/>
         <member type="way" ref="-509" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="72"/>
+        <tag k="hoot:review:sort_order" v="71"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22832,7 +22791,7 @@
         <member type="node" ref="-4072" role="reviewee"/>
         <member type="way" ref="-297" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="359"/>
+        <tag k="hoot:review:sort_order" v="356"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22843,7 +22802,7 @@
         <member type="node" ref="-4072" role="reviewee"/>
         <member type="way" ref="-347" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="386"/>
+        <tag k="hoot:review:sort_order" v="383"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (144m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22854,7 +22813,7 @@
         <member type="node" ref="-4082" role="reviewee"/>
         <member type="way" ref="-369" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="78"/>
+        <tag k="hoot:review:sort_order" v="77"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (1m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22865,8 +22824,8 @@
         <member type="node" ref="-4103" role="reviewee"/>
         <member type="way" ref="-683" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="364"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.0707946/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="361"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22876,7 +22835,7 @@
         <member type="node" ref="-4104" role="reviewee"/>
         <member type="way" ref="-471" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="366"/>
+        <tag k="hoot:review:sort_order" v="363"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22887,7 +22846,7 @@
         <member type="node" ref="-4192" role="reviewee"/>
         <member type="way" ref="-179" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="470"/>
+        <tag k="hoot:review:sort_order" v="467"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (5m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22898,7 +22857,7 @@
         <member type="node" ref="-4192" role="reviewee"/>
         <member type="way" ref="-187" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="416"/>
+        <tag k="hoot:review:sort_order" v="413"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22909,7 +22868,7 @@
         <member type="node" ref="-4192" role="reviewee"/>
         <member type="way" ref="-360" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="411"/>
+        <tag k="hoot:review:sort_order" v="408"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (55m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22920,7 +22879,7 @@
         <member type="node" ref="-4194" role="reviewee"/>
         <member type="way" ref="-374" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="80"/>
+        <tag k="hoot:review:sort_order" v="79"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22931,7 +22890,7 @@
         <member type="node" ref="-4196" role="reviewee"/>
         <member type="way" ref="-377" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="128"/>
+        <tag k="hoot:review:sort_order" v="127"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22942,7 +22901,7 @@
         <member type="node" ref="-4196" role="reviewee"/>
         <member type="way" ref="-378" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="127"/>
+        <tag k="hoot:review:sort_order" v="126"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (1m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22953,8 +22912,8 @@
         <member type="node" ref="-4197" role="reviewee"/>
         <member type="way" ref="-683" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="365"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.0636936/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="362"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.05/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22964,7 +22923,7 @@
         <member type="node" ref="-4198" role="reviewee"/>
         <member type="way" ref="-467" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="363"/>
+        <tag k="hoot:review:sort_order" v="360"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22975,7 +22934,7 @@
         <member type="node" ref="-4213" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="172"/>
+        <tag k="hoot:review:sort_order" v="171"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22986,7 +22945,7 @@
         <member type="node" ref="-4215" role="reviewee"/>
         <member type="way" ref="-714" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="346"/>
+        <tag k="hoot:review:sort_order" v="343"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22997,7 +22956,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="relation" ref="-2" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="501"/>
+        <tag k="hoot:review:sort_order" v="498"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (78m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23008,7 +22967,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-138" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="503"/>
+        <tag k="hoot:review:sort_order" v="500"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (108m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23019,7 +22978,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-139" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="506"/>
+        <tag k="hoot:review:sort_order" v="503"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (67m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23030,7 +22989,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-140" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="504"/>
+        <tag k="hoot:review:sort_order" v="501"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (110m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23041,7 +23000,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-141" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="502"/>
+        <tag k="hoot:review:sort_order" v="499"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (107m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23052,7 +23011,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-142" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="509"/>
+        <tag k="hoot:review:sort_order" v="506"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (41m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23063,7 +23022,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-143" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="507"/>
+        <tag k="hoot:review:sort_order" v="504"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (47m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23074,7 +23033,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-144" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="505"/>
+        <tag k="hoot:review:sort_order" v="502"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (84m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23085,7 +23044,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-145" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="404"/>
+        <tag k="hoot:review:sort_order" v="401"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (99m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23096,7 +23055,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-146" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="414"/>
+        <tag k="hoot:review:sort_order" v="411"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (87m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23107,7 +23066,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-147" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="406"/>
+        <tag k="hoot:review:sort_order" v="403"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (92m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23118,7 +23077,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-148" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="405"/>
+        <tag k="hoot:review:sort_order" v="402"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (106m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23129,7 +23088,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-149" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="510"/>
+        <tag k="hoot:review:sort_order" v="507"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (43m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23140,7 +23099,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-150" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="407"/>
+        <tag k="hoot:review:sort_order" v="404"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (83m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23151,7 +23110,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-151" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="408"/>
+        <tag k="hoot:review:sort_order" v="405"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (67m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23162,7 +23121,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-152" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="399"/>
+        <tag k="hoot:review:sort_order" v="396"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (114m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23173,7 +23132,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-153" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="409"/>
+        <tag k="hoot:review:sort_order" v="406"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (50m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23184,7 +23143,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-154" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="424"/>
+        <tag k="hoot:review:sort_order" v="421"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (102m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23195,7 +23154,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-155" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="491"/>
+        <tag k="hoot:review:sort_order" v="488"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (80m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23206,7 +23165,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-156" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="498"/>
+        <tag k="hoot:review:sort_order" v="495"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (72m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23217,7 +23176,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-157" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="490"/>
+        <tag k="hoot:review:sort_order" v="487"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (59m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23228,7 +23187,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-158" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="492"/>
+        <tag k="hoot:review:sort_order" v="489"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (72m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23239,7 +23198,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-159" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="493"/>
+        <tag k="hoot:review:sort_order" v="490"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (85m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23250,7 +23209,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-160" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="494"/>
+        <tag k="hoot:review:sort_order" v="491"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (91m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23261,7 +23220,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-161" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="495"/>
+        <tag k="hoot:review:sort_order" v="492"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (97m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23272,7 +23231,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-164" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="496"/>
+        <tag k="hoot:review:sort_order" v="493"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (106m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23283,7 +23242,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-165" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="499"/>
+        <tag k="hoot:review:sort_order" v="496"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (104m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23294,7 +23253,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-166" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="484"/>
+        <tag k="hoot:review:sort_order" v="481"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (44m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23305,7 +23264,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-167" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="485"/>
+        <tag k="hoot:review:sort_order" v="482"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (56m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23316,7 +23275,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-168" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="497"/>
+        <tag k="hoot:review:sort_order" v="494"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (109m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23327,7 +23286,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-169" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="464"/>
+        <tag k="hoot:review:sort_order" v="461"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (123m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23338,7 +23297,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-170" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="465"/>
+        <tag k="hoot:review:sort_order" v="462"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23349,7 +23308,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-171" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="500"/>
+        <tag k="hoot:review:sort_order" v="497"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (90m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23360,7 +23319,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-172" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="462"/>
+        <tag k="hoot:review:sort_order" v="459"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (105m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23371,7 +23330,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-173" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="463"/>
+        <tag k="hoot:review:sort_order" v="460"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (110m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23382,7 +23341,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-174" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="508"/>
+        <tag k="hoot:review:sort_order" v="505"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (64m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23393,7 +23352,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-175" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="466"/>
+        <tag k="hoot:review:sort_order" v="463"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (121m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23404,7 +23363,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-176" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="520"/>
+        <tag k="hoot:review:sort_order" v="517"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (112m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23415,7 +23374,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-177" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="486"/>
+        <tag k="hoot:review:sort_order" v="483"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (62m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23426,7 +23385,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-178" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="489"/>
+        <tag k="hoot:review:sort_order" v="486"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (69m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23437,7 +23396,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-179" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="476"/>
+        <tag k="hoot:review:sort_order" v="473"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (34m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23448,7 +23407,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-180" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="482"/>
+        <tag k="hoot:review:sort_order" v="479"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (27m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23459,7 +23418,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-181" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="487"/>
+        <tag k="hoot:review:sort_order" v="484"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (48m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23470,7 +23429,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-182" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="488"/>
+        <tag k="hoot:review:sort_order" v="485"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (42m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23481,7 +23440,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-184" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="471"/>
+        <tag k="hoot:review:sort_order" v="468"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (53m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23492,7 +23451,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-185" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="478"/>
+        <tag k="hoot:review:sort_order" v="475"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (31m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23503,7 +23462,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-186" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="472"/>
+        <tag k="hoot:review:sort_order" v="469"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (38m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23514,7 +23473,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-187" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="477"/>
+        <tag k="hoot:review:sort_order" v="474"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (42m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23525,7 +23484,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-188" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="473"/>
+        <tag k="hoot:review:sort_order" v="470"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (44m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23536,7 +23495,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-189" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="483"/>
+        <tag k="hoot:review:sort_order" v="480"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (17m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23547,7 +23506,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-191" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="474"/>
+        <tag k="hoot:review:sort_order" v="471"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (35m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23558,7 +23517,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-192" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="475"/>
+        <tag k="hoot:review:sort_order" v="472"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (38m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23569,7 +23528,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-193" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="400"/>
+        <tag k="hoot:review:sort_order" v="397"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (133m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23580,7 +23539,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-198" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="401"/>
+        <tag k="hoot:review:sort_order" v="398"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (140m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23591,7 +23550,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-201" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="403"/>
+        <tag k="hoot:review:sort_order" v="400"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (142m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23602,7 +23561,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-202" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="402"/>
+        <tag k="hoot:review:sort_order" v="399"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (125m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23613,7 +23572,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-206" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="521"/>
+        <tag k="hoot:review:sort_order" v="518"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (141m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23624,7 +23583,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-207" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="512"/>
+        <tag k="hoot:review:sort_order" v="509"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (75m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23635,7 +23594,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-208" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="517"/>
+        <tag k="hoot:review:sort_order" v="514"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (127m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23646,7 +23605,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-209" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="515"/>
+        <tag k="hoot:review:sort_order" v="512"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (99m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23657,7 +23616,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-210" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="513"/>
+        <tag k="hoot:review:sort_order" v="510"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (85m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23668,7 +23627,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-211" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="519"/>
+        <tag k="hoot:review:sort_order" v="516"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (138m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23679,7 +23638,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-212" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="516"/>
+        <tag k="hoot:review:sort_order" v="513"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (111m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23690,7 +23649,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-213" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="514"/>
+        <tag k="hoot:review:sort_order" v="511"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (89m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23701,7 +23660,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-214" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="511"/>
+        <tag k="hoot:review:sort_order" v="508"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (79m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23712,7 +23671,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-232" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="390"/>
+        <tag k="hoot:review:sort_order" v="387"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (142m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23723,7 +23682,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-239" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="392"/>
+        <tag k="hoot:review:sort_order" v="389"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (140m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23734,7 +23693,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-243" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="393"/>
+        <tag k="hoot:review:sort_order" v="390"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (136m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23745,7 +23704,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-260" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="387"/>
+        <tag k="hoot:review:sort_order" v="384"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (146m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23756,7 +23715,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-340" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="396"/>
+        <tag k="hoot:review:sort_order" v="393"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (83m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23767,7 +23726,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-341" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="391"/>
+        <tag k="hoot:review:sort_order" v="388"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (110m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23778,7 +23737,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-350" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="398"/>
+        <tag k="hoot:review:sort_order" v="395"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (144m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23789,7 +23748,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-351" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="397"/>
+        <tag k="hoot:review:sort_order" v="394"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (124m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23800,7 +23759,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-352" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="394"/>
+        <tag k="hoot:review:sort_order" v="391"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (99m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23811,7 +23770,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-353" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="395"/>
+        <tag k="hoot:review:sort_order" v="392"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (81m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23822,7 +23781,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-360" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="479"/>
+        <tag k="hoot:review:sort_order" v="476"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (19m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23833,7 +23792,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-361" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="410"/>
+        <tag k="hoot:review:sort_order" v="407"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (51m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23844,7 +23803,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-362" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="412"/>
+        <tag k="hoot:review:sort_order" v="409"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (57m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23855,7 +23814,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-363" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="413"/>
+        <tag k="hoot:review:sort_order" v="410"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (67m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23866,7 +23825,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-364" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="415"/>
+        <tag k="hoot:review:sort_order" v="412"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (72m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23877,7 +23836,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-365" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="468"/>
+        <tag k="hoot:review:sort_order" v="465"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (81m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23888,7 +23847,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-366" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="469"/>
+        <tag k="hoot:review:sort_order" v="466"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (81m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23899,7 +23858,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-542" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="423"/>
+        <tag k="hoot:review:sort_order" v="420"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (113m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23910,7 +23869,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-543" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="442"/>
+        <tag k="hoot:review:sort_order" v="439"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (134m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23921,7 +23880,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-544" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="421"/>
+        <tag k="hoot:review:sort_order" v="418"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (117m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23932,7 +23891,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-546" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="443"/>
+        <tag k="hoot:review:sort_order" v="440"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (145m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23943,7 +23902,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-547" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="422"/>
+        <tag k="hoot:review:sort_order" v="419"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (124m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23954,7 +23913,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-548" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="419"/>
+        <tag k="hoot:review:sort_order" v="416"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (110m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23965,7 +23924,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-551" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="418"/>
+        <tag k="hoot:review:sort_order" v="415"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (91m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23976,7 +23935,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-552" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="444"/>
+        <tag k="hoot:review:sort_order" v="441"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (145m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23987,7 +23946,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-553" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="417"/>
+        <tag k="hoot:review:sort_order" v="414"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (103m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23998,7 +23957,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-556" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="441"/>
+        <tag k="hoot:review:sort_order" v="438"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (131m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24009,7 +23968,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-558" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="454"/>
+        <tag k="hoot:review:sort_order" v="451"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (141m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24020,7 +23979,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-559" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="451"/>
+        <tag k="hoot:review:sort_order" v="448"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (123m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24031,7 +23990,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-560" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="447"/>
+        <tag k="hoot:review:sort_order" v="444"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (114m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24042,7 +24001,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-561" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="449"/>
+        <tag k="hoot:review:sort_order" v="446"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (117m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24053,7 +24012,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-562" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="452"/>
+        <tag k="hoot:review:sort_order" v="449"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (135m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24064,7 +24023,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-566" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="453"/>
+        <tag k="hoot:review:sort_order" v="450"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (134m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24075,7 +24034,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-567" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="450"/>
+        <tag k="hoot:review:sort_order" v="447"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (126m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24086,7 +24045,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-568" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="445"/>
+        <tag k="hoot:review:sort_order" v="442"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (133m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24097,7 +24056,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-569" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="448"/>
+        <tag k="hoot:review:sort_order" v="445"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (119m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24108,7 +24067,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-570" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="455"/>
+        <tag k="hoot:review:sort_order" v="452"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (142m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24119,7 +24078,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-572" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="446"/>
+        <tag k="hoot:review:sort_order" v="443"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (108m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24130,7 +24089,7 @@
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-792" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="467"/>
+        <tag k="hoot:review:sort_order" v="464"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (118m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24141,7 +24100,7 @@
         <member type="node" ref="-4219" role="reviewee"/>
         <member type="way" ref="-47" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="549"/>
+        <tag k="hoot:review:sort_order" v="547"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24152,8 +24111,8 @@
         <member type="node" ref="-4219" role="reviewee"/>
         <member type="way" ref="-799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="544"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.180083/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="542"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.142857/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -24163,7 +24122,7 @@
         <member type="node" ref="-4221" role="reviewee"/>
         <member type="way" ref="-484" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="428"/>
+        <tag k="hoot:review:sort_order" v="425"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24174,7 +24133,7 @@
         <member type="node" ref="-4226" role="reviewee"/>
         <member type="way" ref="-456" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="52"/>
+        <tag k="hoot:review:sort_order" v="51"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24185,7 +24144,7 @@
         <member type="node" ref="-4229" role="reviewee"/>
         <member type="way" ref="-207" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="522"/>
+        <tag k="hoot:review:sort_order" v="519"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (24m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24196,7 +24155,7 @@
         <member type="node" ref="-4229" role="reviewee"/>
         <member type="way" ref="-232" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="527"/>
+        <tag k="hoot:review:sort_order" v="524"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (31m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24207,7 +24166,7 @@
         <member type="node" ref="-4229" role="reviewee"/>
         <member type="way" ref="-340" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="388"/>
+        <tag k="hoot:review:sort_order" v="385"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (18m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24218,7 +24177,7 @@
         <member type="node" ref="-4229" role="reviewee"/>
         <member type="way" ref="-341" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="528"/>
+        <tag k="hoot:review:sort_order" v="525"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24229,7 +24188,7 @@
         <member type="node" ref="-4230" role="reviewee"/>
         <member type="way" ref="-578" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="142"/>
+        <tag k="hoot:review:sort_order" v="141"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24240,8 +24199,8 @@
         <member type="node" ref="-4230" role="reviewee"/>
         <member type="way" ref="-729" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="59"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (140m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.333333/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="58"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (140m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.225/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -24251,8 +24210,8 @@
         <member type="node" ref="-4238" role="reviewee"/>
         <member type="way" ref="-799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="545"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.563694/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="543"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.461538/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -24262,7 +24221,7 @@
         <member type="node" ref="-4307" role="reviewee"/>
         <member type="way" ref="-500" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="75"/>
+        <tag k="hoot:review:sort_order" v="74"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24273,7 +24232,7 @@
         <member type="node" ref="-4307" role="reviewee"/>
         <member type="way" ref="-503" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="74"/>
+        <tag k="hoot:review:sort_order" v="73"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24284,7 +24243,7 @@
         <member type="node" ref="-4320" role="reviewee"/>
         <member type="way" ref="-510" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="139"/>
+        <tag k="hoot:review:sort_order" v="138"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (2m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24295,7 +24254,7 @@
         <member type="node" ref="-4322" role="reviewee"/>
         <member type="way" ref="-420" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="138"/>
+        <tag k="hoot:review:sort_order" v="137"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24306,7 +24265,7 @@
         <member type="node" ref="-4324" role="reviewee"/>
         <member type="way" ref="-69" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="552"/>
+        <tag k="hoot:review:sort_order" v="550"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24317,7 +24276,7 @@
         <member type="node" ref="-4325" role="reviewee"/>
         <member type="way" ref="-20" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="548"/>
+        <tag k="hoot:review:sort_order" v="546"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24328,7 +24287,7 @@
         <member type="node" ref="-4336" role="reviewee"/>
         <member type="way" ref="-207" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="523"/>
+        <tag k="hoot:review:sort_order" v="520"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (30m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24339,7 +24298,7 @@
         <member type="node" ref="-4336" role="reviewee"/>
         <member type="way" ref="-232" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="526"/>
+        <tag k="hoot:review:sort_order" v="523"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (22m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24350,7 +24309,7 @@
         <member type="node" ref="-4336" role="reviewee"/>
         <member type="way" ref="-250" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="524"/>
+        <tag k="hoot:review:sort_order" v="521"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (30m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24361,7 +24320,7 @@
         <member type="node" ref="-4336" role="reviewee"/>
         <member type="way" ref="-257" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="525"/>
+        <tag k="hoot:review:sort_order" v="522"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (29m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24372,7 +24331,7 @@
         <member type="node" ref="-4336" role="reviewee"/>
         <member type="way" ref="-340" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="389"/>
+        <tag k="hoot:review:sort_order" v="386"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (27m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24383,7 +24342,7 @@
         <member type="node" ref="-4336" role="reviewee"/>
         <member type="way" ref="-341" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="529"/>
+        <tag k="hoot:review:sort_order" v="526"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24394,7 +24353,7 @@
         <member type="node" ref="-4428" role="reviewee"/>
         <member type="way" ref="-801" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="109"/>
+        <tag k="hoot:review:sort_order" v="108"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24405,7 +24364,7 @@
         <member type="node" ref="-4429" role="reviewee"/>
         <member type="way" ref="-801" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="110"/>
+        <tag k="hoot:review:sort_order" v="109"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>

--- a/test-files/cmd/glacial/PoiPolygonConflateStandaloneTest/output1.osm
+++ b/test-files/cmd/glacial/PoiPolygonConflateStandaloneTest/output1.osm
@@ -272,6 +272,18 @@
     <node visible="true" id="-4691" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7656224024964899" lon="-122.4083961860541905"/>
     <node visible="true" id="-4690" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7645243936961137" lon="-122.4082942594553316"/>
     <node visible="true" id="-4689" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7645053152394752" lon="-122.4085699989071401"/>
+    <node visible="true" id="-4688" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7694999999999865" lon="-122.4326999999999970">
+        <tag k="wheelchair" v="yes"/>
+        <tag k="addr:state" v="CA"/>
+        <tag k="address" v="Duboce &amp; Scott St"/>
+        <tag k="name" v="Duboce Park Dog Play Area"/>
+        <tag k="addr:postcode" v="94117"/>
+        <tag k="addr:city" v="San Francisco"/>
+        <tag k="leisure" v="dog_park"/>
+        <tag k="phone" v="(415) 717-2872"/>
+        <tag k="REF2" v="0048cb"/>
+        <tag k="error:circular" v="15"/>
+    </node>
     <node visible="true" id="-4687" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7695999999999970" lon="-122.4339999999999975">
         <tag k="wheelchair" v="yes"/>
         <tag k="addr:state" v="CA"/>
@@ -294,6 +306,17 @@
         <tag k="leisure" v="park"/>
         <tag k="phone" v="(415) 203-1299"/>
         <tag k="REF2" v="000d65"/>
+        <tag k="error:circular" v="15"/>
+    </node>
+    <node visible="true" id="-4684" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7648999999999972" lon="-122.4333999999999918">
+        <tag k="wheelchair" v="limited"/>
+        <tag k="addr:state" v="CA"/>
+        <tag k="address" v="Noe St &amp; Beaver St"/>
+        <tag k="name" v="Noe &amp; Beaver Mini Park Community Garden"/>
+        <tag k="addr:postcode" v="94114"/>
+        <tag k="addr:city" v="San Francisco"/>
+        <tag k="leisure" v="garden"/>
+        <tag k="REF2" v="005aa3"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-4683" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7642000000000095" lon="-122.4202999999999975">
@@ -350,18 +373,6 @@
         <tag k="addr:postcode" v="94110"/>
         <tag k="addr:city" v="San Francisco"/>
         <tag k="REF2" v="none"/>
-        <tag k="error:circular" v="15"/>
-    </node>
-    <node visible="true" id="-4677" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7695999999999970" lon="-122.4344999999999999">
-        <tag k="wheelchair" v="yes"/>
-        <tag k="amenity" v="arts_centre"/>
-        <tag k="addr:state" v="CA"/>
-        <tag k="address" v="50 Scott St"/>
-        <tag k="name" v="Harvey Milk Photo Center"/>
-        <tag k="addr:postcode" v="94117"/>
-        <tag k="addr:city" v="San Francisco"/>
-        <tag k="phone" v="(415) 554-9522"/>
-        <tag k="REF2" v="00a471"/>
         <tag k="error:circular" v="15"/>
     </node>
     <node visible="true" id="-4676" timestamp="1970-01-01T00:00:00Z" version="1" lat="37.7695999999999827" lon="-122.4333999999999918">
@@ -7374,17 +7385,9 @@
         <nd ref="-4696"/>
         <nd ref="-4695"/>
         <nd ref="-4700"/>
-        <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="wheelchair" v="limited"/>
         <tag k="area" v="yes"/>
-        <tag k="addr:state" v="CA"/>
         <tag k="name" v="Noe &amp; Beaver Mini Park"/>
-        <tag k="address" v="Noe St &amp; Beaver St"/>
-        <tag k="addr:postcode" v="94114"/>
-        <tag k="alt_name" v="Noe &amp; Beaver Mini Park Community Garden"/>
-        <tag k="addr:city" v="San Francisco"/>
-        <tag k="leisure" v="garden"/>
-        <tag k="REF2" v="none;005aa3"/>
+        <tag k="REF2" v="none"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-801" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -7432,18 +7435,9 @@
         <nd ref="-4673"/>
         <nd ref="-4672"/>
         <nd ref="-4674"/>
-        <tag k="hoot:poipolygon:poismerged" v="1"/>
-        <tag k="wheelchair" v="yes"/>
         <tag k="area" v="yes"/>
-        <tag k="addr:state" v="CA"/>
         <tag k="name" v="Duboce Park"/>
-        <tag k="address" v="Duboce &amp; Scott St"/>
-        <tag k="addr:postcode" v="94117"/>
-        <tag k="alt_name" v="Duboce Park Dog Play Area"/>
-        <tag k="addr:city" v="San Francisco"/>
-        <tag k="leisure" v="dog_park"/>
-        <tag k="phone" v="(415) 717-2872"/>
-        <tag k="REF2" v="none;0048cb"/>
+        <tag k="REF2" v="none"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-797" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -7483,11 +7477,20 @@
         <nd ref="-3945"/>
         <nd ref="-4667"/>
         <nd ref="-4666"/>
+        <tag k="hoot:poipolygon:poismerged" v="1"/>
+        <tag k="wheelchair" v="yes"/>
         <tag k="amenity" v="community_centre"/>
+        <tag k="addr:state" v="CA"/>
         <tag k="name" v="Harvey Milk Recreational Arts Center"/>
+        <tag k="address" v="50 Scott St"/>
+        <tag k="addr:postcode" v="94117"/>
+        <tag k="alt_name" v="Harvey Milk Photo Center"/>
         <tag k="building" v="yes"/>
+        <tag k="addr:city" v="San Francisco"/>
+        <tag k="phone" v="(415) 554-9522"/>
         <tag k="REF1" v="00a471"/>
         <tag k="toilets" v="yes"/>
+        <tag k="REF2" v="00a471"/>
         <tag k="error:circular" v="15"/>
     </way>
     <way visible="true" id="-794" timestamp="1970-01-01T00:00:00Z" version="1">
@@ -18373,7 +18376,7 @@
         <tag k="access" v="customers"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <relation visible="true" id="-548" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-552" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4679" role="reviewee"/>
         <member type="way" ref="-728" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18384,7 +18387,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-547" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-551" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4681" role="reviewee"/>
         <member type="way" ref="-728" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18395,18 +18398,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-546" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4678" role="reviewee"/>
-        <member type="way" ref="-725" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="92"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-545" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-550" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4683" role="reviewee"/>
         <member type="way" ref="-725" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18417,7 +18409,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-544" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-549" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4685" role="reviewee"/>
         <member type="way" ref="-725" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18428,7 +18420,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-543" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-548" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4676" role="reviewee"/>
         <member type="way" ref="-785" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18439,7 +18431,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-542" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-547" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4687" role="reviewee"/>
         <member type="way" ref="-785" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18450,42 +18442,9 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-541" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4677" role="reviewee"/>
-        <member type="way" ref="-795" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="301"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-540" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4730" role="reviewee"/>
-        <member type="way" ref="-795" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="302"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-539" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-546" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-384" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="78"/>
-        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-538" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-2390" role="reviewee"/>
-        <member type="way" ref="-410" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="79"/>
         <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
@@ -18494,29 +18453,40 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-537" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-545" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-2390" role="reviewee"/>
+        <member type="way" ref="-410" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI to Polygon"/>
+        <tag k="hoot:review:sort_order" v="80"/>
+        <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-544" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="237"/>
+        <tag k="hoot:review:sort_order" v="238"/>
         <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-536" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-543" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="249"/>
+        <tag k="hoot:review:sort_order" v="250"/>
         <tag k="hoot:review:note" v="Conflicting information: multiple features have been matched to the same feature and require review."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-535" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-542" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-183" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18527,7 +18497,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-534" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-541" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4217" role="reviewee"/>
         <member type="way" ref="-190" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18538,7 +18508,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-533" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-540" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4438" role="reviewee"/>
         <member type="way" ref="-357" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18549,7 +18519,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-532" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-539" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4452" role="reviewee"/>
         <member type="way" ref="-413" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18560,29 +18530,51 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-529" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4677" role="reviewee"/>
-        <member type="way" ref="-798" role="reviewee"/>
+    <relation visible="true" id="-535" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4678" role="reviewee"/>
+        <member type="way" ref="-725" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="306"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.205039/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="95"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.367347/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-534" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4678" role="reviewee"/>
+        <member type="way" ref="-801" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI to Polygon"/>
+        <tag k="hoot:review:sort_order" v="96"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.346154/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-530" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4684" role="reviewee"/>
+        <member type="way" ref="-802" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI to Polygon"/>
+        <tag k="hoot:review:sort_order" v="8"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.510204/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-528" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4678" role="reviewee"/>
-        <member type="way" ref="-801" role="reviewee"/>
+        <member type="node" ref="-4688" role="reviewee"/>
+        <member type="way" ref="-798" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="95"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.791227/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="306"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.6/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-525" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-527" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4719" role="reviewee"/>
         <member type="way" ref="-139" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18593,18 +18585,18 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-524" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-526" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4722" role="reviewee"/>
         <member type="way" ref="-774" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="138"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0.317916/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="139"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0.2125/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-523" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-525" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4727" role="reviewee"/>
         <member type="way" ref="-413" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18615,7 +18607,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-522" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-524" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4728" role="reviewee"/>
         <member type="way" ref="-343" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18626,7 +18618,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-521" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-523" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4729" role="reviewee"/>
         <member type="way" ref="-523" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18637,29 +18629,40 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-520" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-522" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4730" role="reviewee"/>
         <member type="way" ref="-785" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="307"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.141345/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.0434783/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-521" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4730" role="reviewee"/>
+        <member type="way" ref="-795" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI to Polygon"/>
+        <tag k="hoot:review:sort_order" v="302"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.526316/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-520" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4730" role="reviewee"/>
+        <member type="way" ref="-798" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI to Polygon"/>
+        <tag k="hoot:review:sort_order" v="308"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.0434783/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-519" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4730" role="reviewee"/>
-        <member type="way" ref="-798" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="308"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.141345/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-518" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4732" role="reviewee"/>
         <member type="way" ref="-594" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18670,7 +18673,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-517" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-518" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4735" role="reviewee"/>
         <member type="way" ref="-283" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18681,7 +18684,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-516" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-517" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4735" role="reviewee"/>
         <member type="way" ref="-288" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18692,7 +18695,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-514" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-515" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4737" role="reviewee"/>
         <member type="way" ref="-715" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18703,7 +18706,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-513" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-514" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4738" role="reviewee"/>
         <member type="way" ref="-585" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18714,7 +18717,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-512" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-513" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4740" role="reviewee"/>
         <member type="way" ref="-490" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18725,7 +18728,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-511" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-512" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4741" role="reviewee"/>
         <member type="way" ref="-515" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18736,12 +18739,23 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-510" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-511" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4741" role="reviewee"/>
         <member type="way" ref="-516" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="116"/>
+        <tag k="hoot:review:sort_order" v="117"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (17m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-510" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4741" role="reviewee"/>
+        <member type="way" ref="-517" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI to Polygon"/>
+        <tag k="hoot:review:sort_order" v="119"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (20m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -18749,27 +18763,16 @@
     </relation>
     <relation visible="true" id="-509" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4741" role="reviewee"/>
-        <member type="way" ref="-517" role="reviewee"/>
-        <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="118"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (20m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-508" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4741" role="reviewee"/>
         <member type="way" ref="-518" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="119"/>
+        <tag k="hoot:review:sort_order" v="120"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (22m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-507" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-508" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4741" role="reviewee"/>
         <member type="way" ref="-519" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18780,7 +18783,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-506" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-507" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4741" role="reviewee"/>
         <member type="way" ref="-520" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18791,18 +18794,18 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-505" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-506" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4741" role="reviewee"/>
         <member type="way" ref="-521" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="117"/>
+        <tag k="hoot:review:sort_order" v="118"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: no (18m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-504" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-505" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4742" role="reviewee"/>
         <member type="way" ref="-310" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18813,7 +18816,7 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-503" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-504" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4742" role="reviewee"/>
         <member type="way" ref="-416" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
@@ -18824,23 +18827,34 @@
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-502" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-503" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4744" role="reviewee"/>
         <member type="way" ref="-108" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="511"/>
+        <tag k="hoot:review:sort_order" v="512"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-501" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-502" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4745" role="reviewee"/>
         <member type="way" ref="-729" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="48"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (136m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.476796/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="49"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (136m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.243902/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-501" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="node" ref="-4750" role="reviewee"/>
+        <member type="way" ref="-785" role="reviewee"/>
+        <tag k="hoot:review:type" v="POI to Polygon"/>
+        <tag k="hoot:review:sort_order" v="309"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.027027/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -18848,10 +18862,10 @@
     </relation>
     <relation visible="true" id="-500" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4750" role="reviewee"/>
-        <member type="way" ref="-785" role="reviewee"/>
+        <member type="way" ref="-795" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="309"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.0785515/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="303"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.203125/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -18859,21 +18873,21 @@
     </relation>
     <relation visible="true" id="-499" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="-4750" role="reviewee"/>
-        <member type="way" ref="-795" role="reviewee"/>
+        <member type="way" ref="-798" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="303"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.578552/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="310"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.027027/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-498" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="node" ref="-4750" role="reviewee"/>
-        <member type="way" ref="-798" role="reviewee"/>
+        <member type="node" ref="-4752" role="reviewee"/>
+        <member type="way" ref="-799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="310"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.0785515/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="507"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.681818/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -18894,7 +18908,7 @@
         <member type="node" ref="-4755" role="reviewee"/>
         <member type="way" ref="-443" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="151"/>
+        <tag k="hoot:review:sort_order" v="152"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -18950,7 +18964,7 @@
         <member type="way" ref="-347" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="354"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (79m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.304934/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (79m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.196721/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19037,7 +19051,7 @@
         <member type="node" ref="-1959" role="reviewee"/>
         <member type="way" ref="-77" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="510"/>
+        <tag k="hoot:review:sort_order" v="511"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19048,7 +19062,7 @@
         <member type="node" ref="-1960" role="reviewee"/>
         <member type="way" ref="-443" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="152"/>
+        <tag k="hoot:review:sort_order" v="153"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19092,7 +19106,7 @@
         <member type="node" ref="-1968" role="reviewee"/>
         <member type="way" ref="-18" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="120"/>
+        <tag k="hoot:review:sort_order" v="121"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19114,7 +19128,7 @@
         <member type="node" ref="-2158" role="reviewee"/>
         <member type="way" ref="-415" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="115"/>
+        <tag k="hoot:review:sort_order" v="116"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19125,7 +19139,7 @@
         <member type="node" ref="-2279" role="reviewee"/>
         <member type="way" ref="-453" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="62"/>
+        <tag k="hoot:review:sort_order" v="63"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19136,7 +19150,7 @@
         <member type="node" ref="-2280" role="reviewee"/>
         <member type="way" ref="-411" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="45"/>
+        <tag k="hoot:review:sort_order" v="46"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19147,8 +19161,8 @@
         <member type="node" ref="-2280" role="reviewee"/>
         <member type="way" ref="-670" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="44"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (57m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.17734/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="45"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (57m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.0645161/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19170,7 +19184,7 @@
         <member type="way" ref="-541" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="344"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.323624/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.0888889/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19180,7 +19194,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-16" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="70"/>
+        <tag k="hoot:review:sort_order" v="71"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (90m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19191,7 +19205,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-17" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="68"/>
+        <tag k="hoot:review:sort_order" v="69"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (98m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19202,7 +19216,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-18" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="67"/>
+        <tag k="hoot:review:sort_order" v="68"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (105m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19213,7 +19227,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-367" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="76"/>
+        <tag k="hoot:review:sort_order" v="77"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (32m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19224,7 +19238,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-368" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="75"/>
+        <tag k="hoot:review:sort_order" v="76"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (31m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19235,7 +19249,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-369" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="110"/>
+        <tag k="hoot:review:sort_order" v="111"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (55m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19246,7 +19260,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-370" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="111"/>
+        <tag k="hoot:review:sort_order" v="112"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (63m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19257,7 +19271,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-371" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="112"/>
+        <tag k="hoot:review:sort_order" v="113"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (70m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19268,7 +19282,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-372" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="73"/>
+        <tag k="hoot:review:sort_order" v="74"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (31m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19279,7 +19293,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-373" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="74"/>
+        <tag k="hoot:review:sort_order" v="75"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (31m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19290,7 +19304,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-374" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="72"/>
+        <tag k="hoot:review:sort_order" v="73"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (33m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19301,7 +19315,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-375" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="98"/>
+        <tag k="hoot:review:sort_order" v="99"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (89m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19312,7 +19326,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-376" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="99"/>
+        <tag k="hoot:review:sort_order" v="100"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (100m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19323,7 +19337,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-377" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="101"/>
+        <tag k="hoot:review:sort_order" v="102"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (86m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19334,7 +19348,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-378" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="107"/>
+        <tag k="hoot:review:sort_order" v="108"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (78m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19345,7 +19359,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-379" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="108"/>
+        <tag k="hoot:review:sort_order" v="109"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (72m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19356,7 +19370,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-380" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="109"/>
+        <tag k="hoot:review:sort_order" v="110"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (60m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19367,7 +19381,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-381" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="105"/>
+        <tag k="hoot:review:sort_order" v="106"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (52m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19378,7 +19392,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-382" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="106"/>
+        <tag k="hoot:review:sort_order" v="107"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (45m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19389,7 +19403,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-383" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="77"/>
+        <tag k="hoot:review:sort_order" v="78"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (23m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19400,7 +19414,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-385" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="80"/>
+        <tag k="hoot:review:sort_order" v="81"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (6m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19411,7 +19425,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-386" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="61"/>
+        <tag k="hoot:review:sort_order" v="62"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (111m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19422,7 +19436,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-387" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="59"/>
+        <tag k="hoot:review:sort_order" v="60"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (114m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19433,7 +19447,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-388" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="60"/>
+        <tag k="hoot:review:sort_order" v="61"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (115m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19444,7 +19458,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-389" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="56"/>
+        <tag k="hoot:review:sort_order" v="57"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19455,7 +19469,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-390" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="57"/>
+        <tag k="hoot:review:sort_order" v="58"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (124m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19466,7 +19480,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-391" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="58"/>
+        <tag k="hoot:review:sort_order" v="59"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (130m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19477,7 +19491,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-392" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="54"/>
+        <tag k="hoot:review:sort_order" v="55"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (133m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19488,7 +19502,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-393" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="55"/>
+        <tag k="hoot:review:sort_order" v="56"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (142m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19499,7 +19513,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-394" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="53"/>
+        <tag k="hoot:review:sort_order" v="54"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (146m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19510,7 +19524,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-415" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="100"/>
+        <tag k="hoot:review:sort_order" v="101"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (99m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19521,7 +19535,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-418" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="89"/>
+        <tag k="hoot:review:sort_order" v="90"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (127m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19532,7 +19546,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-419" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="88"/>
+        <tag k="hoot:review:sort_order" v="89"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (136m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19543,7 +19557,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-480" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="81"/>
+        <tag k="hoot:review:sort_order" v="82"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (140m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19554,7 +19568,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-481" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="84"/>
+        <tag k="hoot:review:sort_order" v="85"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (139m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19565,7 +19579,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-482" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="85"/>
+        <tag k="hoot:review:sort_order" v="86"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (139m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19576,7 +19590,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-483" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="86"/>
+        <tag k="hoot:review:sort_order" v="87"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (135m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19587,7 +19601,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-497" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="90"/>
+        <tag k="hoot:review:sort_order" v="91"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (139m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19598,7 +19612,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-498" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="91"/>
+        <tag k="hoot:review:sort_order" v="92"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (136m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19609,7 +19623,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-499" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="82"/>
+        <tag k="hoot:review:sort_order" v="83"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (134m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19620,7 +19634,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-506" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="83"/>
+        <tag k="hoot:review:sort_order" v="84"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (136m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19631,7 +19645,7 @@
         <member type="node" ref="-2390" role="reviewee"/>
         <member type="way" ref="-522" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="87"/>
+        <tag k="hoot:review:sort_order" v="88"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (146m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19675,7 +19689,7 @@
         <member type="node" ref="-2456" role="reviewee"/>
         <member type="way" ref="-18" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="121"/>
+        <tag k="hoot:review:sort_order" v="122"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19719,8 +19733,8 @@
         <member type="node" ref="-2465" role="reviewee"/>
         <member type="way" ref="-408" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="134"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0.392/1), name: no (score: 0.17734/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="135"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0.392/1), name: no (score: 0.0285714/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19730,7 +19744,7 @@
         <member type="node" ref="-2473" role="reviewee"/>
         <member type="way" ref="-461" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="47"/>
+        <tag k="hoot:review:sort_order" v="48"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (1m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19741,8 +19755,8 @@
         <member type="node" ref="-2552" role="reviewee"/>
         <member type="way" ref="-670" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="43"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (88m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.17734/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="44"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (88m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19764,7 +19778,7 @@
         <member type="way" ref="-347" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="330"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (126m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.101532/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (126m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.0212766/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -19895,7 +19909,7 @@
         <member type="node" ref="-3309" role="reviewee"/>
         <member type="way" ref="-573" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="52"/>
+        <tag k="hoot:review:sort_order" v="53"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19906,7 +19920,7 @@
         <member type="node" ref="-3309" role="reviewee"/>
         <member type="way" ref="-575" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="51"/>
+        <tag k="hoot:review:sort_order" v="52"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19928,7 +19942,7 @@
         <member type="node" ref="-3336" role="reviewee"/>
         <member type="way" ref="-579" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="127"/>
+        <tag k="hoot:review:sort_order" v="128"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19939,7 +19953,7 @@
         <member type="node" ref="-3337" role="reviewee"/>
         <member type="way" ref="-577" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="126"/>
+        <tag k="hoot:review:sort_order" v="127"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19950,7 +19964,7 @@
         <member type="node" ref="-3338" role="reviewee"/>
         <member type="way" ref="-442" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="142"/>
+        <tag k="hoot:review:sort_order" v="143"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (133m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19961,7 +19975,7 @@
         <member type="node" ref="-3338" role="reviewee"/>
         <member type="way" ref="-443" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="140"/>
+        <tag k="hoot:review:sort_order" v="141"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (102m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19972,7 +19986,7 @@
         <member type="node" ref="-3338" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="217"/>
+        <tag k="hoot:review:sort_order" v="218"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (119m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19983,7 +19997,7 @@
         <member type="node" ref="-3338" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="163"/>
+        <tag k="hoot:review:sort_order" v="164"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (107m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -19994,7 +20008,7 @@
         <member type="node" ref="-3338" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="159"/>
+        <tag k="hoot:review:sort_order" v="160"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (94m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20005,7 +20019,7 @@
         <member type="node" ref="-3338" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="211"/>
+        <tag k="hoot:review:sort_order" v="212"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (129m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20016,7 +20030,7 @@
         <member type="node" ref="-3338" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="154"/>
+        <tag k="hoot:review:sort_order" v="155"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (75m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20027,7 +20041,7 @@
         <member type="node" ref="-3339" role="reviewee"/>
         <member type="way" ref="-442" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="143"/>
+        <tag k="hoot:review:sort_order" v="144"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (143m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20038,7 +20052,7 @@
         <member type="node" ref="-3339" role="reviewee"/>
         <member type="way" ref="-443" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="145"/>
+        <tag k="hoot:review:sort_order" v="146"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (113m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20049,7 +20063,7 @@
         <member type="node" ref="-3339" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="218"/>
+        <tag k="hoot:review:sort_order" v="219"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (118m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20060,7 +20074,7 @@
         <member type="node" ref="-3339" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="164"/>
+        <tag k="hoot:review:sort_order" v="165"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (107m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20071,7 +20085,7 @@
         <member type="node" ref="-3339" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="160"/>
+        <tag k="hoot:review:sort_order" v="161"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (95m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20082,7 +20096,7 @@
         <member type="node" ref="-3339" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="212"/>
+        <tag k="hoot:review:sort_order" v="213"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (128m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20093,7 +20107,7 @@
         <member type="node" ref="-3339" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="157"/>
+        <tag k="hoot:review:sort_order" v="158"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (79m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20104,7 +20118,7 @@
         <member type="node" ref="-3339" role="reviewee"/>
         <member type="way" ref="-658" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="272"/>
+        <tag k="hoot:review:sort_order" v="273"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (20m; score: 2/2), type: yes (score: 0.9/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20115,7 +20129,7 @@
         <member type="node" ref="-3340" role="reviewee"/>
         <member type="way" ref="-443" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="146"/>
+        <tag k="hoot:review:sort_order" v="147"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (119m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20126,7 +20140,7 @@
         <member type="node" ref="-3340" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="219"/>
+        <tag k="hoot:review:sort_order" v="220"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (115m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20137,7 +20151,7 @@
         <member type="node" ref="-3340" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="165"/>
+        <tag k="hoot:review:sort_order" v="166"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (105m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20148,7 +20162,7 @@
         <member type="node" ref="-3340" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="161"/>
+        <tag k="hoot:review:sort_order" v="162"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (94m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20159,7 +20173,7 @@
         <member type="node" ref="-3340" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="209"/>
+        <tag k="hoot:review:sort_order" v="210"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (125m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20170,7 +20184,7 @@
         <member type="node" ref="-3340" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="158"/>
+        <tag k="hoot:review:sort_order" v="159"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (79m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20181,8 +20195,8 @@
         <member type="node" ref="-3340" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="264"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (142m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.194692/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="265"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (142m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0188679/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -20192,7 +20206,7 @@
         <member type="node" ref="-3341" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="215"/>
+        <tag k="hoot:review:sort_order" v="216"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20203,7 +20217,7 @@
         <member type="node" ref="-3341" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="175"/>
+        <tag k="hoot:review:sort_order" v="176"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (109m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20214,7 +20228,7 @@
         <member type="node" ref="-3341" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="173"/>
+        <tag k="hoot:review:sort_order" v="174"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (101m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20225,7 +20239,7 @@
         <member type="node" ref="-3341" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="210"/>
+        <tag k="hoot:review:sort_order" v="211"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (123m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20236,7 +20250,7 @@
         <member type="node" ref="-3341" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="170"/>
+        <tag k="hoot:review:sort_order" v="171"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (95m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20247,8 +20261,8 @@
         <member type="node" ref="-3341" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="265"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (124m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.290242/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="266"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (124m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.129032/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -20258,7 +20272,7 @@
         <member type="node" ref="-3342" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="216"/>
+        <tag k="hoot:review:sort_order" v="217"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20269,7 +20283,7 @@
         <member type="node" ref="-3342" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="176"/>
+        <tag k="hoot:review:sort_order" v="177"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (110m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20280,7 +20294,7 @@
         <member type="node" ref="-3342" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="174"/>
+        <tag k="hoot:review:sort_order" v="175"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (103m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20291,7 +20305,7 @@
         <member type="node" ref="-3342" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="198"/>
+        <tag k="hoot:review:sort_order" v="199"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (123m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20302,7 +20316,7 @@
         <member type="node" ref="-3342" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="171"/>
+        <tag k="hoot:review:sort_order" v="172"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (98m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20313,8 +20327,8 @@
         <member type="node" ref="-3342" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="266"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (120m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.326844/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="267"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (120m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0344828/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -20324,7 +20338,7 @@
         <member type="node" ref="-3343" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="186"/>
+        <tag k="hoot:review:sort_order" v="187"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (118m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20335,7 +20349,7 @@
         <member type="node" ref="-3343" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="177"/>
+        <tag k="hoot:review:sort_order" v="178"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (113m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20346,7 +20360,7 @@
         <member type="node" ref="-3343" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="178"/>
+        <tag k="hoot:review:sort_order" v="179"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (107m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20357,7 +20371,7 @@
         <member type="node" ref="-3343" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="199"/>
+        <tag k="hoot:review:sort_order" v="200"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (124m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20368,7 +20382,7 @@
         <member type="node" ref="-3343" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="172"/>
+        <tag k="hoot:review:sort_order" v="173"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (104m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20379,8 +20393,8 @@
         <member type="node" ref="-3343" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="267"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.147284/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="268"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -20390,8 +20404,8 @@
         <member type="node" ref="-3344" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="261"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.127387/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="262"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0434783/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -20401,7 +20415,7 @@
         <member type="node" ref="-3345" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="192"/>
+        <tag k="hoot:review:sort_order" v="193"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (119m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20412,7 +20426,7 @@
         <member type="node" ref="-3345" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="188"/>
+        <tag k="hoot:review:sort_order" v="189"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (120m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20423,7 +20437,7 @@
         <member type="node" ref="-3345" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="189"/>
+        <tag k="hoot:review:sort_order" v="190"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (119m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20434,7 +20448,7 @@
         <member type="node" ref="-3345" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="196"/>
+        <tag k="hoot:review:sort_order" v="197"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (120m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20445,7 +20459,7 @@
         <member type="node" ref="-3345" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="182"/>
+        <tag k="hoot:review:sort_order" v="183"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (122m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20456,7 +20470,7 @@
         <member type="node" ref="-3345" role="reviewee"/>
         <member type="way" ref="-659" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="277"/>
+        <tag k="hoot:review:sort_order" v="278"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20467,7 +20481,7 @@
         <member type="node" ref="-3345" role="reviewee"/>
         <member type="way" ref="-672" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="181"/>
+        <tag k="hoot:review:sort_order" v="182"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (90m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20478,7 +20492,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-443" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="149"/>
+        <tag k="hoot:review:sort_order" v="150"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (142m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20489,7 +20503,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-459" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="204"/>
+        <tag k="hoot:review:sort_order" v="205"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (135m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20500,7 +20514,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-460" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="205"/>
+        <tag k="hoot:review:sort_order" v="206"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (138m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20511,7 +20525,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="213"/>
+        <tag k="hoot:review:sort_order" v="214"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (94m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20522,7 +20536,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="220"/>
+        <tag k="hoot:review:sort_order" v="221"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (87m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20533,7 +20547,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="224"/>
+        <tag k="hoot:review:sort_order" v="225"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (79m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20544,7 +20558,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="202"/>
+        <tag k="hoot:review:sort_order" v="203"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (102m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20555,7 +20569,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="166"/>
+        <tag k="hoot:review:sort_order" v="167"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (75m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20566,7 +20580,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-659" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="271"/>
+        <tag k="hoot:review:sort_order" v="272"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (76m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20577,7 +20591,7 @@
         <member type="node" ref="-3377" role="reviewee"/>
         <member type="way" ref="-672" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="179"/>
+        <tag k="hoot:review:sort_order" v="180"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (27m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20588,7 +20602,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-443" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="150"/>
+        <tag k="hoot:review:sort_order" v="151"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (134m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20599,7 +20613,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-459" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="206"/>
+        <tag k="hoot:review:sort_order" v="207"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (134m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20610,7 +20624,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-460" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="207"/>
+        <tag k="hoot:review:sort_order" v="208"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (137m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20621,7 +20635,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="223"/>
+        <tag k="hoot:review:sort_order" v="224"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (94m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20632,7 +20646,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="221"/>
+        <tag k="hoot:review:sort_order" v="222"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (86m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20643,7 +20657,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="225"/>
+        <tag k="hoot:review:sort_order" v="226"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (77m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20654,7 +20668,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="203"/>
+        <tag k="hoot:review:sort_order" v="204"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (102m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20665,7 +20679,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="167"/>
+        <tag k="hoot:review:sort_order" v="168"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (70m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20676,7 +20690,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-659" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="274"/>
+        <tag k="hoot:review:sort_order" v="275"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (74m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20687,7 +20701,7 @@
         <member type="node" ref="-3378" role="reviewee"/>
         <member type="way" ref="-672" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="156"/>
+        <tag k="hoot:review:sort_order" v="157"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (21m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20698,7 +20712,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-421" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="285"/>
+        <tag k="hoot:review:sort_order" v="286"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (59m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20709,7 +20723,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-422" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="283"/>
+        <tag k="hoot:review:sort_order" v="284"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (62m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20720,7 +20734,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-423" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="281"/>
+        <tag k="hoot:review:sort_order" v="282"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (42m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20731,7 +20745,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-424" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="280"/>
+        <tag k="hoot:review:sort_order" v="281"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (30m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20742,7 +20756,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-426" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="295"/>
+        <tag k="hoot:review:sort_order" v="296"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (127m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20753,7 +20767,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-428" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="294"/>
+        <tag k="hoot:review:sort_order" v="295"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (134m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20764,7 +20778,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-429" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="284"/>
+        <tag k="hoot:review:sort_order" v="285"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (49m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20775,7 +20789,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-432" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="282"/>
+        <tag k="hoot:review:sort_order" v="283"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (37m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20786,7 +20800,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-433" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="297"/>
+        <tag k="hoot:review:sort_order" v="298"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (78m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20797,7 +20811,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-435" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="296"/>
+        <tag k="hoot:review:sort_order" v="297"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (113m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20808,7 +20822,7 @@
         <member type="node" ref="-3379" role="reviewee"/>
         <member type="way" ref="-737" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="299"/>
+        <tag k="hoot:review:sort_order" v="300"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (128m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20831,7 +20845,7 @@
         <member type="way" ref="-411" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="4"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (37m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.127387/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (37m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -20841,7 +20855,7 @@
         <member type="node" ref="-3384" role="reviewee"/>
         <member type="way" ref="-425" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="30"/>
+        <tag k="hoot:review:sort_order" v="31"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (103m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20852,7 +20866,7 @@
         <member type="node" ref="-3384" role="reviewee"/>
         <member type="way" ref="-426" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="18"/>
+        <tag k="hoot:review:sort_order" v="19"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (140m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20863,7 +20877,7 @@
         <member type="node" ref="-3384" role="reviewee"/>
         <member type="way" ref="-427" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="31"/>
+        <tag k="hoot:review:sort_order" v="32"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (110m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20874,7 +20888,7 @@
         <member type="node" ref="-3384" role="reviewee"/>
         <member type="way" ref="-428" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="33"/>
+        <tag k="hoot:review:sort_order" v="34"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (126m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20885,7 +20899,7 @@
         <member type="node" ref="-3384" role="reviewee"/>
         <member type="way" ref="-430" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="38"/>
+        <tag k="hoot:review:sort_order" v="39"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (52m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20896,7 +20910,7 @@
         <member type="node" ref="-3384" role="reviewee"/>
         <member type="way" ref="-431" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="34"/>
+        <tag k="hoot:review:sort_order" v="35"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (94m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20907,7 +20921,7 @@
         <member type="node" ref="-3384" role="reviewee"/>
         <member type="way" ref="-434" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="32"/>
+        <tag k="hoot:review:sort_order" v="33"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (118m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20918,7 +20932,7 @@
         <member type="node" ref="-3384" role="reviewee"/>
         <member type="way" ref="-436" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="8"/>
+        <tag k="hoot:review:sort_order" v="9"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (86m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20930,7 +20944,7 @@
         <member type="way" ref="-411" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="1"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (46m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.127387/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (46m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -20940,7 +20954,7 @@
         <member type="node" ref="-3385" role="reviewee"/>
         <member type="way" ref="-425" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="9"/>
+        <tag k="hoot:review:sort_order" v="10"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (107m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20951,7 +20965,7 @@
         <member type="node" ref="-3385" role="reviewee"/>
         <member type="way" ref="-426" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="19"/>
+        <tag k="hoot:review:sort_order" v="20"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (144m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20962,7 +20976,7 @@
         <member type="node" ref="-3385" role="reviewee"/>
         <member type="way" ref="-427" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="24"/>
+        <tag k="hoot:review:sort_order" v="25"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (114m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20973,7 +20987,7 @@
         <member type="node" ref="-3385" role="reviewee"/>
         <member type="way" ref="-428" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="20"/>
+        <tag k="hoot:review:sort_order" v="21"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (129m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20984,7 +20998,7 @@
         <member type="node" ref="-3385" role="reviewee"/>
         <member type="way" ref="-430" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="35"/>
+        <tag k="hoot:review:sort_order" v="36"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (61m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -20995,7 +21009,7 @@
         <member type="node" ref="-3385" role="reviewee"/>
         <member type="way" ref="-431" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="10"/>
+        <tag k="hoot:review:sort_order" v="11"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (99m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21006,7 +21020,7 @@
         <member type="node" ref="-3385" role="reviewee"/>
         <member type="way" ref="-434" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="25"/>
+        <tag k="hoot:review:sort_order" v="26"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (121m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21017,7 +21031,7 @@
         <member type="node" ref="-3385" role="reviewee"/>
         <member type="way" ref="-436" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="11"/>
+        <tag k="hoot:review:sort_order" v="12"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (91m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21029,7 +21043,7 @@
         <member type="way" ref="-411" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="2"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (50m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.203063/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (50m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21039,7 +21053,7 @@
         <member type="node" ref="-3386" role="reviewee"/>
         <member type="way" ref="-425" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="12"/>
+        <tag k="hoot:review:sort_order" v="13"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (108m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21050,7 +21064,7 @@
         <member type="node" ref="-3386" role="reviewee"/>
         <member type="way" ref="-426" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="21"/>
+        <tag k="hoot:review:sort_order" v="22"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (145m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21061,7 +21075,7 @@
         <member type="node" ref="-3386" role="reviewee"/>
         <member type="way" ref="-427" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="26"/>
+        <tag k="hoot:review:sort_order" v="27"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (115m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21072,7 +21086,7 @@
         <member type="node" ref="-3386" role="reviewee"/>
         <member type="way" ref="-428" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="22"/>
+        <tag k="hoot:review:sort_order" v="23"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (130m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21083,7 +21097,7 @@
         <member type="node" ref="-3386" role="reviewee"/>
         <member type="way" ref="-430" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="36"/>
+        <tag k="hoot:review:sort_order" v="37"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (64m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21094,7 +21108,7 @@
         <member type="node" ref="-3386" role="reviewee"/>
         <member type="way" ref="-431" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="13"/>
+        <tag k="hoot:review:sort_order" v="14"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (100m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21105,7 +21119,7 @@
         <member type="node" ref="-3386" role="reviewee"/>
         <member type="way" ref="-434" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="27"/>
+        <tag k="hoot:review:sort_order" v="28"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (123m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21116,7 +21130,7 @@
         <member type="node" ref="-3386" role="reviewee"/>
         <member type="way" ref="-436" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="14"/>
+        <tag k="hoot:review:sort_order" v="15"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (93m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21138,7 +21152,7 @@
         <member type="node" ref="-3387" role="reviewee"/>
         <member type="way" ref="-425" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="15"/>
+        <tag k="hoot:review:sort_order" v="16"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (111m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21149,7 +21163,7 @@
         <member type="node" ref="-3387" role="reviewee"/>
         <member type="way" ref="-427" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="28"/>
+        <tag k="hoot:review:sort_order" v="29"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (118m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21160,7 +21174,7 @@
         <member type="node" ref="-3387" role="reviewee"/>
         <member type="way" ref="-428" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="23"/>
+        <tag k="hoot:review:sort_order" v="24"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (132m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21171,7 +21185,7 @@
         <member type="node" ref="-3387" role="reviewee"/>
         <member type="way" ref="-430" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="37"/>
+        <tag k="hoot:review:sort_order" v="38"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (69m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21182,7 +21196,7 @@
         <member type="node" ref="-3387" role="reviewee"/>
         <member type="way" ref="-431" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="16"/>
+        <tag k="hoot:review:sort_order" v="17"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (103m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21193,7 +21207,7 @@
         <member type="node" ref="-3387" role="reviewee"/>
         <member type="way" ref="-434" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="29"/>
+        <tag k="hoot:review:sort_order" v="30"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (125m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21204,7 +21218,7 @@
         <member type="node" ref="-3387" role="reviewee"/>
         <member type="way" ref="-436" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="17"/>
+        <tag k="hoot:review:sort_order" v="18"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (96m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21216,7 +21230,7 @@
         <member type="way" ref="-670" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="5"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (53m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.0636936/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (53m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.0322581/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21226,7 +21240,7 @@
         <member type="node" ref="-3746" role="reviewee"/>
         <member type="way" ref="-381" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="102"/>
+        <tag k="hoot:review:sort_order" v="103"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21237,7 +21251,7 @@
         <member type="node" ref="-3746" role="reviewee"/>
         <member type="way" ref="-382" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="103"/>
+        <tag k="hoot:review:sort_order" v="104"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21248,7 +21262,7 @@
         <member type="node" ref="-3746" role="reviewee"/>
         <member type="way" ref="-383" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="104"/>
+        <tag k="hoot:review:sort_order" v="105"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21270,7 +21284,7 @@
         <member type="node" ref="-3767" role="reviewee"/>
         <member type="way" ref="-333" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="129"/>
+        <tag k="hoot:review:sort_order" v="130"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (1m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21303,7 +21317,7 @@
         <member type="node" ref="-3769" role="reviewee"/>
         <member type="way" ref="-408" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="135"/>
+        <tag k="hoot:review:sort_order" v="136"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (2m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21314,8 +21328,8 @@
         <member type="node" ref="-3799" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="262"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (104m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.180083/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="263"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (104m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0263158/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21325,7 +21339,7 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-441" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="139"/>
+        <tag k="hoot:review:sort_order" v="140"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (146m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21336,7 +21350,7 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-442" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="144"/>
+        <tag k="hoot:review:sort_order" v="145"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (127m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21347,7 +21361,7 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-443" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="141"/>
+        <tag k="hoot:review:sort_order" v="142"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (96m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21358,7 +21372,7 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="222"/>
+        <tag k="hoot:review:sort_order" v="223"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (122m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21369,7 +21383,7 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="168"/>
+        <tag k="hoot:review:sort_order" v="169"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (110m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21380,7 +21394,7 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="162"/>
+        <tag k="hoot:review:sort_order" v="163"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (96m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21391,7 +21405,7 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="214"/>
+        <tag k="hoot:review:sort_order" v="215"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (133m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21402,7 +21416,7 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="155"/>
+        <tag k="hoot:review:sort_order" v="156"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (75m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21413,8 +21427,8 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-653" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="273"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (28m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0457527/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="274"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (28m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21424,8 +21438,8 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-656" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="275"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (37m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.215194/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="276"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (37m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0392157/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21435,8 +21449,8 @@
         <member type="node" ref="-3807" role="reviewee"/>
         <member type="way" ref="-658" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="147"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0.56/1), name: no (score: 0.0799137/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="148"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0.56/1), name: no (score: 0.0222222/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21446,7 +21460,7 @@
         <member type="node" ref="-3951" role="reviewee"/>
         <member type="way" ref="-18" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="122"/>
+        <tag k="hoot:review:sort_order" v="123"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (1m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21457,7 +21471,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-456" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="245"/>
+        <tag k="hoot:review:sort_order" v="246"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (142m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21468,7 +21482,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-457" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="251"/>
+        <tag k="hoot:review:sort_order" v="252"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (111m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21479,7 +21493,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-458" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="252"/>
+        <tag k="hoot:review:sort_order" v="253"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (103m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21490,7 +21504,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-459" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="253"/>
+        <tag k="hoot:review:sort_order" v="254"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (91m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21501,7 +21515,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-460" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="254"/>
+        <tag k="hoot:review:sort_order" v="255"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (86m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21512,7 +21526,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-461" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="246"/>
+        <tag k="hoot:review:sort_order" v="247"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (134m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21523,7 +21537,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="256"/>
+        <tag k="hoot:review:sort_order" v="257"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (57m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21534,7 +21548,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="257"/>
+        <tag k="hoot:review:sort_order" v="258"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (67m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21545,7 +21559,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="201"/>
+        <tag k="hoot:review:sort_order" v="202"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (80m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21556,7 +21570,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="255"/>
+        <tag k="hoot:review:sort_order" v="256"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (44m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21567,7 +21581,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="200"/>
+        <tag k="hoot:review:sort_order" v="201"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (93m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21578,8 +21592,8 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="259"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0.5/1), name: no (score: 0.275848/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="260"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (3m; score: 2/2), type: no (score: 0.5/1), name: no (score: 0.0192308/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21589,7 +21603,7 @@
         <member type="node" ref="-3954" role="reviewee"/>
         <member type="way" ref="-672" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="187"/>
+        <tag k="hoot:review:sort_order" v="188"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21600,7 +21614,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-456" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="243"/>
+        <tag k="hoot:review:sort_order" v="244"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (112m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21611,7 +21625,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-457" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="241"/>
+        <tag k="hoot:review:sort_order" v="242"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (60m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21622,7 +21636,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-458" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="239"/>
+        <tag k="hoot:review:sort_order" v="240"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (53m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21633,7 +21647,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-459" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="247"/>
+        <tag k="hoot:review:sort_order" v="248"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (40m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21644,7 +21658,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-460" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="248"/>
+        <tag k="hoot:review:sort_order" v="249"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (39m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21655,7 +21669,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-461" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="242"/>
+        <tag k="hoot:review:sort_order" v="243"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (90m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21666,7 +21680,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-462" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="244"/>
+        <tag k="hoot:review:sort_order" v="245"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (109m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21677,7 +21691,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="235"/>
+        <tag k="hoot:review:sort_order" v="236"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (8m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21688,7 +21702,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="230"/>
+        <tag k="hoot:review:sort_order" v="231"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (25m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21699,7 +21713,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="228"/>
+        <tag k="hoot:review:sort_order" v="229"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (40m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21710,7 +21724,7 @@
         <member type="node" ref="-3955" role="reviewee"/>
         <member type="way" ref="-672" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="169"/>
+        <tag k="hoot:review:sort_order" v="170"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (81m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21721,7 +21735,7 @@
         <member type="node" ref="-3958" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="238"/>
+        <tag k="hoot:review:sort_order" v="239"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21732,7 +21746,7 @@
         <member type="node" ref="-3958" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="250"/>
+        <tag k="hoot:review:sort_order" v="251"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21743,7 +21757,7 @@
         <member type="node" ref="-3958" role="reviewee"/>
         <member type="way" ref="-662" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="260"/>
+        <tag k="hoot:review:sort_order" v="261"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (139m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21754,7 +21768,7 @@
         <member type="node" ref="-3958" role="reviewee"/>
         <member type="way" ref="-671" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="193"/>
+        <tag k="hoot:review:sort_order" v="194"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (41m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21765,8 +21779,8 @@
         <member type="node" ref="-3959" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="263"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (97m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.17734/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="264"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (97m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.03125/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21776,8 +21790,8 @@
         <member type="node" ref="-3959" role="reviewee"/>
         <member type="way" ref="-658" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="270"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (67m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0799137/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="271"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (67m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0263158/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21787,8 +21801,8 @@
         <member type="node" ref="-3959" role="reviewee"/>
         <member type="way" ref="-663" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="191"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (74m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.17734/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="192"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (74m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0227273/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21798,7 +21812,7 @@
         <member type="node" ref="-3959" role="reviewee"/>
         <member type="way" ref="-666" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="194"/>
+        <tag k="hoot:review:sort_order" v="195"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (82m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21809,7 +21823,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-443" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="148"/>
+        <tag k="hoot:review:sort_order" v="149"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (133m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21820,7 +21834,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-457" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="231"/>
+        <tag k="hoot:review:sort_order" v="232"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (114m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21831,7 +21845,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-458" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="232"/>
+        <tag k="hoot:review:sort_order" v="233"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (110m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21842,7 +21856,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-459" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="233"/>
+        <tag k="hoot:review:sort_order" v="234"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (98m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21853,7 +21867,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-460" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="234"/>
+        <tag k="hoot:review:sort_order" v="235"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (102m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21864,7 +21878,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-461" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="240"/>
+        <tag k="hoot:review:sort_order" v="241"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (146m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21875,7 +21889,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="208"/>
+        <tag k="hoot:review:sort_order" v="209"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (60m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21886,7 +21900,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="229"/>
+        <tag k="hoot:review:sort_order" v="230"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (50m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21897,7 +21911,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="226"/>
+        <tag k="hoot:review:sort_order" v="227"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (39m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21908,7 +21922,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="236"/>
+        <tag k="hoot:review:sort_order" v="237"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (70m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21919,7 +21933,7 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="227"/>
+        <tag k="hoot:review:sort_order" v="228"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (35m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21930,8 +21944,8 @@
         <member type="node" ref="-3961" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="195"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (104m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.203063/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="196"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (104m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0227273/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21941,7 +21955,7 @@
         <member type="node" ref="-3962" role="reviewee"/>
         <member type="way" ref="-649" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="258"/>
+        <tag k="hoot:review:sort_order" v="259"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (64m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21952,8 +21966,8 @@
         <member type="node" ref="-3962" role="reviewee"/>
         <member type="way" ref="-658" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="180"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (98m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.17734/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="181"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (98m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0384615/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -21974,7 +21988,7 @@
         <member type="node" ref="-3971" role="reviewee"/>
         <member type="way" ref="-580" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="190"/>
+        <tag k="hoot:review:sort_order" v="191"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (130m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21985,7 +21999,7 @@
         <member type="node" ref="-3971" role="reviewee"/>
         <member type="way" ref="-581" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="183"/>
+        <tag k="hoot:review:sort_order" v="184"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (129m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -21996,7 +22010,7 @@
         <member type="node" ref="-3971" role="reviewee"/>
         <member type="way" ref="-582" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="185"/>
+        <tag k="hoot:review:sort_order" v="186"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (126m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22007,7 +22021,7 @@
         <member type="node" ref="-3971" role="reviewee"/>
         <member type="way" ref="-583" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="197"/>
+        <tag k="hoot:review:sort_order" v="198"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (134m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22018,7 +22032,7 @@
         <member type="node" ref="-3971" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="184"/>
+        <tag k="hoot:review:sort_order" v="185"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (126m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22029,8 +22043,8 @@
         <member type="node" ref="-3973" role="reviewee"/>
         <member type="way" ref="-650" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="278"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.343703/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="279"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (116m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.126214/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22040,8 +22054,8 @@
         <member type="node" ref="-3973" role="reviewee"/>
         <member type="way" ref="-651" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="276"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (106m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.383548/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="277"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (106m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.282609/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22051,8 +22065,8 @@
         <member type="node" ref="-3973" role="reviewee"/>
         <member type="way" ref="-663" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="268"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (77m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.156355/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="269"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (77m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.0777778/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22062,8 +22076,8 @@
         <member type="node" ref="-3973" role="reviewee"/>
         <member type="way" ref="-666" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="269"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (89m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.274604/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="270"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (89m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.113636/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22073,8 +22087,8 @@
         <member type="node" ref="-3976" role="reviewee"/>
         <member type="way" ref="-650" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="131"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (129m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.198771/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="132"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (129m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.119403/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22084,7 +22098,7 @@
         <member type="node" ref="-3976" role="reviewee"/>
         <member type="way" ref="-654" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="132"/>
+        <tag k="hoot:review:sort_order" v="133"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22095,8 +22109,8 @@
         <member type="node" ref="-3976" role="reviewee"/>
         <member type="way" ref="-734" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="130"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (104m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.198771/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="131"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (104m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.119403/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22106,8 +22120,8 @@
         <member type="node" ref="-3985" role="reviewee"/>
         <member type="way" ref="-408" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="137"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (35m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.236767/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="138"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (35m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22117,7 +22131,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-421" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="287"/>
+        <tag k="hoot:review:sort_order" v="288"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (50m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22128,7 +22142,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-422" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="286"/>
+        <tag k="hoot:review:sort_order" v="287"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (56m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22139,7 +22153,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-423" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="289"/>
+        <tag k="hoot:review:sort_order" v="290"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (33m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22150,7 +22164,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-424" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="279"/>
+        <tag k="hoot:review:sort_order" v="280"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (18m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22161,7 +22175,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-426" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="291"/>
+        <tag k="hoot:review:sort_order" v="292"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (123m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22172,7 +22186,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-428" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="292"/>
+        <tag k="hoot:review:sort_order" v="293"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (130m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22183,7 +22197,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-429" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="288"/>
+        <tag k="hoot:review:sort_order" v="289"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (42m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22194,7 +22208,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-432" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="290"/>
+        <tag k="hoot:review:sort_order" v="291"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (27m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22205,7 +22219,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-433" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="298"/>
+        <tag k="hoot:review:sort_order" v="299"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (73m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22227,7 +22241,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-435" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="293"/>
+        <tag k="hoot:review:sort_order" v="294"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (109m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22238,7 +22252,7 @@
         <member type="node" ref="-3987" role="reviewee"/>
         <member type="way" ref="-737" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="300"/>
+        <tag k="hoot:review:sort_order" v="301"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (142m; score: 2/2), type: yes (score: 1/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22260,7 +22274,7 @@
         <member type="node" ref="-3990" role="reviewee"/>
         <member type="way" ref="-799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="507"/>
+        <tag k="hoot:review:sort_order" v="508"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22304,7 +22318,7 @@
         <member type="node" ref="-4010" role="reviewee"/>
         <member type="way" ref="-18" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="123"/>
+        <tag k="hoot:review:sort_order" v="124"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22337,7 +22351,7 @@
         <member type="node" ref="-4025" role="reviewee"/>
         <member type="way" ref="-654" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="133"/>
+        <tag k="hoot:review:sort_order" v="134"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22348,7 +22362,7 @@
         <member type="node" ref="-4046" role="reviewee"/>
         <member type="way" ref="-28" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="514"/>
+        <tag k="hoot:review:sort_order" v="515"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22359,7 +22373,7 @@
         <member type="node" ref="-4046" role="reviewee"/>
         <member type="way" ref="-45" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="515"/>
+        <tag k="hoot:review:sort_order" v="516"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (2m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22370,7 +22384,7 @@
         <member type="node" ref="-4048" role="reviewee"/>
         <member type="way" ref="-430" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="39"/>
+        <tag k="hoot:review:sort_order" v="40"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (1m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22381,8 +22395,8 @@
         <member type="node" ref="-4049" role="reviewee"/>
         <member type="way" ref="-670" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="42"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (138m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.174317/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="43"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (138m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0.03125/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22392,7 +22406,7 @@
         <member type="node" ref="-4050" role="reviewee"/>
         <member type="way" ref="-670" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="41"/>
+        <tag k="hoot:review:sort_order" v="42"/>
         <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (119m; score: 2/2), type: yes (score: 0.7/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22403,8 +22417,8 @@
         <member type="node" ref="-4052" role="reviewee"/>
         <member type="way" ref="-670" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="40"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (75m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.225313/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="41"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (75m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.12/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22414,7 +22428,7 @@
         <member type="node" ref="-4060" role="reviewee"/>
         <member type="way" ref="-525" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="49"/>
+        <tag k="hoot:review:sort_order" v="50"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22425,8 +22439,8 @@
         <member type="node" ref="-4065" role="reviewee"/>
         <member type="way" ref="-408" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="136"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.106693/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="137"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.0344828/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22436,7 +22450,7 @@
         <member type="node" ref="-4068" role="reviewee"/>
         <member type="way" ref="-501" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="64"/>
+        <tag k="hoot:review:sort_order" v="65"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22447,7 +22461,7 @@
         <member type="node" ref="-4069" role="reviewee"/>
         <member type="way" ref="-509" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="63"/>
+        <tag k="hoot:review:sort_order" v="64"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22480,7 +22494,7 @@
         <member type="node" ref="-4082" role="reviewee"/>
         <member type="way" ref="-369" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="69"/>
+        <tag k="hoot:review:sort_order" v="70"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (1m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22492,7 +22506,7 @@
         <member type="way" ref="-683" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="337"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.0707946/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22546,7 +22560,7 @@
         <member type="node" ref="-4194" role="reviewee"/>
         <member type="way" ref="-374" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="71"/>
+        <tag k="hoot:review:sort_order" v="72"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22557,7 +22571,7 @@
         <member type="node" ref="-4196" role="reviewee"/>
         <member type="way" ref="-377" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="114"/>
+        <tag k="hoot:review:sort_order" v="115"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22568,7 +22582,7 @@
         <member type="node" ref="-4196" role="reviewee"/>
         <member type="way" ref="-378" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="113"/>
+        <tag k="hoot:review:sort_order" v="114"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (1m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -22580,7 +22594,7 @@
         <member type="way" ref="-683" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
         <tag k="hoot:review:sort_order" v="338"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.0636936/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.05/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -22601,7 +22615,7 @@
         <member type="node" ref="-4213" role="reviewee"/>
         <member type="way" ref="-584" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="153"/>
+        <tag k="hoot:review:sort_order" v="154"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23767,7 +23781,7 @@
         <member type="node" ref="-4219" role="reviewee"/>
         <member type="way" ref="-47" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="513"/>
+        <tag k="hoot:review:sort_order" v="514"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23778,8 +23792,8 @@
         <member type="node" ref="-4219" role="reviewee"/>
         <member type="way" ref="-799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="508"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.180083/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="509"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.142857/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -23800,7 +23814,7 @@
         <member type="node" ref="-4226" role="reviewee"/>
         <member type="way" ref="-456" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="46"/>
+        <tag k="hoot:review:sort_order" v="47"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23855,7 +23869,7 @@
         <member type="node" ref="-4230" role="reviewee"/>
         <member type="way" ref="-578" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="128"/>
+        <tag k="hoot:review:sort_order" v="129"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23866,8 +23880,8 @@
         <member type="node" ref="-4230" role="reviewee"/>
         <member type="way" ref="-729" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="50"/>
-        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (140m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.333333/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="51"/>
+        <tag k="hoot:review:note" v="Similarity score: 1; less than match threshold: 3; meets review threshold: 1. distance: no (140m; score: 2/2), type: yes (score: 1/1), name: no (score: 0.225/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -23899,8 +23913,8 @@
         <member type="node" ref="-4238" role="reviewee"/>
         <member type="way" ref="-799" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="509"/>
-        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.563694/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
+        <tag k="hoot:review:sort_order" v="510"/>
+        <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0.461538/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:score" v="1"/>
@@ -23910,7 +23924,7 @@
         <member type="node" ref="-4307" role="reviewee"/>
         <member type="way" ref="-500" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="66"/>
+        <tag k="hoot:review:sort_order" v="67"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23921,7 +23935,7 @@
         <member type="node" ref="-4307" role="reviewee"/>
         <member type="way" ref="-503" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="65"/>
+        <tag k="hoot:review:sort_order" v="66"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (4m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23932,7 +23946,7 @@
         <member type="node" ref="-4320" role="reviewee"/>
         <member type="way" ref="-510" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="125"/>
+        <tag k="hoot:review:sort_order" v="126"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (2m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23943,7 +23957,7 @@
         <member type="node" ref="-4322" role="reviewee"/>
         <member type="way" ref="-420" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="124"/>
+        <tag k="hoot:review:sort_order" v="125"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23954,7 +23968,7 @@
         <member type="node" ref="-4324" role="reviewee"/>
         <member type="way" ref="-69" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="516"/>
+        <tag k="hoot:review:sort_order" v="517"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -23965,7 +23979,7 @@
         <member type="node" ref="-4325" role="reviewee"/>
         <member type="way" ref="-20" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="512"/>
+        <tag k="hoot:review:sort_order" v="513"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24042,7 +24056,7 @@
         <member type="node" ref="-4428" role="reviewee"/>
         <member type="way" ref="-801" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="96"/>
+        <tag k="hoot:review:sort_order" v="97"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
@@ -24053,7 +24067,7 @@
         <member type="node" ref="-4429" role="reviewee"/>
         <member type="way" ref="-801" role="reviewee"/>
         <tag k="hoot:review:type" v="POI to Polygon"/>
-        <tag k="hoot:review:sort_order" v="97"/>
+        <tag k="hoot:review:sort_order" v="98"/>
         <tag k="hoot:review:note" v="Similarity score: 2; less than match threshold: 3; meets review threshold: 1. distance: yes (0m; score: 2/2), type: no (score: 0/1), name: no (score: 0/1), address: no (score: 0/1). Max distance allowed for match: 5m, review: 146.213m."/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>


### PR DESCRIPTION
Changing the default string comparison algorithm used for name comparisons from `MeanWordSetDistance` to `KskipBigramDistance` yields slightly better regression test scores overall.