### PR TITLE
surface the element merge error to the http response

### DIFF
--- a/translations/ElementMergeServer.js
+++ b/translations/ElementMergeServer.js
@@ -80,7 +80,14 @@ function ElementMergeserver(request, response) {
 
             request.on('end', function() {
 
-                var result = postHandler(payload);
+                var result;
+                try {
+                    result = postHandler(payload);
+                } catch (err) {
+                    var status = 400;
+                    response.writeHead(status, header);
+                    response.end(JSON.stringify({error: err}));
+                }
 
                 response.writeHead(200, header);
                 response.end(result);


### PR DESCRIPTION
refs #2231

This doesn't fix getting redirecting to the tomcat log, but it does surface any error to the UI.  I think because the call to postHandler was in the on end callback, the exceptions thrown were not handled by the outer try/catch.