### PR TITLE
Cut and Replace apply can give zero value for version of modify/delete element

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetElementTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiChangesetElementTest.cpp
@@ -59,7 +59,7 @@ public:
 
     HOOT_STR_EQUALS("\t\t<node id=\"-1\" version=\"0\" "
                     "lat=\"38.8549321261880536\" lon=\"-104.8979050333482093\" changeset=\"1\"/>\n",
-                    node.toString(1));
+                    node.toString(1, ChangesetType::TypeCreate));
 
     QXmlStreamAttributes tagAttributes;
     tagAttributes.append("k", "name");
@@ -73,7 +73,7 @@ public:
                     "lat=\"38.8549321261880536\" lon=\"-104.8979050333482093\" changeset=\"1\">\n"
                     "\t\t\t<tag k=\"name\" v=\"node name\"/>\n"
                     "\t\t</node>\n",
-                    node.toString(1));
+                    node.toString(1, ChangesetType::TypeCreate));
   }
 
   void runNonAsciiChangesetNodeTest()
@@ -116,7 +116,7 @@ public:
                     "\t\t\t<tag k=\"name:zh\" v=\"埃及大使馆\"/>\n"
                     "\t\t\t<tag k=\"name:fr\" v=\"Ambassade de l'Égypte\"/>\n"
                     "\t\t</node>\n",
-                    node.toString(1));
+                    node.toString(1, ChangesetType::TypeCreate));
   }
 
   void runChangesetWayTest()
@@ -131,7 +131,7 @@ public:
     ChangesetWay way(w, NULL);
 
     HOOT_STR_EQUALS("\t\t<way id=\"-1\" version=\"0\" timestamp=\"\" changeset=\"1\">\n\t\t</way>\n",
-                    way.toString(1));
+                    way.toString(1, ChangesetType::TypeCreate));
 
     way.addNode(-1);
     way.addNode(-2);
@@ -140,7 +140,7 @@ public:
                     "\t\t\t<nd ref=\"-1\"/>\n"
                     "\t\t\t<nd ref=\"-2\"/>\n"
                     "\t\t</way>\n",
-                    way.toString(1));
+                    way.toString(1, ChangesetType::TypeCreate));
 
     QXmlStreamAttributes tagAttributes;
     tagAttributes.append("k", "name");
@@ -155,7 +155,7 @@ public:
                     "\t\t\t<nd ref=\"-2\"/>\n"
                     "\t\t\t<tag k=\"name\" v=\"way name\"/>\n"
                     "\t\t</way>\n",
-                    way.toString(1));
+                    way.toString(1, ChangesetType::TypeCreate));
   }
 
   void runChangesetRelationTest()
@@ -170,7 +170,7 @@ public:
     ChangesetRelation relation(w, NULL);
 
     HOOT_STR_EQUALS("\t\t<relation id=\"-1\" version=\"0\" timestamp=\"\" changeset=\"1\">\n\t\t</relation>\n",
-                    relation.toString(1));
+                    relation.toString(1, ChangesetType::TypeCreate));
 
     QXmlStreamAttributes member1;
     member1.append("type", "way");
@@ -195,7 +195,7 @@ public:
                     "\t\t\t<member type=\"way\" ref=\"-2\" role=\"inner\"/>\n"
                     "\t\t\t<tag k=\"type\" v=\"multipolygon\"/>\n"
                     "\t\t</relation>\n",
-                    relation.toString(1));
+                    relation.toString(1, ChangesetType::TypeCreate));
   }
 
   void runTagTruncateTest()
@@ -228,7 +228,7 @@ public:
                     "\t\t\t<tag k=\"too:long\" v=\"&quot;" +
                     QString(ConfigOptions().getMaxTagLength() - 9, 'X') + "\"/>\n" /** No ending '&quot;' because it was truncated */
                     "\t\t</node>\n",
-                    node.toString(1));
+                    node.toString(1, ChangesetType::TypeCreate));
   }
 
 };

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -110,14 +110,6 @@ public:
    * @return true if there aren't any elements left to receive updates from
    */
   bool isDone() { return (long)(_allNodes.size() + _allWays.size() + _allRelations.size()) <= _processedCount + _failedCount; }
