### PR TITLE
Changeset Apply 410 Error

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiMatchFailureTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiMatchFailureTest.cpp
@@ -179,6 +179,15 @@ public:
     hint = "Changeset conflict: The changeset 49514404 was closed at 2020-01-23 20:11:10 UTC";
     found = failureCheck.matchesChangesetClosedFailure(hint);
     CPPUNIT_ASSERT_EQUAL(true, found);
+
+    //  Test element gone deleted
+    id = 0;
+    type = ElementType::Unknown;
+    hint = "Gone: The node with the id 12345 has already been deleted";
+    found = failureCheck.matchesElementGoneDeletedFailure(hint, id, type);
+    CPPUNIT_ASSERT_EQUAL(true, found);
+    CPPUNIT_ASSERT_EQUAL(12345L, id);
+    CPPUNIT_ASSERT_EQUAL(ElementType::Node, type);
   }
 
 };

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
@@ -197,6 +197,26 @@ protected:
   bool respond(HttpConnection::HttpConnectionPtr &connection) override;
 };
 
+class ElementGoneTestServer : public HttpTestServer
+{
+public:
+  /** Constructor */
+  ElementGoneTestServer(int port) : HttpTestServer(port) { }
+
+protected:
+  /** respond() function that responds to a series of OSM API requests
+   *  to simulate an element gone test.
+   *  Requests, in order:
+   *   - Capabilities
+   *   - Permissions
+   *   - Changeset Create
+   *   - Changeset Upload Gone Failure - responds with HTTP 410
+   *   - Changeset Upload - responds with HTTP 200
+   *   - Changeset Close
+   */
+  bool respond(HttpConnection::HttpConnectionPtr &connection) override;
+};
+
 class OsmApiSampleRequestResponse
 {
 public:
@@ -230,6 +250,9 @@ public:
   static const char* SAMPLE_CHANGESET_VERSION_FAILURE_RESPONSE;
   /** Sample Element GET response body for version conflict resolution */
   static const char* SAMPLE_CHANGESET_VERSION_FAILURE_GET_RESPONSE;
+  /** Sample Element response bodies for a GONE response sequence to '/api/0.6/changeset/1/upload' */
+  static const char* SAMPLE_ELEMENT_GONE_RESPONSE_1;
+  static const char* SAMPLE_ELEMENT_GONE_RESPONSE_2;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
@@ -392,6 +392,11 @@ public:
    */
   int getMemberCount() const { return _members.size(); }
   /**
+   * @brief removeMember Remove the relation member at index
+   * @param index Index in the member vector
+   */
+  void removeMember(int index) { _members.removeAt(index); }
+  /**
    * @brief hasMember Search the relation for a specific element type with the given ID
    * @param type Element type to search for (node/way/relation)
    * @param id ID of the element to search for

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiMatchFailure.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiMatchFailure.h
@@ -115,6 +115,16 @@ public:
    */
   bool matchesChangesetClosedFailure(const QString& hint) const;
 
+  /**
+   * @brief matchesElementGoneDeletedFailure
+   *        "The node with the id 12345 has already been deleted"
+   * @param hint Error message from OSM API
+   * @param member_id ID of the element that was already deleted
+   * @param member_type Type of the element that was already deleted
+   * @return True if the message matches
+   */
+  bool matchesElementGoneDeletedFailure(const QString& hint, long& element_id, ElementType::Type& element_type) const;
+
 private:
   /** Precompiled regular expressions */
   QRegularExpression _placeholderFailure;
@@ -123,6 +133,7 @@ private:
   QRegularExpression _deletePreconditionFailure;
   QRegularExpression _conflictVersionFailure;
   QRegularExpression _changesetClosedFailure;
+  QRegularExpression _elementGoneDeletedFailure;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
@@ -485,10 +485,13 @@ void OsmApiWriter::_changesetThreadFunc(int index)
         case HttpResponseCode::HTTP_INTERNAL_SERVER_ERROR:  //  Internal Server Error, could be caused by the database being saturated
         case HttpResponseCode::HTTP_BAD_GATEWAY:            //  Bad Gateway, there are issues with the gateway, split and retry
         case HttpResponseCode::HTTP_GATEWAY_TIMEOUT:        //  Gateway Timeout, server is taking too long, split and retry
+        case HttpResponseCode::HTTP_GONE:                   //  Element has already been deleted, split and retry (error body is blank sometimes)
           if (!_splitChangeset(workInfo, info->response))
           {
             //  Splitting failed which means that the changeset only has one element in it,
             //  push it back on the queue and give the API a break
+            //  For HTTP_GONE, it could come back false if the element that is gone is removed
+            //  successfully and the rest of the changeset needs to be processed
             _pushChangesets(workInfo);
             //  Sleep the thread
             _yield();

--- a/hoot-core/src/main/cpp/hoot/core/util/HootNetworkUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/HootNetworkUtils.h
@@ -39,6 +39,7 @@ namespace HttpResponseCode
   const int HTTP_NOT_FOUND              = 404;
   const int HTTP_METHOD_NOT_ALLOWED     = 405;
   const int HTTP_CONFLICT               = 409;
+  const int HTTP_GONE                   = 410;
   const int HTTP_PRECONDITION_FAILED    = 412;
   const int HTTP_INTERNAL_SERVER_ERROR  = 500;
   const int HTTP_BAD_GATEWAY            = 502;

--- a/test-files/io/OsmChangesetElementTest/ChangesetErrorFixExpected.osc
+++ b/test-files/io/OsmChangesetElementTest/ChangesetErrorFixExpected.osc
@@ -26,5 +26,11 @@
 			<tag k="type" v="route"/>
 			<tag k="route" v="road"/>
 		</relation>
+		<relation id="-2" version="0" timestamp="" changeset="1">
+			<member type="node" ref="-1" role="forward"/>
+			<tag k="name" v="Test Drop"/>
+			<tag k="type" v="route"/>
+			<tag k="route" v="road"/>
+		</relation>
 	</create>
 </osmChange>

--- a/test-files/io/OsmChangesetElementTest/ChangesetErrorFixInput.osc
+++ b/test-files/io/OsmChangesetElementTest/ChangesetErrorFixInput.osc
@@ -26,6 +26,13 @@
 			<tag k="type" v="route"/>
 			<tag k="route" v="road"/>
 		</relation>
+    <relation id="-2" version="0" timestamp="">
+      <member type="node" ref="-1" role="forward"/>
+      <member type="node" ref="-100" role="forward"/>
+      <tag k="name" v="Test Drop"/>
+      <tag k="type" v="route"/>
+      <tag k="route" v="road"/>
+    </relation>
 	</create>
 	<modify>
 		<node id="-10" version="0" lat="38.8542471187715179" lon="-104.9010788637033329" timestamp=""/>


### PR DESCRIPTION
Add HTTP 410 handling for `changeset-apply`.  In some cases something/someone else deletes an element that `changeset-apply` is also deleting and the HTTP 410 error is emitted.  It is safe to handle this error by setting that element to successfully uploaded because both operations meant to delete the element.

Also found an instance where creating a relation had a member with a negative ID (meaning create the member too) but it wasn't found in the changeset itself so that member is removed before sending.

Closes #4168 