### PR TITLE
Throttle 'changeset-apply' for CGImap-backed databases

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -24,7 +24,7 @@
 // contain any special characters.
 // === key.name
 //
-// * Data Type: <string, double, list, bool>
+// * Data Type: <string, double, list, bool, int, long>
 // * Default Value: <value>
 //
 // If the default value is for a list then the default value should be followed
@@ -570,12 +570,27 @@ Flag to turn on throttling for OSM API changeset writes.  When turned on, each p
 will wait `changeset.api.writers.throttle.time` seconds after a successful write before submitting
 another changeset to the OSM API.
 
+=== changeset.apidb.writers.throttle.cgimap
+
+* Data Type: bool
+* Default Value: `true`
+
+Flag to turn on throttling if the OSM API uses CGImap in the back end instead of the rails port.
+Checks the usage of CGImap and then enables `changeset.apidb.writers.throttle`.
+
 === changeset.apidb.writers.throttle.time
 
 * Data Type: long
-* Default Value: `30`
+* Default Value: `10`
 
 The number of seconds after a successful write before submitting another changeset to the OSM API.
+
+=== changeset.apidb.writers.throttle.timespan
+
+* Data Type: long
+* Default Value: `0`
+
+The number of seconds plus or minus for random throttling of the OSM API writer.
 
 === changeset.description
 

--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -573,7 +573,7 @@ another changeset to the OSM API.
 === changeset.apidb.writers.throttle.cgimap
 
 * Data Type: bool
-* Default Value: `true`
+* Default Value: `false`
 
 Flag to turn on throttling if the OSM API uses CGImap in the back end instead of the rails port.
 Checks the usage of CGImap and then enables `changeset.apidb.writers.throttle`.

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
@@ -202,6 +202,48 @@ bool ChangesetOutputTestServer::respond(HttpConnection::HttpConnectionPtr& conne
   return continue_processing && !get_interupt();
 }
 
+bool ChangesetOutputThrottleTestServer::respond(HttpConnection::HttpConnectionPtr& connection)
+{
+  //  Stop processing by setting this to false
+  bool continue_processing = true;
+  //  Read the HTTP request headers
+  std::string headers = read_request_headers(connection);
+  //  Determine the response message's HTTP header
+  HttpResponsePtr response;
+  if (headers.find(OsmApiEndpoints::API_PATH_CAPABILITIES) != std::string::npos)
+    response.reset(new HttpResponse(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CAPABILITIES_RESPONSE));
+  else if (headers.find(OsmApiEndpoints::API_PATH_PERMISSIONS) != std::string::npos)
+    response.reset(new HttpResponse(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_PERMISSIONS_RESPONSE));
+  else if (headers.find(OsmApiEndpoints::API_PATH_MAP) != std::string::npos)
+    response.reset(new HttpResponse(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CGIMAP_RESPONSE));
+  else if (headers.find(OsmApiEndpoints::API_PATH_CREATE_CHANGESET) != std::string::npos)
+    response.reset(new HttpResponse(HttpResponseCode::HTTP_OK, "1"));
+  else if (headers.find("POST") != std::string::npos)
+  {
+    //  Read the HTTP request body to figure out which response to send back
+    std::string body = read_request_body(headers, connection);
+    if (body.find("way id=\"1\"") != std::string::npos)
+      response.reset(new HttpResponse(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CHANGESET_SUCCESS_1_RESPONSE));
+    else
+      response.reset(new HttpResponse(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CHANGESET_SUCCESS_2_RESPONSE));
+  }
+  else if (headers.find(QString(OsmApiEndpoints::API_PATH_CLOSE_CHANGESET).arg(1).toStdString()) != std::string::npos)
+  {
+    response.reset(new HttpResponse(HttpResponseCode::HTTP_OK));
+    continue_processing = false;
+  }
+  else
+  {
+    //  Error out here
+    response.reset(new HttpResponse(HttpResponseCode::HTTP_NOT_FOUND));
+    continue_processing = false;
+  }
+  //  Write out the response
+  write_response(connection, response->to_string());
+  //  Return true if we should continue listening and processing requests
+  return continue_processing && !get_interupt();
+}
+
 bool ChangesetCreateFailureTestServer::respond(HttpConnection::HttpConnectionPtr& connection)
 {
   //  Stop processing by setting this to false
@@ -391,6 +433,21 @@ const char* OsmApiSampleRequestResponse::SAMPLE_CHANGESET_1_RESPONSE =
     "  <way old_id='3' new_id='3' new_version='2'/>\n"
     "  <way old_id='4' new_id='4' new_version='2'/>\n"
     "</diffResult>";
+const char* OsmApiSampleRequestResponse::SAMPLE_CGIMAP_RESPONSE =
+    "<?xml version='1.0' encoding='UTF-8'?>\n"
+    "<osm generator='CGImap 0.8.3' version='0.6'>\n"
+    "  <bounds minlat='38.9600315' minlon='-77.4224954' maxlat='38.9600315' maxlon='-77.4224954'/>\n"
+    "  <node id='1' visible='true' version='1' changeset='1' lat='38.9600315' lon='-77.4224954'>\n"
+    "    <tag k='addr:city' v='Herndon'/>\n"
+    "    <tag k='addr:housenumber' v='2325'/>\n"
+    "    <tag k='addr:postcode' v='20171'/>\n"
+    "    <tag k='addr:street' v='Dulles Corner Boulevard'/>\n"
+    "    <tag k='facility:id' v='37489576'/>\n"
+    "    <tag k='name' v='Maxar'/>\n"
+    "    <tag k='office' v='company'/>\n"
+    "    <tag k='website' v='https://www.maxar.com/'/>\n"
+    "  </node>\n"
+    "</osm>";
 const char* OsmApiSampleRequestResponse::SAMPLE_ELEMENT_1_GET_RESPONSE =
     "<?xml version='1.0' encoding='UTF-8'?>\n"
     "<osm version='0.6' generator='OpenStreetMap server'>\n"

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
@@ -119,6 +119,27 @@ protected:
   bool respond(HttpConnection::HttpConnectionPtr& connection) override;
 };
 