-  /** Elements in a changeset can be in three sections, create, modify, and delete.  Max is used for iterating */
-  enum ChangesetType : int
-  {
-    TypeCreate = 0,
-    TypeModify,
-    TypeDelete,
-    TypeMax
-  };
   /** Convert ChangesetType to string */
   static QString getString(ChangesetType type);
   /**
@@ -506,21 +498,21 @@ public:
    * @param changeset_type Describes the changeset method as create, modify, or delete
    * @param id Element ID of the element to add
    */
-  void add(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type, long id);
+  void add(ElementType::Type element_type, ChangesetType changeset_type, long id);
   /**
    * @brief remove Remove an element ID of a certain type from the changeset type
    * @param element_type Describes the 'id' argument as a node, way, or relation
    * @param changeset_type Describes the changeset method as create, modify, or delete
    * @param id Element ID of the element to remove
    */
-  void remove(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type, long id);
+  void remove(ElementType::Type element_type, ChangesetType changeset_type, long id);
   /**
    * @brief getFirst Get the first element of the types
    * @param element_type Describes the element type: node, way, or relation
    * @param changeset_type Describes the type: create, modify, delete
    * @return
    */
-  long getFirst(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type);
+  long getFirst(ElementType::Type element_type, ChangesetType changeset_type);
   /**
    * @brief clear Clear out this entire changeset subset
    */
@@ -532,21 +524,21 @@ public:
    * @param id Element ID that is being searched for
    * @return true if it is found
    */
-  bool contains(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type, long id);
+  bool contains(ElementType::Type element_type, ChangesetType changeset_type, long id);
   /**
    * @brief begin Begin iterator
    * @param element_type Describes the type (node/way/relation) to iterate
    * @param changeset_type Describes the type (create/modify/delete) to iterate
    * @return iterator pointing to the beginning of the set
    */
-  iterator begin(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type);
+  iterator begin(ElementType::Type element_type, ChangesetType changeset_type);
   /**
    * @brief end End iterator
    * @param element_type Describes the type (node/way/relation) to iterate
    * @param changeset_type Describes the type (create/modify/delete) to iterate
    * @return iterator pointing off of the end of the set
    */
-  iterator end(ElementType::Type element_type, XmlChangeset::ChangesetType changeset_type);
+  iterator end(ElementType::Type element_type, ChangesetType changeset_type);
   /**
    * @brief size Total number of ElementType::Type elements (node/way/relation) of a specific changeset
    *  type (create/modify/delete) within this subset
@@ -554,7 +546,7 @@ public:
    * @param changesetType Describes the type (create/modify/delete) to count
    * @return count based on types
    */
-  size_t size(ElementType::Type elementType, XmlChangeset::ChangesetType changesetType);
+  size_t size(ElementType::Type elementType, ChangesetType changesetType);
   /**
    * @brief size Total number of elements in the subset
    * @return total count
@@ -578,7 +570,7 @@ public:
 
 private:
   /** 3x3 array of containers for elements in this subset */
