### PR TITLE
OsmNetworkExtractor debug crash

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/OsmNetworkExtractor.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/OsmNetworkExtractor.h
@@ -79,6 +79,9 @@ private:
    * can let that be use case driven.
    */
   bool _isContiguous(const ConstRelationPtr& r);
+  bool _isContiguous(const ConstRelationPtr& r, long& lastNode);
+
+  void _getFirstLastNodes(const ConstRelationPtr& r, ElementId& first, ElementId& last);
 
   bool _isValidElement(const ConstElementPtr& e);
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.h
@@ -241,6 +241,7 @@ public:
 
   virtual const ConstRelationPtr getRelation(long id) const;
   virtual const RelationPtr getRelation(long id);
+  const ConstRelationPtr getRelation(ElementId eid) const;
   const RelationMap& getRelations() const { return _relations; }
   QSet<long> getRelationIds() const;
   QSet<ElementId> getRelationElementIds() const;
@@ -454,6 +455,11 @@ inline const ConstRelationPtr OsmMap::getRelation(long id) const
   {
     return _nullRelation;
   }
+}
+
+inline const ConstRelationPtr OsmMap::getRelation(ElementId eid) const
+{
+  return getRelation(eid.getId());
 }
 
 inline const RelationPtr OsmMap::getRelation(long id)


### PR DESCRIPTION
`OsmNetworkExtractor::_isContiguous` crashes on an `assert` call in debug mode.  The function ran on the assumption that linear relations only consisted of ways while some data consists of relations of relations of ways.  For example a route can consist of other route relations.