+class ChangesetOutputThrottleTestServer : public HttpTestServer
+{
+public:
+  /** Constructor */
+  ChangesetOutputThrottleTestServer(int port) : HttpTestServer(port) { }
+
+protected:
+  /** respond() function that responds to a series of OSM API requests
+   *  to simulate a changeset upload.
+   *  Requests, in order:
+   *   - Capabilities
+   *   - Permissions
+   *   - Map Request - responds with HTTP 200
+   *   - Changeset Create
+   *   - Changeset Upload - responds with HTTP 200
+   *   - Changeset Upload - responds with HTTP 200
+   *   - Changeset Close
+   */
+  bool respond(HttpConnection::HttpConnectionPtr& connection) override;
+};
+
 class ChangesetCreateFailureTestServer : public HttpTestServer
 {
 public:
@@ -193,6 +214,8 @@ public:
   static const char* SAMPLE_CHANGESET_REQUEST;
   /** Sample Changeset upload response body from '/api/0.6/changeset/1/upload' */
   static const char* SAMPLE_CHANGESET_1_RESPONSE;
+  /** Sample map GET response from '/api/0.6/map' with the CGImap generator attribute */
+  static const char* SAMPLE_CGIMAP_RESPONSE;
   /** Sample element GET response from '/api/0.6/way/1' */
   static const char* SAMPLE_ELEMENT_1_GET_RESPONSE;
   /** Sample Changeset upload response bodies from '/api/0.6/changeset/1/upload' divided into two responses */

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
@@ -582,7 +582,7 @@ void OsmApiWriter::_yield(int milliseconds)
 void OsmApiWriter::_yield(int minimum_ms, int maximum_ms)
 {
   //  Yield for a random amount of time between minimum_ms and maximum_ms
-  _yield((minimum_ms + Tgs::Random::instance()->generateInt(maximum_ms - minimum_ms)));
+  _yield(minimum_ms + Tgs::Random::instance()->generateInt(maximum_ms - minimum_ms));
 }
 
 void OsmApiWriter::setConfiguration(const Settings& conf)
@@ -679,7 +679,8 @@ bool OsmApiWriter::usingCgiMap(HootNetworkRequestPtr request)
     map.setQuery(query);
     request->networkRequest(map);
     QString responseXml = QString::fromUtf8(request->getResponseContent().data());
-    cgimap = responseXml.contains("generator=\"CGImap", Qt::CaseInsensitive);
+    QRegExp regex("generator=(\"|')CGImap", Qt::CaseInsensitive);
+    cgimap = responseXml.contains(regex);
   }
   catch (HootException& ex)
   {

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
@@ -33,6 +33,7 @@
 #include <hoot/core/io/OsmApiChangesetElement.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/FileUtils.h>
+#include <hoot/core/util/GeometryUtils.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/HootNetworkUtils.h>
 #include <hoot/core/util/Log.h>
@@ -43,6 +44,7 @@
 #include <tgs/System/Timer.h>
 
 //  Qt
+#include <QUrlQuery>
 #include <QXmlStreamReader>
 
 using namespace std;
@@ -61,6 +63,7 @@ OsmApiWriter::OsmApiWriter(const QUrl &url, const QString &changeset)
     _maxChangesetSize(ConfigOptions().getChangesetMaxSize()),
     _throttleWriters(ConfigOptions().getChangesetApidbWritersThrottle()),
     _throttleTime(ConfigOptions().getChangesetApidbWritersThrottleTime()),
+    _throttlePlusMinus(ConfigOptions().getChangesetApidbWritersThrottleTimespan()),
     _showProgress(false),
     _consumerKey(ConfigOptions().getHootOsmAuthConsumerKey()),
     _consumerSecret(ConfigOptions().getHootOsmAuthConsumerSecret()),
@@ -70,7 +73,8 @@ OsmApiWriter::OsmApiWriter(const QUrl &url, const QString &changeset)
     _debugOutput(ConfigOptions().getChangesetApidbWriterDebugOutput()),
     _debugOutputPath(ConfigOptions().getChangesetApidbWriterDebugOutputPath()),
     _apiId(0),
-    _threadsCanExit(false)
+    _threadsCanExit(false),
+    _throttleCgiMap(ConfigOptions().getChangesetApidbWritersThrottleCgimap())
 {
   _changesets.push_back(changeset);
   if (isSupported(url))
@@ -88,6 +92,7 @@ OsmApiWriter::OsmApiWriter(const QUrl& url, const QList<QString>& changesets)
     _maxChangesetSize(ConfigOptions().getChangesetMaxSize()),
     _throttleWriters(ConfigOptions().getChangesetApidbWritersThrottle()),
     _throttleTime(ConfigOptions().getChangesetApidbWritersThrottleTime()),
+    _throttlePlusMinus(ConfigOptions().getChangesetApidbWritersThrottleTimespan()),
     _showProgress(false),
     _consumerKey(ConfigOptions().getHootOsmAuthConsumerKey()),
     _consumerSecret(ConfigOptions().getHootOsmAuthConsumerSecret()),
@@ -97,7 +102,8 @@ OsmApiWriter::OsmApiWriter(const QUrl& url, const QList<QString>& changesets)
     _debugOutput(ConfigOptions().getChangesetApidbWriterDebugOutput()),
     _debugOutputPath(ConfigOptions().getChangesetApidbWriterDebugOutputPath()),
     _apiId(0),
-    _threadsCanExit(false)
+    _threadsCanExit(false),
+    _throttleCgiMap(ConfigOptions().getChangesetApidbWritersThrottleCgimap())
 {
   if (isSupported(url))
     _url = url;
@@ -130,6 +136,9 @@ bool OsmApiWriter::apply()
     return false;
   }
   _stats.append(SingleStat("API Permissions Query Time (sec)", timer.getElapsedAndRestart()));
+  //  Throttle uploads when using CGImap if requested
+  if (_throttleCgiMap && usingCgiMap(request))
+    _throttleWriters = true;
   bool success = true;
   //  Load all of the changesets into memory
   _changeset.setMaxPushSize(_maxPushSize);
@@ -387,7 +396,7 @@ void OsmApiWriter::_changesetThreadFunc(int index)
         }
         //  Throttle the input rate if desired
         if (_throttleWriters && !_changeset.isDone())
-          _yield(_throttleTime * 1000);
+          _yield(std::max(_throttleTime - _throttlePlusMinus, 0) * 1000, (_throttleTime + _throttlePlusMinus) * 1000);
       }
       else
       {
@@ -587,12 +596,14 @@ void OsmApiWriter::setConfiguration(const Settings& conf)
   _maxWriters = options.getChangesetApidbWritersMax();
   _throttleWriters = options.getChangesetApidbWritersThrottle();
   _throttleTime = options.getChangesetApidbWritersThrottleTime();
+  _throttlePlusMinus = options.getChangesetApidbWritersThrottleTimespan();
   _consumerKey = options.getHootOsmAuthConsumerKey();
   _consumerSecret = options.getHootOsmAuthConsumerSecret();
   _accessToken = options.getHootOsmAuthAccessToken();
   _secretToken = options.getHootOsmAuthAccessTokenSecret();
   _debugOutput = options.getChangesetApidbWriterDebugOutput();
   _debugOutputPath = options.getChangesetApidbWriterDebugOutputPath();
+  _throttleCgiMap = options.getChangesetApidbWritersThrottleCgimap();
 }
 
 bool OsmApiWriter::isSupported(const QUrl &url)
