### PR TITLE
add disable cleaning option to cut&replace

### DIFF
--- a/conf/services/changesetReplacement.json
+++ b/conf/services/changesetReplacement.json
@@ -1,6 +1,7 @@
 {
     "strictBounds": "--strict-bounds",
     "fullReplacement": "--full-replacement",
-    "disableWaySnapping": "--disable-way-snapping",
-    "disableConflation": "--disable-conflation"
+    "disableCleaning": "--disable-cleaning",
+    "disableConflation": "--disable-conflation",
+    "disableWaySnapping": "--disable-way-snapping"
 }

--- a/conf/services/changesetReplacementOps.json
+++ b/conf/services/changesetReplacementOps.json
@@ -19,12 +19,12 @@
       "label": "Full replacement"
     },
     {
-      "description": "Disables the snapping of unconnected ways before changeset derivation.",
+      "description": "Disables the cleaning of input data.",
       "default": "false",
       "input": "checkbox",
       "type": "bool",
-      "id": "disableWaySnapping",
-      "label": "Disable way snapping"
+      "id": "disableCleaning",
+      "label": "Disable cleaning"
     },
     {
       "description": "Disables the conflation of data cut out during replacement and the replacement data.",
@@ -33,6 +33,14 @@
       "type": "bool",
       "id": "disableConflation",
       "label": "Disable conflation"
+    },
+    {
+      "description": "Disables the snapping of unconnected ways before changeset derivation.",
+      "default": "false",
+      "input": "checkbox",
+      "type": "bool",
+      "id": "disableWaySnapping",
+      "label": "Disable way snapping"
     }
   ]
 }


### PR DESCRIPTION
refs #4178

So this option config is not automatically generated, that's only for advanced conflation options that have default values defined in ConfigOptions.asciidoc.