-  std::array<std::array<container, XmlChangeset::TypeMax>, ElementType::Unknown> _changeset;
+  std::array<std::array<container, ChangesetType::TypeMax>, ElementType::Unknown> _changeset;
   /** Flag set after attempt to resolve changeset issues has completed. */
   bool _attemptedResolveChangesetIssues;
   /** Number of times this exact changeset has been retried from failures unsuccessfully */

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
@@ -129,7 +129,6 @@ QString ChangesetElement::toString(const ElementAttributes& attributes, long cha
     else if (name == "version") //  Versions are updated by the API
     {
       //  Don't allow negative or zero versions for modify and delete, force them to 1
-      //  zero
       if (_version < 1)
         ts << ((type == ChangesetType::TypeCreate) ? 0 : 1);
       else

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
@@ -55,6 +55,15 @@ typedef std::vector<std::pair<QString, QString>> ElementAttributes;
 typedef std::pair<QString, QString> ElementTag;
 typedef std::vector<ElementTag> ElementTags;
 
+/** Elements in a changeset can be in three sections, create, modify, and delete.  Max is used for iterating */
+enum ChangesetType : int
+{
+  TypeCreate = 0,
+  TypeModify,
+  TypeDelete,
+  TypeMax
+};
+
 /** Changeset element abstraction for simplified nodes, ways, and relations */
 class ChangesetElement
 {
@@ -107,9 +116,10 @@ public:
   /**
    * @brief toString Get the XML string equivalent for the element
    * @param changesetId ID of the changeset to insert into the element
+   * @param type Changeset section type (create, modify, delete)
    * @return XML string
    */
-  virtual QString toString(long changesetId) const = 0;
+  virtual QString toString(long changesetId, ChangesetType type) const = 0;
   /**
    *  Getter/setter for the element version
    */
@@ -135,9 +145,10 @@ protected:
    * @brief toString Get the XML string of the attributes only
    * @param attributes XML attributes
    * @param changesetId ID of the changeset to insert into the attributes
+   * @param type Changeset section type (create, modify, delete)
    * @return XML string
    */
-  QString toString(const ElementAttributes& attributes, long changesetId) const;
+  QString toString(const ElementAttributes& attributes, long changesetId, ChangesetType type) const;
   /**
    * @brief toTagString Get the XML string of a single tag with key/value pair
    * @param tag Key/value pair from tag
@@ -214,9 +225,10 @@ public:
   /**
    * @brief toString Get the XML string equivalent for the node
    * @param changesetId ID of the changeset to insert into the node
+   * @param type Changeset section type (create, modify, delete)
    * @return XML string
    */
-  virtual QString toString(long changesetId) const;
+  virtual QString toString(long changesetId, ChangesetType type) const;
   /**
    * @brief diff Compare two nodes and build a 'diff' style string
    * @param node Node to compare this node against
@@ -270,9 +282,10 @@ public:
   /**
    * @brief toString Get the XML string equivalent for the way
    * @param changesetId ID of the changeset to insert into the way
+   * @param type Changeset section type (create, modify, delete)
    * @return XML string
    */
-  virtual QString toString(long changesetId) const;
+  virtual QString toString(long changesetId, ChangesetType type) const;
   /**
    * @brief diff Compare two ways and build a 'diff' style string
    * @param way Way to compare this way against
@@ -388,9 +401,10 @@ public:
   /**
    * @brief toString Get the XML string equivalent for the relation
    * @param changesetId ID of the changeset to insert into the relation
+   * @param type Changeset section type (create, modify, delete)
    * @return XML string
    */
-  virtual QString toString(long changesetId) const;
+  virtual QString toString(long changesetId, ChangesetType type) const;
   /**
    * @brief diff Compare two relations and build a 'diff' style string
    * @param relation Relation to compare this relation against

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
@@ -888,10 +888,11 @@ bool OsmApiWriter::_fixConflict(HootNetworkRequestPtr request, ChangesetInfoPtr 
     //  Increment the retry version count
     changeset->retryVersion();
     //  Iterate the changeset types looking for the element, no need to check XmlChangeset::TypeCreate
-    for (int changesetType = XmlChangeset::TypeModify; changesetType < XmlChangeset::TypeMax; ++changesetType)
+    for (int changesetType = ChangesetType::TypeModify; changesetType < ChangesetType::TypeMax; ++changesetType)
     {
-      ChangesetInfo::iterator element = changeset->begin((ElementType::Type)element_type, (XmlChangeset::ChangesetType)changesetType);
-      if (element != changeset->end((ElementType::Type)element_type, (XmlChangeset::ChangesetType)changesetType))
+      ChangesetType type = static_cast<ChangesetType>(changesetType);
+      ChangesetInfo::iterator element = changeset->begin(element_type, type);
+      if (element != changeset->end(element_type, type))
       {
         QString update = "";
         //  Get the element from the OSM API
@@ -922,11 +923,13 @@ bool OsmApiWriter::_resolveIssues(HootNetworkRequestPtr request, ChangesetInfoPt
     return false;
   for (int elementType = ElementType::Node; elementType < ElementType::Unknown; ++elementType)
   {
+    ElementType::Type e_type = static_cast<ElementType::Type>(elementType);
     //  Creates cannot be fixed with this method, skip them here
-    for (int changesetType = XmlChangeset::TypeModify; changesetType < XmlChangeset::TypeMax; ++changesetType)
+    for (int changesetType = ChangesetType::TypeModify; changesetType < ChangesetType::TypeMax; ++changesetType)
     {
-      ChangesetInfo::iterator element = changeset->begin((ElementType::Type)elementType, (XmlChangeset::ChangesetType)changesetType);
-      if (element != changeset->end((ElementType::Type)elementType, (XmlChangeset::ChangesetType)changesetType))
+      ChangesetType c_type = static_cast<ChangesetType>(changesetType);
+      ChangesetInfo::iterator element = changeset->begin(e_type, c_type);
+      if (element != changeset->end(e_type, c_type))
       {
         long id = *element;
         QString update = "";

--- a/test-files/io/OsmChangesetElementTest/ChangesetErrorFixErrors.osc
+++ b/test-files/io/OsmChangesetElementTest/ChangesetErrorFixErrors.osc
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osmChange version="0.6" generator="hootenanny">
 	<modify>
-		<node id="-10" version="0" lat="38.8542471187715179" lon="-104.9010788637033329" timestamp="" changeset="0"/>
-		<way id="-10" version="0" timestamp="" changeset="0">
+		<node id="-10" version="1" lat="38.8542471187715179" lon="-104.9010788637033329" timestamp="" changeset="0"/>
+		<way id="-10" version="1" timestamp="" changeset="0">
 			<nd ref="10"/>
 			<nd ref="20"/>
 			<tag k="key1" v="value1"/>
 			<tag k="error:circular" v="15"/>
 		</way>
-		<way id="-15" version="0" timestamp="" changeset="0">
+		<way id="-15" version="1" timestamp="" changeset="0">
 			<nd ref="12"/>
 			<nd ref="13"/>
 			<tag k="key1" v="value1"/>
@@ -16,24 +16,24 @@
 		</way>
 	</modify>
 	<delete>
-		<relation id="-10" version="0" timestamp="" changeset="0">
+		<relation id="-10" version="1" timestamp="" changeset="0">
 			<member type="node" ref="17" role="role1"/>
 			<member type="way" ref="13" role="role2"/>
 			<tag k="key2" v="value2"/>
 			<tag k="error:circular" v="15"/>
 		</relation>
-		<way id="-12" version="0" timestamp="" changeset="0">
+		<way id="-12" version="1" timestamp="" changeset="0">
 			<nd ref="14"/>
 			<nd ref="15"/>
 			<tag k="key1" v="value1"/>
 			<tag k="error:circular" v="15"/>
 		</way>
-		<way id="-14" version="0" timestamp="" changeset="0">
+		<way id="-14" version="1" timestamp="" changeset="0">
 			<nd ref="19"/>
 			<nd ref="20"/>
 			<tag k="key1" v="value1"/>
 			<tag k="error:circular" v="15"/>
 		</way>
-		<node id="-16" version="0" lat="38.8542471187715179" lon="-104.9010788637033329" timestamp="" changeset="0"/>
+		<node id="-16" version="1" lat="38.8542471187715179" lon="-104.9010788637033329" timestamp="" changeset="0"/>
 	</delete>
 </osmChange>

--- a/test-files/io/OsmChangesetElementTest/RetryConflictExpected-error.osc
+++ b/test-files/io/OsmChangesetElementTest/RetryConflictExpected-error.osc
@@ -20,7 +20,7 @@
 		</way>
 	</modify>
 	<delete>
-		<node id="-1" version="0" lat="38.8549321261880536" lon="-104.8979050333482093" timestamp="" changeset="0">
+		<node id="-1" version="1" lat="38.8549321261880536" lon="-104.8979050333482093" timestamp="" changeset="0">
 			<tag k="node" v="Should fail"/>
 		</node>
 		<node id="2" version="1" lat="38.8549524185660573" lon="-104.8987388916486054" timestamp="" changeset="0"/>

--- a/test-files/io/OsmChangesetElementTest/ToyTestAConflicts.osc
+++ b/test-files/io/OsmChangesetElementTest/ToyTestAConflicts.osc
@@ -20,7 +20,7 @@
         </way>
     </modify>
     <delete>
-        <node id="-1" version="0" lat="38.8549321261880536" lon="-104.8979050333482093" timestamp="">
+        <node id="-1" version="1" lat="38.8549321261880536" lon="-104.8979050333482093" timestamp="">
             <tag k="node" v="Should fail"/>
         </node>
         <node id="2" version="1" lat="38.8549524185660573" lon="-104.8987388916486054" timestamp=""/>


### PR DESCRIPTION
In some cases, certain elements aren't getting the correct version (0) when pushing cut & replace.  Updated changeset code to not output zero for version unless it is for a create operation, default to one otherwise.