@@ -651,6 +662,30 @@ bool OsmApiWriter::validatePermissions(HootNetworkRequestPtr request)
     LOG_WARN(ex.what());
   }
   return success;
+}
+
+bool OsmApiWriter::usingCgiMap(HootNetworkRequestPtr request)
+{
+  bool cgimap = false;
+  try
+  {
+    QUrl map = _url;
+    map.setPath(OsmApiEndpoints::API_PATH_MAP);
+    QUrlQuery query(map);
+    //  Use the correct type of bbox for this query
+    geos::geom::Envelope envelope(-77.42249541, -77.42249539, 38.96003149, 38.96003151);
+    QString bboxQuery = GeometryUtils::toConfigString(envelope);
+    query.addQueryItem("bbox", bboxQuery);
+    map.setQuery(query);
+    request->networkRequest(map);
+    QString responseXml = QString::fromUtf8(request->getResponseContent().data());
+    cgimap = responseXml.contains("generator=\"CGImap", Qt::CaseInsensitive);
+  }
+  catch (HootException& ex)
+  {
+    LOG_WARN(ex.what());
+  }
+  return cgimap;
 }
 
 OsmApiCapabilites OsmApiWriter::_parseCapabilities(const QString& capabilites)

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -110,6 +110,12 @@ public:
    */
   bool validatePermissions(HootNetworkRequestPtr request);
   /**
+   * @brief usingCgiMap Run a small query on the OSM API and check the generator for CGImap
+   * @param request - Network request object initialized with OSM API URL
+   * @return true if the response comes from CGImap
+   */
+  bool usingCgiMap(HootNetworkRequestPtr request);
+  /**
    * @brief getStats Get the stats object
    * @return
    */
@@ -373,6 +379,8 @@ private:
   bool _throttleWriters;
   /** Number of seconds for a writer thread to wait after a successful API writer before continuing, if enabled */
   int _throttleTime;
+  /** Number of seconds plus or minus for random throttle intervals, if enabled */
+  int _throttlePlusMinus;
   /** Queried capabilities from the target OSM API */
   OsmApiCapabilites _capabilities;
   /** Actual statistics */
@@ -404,6 +412,8 @@ private:
   bool _threadsCanExit;
   /** Error message for why the process failed */
   QString _errorMessage;
+  /** Enable throttling for API uploads through CGImap (instead of the rails port) */
+  bool _throttleCgiMap;
   /** For white box testing */
   friend class OsmApiWriterTest;
   /** Default constructor for testing purposes only */

--- a/tgs/src/main/cpp/tgs/Statistics/Random.cpp
+++ b/tgs/src/main/cpp/tgs/Statistics/Random.cpp
@@ -75,7 +75,10 @@ namespace Tgs
 
   int Random::generateInt(int max)
   {
-    return generateInt() % max;
+    if (max <= 0)
+      return 0;
+    else
+      return generateInt() % max;
   }
 
   int Random::generateInt()


### PR DESCRIPTION
Add throttling for CGImap 'changeset-apply' operations to keep from overwhelming the database.