### PR TITLE
Prevent runaway processing during complex line matching

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -2501,11 +2501,20 @@ Size is specified in bytes unless followed by one of these suffixes.
 * MB = size * 1000 * 1000
 * GB = size * 1000 * 1000 * 1000
 
-For instance setting the value to 500KB is equivalent to 500000 bytes.
+For instance, setting the value to 500KB is equivalent to 500000 bytes.
 
 The Linux utility RLIMIT_AS is used for limiting virtual memory. This is analagous to RAM, but
 less RAM will be utilized than the value specified. Typically this is most useful when limiting
 RAM usage of applications in a shared server environment.
+
+=== maximal.subline.max.recursive.complexity
+
+* Data Type: int
+* Default Value: `-1`
+
+Maximum recursive calls allowed in MaximalSubline as it looks for line matches. Too low of a number
+may degrade Unifying algorithm line matching conflate performance. Too high of a number may result
+in runaway line matching processing times. -1 indicates no limit.
 
 === maximal.subline.spacing
 
@@ -5018,22 +5027,6 @@ SampledAngleHistogramExtractor
 Automatically calculates the search radius to be used during conflation of waterways using rubber
 sheet tie point distances.
 
-=== waterway.long.way.length.threshold
-
-* Data Type: int
-* Default Value: `150000`
-
-Way length threshold, in meters, at or above which River Conflation will switch from the configured
-subline matcher to Frechet subline matching to increase runtime performance.
-
-=== waterway.long.way.node.count.threshold
-
-* Data Type: int
-* Default Value: `750`
-
-Way node count threshold at or above which River Conflation will switch from the configured subline
-matcher to Frechet subline matching to increase runtime performance.
-
 === waterway.matcher.heading.delta
 
 * Data Type: double
@@ -5048,6 +5041,13 @@ The distance around a point on a waterway to look when calculating the heading. 
 * Default Value: `90.0`
 
 Sets that maximum angle that is still considered a waterway match. Units in degrees.
+
+=== waterway.maximal.subline.max.recursive.complexity
+
+* Data Type: int
+* Default Value: `50`
+
+River specific version of maximal.subline.max.recursive.complexity.
 
 === waterway.name.threshold
 

--- a/docs/commands/node-density-tiles.asciidoc
+++ b/docs/commands/node-density-tiles.asciidoc
@@ -22,9 +22,6 @@ the specified input(s), honoring a maximum node per box limit, and writes the bo
                                  as possible.
 * +--pixelSizeReductionFactor+ - Optional percentage by which +--pixelSize+ will be automatically reduced if +--maxAttempts+ is greater than 
                                  one and any calculation attempt fails. The default value is 10%.
-* +--alwaysFailWithNoSolution+ - By default, if no solution satisfying the input parameters is found the command will assume uniform node 
-                                 density and simply return a set of bounding boxes of equal size calculated by dividing the total number of nodes
-                                 by the maximum requested nodes per box. Adding this option will cause a failure instead if no solution is found.
 * +--random+                   - Optionally selects a single random tile from those calculated
 * +--randomSeed+               - Optionally seeds the random number generator for consistent tile boundary selection; valid only if +--random+ 
                                  is specified; use -1 for pseudo-random seeding; defaults to -1

--- a/docs/commands/node-density-tiles.asciidoc
+++ b/docs/commands/node-density-tiles.asciidoc
@@ -4,7 +4,7 @@
 === Description
 
 The +node-density-tiles+ command calculates a collection of bounding boxes that contain roughly equal distributions of node data from
-the specified input(s) and writes the output to a file.
+the specified input(s), honoring a maximum node per box limit, and writes the bounding box output to a file.
 
 * +input(s)+                   - One or more inputs; may be any supported input format (e.g. OSM file). Specify multiple inputs by separating 
                                  them with a semicolon.
@@ -19,9 +19,12 @@ the specified input(s) and writes the output to a file.
                                  the runtime of a calculation.
 * +--maxTimePerAttempt+        - Optional maximum time allowed, in seconds, for a calculation attempt. Defaults to no time limit (-1). The 
                                  timeout is not guaranteed to happen exactly after the specified time has elapsed and will happen as close to it 
-                                 as possible. .
+                                 as possible.
 * +--pixelSizeReductionFactor+ - Optional percentage by which +--pixelSize+ will be automatically reduced if +--maxAttempts+ is greater than 
                                  one and any calculation attempt fails. The default value is 10%.
+* +--alwaysFailWithNoSolution+ - By default, if no solution satisfying the input parameters is found the command will assume uniform node 
+                                 density and simply return a set of bounding boxes of equal size calculated by dividing the total number of nodes
+                                 by the maximum requested nodes per box. Adding this option will cause a failure instead if no solution is found.
 * +--random+                   - Optionally selects a single random tile from those calculated
 * +--randomSeed+               - Optionally seeds the random number generator for consistent tile boundary selection; valid only if +--random+ 
                                  is specified; use -1 for pseudo-random seeding; defaults to -1

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetReplacementGridTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetReplacementGridTest.cpp
@@ -82,25 +82,34 @@ public:
     _opTimer.start();
     _subTaskTimer.start();
 
-    if (!CROP_INPUT_BOUNDS.isEmpty())
+    try
     {
-      _cropInputs();
+      if (!CROP_INPUT_BOUNDS.isEmpty())
+      {
+        _cropInputs();
+      }
+
+      _initDbs();
+      _loadDataToReplaceDb();
+
+      int numTaskGridCells = 0;
+      const std::vector<std::vector<geos::geom::Envelope>> taskGrid = _calcTaskGrid(numTaskGridCells);
+
+      _replaceData(taskGrid, numTaskGridCells);
+      _getUpdatedData();
+
+      _cleanup();
+
+      LOG_STATUS(
+        "Entire task grid cell replacement operation finished in: " <<
+        StringUtils::millisecondsToDhms(_opTimer.elapsed()));
     }
-
-    _initDbs();
-    _loadDataToReplaceDb();
-
-    int numTaskGridCells = 0;
-    const std::vector<std::vector<geos::geom::Envelope>> taskGrid = _calcTaskGrid(numTaskGridCells);
-
-    _replaceData(taskGrid, numTaskGridCells);
-    _getUpdatedData();
-
-    _cleanup();
-
-    LOG_STATUS(
-      "Entire task grid cell replaced operation finished in: " <<
-      StringUtils::millisecondsToDhms(_opTimer.elapsed()));
+    catch (const HootException& e)
+    {
+      LOG_ERROR(
+        "Entire task grid cell replacement operation failed in: " <<
+        StringUtils::millisecondsToDhms(_opTimer.elapsed()) << "; Error: " << e.getWhat());
+    }
   }
 
 private:

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetReplacementGridTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetReplacementGridTest.cpp
@@ -52,10 +52,19 @@ static const QString DATA_TO_REPLACE_FILE = "NOMEData.osm";
 static const QString REPLACEMENT_DATA_URL =
   ServicesDbTestUtils::getDbModifyUrl(TEST_NAME).toString();
 static const QString REPLACEMENT_DATA_FILE = "OSMData.osm";
+
+// all - fails on 3rd changeset
 //static const QString CROP_INPUT_BOUNDS = "";
-static const QString CROP_INPUT_BOUNDS = "-115.3314,36.2825,-115.2527,36.3387"; // 4 sq blocks
-//static const QString REPLACEMENT_BOUNDS = "-115.3528,36.0919,-114.9817,36.3447"; // all
-static const QString REPLACEMENT_BOUNDS = "-115.3059,36.2849,-115.2883,36.2991"; // 4 sq blocks
+//static const QString REPLACEMENT_BOUNDS = "-115.3528,36.0919,-114.9817,36.3447";
+
+// 4 sq blocks - good
+//static const QString CROP_INPUT_BOUNDS = "-115.3314,36.2825,-115.2527,36.3387";
+//static const QString REPLACEMENT_BOUNDS = "-115.3059,36.2849,-115.2883,36.2991";
+
+// 1/4 of city - fails with zero alpha shape
+static const QString CROP_INPUT_BOUNDS = "-115.3441,36.2012,-115.1942,36.3398";
+static const QString REPLACEMENT_BOUNDS = "-115.3332,36.2178,-115.1837,36.3400";
+
 static const QString TASK_GRID_FILE = ROOT_DIR + "/bounds.osm";
 
 /*
@@ -225,7 +234,7 @@ private:
 
   std::vector<std::vector<geos::geom::Envelope>> _calcTaskGrid(int& numTaskGridCells)
   {
-    // This ends up being much slower than using a file. The bounded query needs work.
+    // This ends up being much slower than using a file. The bounded query needs work. - #4180
 //    LOG_STATUS(
 //      "Loading the replacement data db from: " << rootDir << "/" << _replacementDataFile <<
 //      " to: " << REPLACEMENT_DATA_URL << "...");
@@ -275,7 +284,7 @@ private:
     LOG_STATUS("Calculating task grid cells for replacement data to: " << TASK_GRID_FILE << "...");
     NodeDensityTileBoundsCalculator boundsCalc;
     boundsCalc.setPixelSize(0.001);
-    boundsCalc.setMaxNodesPerTile(/*100000*/2000);
+    boundsCalc.setMaxNodesPerTile(/*100000*/10000);
     boundsCalc.setMaxNumTries(3);
     boundsCalc.setMaxTimePerAttempt(300);
     boundsCalc.setPixelSizeRetryReductionFactor(10);

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetReplacementGridTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetReplacementGridTest.cpp
@@ -279,7 +279,7 @@ public:
           "Applying changeset: " << StringUtils::formatLargeNumber(boundsCtr) << " / " <<
           StringUtils::formatLargeNumber(boundsCalc.getTileCount()) << ": " << changesetId <<
           " over bounds: " << boundsStr << " from file: " << changesetFile << "...");
-        changesetApplier.write(changesetFile);
+        changesetApplier.write(QFile(changesetFile));
         LOG_STATUS(
           "Changeset applied in: " <<
           StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetReplacementGridTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetReplacementGridTest.cpp
@@ -110,7 +110,8 @@ public:
     map.reset(new OsmMap());
     OsmMapReaderFactory::read(map, rootDir + "/NOMEData.osm", true, Status::Unknown1);
     OsmMapWriterFactory::write(map, dataToReplaceUrl);
-    LOG_STATUS("data to replace size after initial write: " << map->size());
+    LOG_STATUS(
+      "Elements being replaced: " << StringUtils::formatLargeNumber(map->size()));
     LOG_STATUS(
       "Data to replace loaded in: " <<
       StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
@@ -120,7 +121,8 @@ public:
     map.reset(new OsmMap());
     OsmMapReaderFactory::read(map, rootDir + "/OSMData.osm", true, Status::Unknown2);
     OsmMapWriterFactory::write(map, replacementDataUrl);
-    LOG_STATUS("replacement data size after initial write: " << map->size());
+    LOG_STATUS(
+      "Replacing elements: " << StringUtils::formatLargeNumber(map->size()));
     LOG_STATUS(
       "Replacement data loaded in: " <<
       StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
@@ -129,7 +131,7 @@ public:
     LOG_STATUS("Reading the data to replace out of the db...");
     map.reset(new OsmMap());
     OsmMapReaderFactory::read(map, dataToReplaceUrl, true, Status::Unknown1);
-    LOG_STATUS("data to replace size after read: " << map->size());
+    LOG_STATUS("Elements being replaced: " << StringUtils::formatLargeNumber(map->size()));
     LOG_STATUS(
       "Data to replace read in: " <<
       StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
@@ -138,7 +140,7 @@ public:
     LOG_STATUS("Calculating task grid cells...");
     NodeDensityTileBoundsCalculator boundsCalc;
     boundsCalc.setPixelSize(0.001);
-    boundsCalc.setMaxNodesPerTile(10000);
+    boundsCalc.setMaxNodesPerTile(50000);
     boundsCalc.setMaxNumTries(5);
     boundsCalc.setMaxTimePerAttempt(300);
     boundsCalc.setPixelSizeRetryReductionFactor(10);
@@ -146,7 +148,9 @@ public:
     const std::vector<std::vector<geos::geom::Envelope>> taskGrid = boundsCalc.getTiles();
     const std::vector<std::vector<long>> nodeCounts = boundsCalc.getNodeCounts();
     TileBoundsWriter::writeTilesToOsm(taskGrid, nodeCounts, rootDir + "/bounds.osm");
-    LOG_STATUS("Calculated " << boundsCalc.getTileCount() << " task grid cells.");
+    LOG_STATUS(
+      "Calculated " << StringUtils::formatLargeNumber(boundsCalc.getTileCount()) <<
+      " task grid cells.");
     LOG_STATUS(
       "Task grid cells calculated in: " <<
       StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
@@ -174,8 +178,9 @@ public:
         const QString changesetFile = rootDir + "changeset-" + changesetId + ".osc.sql";
 
         LOG_STATUS(
-          "Deriving changeset " << boundsCtr << " / " << boundsCalc.getTileCount() << ": " <<
-          changesetId << " over bounds: " << boundsStr << "...");
+          "Deriving changeset " << StringUtils::formatLargeNumber(boundsCtr) << " / " <<
+          StringUtils::formatLargeNumber(boundsCalc.getTileCount()) << ": " << changesetId <<
+          " over bounds: " << boundsStr << "...");
         changesetCreator.create(dataToReplaceUrl, replacementDataUrl, bounds, changesetFile);
         LOG_STATUS(
           "Changeset derived in: " <<
@@ -183,8 +188,9 @@ public:
         subTaskTimer.restart();
 
         LOG_STATUS(
-          "Applying changeset: " << boundsCtr << " / " << boundsCalc.getTileCount() << ": " <<
-          changesetId << " over bounds: " << boundsStr << "...");
+          "Applying changeset: " << StringUtils::formatLargeNumber(boundsCtr) << " / " <<
+          StringUtils::formatLargeNumber(boundsCalc.getTileCount()) << ": " << changesetId <<
+          " over bounds: " << boundsStr << "...");
         changesetApplier.write(changesetFile);
         LOG_STATUS(
           "Changeset applied in: " <<
@@ -198,7 +204,7 @@ public:
     LOG_STATUS("Reading the modified data...");
     map.reset(new OsmMap());
     OsmMapReaderFactory::read(map, dataToReplaceUrl, true, Status::Unknown1);
-    LOG_STATUS("modified data size: " << map->size());
+    LOG_STATUS("Modified data size: " << StringUtils::formatLargeNumber(map->size()));
     OsmMapWriterFactory::write(map, rootDir + "/replaced-data.osm");
     LOG_STATUS(
       "Modified data read in: " <<

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetReplacementGridTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetReplacementGridTest.cpp
@@ -1,0 +1,231 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2020 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+
+// Hoot
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/algorithms/changeset/ChangesetReplacementCreator.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/io/OsmMapReaderFactory.h>
+#include <hoot/core/io/OsmMapWriterFactory.h>
+#include <hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.h>
+#include <hoot/core/util/GeometryUtils.h>
+#include <hoot/core/io/OsmApiDbSqlChangesetApplier.h>
+#include <hoot/core/io/ServicesDbTestUtils.h>
+#include <hoot/core/io/HootApiDbWriter.h>
+#include <hoot/core/io/TileBoundsWriter.h>
+#include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/StringUtils.h>
+
+namespace hoot
+{
+
+/*
+ * TODO
+ */
+class ChangesetReplacementGridTest : public HootTestFixture
+{
+  CPPUNIT_TEST_SUITE(ChangesetReplacementGridTest);
+  // FOR DEBUGGING ONLY
+  CPPUNIT_TEST(runGridCellTest);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  ChangesetReplacementGridTest()
+  {
+    setResetType(ResetAll);
+  }
+
+  void runGridCellTest()
+  {
+    const QString rootDir = "/home/vagrant/hoot/tmp/4158/combined-data";
+    const QString testName = "ChangesetReplacementGridTest::runGridCellTest";
+    OsmMapPtr map;
+    const QString dataToReplaceUrl = ServicesDbTestUtils::getOsmApiDbUrl().toString();
+    const QString replacementDataUrl = ServicesDbTestUtils::getDbModifyUrl(testName).toString();
+
+    // config opts
+    conf().set(ConfigOptions::getOsmapidbBulkInserterReserveRecordIdsBeforeWritingDataKey(), true);
+    conf().set(ConfigOptions::getApidbBulkInserterValidateDataKey(), true);
+    conf().set(ConfigOptions::getWriterIncludeDebugTagsKey(), true);
+    conf().set(ConfigOptions::getReaderAddSourceDatetimeKey(), false);
+    conf().set(ConfigOptions::getWriterIncludeCircularErrorTagsKey(), false);
+    conf().set(ConfigOptions::getConvertBoundingBoxRemoveMissingElementsKey(), false);
+    conf().set(ConfigOptions::getDebugMapsWriteKey(), false);
+    conf().set(ConfigOptions::getDebugMapsRemoveMissingElementsKey(), true);
+    conf().set(ConfigOptions::getMapReaderAddChildRefsWhenMissingKey(), true);
+    const QString userEmail = testName + "@hoottestcpp.org";
+    conf().set(ConfigOptions::getApiDbEmailKey(), userEmail);
+    conf().set(ConfigOptions::getHootapiDbWriterCreateUserKey(), true);
+    conf().set(ConfigOptions::getHootapiDbWriterOverwriteMapKey(), true);
+    conf().set(ConfigOptions::getChangesetUserIdKey(), 1);
+    conf().set(ConfigOptions::getChangesetMaxSizeKey(), 999999);
+    conf().set(ConfigOptions::getSnapUnconnectedWaysExistingWayNodeToleranceKey(), 0.5);
+    conf().set(ConfigOptions::getSnapUnconnectedWaysSnapToleranceKey(), 5.0);
+
+    QElapsedTimer opTimer;
+    opTimer.start();
+    QElapsedTimer subTaskTimer;
+    subTaskTimer.start();
+
+    LOG_STATUS("Initializing the data to replace db...");
+    ServicesDbTestUtils::deleteDataFromOsmApiTestDatabase();
+    ApiDb::execSqlFile(dataToReplaceUrl, "test-files/servicesdb/users.sql");
+    map.reset(new OsmMap());
+    OsmMapReaderFactory::read(map, dataToReplaceUrl, true, Status::Unknown1);
+    if (map->size() != 0)
+    {
+      throw HootException("Data to replace db is not empty at start.");
+    }
+    LOG_STATUS(
+      "Data to replace db initialized in: " <<
+      StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
+    subTaskTimer.restart();
+
+    LOG_STATUS("Loading the data to replace db...");
+    map.reset(new OsmMap());
+    OsmMapReaderFactory::read(map, rootDir + "/NOMEData.osm", true, Status::Unknown1);
+    OsmMapWriterFactory::write(map, dataToReplaceUrl);
+    LOG_STATUS("data to replace size after initial write: " << map->size());
+    LOG_STATUS(
+      "Data to replace loaded in: " <<
+      StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
+    subTaskTimer.restart();
+
+    LOG_STATUS("Loading the replacement data db...");
+    map.reset(new OsmMap());
+    OsmMapReaderFactory::read(map, rootDir + "/OSMData.osm", true, Status::Unknown2);
+    OsmMapWriterFactory::write(map, replacementDataUrl);
+    LOG_STATUS("replacement data size after initial write: " << map->size());
+    LOG_STATUS(
+      "Replacement data loaded in: " <<
+      StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
+    subTaskTimer.restart();
+
+    LOG_STATUS("Reading the data to replace out of the db...");
+    map.reset(new OsmMap());
+    OsmMapReaderFactory::read(map, dataToReplaceUrl, true, Status::Unknown1);
+    LOG_STATUS("data to replace size after read: " << map->size());
+    LOG_STATUS(
+      "Data to replace read in: " <<
+      StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
+    subTaskTimer.restart();
+
+    LOG_STATUS("Calculating task grid cells...");
+    NodeDensityTileBoundsCalculator boundsCalc;
+    boundsCalc.setPixelSize(0.001);
+    boundsCalc.setMaxNodesPerTile(10000);
+    boundsCalc.setMaxNumTries(5);
+    boundsCalc.setMaxTimePerAttempt(300);
+    boundsCalc.setPixelSizeRetryReductionFactor(10);
+    boundsCalc.calculateTiles(map);
+    const std::vector<std::vector<geos::geom::Envelope>> taskGrid = boundsCalc.getTiles();
+    const std::vector<std::vector<long>> nodeCounts = boundsCalc.getNodeCounts();
+    TileBoundsWriter::writeTilesToOsm(taskGrid, nodeCounts, rootDir + "/bounds.osm");
+    LOG_STATUS("Calculated " << boundsCalc.getTileCount() << " task grid cells.");
+    LOG_STATUS(
+      "Task grid cells calculated in: " <<
+      StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
+    subTaskTimer.restart();
+
+    ChangesetReplacementCreator changesetCreator(false, "", dataToReplaceUrl);
+    changesetCreator.setFullReplacement(true);
+    changesetCreator.setBoundsInterpretation(
+      ChangesetReplacementCreator::BoundsInterpretation::Lenient);
+    changesetCreator.setWaySnappingEnabled(true);
+    changesetCreator.setConflationEnabled(false);
+    changesetCreator.setCleaningEnabled(false);
+    changesetCreator.setTagOobConnectedWays(true);
+    OsmApiDbSqlChangesetApplier changesetApplier(dataToReplaceUrl);
+
+    // derive and apply a changeset for each task grid cell
+    int boundsCtr = 1;
+    for (size_t tx = 0; tx < taskGrid.size(); tx++)
+    {
+      for (size_t ty = 0; ty < taskGrid[tx].size(); ty++)
+      {
+        const QString changesetId = QString::number((int)tx) + "-" + QString::number((int)ty);
+        const geos::geom::Envelope bounds = taskGrid[tx][ty];
+        const QString boundsStr = GeometryUtils::toString(bounds);
+        const QString changesetFile = rootDir + "changeset-" + changesetId + ".osc.sql";
+
+        LOG_STATUS(
+          "Deriving changeset " << boundsCtr << " / " << boundsCalc.getTileCount() << ": " <<
+          changesetId << " over bounds: " << boundsStr << "...");
+        changesetCreator.create(dataToReplaceUrl, replacementDataUrl, bounds, changesetFile);
+        LOG_STATUS(
+          "Changeset derived in: " <<
+          StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
+        subTaskTimer.restart();
+
+        LOG_STATUS(
+          "Applying changeset: " << boundsCtr << " / " << boundsCalc.getTileCount() << ": " <<
+          changesetId << " over bounds: " << boundsStr << "...");
+        changesetApplier.write(changesetFile);
+        LOG_STATUS(
+          "Changeset applied in: " <<
+          StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
+        subTaskTimer.restart();
+
+        boundsCtr++;
+      }
+    }
+
+    LOG_STATUS("Reading the modified data...");
+    map.reset(new OsmMap());
+    OsmMapReaderFactory::read(map, dataToReplaceUrl, true, Status::Unknown1);
+    LOG_STATUS("modified data size: " << map->size());
+    OsmMapWriterFactory::write(map, rootDir + "/replaced-data.osm");
+    LOG_STATUS(
+      "Modified data read in: " <<
+      StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
+    subTaskTimer.restart();
+
+    LOG_STATUS("Cleaning up the modified db...");
+    ServicesDbTestUtils::deleteDataFromOsmApiTestDatabase();
+    LOG_STATUS(
+      "Modified db cleaned in: " <<
+      StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
+    subTaskTimer.restart();
+
+    LOG_STATUS("Cleaning up the replacement data db...");
+    ServicesDbTestUtils::deleteUser(userEmail);
+    HootApiDbWriter().deleteMap(testName);
+    LOG_STATUS(
+      "Replacement data cleaned in: " <<
+      StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
+    subTaskTimer.restart();
+
+    LOG_STATUS(
+      "Entire task grid cell replaced operation finished in: " <<
+      StringUtils::millisecondsToDhms(opTimer.elapsed()));
+  }
+};
+
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ChangesetReplacementGridTest, "glacial");
+
+}

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetReplacementGridTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetReplacementGridTest.cpp
@@ -44,6 +44,18 @@
 namespace hoot
 {
 
+static const QString ROOT_DIR = "/home/vagrant/hoot/tmp/4158/combined-data";
+static const QString TEST_NAME = "ChangesetReplacementGridTest::runGridCellTest";
+static const QString USER_EMAIL = TEST_NAME + "@hoottestcpp.org";
+static const QString DATA_TO_REPLACE_URL = ServicesDbTestUtils::getOsmApiDbUrl().toString();
+static const QString DATA_TO_REPLACE_FILE = "NOMEData.osm";
+static const QString REPLACEMENT_DATA_URL =
+  ServicesDbTestUtils::getDbModifyUrl(TEST_NAME).toString();
+static const QString REPLACEMENT_DATA_FILE = "OSMData.osm";
+static const QString CROP_INPUT_BOUNDS = ""/*-115.1541,36.2614,-115.1336,36.2775"*/;
+static const QString REPLACEMENT_BOUNDS = "-115.3528,36.0919,-114.9817,36.3447";
+static const QString TASK_GRID_FILE = ROOT_DIR + "/bounds.osm";
+
 /*
  * TODO
  */
@@ -56,25 +68,51 @@ class ChangesetReplacementGridTest : public HootTestFixture
 
 public:
 
-  ChangesetReplacementGridTest()
+  ChangesetReplacementGridTest() :
+  _dataToReplaceFile(DATA_TO_REPLACE_FILE),
+  _replacementDataFile(REPLACEMENT_DATA_FILE)
   {
     setResetType(ResetAll);
   }
 
   void runGridCellTest()
   {
-    const QString rootDir = "/home/vagrant/hoot/tmp/4158/combined-data";
-    const QString testName = "ChangesetReplacementGridTest::runGridCellTest";
-    OsmMapPtr map;
-    const QString dataToReplaceUrl = ServicesDbTestUtils::getOsmApiDbUrl().toString();
-    QString dataToReplaceFile = "NOMEData.osm";
-    const QString replacementDataUrl = ServicesDbTestUtils::getDbModifyUrl(testName).toString();
-    LOG_VART(replacementDataUrl);
-    QString replacementDataFile = "OSMData.osm";
-    const QString cropInputBounds = ""/*-115.1541,36.2614,-115.1336,36.2775"*/;
-    const QString replacementBounds = "-115.3528,36.0919,-114.9817,36.3447";
+    _initConfig();
 
-    // config opts
+    _opTimer.start();
+    _subTaskTimer.start();
+
+    if (!CROP_INPUT_BOUNDS.isEmpty())
+    {
+      _cropInputs();
+    }
+
+    _initDbs();
+    _loadDataToReplaceDb();
+
+    int numTaskGridCells = 0;
+    const std::vector<std::vector<geos::geom::Envelope>> taskGrid = _calcTaskGrid(numTaskGridCells);
+
+    _replaceData(taskGrid, numTaskGridCells);
+    _getUpdatedData();
+
+    _cleanup();
+
+    LOG_STATUS(
+      "Entire task grid cell replaced operation finished in: " <<
+      StringUtils::millisecondsToDhms(_opTimer.elapsed()));
+  }
+
+private:
+
+  QElapsedTimer _opTimer;
+  QElapsedTimer _subTaskTimer;
+
+  QString _dataToReplaceFile;
+  QString _replacementDataFile;
+
+  void _initConfig()
+  {
     conf().set(ConfigOptions::getOsmapidbBulkInserterReserveRecordIdsBeforeWritingDataKey(), true);
     conf().set(ConfigOptions::getApidbBulkInserterValidateDataKey(), true);
     conf().set(ConfigOptions::getWriterIncludeDebugTagsKey(), true);
@@ -84,8 +122,7 @@ public:
     conf().set(ConfigOptions::getDebugMapsWriteKey(), false);
     conf().set(ConfigOptions::getDebugMapsRemoveMissingElementsKey(), true);
     conf().set(ConfigOptions::getMapReaderAddChildRefsWhenMissingKey(), true);
-    const QString userEmail = testName + "@hoottestcpp.org";
-    conf().set(ConfigOptions::getApiDbEmailKey(), userEmail);
+    conf().set(ConfigOptions::getApiDbEmailKey(), USER_EMAIL);
     conf().set(ConfigOptions::getHootapiDbWriterCreateUserKey(), true);
     conf().set(ConfigOptions::getHootapiDbWriterOverwriteMapKey(), true);
     conf().set(ConfigOptions::getChangesetUserIdKey(), 1);
@@ -93,119 +130,131 @@ public:
     conf().set(ConfigOptions::getSnapUnconnectedWaysExistingWayNodeToleranceKey(), 0.5);
     conf().set(ConfigOptions::getSnapUnconnectedWaysSnapToleranceKey(), 5.0);
     conf().set(ConfigOptions::getDebugMapsWriteKey(), true);
-    conf().set(ConfigOptions::getDebugMapsFilenameKey(), rootDir + "/debug.osm");
+    conf().set(ConfigOptions::getDebugMapsFilenameKey(), ROOT_DIR + "/debug.osm");
+  }
 
-    QElapsedTimer opTimer;
-    opTimer.start();
-    QElapsedTimer subTaskTimer;
-    subTaskTimer.start();
-
-    if (!cropInputBounds.isEmpty())
-    {
-      MapCropper cropper(GeometryUtils::envelopeFromConfigString(cropInputBounds));
-      cropper.setRemoveMissingElements(false);
-      cropper.setRemoveSuperflousFeatures(false);
-
-      LOG_STATUS("Cropping data to replace from: " << rootDir << "/" << dataToReplaceFile << "...");
-      map.reset(new OsmMap());
-      OsmMapReaderFactory::read(map, rootDir + "/" + dataToReplaceFile, true, Status::Unknown1);
-      LOG_STATUS(
-        "Data to replace pre-cropped size: " << StringUtils::formatLargeNumber(map->size()));
-      cropper.apply(map);
-      QString cropOutputFile = dataToReplaceFile.replace(".osm", "-cropped.osm");
-      OsmMapWriterFactory::write(map, rootDir + "/" + cropOutputFile);
-      dataToReplaceFile = cropOutputFile;
-      LOG_STATUS(
-        "Data to replace cropped in: " <<
-        StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
-      subTaskTimer.restart();
-
-      LOG_STATUS(
-        "Cropping replacement data from: " << rootDir << "/" << replacementDataFile << "...");
-      map.reset(new OsmMap());
-      OsmMapReaderFactory::read(map, rootDir + "/" + replacementDataFile, true, Status::Unknown2);
-      LOG_STATUS(
-        "Replacement data pre-cropped size: " << StringUtils::formatLargeNumber(map->size()));
-      cropper.apply(map);
-      cropOutputFile = replacementDataFile.replace(".osm", "-cropped.osm");
-      OsmMapWriterFactory::write(map, rootDir + "/" + cropOutputFile);
-      replacementDataFile = cropOutputFile;
-      LOG_STATUS(
-        "Replacement data cropped in: " <<
-        StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
-      subTaskTimer.restart();
-    }
-
-    LOG_STATUS("Initializing the data to replace db at: " << dataToReplaceUrl << "...");
+  void _initDbs()
+  {
+    LOG_STATUS("Initializing the data to replace db at: " << DATA_TO_REPLACE_URL << "...");
     ServicesDbTestUtils::deleteDataFromOsmApiTestDatabase();
-    ApiDb::execSqlFile(dataToReplaceUrl, "test-files/servicesdb/users.sql");
-    map.reset(new OsmMap());
-    OsmMapReaderFactory::read(map, dataToReplaceUrl, true, Status::Unknown1);
+    ApiDb::execSqlFile(DATA_TO_REPLACE_URL, "test-files/servicesdb/users.sql");
+    OsmMapPtr map(new OsmMap());
+    OsmMapReaderFactory::read(map, DATA_TO_REPLACE_URL, true, Status::Unknown1);
     if (map->size() != 0)
     {
       throw HootException("Data to replace db is not empty at start.");
     }
     LOG_STATUS(
       "Data to replace db initialized in: " <<
-      StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
-    subTaskTimer.restart();
+      StringUtils::millisecondsToDhms(_subTaskTimer.elapsed()));
+    _subTaskTimer.restart();
+  }
+
+  void _cropInputs()
+  {
+    MapCropper cropper(GeometryUtils::envelopeFromConfigString(CROP_INPUT_BOUNDS));
+    cropper.setRemoveMissingElements(false);
+    cropper.setRemoveSuperflousFeatures(false);
 
     LOG_STATUS(
-      "Loading the data to replace db from: " << rootDir << "/" << dataToReplaceFile << " to: " <<
-      dataToReplaceUrl << "...");
+      "Cropping data to replace from: " << ROOT_DIR << "/" << DATA_TO_REPLACE_FILE << "...");
+    OsmMapPtr map(new OsmMap());
+    OsmMapReaderFactory::read(map, ROOT_DIR + "/" + DATA_TO_REPLACE_FILE, true, Status::Unknown1);
+    LOG_STATUS(
+      "Data to replace pre-cropped size: " << StringUtils::formatLargeNumber(map->size()));
+    cropper.apply(map);
+    QString cropOutputFile = DATA_TO_REPLACE_FILE;
+    cropOutputFile = cropOutputFile.replace(".osm", "-cropped.osm");
+    OsmMapWriterFactory::write(map, ROOT_DIR + "/" + cropOutputFile);
+    _dataToReplaceFile = cropOutputFile;
+    LOG_STATUS(
+      "Data to replace cropped in: " <<
+      StringUtils::millisecondsToDhms(_subTaskTimer.elapsed()));
+    _subTaskTimer.restart();
+
+    LOG_STATUS(
+      "Cropping replacement data from: " << ROOT_DIR << "/" << REPLACEMENT_DATA_FILE << "...");
     map.reset(new OsmMap());
-    OsmMapReaderFactory::read(map, rootDir + "/" + dataToReplaceFile, true, Status::Unknown1);
-    OsmMapWriterFactory::write(map, dataToReplaceUrl);
+    OsmMapReaderFactory::read(map, ROOT_DIR + "/" + REPLACEMENT_DATA_FILE, true, Status::Unknown2);
+    LOG_STATUS(
+      "Replacement data pre-cropped size: " << StringUtils::formatLargeNumber(map->size()));
+    cropper.apply(map);
+    cropOutputFile = REPLACEMENT_DATA_FILE;
+    cropOutputFile = cropOutputFile.replace(".osm", "-cropped.osm");
+    OsmMapWriterFactory::write(map, ROOT_DIR + "/" + cropOutputFile);
+    _replacementDataFile = cropOutputFile;
+    LOG_STATUS(
+      "Replacement data cropped in: " <<
+      StringUtils::millisecondsToDhms(_subTaskTimer.elapsed()));
+    _subTaskTimer.restart();
+  }
+
+  void _loadDataToReplaceDb()
+  {
+    LOG_STATUS(
+      "Loading the data to replace db from: " << ROOT_DIR << "/" << DATA_TO_REPLACE_FILE <<
+      " to: " << DATA_TO_REPLACE_URL << "...");
+    OsmMapPtr map(new OsmMap());
+    OsmMapReaderFactory::read(map, ROOT_DIR + "/" + DATA_TO_REPLACE_FILE, true, Status::Unknown1);
+    OsmMapWriterFactory::write(map, DATA_TO_REPLACE_URL);
     LOG_STATUS(
       "Total elements in data being replaced: " << StringUtils::formatLargeNumber(map->size()));
     LOG_STATUS(
       "Data to replace loaded in: " <<
-      StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
-    subTaskTimer.restart();
+      StringUtils::millisecondsToDhms(_subTaskTimer.elapsed()));
+    _subTaskTimer.restart();
+  }
 
-    LOG_STATUS(
-      "Loading the replacement data db from: " << rootDir << "/" << replacementDataFile <<
-      " to: " << replacementDataUrl << "...");
-    map.reset(new OsmMap());
-    OsmMapReaderFactory::read(map, rootDir + "/" + replacementDataFile, true, Status::Unknown2);
-    OsmMapWriterFactory::write(map, replacementDataUrl);
-    LOG_STATUS(
-      "Replacing elements: " << StringUtils::formatLargeNumber(map->size()));
-    LOG_STATUS(
-      "Replacement data loaded in: " <<
-      StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
-    subTaskTimer.restart();
+  std::vector<std::vector<geos::geom::Envelope>> _calcTaskGrid(int& numTaskGridCells)
+  {
+    // This ends up being much slower than using a file. The bounded query needs work.
+//    LOG_STATUS(
+//      "Loading the replacement data db from: " << rootDir << "/" << REPLACEMENT_DATA_FILE <<
+//      " to: " << REPLACEMENT_DATA_URL << "...");
+//    map.reset(new OsmMap());
+//    OsmMapReaderFactory::read(map, rootDir + "/" + REPLACEMENT_DATA_FILE, true, Status::Unknown2);
+//    OsmMapWriterFactory::write(map, REPLACEMENT_DATA_URL);
+//    LOG_STATUS(
+//      "Replacing elements: " << StringUtils::formatLargeNumber(map->size()));
+//    LOG_STATUS(
+//      "Replacement data loaded in: " <<
+//      StringUtils::millisecondsToDhms(_subTaskTimer.elapsed()));
+//    _subTaskTimer.restart();
 
-    LOG_STATUS(
-      "Reading the replacement data out of the db for task grid cell calculation from: " <<
-      replacementDataUrl << "...");
-    map.reset(new OsmMap());
-    // IMPORTANT: must be unknown1 for node density to work
-    OsmMapReaderFactory::read(map, replacementDataUrl, true, Status::Unknown1);
-    LOG_STATUS(
-      "Replacement data read in: " <<
-      StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
-    subTaskTimer.restart();
-
-//    LOG_STATUS("Reading the replacement data for task grid cell calculation...");
+//    LOG_STATUS(
+//      "Reading the replacement data out of the db for task grid cell calculation from: " <<
+//      REPLACEMENT_DATA_URL << "...");
 //    map.reset(new OsmMap());
 //    // changeset derive will overwrite these as needed
-//    conf().set(ConfigOptions::getConvertBoundingBoxKey(), replacementBounds);
+//    conf().set(ConfigOptions::getConvertBoundingBoxKey(), REPLACEMENT_BOUNDS);
 //    conf().set(ConfigOptions::getConvertBoundingBoxKeepEntireFeaturesCrossingBoundsKey(), false);
 //    conf().set(
 //      ConfigOptions::getConvertBoundingBoxKeepImmediatelyConnectedWaysOutsideBoundsKey(), false);
 //    conf().set(ConfigOptions::getConvertBoundingBoxKeepOnlyFeaturesInsideBoundsKey(), true);
 //    // IMPORTANT: must be unknown1 for node density to work
-//    OsmMapReaderFactory::read(map, rootDir + "/" + replacementDataFile, true, Status::Unknown1);
-//    LOG_STATUS("Replacement elements: " << StringUtils::formatLargeNumber(map->size()));
+//    OsmMapReaderFactory::read(map, REPLACEMENT_DATA_URL, true, Status::Unknown1);
 //    LOG_STATUS(
 //      "Replacement data read in: " <<
-//      StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
-//    subTaskTimer.restart();
+//      StringUtils::millisecondsToDhms(_subTaskTimer.elapsed()));
+//    _subTaskTimer.restart();
 
-    const QString taskGridCellsFile = rootDir + "/bounds.osm";
+    LOG_STATUS("Reading the replacement data for task grid cell calculation...");
+    OsmMapPtr map(new OsmMap());
+    // changeset derive will overwrite these as needed
+    conf().set(ConfigOptions::getConvertBoundingBoxKey(), REPLACEMENT_BOUNDS);
+    conf().set(ConfigOptions::getConvertBoundingBoxKeepEntireFeaturesCrossingBoundsKey(), false);
+    conf().set(
+      ConfigOptions::getConvertBoundingBoxKeepImmediatelyConnectedWaysOutsideBoundsKey(), false);
+    conf().set(ConfigOptions::getConvertBoundingBoxKeepOnlyFeaturesInsideBoundsKey(), true);
+    // IMPORTANT: must be unknown1 for node density to work
+    OsmMapReaderFactory::read(map, ROOT_DIR + "/" + REPLACEMENT_DATA_FILE, true, Status::Unknown1);
+    LOG_STATUS("Replacement elements: " << StringUtils::formatLargeNumber(map->size()));
     LOG_STATUS(
-      "Calculating task grid cells for replacement data to: " << taskGridCellsFile << "...");
+      "Replacement data read in: " <<
+      StringUtils::millisecondsToDhms(_subTaskTimer.elapsed()));
+    _subTaskTimer.restart();
+
+    LOG_STATUS("Calculating task grid cells for replacement data to: " << TASK_GRID_FILE << "...");
     NodeDensityTileBoundsCalculator boundsCalc;
     boundsCalc.setPixelSize(0.001);
     boundsCalc.setMaxNodesPerTile(100000);
@@ -217,12 +266,12 @@ public:
     boundsCalc.calculateTiles(map);
     map.reset();
     const std::vector<std::vector<geos::geom::Envelope>> taskGrid = boundsCalc.getTiles();
+    numTaskGridCells = boundsCalc.getTileCount();
     LOG_VAR(taskGrid.size());
     const std::vector<std::vector<long>> nodeCounts = boundsCalc.getNodeCounts();
-    TileBoundsWriter::writeTilesToOsm(taskGrid, nodeCounts, taskGridCellsFile);
+    TileBoundsWriter::writeTilesToOsm(taskGrid, nodeCounts, TASK_GRID_FILE);
     LOG_STATUS(
-      "Calculated " << StringUtils::formatLargeNumber(boundsCalc.getTileCount()) <<
-      " task grid cells.");
+      "Calculated " << StringUtils::formatLargeNumber(numTaskGridCells) << " task grid cells.");
     LOG_STATUS(
       "Maximum node count in any one tile: " <<
       StringUtils::formatLargeNumber(boundsCalc.getMaxNodeCountInOneTile()));
@@ -235,11 +284,17 @@ public:
       StringUtils::formatLargeNumber(boundsCalc.getMaxNodesPerTile()));
     LOG_STATUS(
       "Task grid cells calculated in: " <<
-      StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
-    subTaskTimer.restart();
+      StringUtils::millisecondsToDhms(_subTaskTimer.elapsed()));
+    _subTaskTimer.restart();
 
+    return taskGrid;
+  }
+
+  void _replaceData(const std::vector<std::vector<geos::geom::Envelope>>& taskGrid,
+                    const int numTiles)
+  {
     // recommended C&R production config
-    ChangesetReplacementCreator changesetCreator(true, "", dataToReplaceUrl);
+    ChangesetReplacementCreator changesetCreator(true, "", DATA_TO_REPLACE_URL);
     changesetCreator.setFullReplacement(true);
     changesetCreator.setBoundsInterpretation(
       ChangesetReplacementCreator::BoundsInterpretation::Lenient);
@@ -248,7 +303,7 @@ public:
     changesetCreator.setCleaningEnabled(false);
     changesetCreator.setTagOobConnectedWays(true);
 
-    OsmApiDbSqlChangesetApplier changesetApplier(dataToReplaceUrl);
+    OsmApiDbSqlChangesetApplier changesetApplier(DATA_TO_REPLACE_URL);
 
     // for each task grid cell
     int boundsCtr = 1;
@@ -259,64 +314,66 @@ public:
         const QString changesetId = QString::number((int)tx) + "-" + QString::number((int)ty);
         const geos::geom::Envelope bounds = taskGrid[tx][ty];
         const QString boundsStr = GeometryUtils::toString(bounds);
-        const QString changesetFile = rootDir + "/changeset-" + changesetId + ".osc.sql";
+        QFile changesetFile(ROOT_DIR + "/changeset-" + changesetId + ".osc.sql");
 
         // derive the difference between the replacement data and the being replaced
         LOG_STATUS(
           "Deriving changeset " << StringUtils::formatLargeNumber(boundsCtr) << " / " <<
-          StringUtils::formatLargeNumber(boundsCalc.getTileCount()) << ": " << changesetId <<
-          " over bounds: " << boundsStr << " to file: " << changesetFile << "...");
+          StringUtils::formatLargeNumber(numTiles) << ": " << changesetId << " over bounds: " <<
+          boundsStr << " to file: " << changesetFile.fileName() << "...");
         changesetCreator.create(
-          dataToReplaceUrl, replacementDataUrl/*rootDir + "/" + replacementDataFile*/, bounds,
-          changesetFile);
+          DATA_TO_REPLACE_URL, /*REPLACEMENT_DATA_URL*/ROOT_DIR + "/" + REPLACEMENT_DATA_FILE,
+          bounds, changesetFile.fileName());
         LOG_STATUS(
           "Changeset derived in: " <<
-          StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
-        subTaskTimer.restart();
+          StringUtils::millisecondsToDhms(_subTaskTimer.elapsed()));
+        _subTaskTimer.restart();
 
         // apply the difference back to the data being replaced
         LOG_STATUS(
           "Applying changeset: " << StringUtils::formatLargeNumber(boundsCtr) << " / " <<
-          StringUtils::formatLargeNumber(boundsCalc.getTileCount()) << ": " << changesetId <<
-          " over bounds: " << boundsStr << " from file: " << changesetFile << "...");
-        changesetApplier.write(QFile(changesetFile));
+          StringUtils::formatLargeNumber(numTiles) << ": " << changesetId << " over bounds: " <<
+          boundsStr << " from file: " << changesetFile.fileName() << "...");
+        changesetApplier.write(changesetFile);
         LOG_STATUS(
           "Changeset applied in: " <<
-          StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
-        subTaskTimer.restart();
+          StringUtils::millisecondsToDhms(_subTaskTimer.elapsed()));
+        _subTaskTimer.restart();
 
         boundsCtr++;
       }
     }
+  }
 
-    LOG_STATUS("Reading the modified data out of: " << dataToReplaceUrl << "...");
-    map.reset(new OsmMap());
-    OsmMapReaderFactory::read(map, dataToReplaceUrl, true, Status::Unknown1);
+  void _getUpdatedData()
+  {
+    LOG_STATUS("Reading the modified data out of: " << DATA_TO_REPLACE_URL << "...");
+    OsmMapPtr map(new OsmMap());
+    OsmMapReaderFactory::read(map, DATA_TO_REPLACE_URL, true, Status::Unknown1);
     LOG_STATUS("Modified data size: " << StringUtils::formatLargeNumber(map->size()));
-    OsmMapWriterFactory::write(map, rootDir + "/replaced-data.osm");
+    OsmMapWriterFactory::write(map, ROOT_DIR + "/replaced-data.osm");
     LOG_STATUS(
       "Modified data read in: " <<
-      StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
-    subTaskTimer.restart();
+      StringUtils::millisecondsToDhms(_subTaskTimer.elapsed()));
+    _subTaskTimer.restart();
+  }
 
-    LOG_STATUS("Cleaning up the modified db at: " << dataToReplaceUrl << "...");
+  void _cleanup()
+  {
+    LOG_STATUS("Cleaning up the modified db at: " << DATA_TO_REPLACE_URL << "...");
     ServicesDbTestUtils::deleteDataFromOsmApiTestDatabase();
     LOG_STATUS(
       "Modified db cleaned in: " <<
-      StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
-    subTaskTimer.restart();
+      StringUtils::millisecondsToDhms(_subTaskTimer.elapsed()));
+    _subTaskTimer.restart();
 
-    LOG_STATUS("Cleaning up the replacement data db at: " << replacementDataUrl << "...");
-    ServicesDbTestUtils::deleteUser(userEmail);
-    HootApiDbWriter().deleteMap(testName);
-    LOG_STATUS(
-      "Replacement data cleaned in: " <<
-      StringUtils::millisecondsToDhms(subTaskTimer.elapsed()));
-    subTaskTimer.restart();
-
-    LOG_STATUS(
-      "Entire task grid cell replaced operation finished in: " <<
-      StringUtils::millisecondsToDhms(opTimer.elapsed()));
+//    LOG_STATUS("Cleaning up the replacement data db at: " << REPLACEMENT_DATA_URL << "...");
+//    ServicesDbTestUtils::deleteUser(userEmail);
+//    HootApiDbWriter().deleteMap(testName);
+//    LOG_STATUS(
+//      "Replacement data cleaned in: " <<
+//      StringUtils::millisecondsToDhms(_subTaskTimer.elapsed()));
+//    _subTaskTimer.restart();
   }
 };
 

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetReplacementGridTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetReplacementGridTest.cpp
@@ -74,7 +74,7 @@ class ChangesetReplacementGridTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ChangesetReplacementGridTest);
   // FOR DEBUGGING ONLY
-  CPPUNIT_TEST(runGridCellTest);
+  //CPPUNIT_TEST(runGridCellTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ServiceChangesetReplacementGridTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ServiceChangesetReplacementGridTest.cpp
@@ -291,7 +291,6 @@ private:
     boundsCalc.setMaxNumTries(3);
     boundsCalc.setMaxTimePerAttempt(300);
     boundsCalc.setPixelSizeRetryReductionFactor(10);
-    boundsCalc.setFailWithNoSolution(false);
     boundsCalc.setSlop(0.1);
     boundsCalc.calculateTiles(map);
     map.reset();

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ServiceChangesetReplacementGridTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ServiceChangesetReplacementGridTest.cpp
@@ -69,17 +69,20 @@ static const QString TASK_GRID_FILE = ROOT_DIR + "/bounds.osm";
 
 /*
  * TODO
+ *
+ * TODO: add the option to pass in a uniform grid
+ * TODO: add the option to pass in specific grid cells
  */
-class ChangesetReplacementGridTest : public HootTestFixture
+class ServiceChangesetReplacementGridTest : public HootTestFixture
 {
-  CPPUNIT_TEST_SUITE(ChangesetReplacementGridTest);
+  CPPUNIT_TEST_SUITE(ServiceChangesetReplacementGridTest);
   // FOR DEBUGGING ONLY
   //CPPUNIT_TEST(runGridCellTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
 
-  ChangesetReplacementGridTest() :
+  ServiceChangesetReplacementGridTest() :
   _dataToReplaceFile(DATA_TO_REPLACE_FILE),
   _replacementDataFile(REPLACEMENT_DATA_FILE)
   {
@@ -404,6 +407,8 @@ private:
   }
 };
 
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ChangesetReplacementGridTest, "glacial");
+#ifdef HOOT_HAVE_SERVICES
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceChangesetReplacementGridTest, "glacial");
+#endif
 
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ServiceChangesetReplacementGridTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ServiceChangesetReplacementGridTest.cpp
@@ -68,7 +68,8 @@ static const QString REPLACEMENT_BOUNDS = "-115.3332,36.2178,-115.1837,36.3400";
 static const QString TASK_GRID_FILE = ROOT_DIR + "/bounds.osm";
 
 /*
- * TODO
+ * This is meant for manually testing cut and replace across adjacent task grid cells. Not meant to
+ * be run automatically.
  *
  * TODO: add the option to pass in a uniform grid
  * TODO: add the option to pass in specific grid cells

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbBulkInserterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbBulkInserterTest.cpp
@@ -154,7 +154,6 @@ private:
 
 #ifdef HOOT_HAVE_SERVICES
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceHootApiDbBulkInserterTest, "slow");
-//CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ServiceHootApiDbBulkInserterTest, "serial");
 #endif  // HOOT_HAVE_SERVICES
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetCreator.cpp
@@ -78,6 +78,17 @@ _numCreateChanges(0),
 _numModifyChanges(0),
 _numDeleteChanges(0)
 {
+  if (printDetailedStats)
+  {
+    QFile statsFile(statsOutputFile);
+    if (statsFile.exists())
+    {
+      if (!statsFile.remove())
+      {
+        LOG_ERROR("Unable to remove changeset statistics file: " << statsOutputFile);
+      }
+    }
+  }
 }
 
 void ChangesetCreator::create(const QString& output, const QString& input1, const QString& input2)

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.cpp
@@ -412,8 +412,6 @@ void ChangesetReplacementCreator::create(
   QList<OsmMapPtr> refMaps;
   QList<OsmMapPtr> conflatedMaps;
   int passCtr = 1;
-  //_rawRefMap.reset();
-  //_rawSecMap.reset();
   for (QMap<GeometryTypeCriterion::GeometryType, ElementCriterionPtr>::const_iterator itr =
          refFilters.begin(); itr != refFilters.end(); ++itr)
   {
@@ -471,8 +469,6 @@ void ChangesetReplacementCreator::create(
 
     passCtr++;
   }
-  //_rawRefMap.reset();
-  //_rawSecMap.reset();
 
   LOG_VART(refMaps.size());
   LOG_VART(conflatedMaps.size());

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.cpp
@@ -390,18 +390,9 @@ void ChangesetReplacementCreator::create(
 {
   // INPUT VALIDATION AND SETUP
 
-  _validateInputs(input1, input2);
+  _validateInputs(input1, input2, output);
   const QString boundsStr = GeometryUtils::envelopeToConfigString(bounds);
   _setGlobalOpts(boundsStr);
-  QFile outputFile(output);
-  if (outputFile.exists())
-  {
-    if (!outputFile.remove())
-    {
-      LOG_ERROR("Unable to remove changeset output file: " << output);
-    }
-  }
-
   _printJobDescription(input1, input2, boundsStr, output);
 
   // If a retainment filter was specified, we'll AND it together with each geometry type filter to
@@ -480,6 +471,8 @@ void ChangesetReplacementCreator::create(
 
     passCtr++;
   }
+  _rawRefMap.reset();
+  _rawSecMap.reset();
 
   LOG_VART(refMaps.size());
   LOG_VART(conflatedMaps.size());
@@ -780,7 +773,8 @@ void ChangesetReplacementCreator::_getMapsForGeometryType(
   LOG_VART(conflatedMap->getElementCount());
 }
 
-void ChangesetReplacementCreator::_validateInputs(const QString& input1, const QString& input2)
+void ChangesetReplacementCreator::_validateInputs(const QString& input1, const QString& input2,
+                                                  const QString& output)
 {
   // Fail if the reader that supports either input doesn't implement Boundable.
   std::shared_ptr<Boundable> boundable =
@@ -805,6 +799,15 @@ void ChangesetReplacementCreator::_validateInputs(const QString& input1, const Q
   {
     throw IllegalArgumentException(
       "GeoJSON inputs are not supported by replacement changeset derivation.");
+  }
+
+  QFile outputFile(output);
+  if (outputFile.exists())
+  {
+    if (!outputFile.remove())
+    {
+      throw HootException("Unable to remove changeset output file: " + output);
+    }
   }
 
   LOG_VARD(_fullReplacement);

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.cpp
@@ -307,11 +307,11 @@ QString ChangesetReplacementCreator::_boundsInterpretationToString(
   }
 }
 
-QString ChangesetReplacementCreator::_getJobDescription(
+void ChangesetReplacementCreator::_printJobDescription(
   const QString& input1, const QString& input2, const QString& bounds,
   const QString& output) const
 {
-  const int maxFilePrintLength = ConfigOptions().getProgressVarPrintLengthMax();
+  const int maxFilePrintLength = ConfigOptions().getProgressVarPrintLengthMax() * 2;
   QString boundsStr = "Bounds calculation is " +
     _boundsInterpretationToString(_boundsInterpretation);
   const QString replacementTypeStr = _fullReplacement ? "full" : "overlapping only";
@@ -363,6 +363,9 @@ QString ChangesetReplacementCreator::_getJobDescription(
   str += "\nBeing replaced: ..." + input1.right(maxFilePrintLength);
   str += "\nReplacing with ..." + input2.right(maxFilePrintLength);
   str += "\nOutput Changeset: ..." + output.right(maxFilePrintLength);
+  LOG_STATUS(str);
+
+  str = "";
   str += "\nBounds interpretation: " + bounds + "; " + boundsStr;
   str += "\nReplacement is: " + replacementTypeStr;
   str += "\nGeometry filters: " + geometryFiltersStr;
@@ -372,7 +375,7 @@ QString ChangesetReplacementCreator::_getJobDescription(
   str += "\nCleaning: " + cleaningStr;
   str += "\nWay snapping: " + waySnappingStr;
   str += "\nOut of bounds way handling: " + oobWayHandlingStr;
-  return str;
+  LOG_DEBUG(str);
 }
 
 void ChangesetReplacementCreator::setRetainmentFilterOptions(const QStringList& optionKvps)
@@ -399,7 +402,7 @@ void ChangesetReplacementCreator::create(
     }
   }
 
-  LOG_DEBUG(_getJobDescription(input1, input2, boundsStr, output));
+  _printJobDescription(input1, input2, boundsStr, output);
 
   // If a retainment filter was specified, we'll AND it together with each geometry type filter to
   // further restrict what reference data gets replaced in the final changeset.

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.cpp
@@ -390,6 +390,14 @@ void ChangesetReplacementCreator::create(
   _validateInputs(input1, input2);
   const QString boundsStr = GeometryUtils::envelopeToConfigString(bounds);
   _setGlobalOpts(boundsStr);
+  QFile outputFile(output);
+  if (outputFile.exists())
+  {
+    if (!outputFile.remove())
+    {
+      LOG_ERROR("Unable to remove changeset output file: " << output);
+    }
+  }
 
   LOG_DEBUG(_getJobDescription(input1, input2, boundsStr, output));
 
@@ -745,7 +753,7 @@ void ChangesetReplacementCreator::_getMapsForGeometryType(
     _excludeFeaturesFromChangesetDeletion(refMap, boundsStr);
   }
 
-  // clean up introduced mistakes
+  // clean up any mistakes introduced
   _cleanup(refMap);
   _cleanup(conflatedMap);
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.h
@@ -222,8 +222,8 @@ private:
   BoundsOptions _boundsOpts;
 
   // TODO
-  OsmMapPtr _rawRefMap;
-  OsmMapPtr _rawSecMap;
+  //OsmMapPtr _rawRefMap;
+  //OsmMapPtr _rawSecMap;
 
   // determines if the current changeset map generation pass contains only linear features
   bool _currentChangeDerivationPassIsLinear;

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.h
@@ -221,6 +221,7 @@ private:
   // controls cropping
   BoundsOptions _boundsOpts;
 
+  // TODO
   OsmMapPtr _rawRefMap;
   OsmMapPtr _rawSecMap;
 
@@ -232,7 +233,7 @@ private:
 
   QString _boundsInterpretationToString(const BoundsInterpretation& boundsInterpretation) const;
 
-  void _validateInputs(const QString& input1, const QString& input2);
+  void _validateInputs(const QString& input1, const QString& input2, const QString& output);
 
   void _printJobDescription(
     const QString& input1, const QString& input2, const QString& bounds,

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.h
@@ -221,6 +221,9 @@ private:
   // controls cropping
   BoundsOptions _boundsOpts;
 
+  OsmMapPtr _rawRefMap;
+  OsmMapPtr _rawSecMap;
+
   // determines if the current changeset map generation pass contains only linear features
   bool _currentChangeDerivationPassIsLinear;
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.h
@@ -221,10 +221,6 @@ private:
   // controls cropping
   BoundsOptions _boundsOpts;
 
-  // TODO
-  //OsmMapPtr _rawRefMap;
-  //OsmMapPtr _rawSecMap;
-
   // determines if the current changeset map generation pass contains only linear features
   bool _currentChangeDerivationPassIsLinear;
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.h
@@ -234,7 +234,7 @@ private:
 
   void _validateInputs(const QString& input1, const QString& input2);
 
-  QString _getJobDescription(
+  void _printJobDescription(
     const QString& input1, const QString& input2, const QString& bounds,
     const QString& output) const;
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheet.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheet.cpp
@@ -134,7 +134,8 @@ void RubberSheet::setCriteria(const QStringList& criteria, OsmMapPtr map)
         }
         if (conflatableCrit)
         {
-          const GeometryTypeCriterion::GeometryType geometryType = conflatableCrit->getGeometryType();
+          const GeometryTypeCriterion::GeometryType geometryType =
+            conflatableCrit->getGeometryType();
           if (geometryType != GeometryTypeCriterion::GeometryType::Line &&
               geometryType != GeometryTypeCriterion::GeometryType::Polygon)
           {
@@ -658,8 +659,8 @@ bool RubberSheet::_findTies()
   if ((long)_ties.size() >= _minimumTies)
   {
     LOG_DEBUG(
-      "Found " << _ties.size() << " tie points, out of a required minimum of " <<
-      _minimumTies << ", which is enough to perform rubbersheeting.");
+      "Found " << StringUtils::formatLargeNumber(_ties.size()) << " tie points out of a " <<
+      "required minimum of " << _minimumTies << ", which is enough to perform rubbersheeting.");
 
     // experimentally determine the best interpolator.
     _interpolatorClassName.clear();

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/MaximalSubline.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/MaximalSubline.h
@@ -46,7 +46,7 @@ class WaySublineMatch;
  * Given a set of limitations on defining whether or not two points "match", calculate an
  * approximation of the maximal line within those constraints.
  *
- * @note It may be worth investaging a probabilistic approach to this problem. Although we'll either
+ * @todo It may be worth investaging a probabilistic approach to this problem. Although we'll either
  * need a clever way to do it unsupervised, or some point matching training data to establish
  * distributions. It'll also likely increase the computational complexity.
  */
@@ -116,7 +116,6 @@ public:
 
     Meters _maxDistance;
     Radians _maxAngleDiff;
-
   };
 
   /**
@@ -162,8 +161,10 @@ public:
    *  vector will be resized as needed.
    * @return 0.0 if there are no common sublines, otherwise the score of the best subline.
    */
-  double findMaximalSubline(const ConstOsmMapPtr &map, const ConstWayPtr& w1, const ConstWayPtr &w2,
-    std::vector<WayLocation>& wl1, std::vector<WayLocation> &wl2);
+  double findMaximalSubline(const ConstOsmMapPtr &map, const ConstWayPtr& w1, const ConstWayPtr& w2,
+    std::vector<WayLocation>& wl1, std::vector<WayLocation>& wl2);
+
+  void setMaxRecursionComplexity(int maxRecursions) { _maxRecursionComplexity = maxRecursions; }
 
 private:
 
@@ -172,6 +173,11 @@ private:
   std::shared_ptr<MatchCriteria> _criteria;
   Meters _spacing;
   Meters _minSplitSize;
+
+  // places a limit on the number of recursive matching calls that can be made and throws an
+  // exception once that limit has been reached; only used in select places in the code
+  int _maxRecursionComplexity;
+  int _findBestMatchesRecursionCount;
 
   struct SublineScore
   {
@@ -186,30 +192,30 @@ private:
    * @param index The index of the first node in the line segment to look at.
    */
   WayLocation _calculateEndWayLocation(const ConstOsmMapPtr &map, const ConstWayPtr& a,
-    const ConstWayPtr &b, int indexA, int indexB);
+    const ConstWayPtr& b, int indexA, int indexB);
 
   /**
    * Determines the start of the way location in way a. The way location will start in the line
    * segment specified by index.
    * @param index The index of the first node in the line segment to look at.
    */
-  WayLocation _calculateStartWayLocation(const ConstOsmMapPtr &map, const ConstWayPtr& a,
-    const ConstWayPtr &b, int indexA, int indexB);
+  WayLocation _calculateStartWayLocation(const ConstOsmMapPtr& map, const ConstWayPtr& a,
+    const ConstWayPtr& b, int indexA, int indexB);
 
-  void _calculateSublineScores(const ConstOsmMapPtr &map, const ConstWayPtr& w1,
-    const ConstWayPtr &w2, Sparse2dMatrix &scores);
+  void _calculateSublineScores(const ConstOsmMapPtr& map, const ConstWayPtr& w1,
+    const ConstWayPtr& w2, Sparse2dMatrix &scores);
 
   std::vector<std::pair<WayLocation, WayLocation>> _discretizePointPairs(const ConstOsmMapPtr &map,
     const ConstWayPtr& w1, const ConstWayPtr& w2, std::vector<WaySublineMatch> &rawSublineMatches);
 
-  std::vector<WaySublineMatch> _extractAllMatches(const ConstOsmMapPtr &map, const ConstWayPtr& w1,
-    const ConstWayPtr &w2, Sparse2dMatrix &sublineMatrix);
+  std::vector<WaySublineMatch> _extractAllMatches(const ConstOsmMapPtr& map, const ConstWayPtr& w1,
+    const ConstWayPtr& w2, Sparse2dMatrix& sublineMatrix);
 
-  std::vector<WaySublineMatch> _findBestMatches(const ConstOsmMapPtr &map, const ConstWayPtr& w1,
-    const ConstWayPtr &w2, Sparse2dMatrix &sublineMatrix, double &bestScore);
+  std::vector<WaySublineMatch> _findBestMatches(const ConstOsmMapPtr& map, const ConstWayPtr& w1,
+    const ConstWayPtr& w2, Sparse2dMatrix& sublineMatrix, double& bestScore);
 
-  double _findBestMatchesRecursive(std::vector<WaySublineMatch>& candidates, std::vector<bool>& keepers,
-    size_t offset);
+  double _findBestMatchesRecursive(std::vector<WaySublineMatch>& candidates,
+                                   std::vector<bool>& keepers, size_t offset);
 
   /**
    * Find the ends of all the subline matches.
@@ -254,7 +260,6 @@ private:
                                   const std::vector<WaySublineMatch>& rawSublineMatches,
                                   const std::vector<std::pair<WayLocation, WayLocation>>& pairs,
                                   cv::Mat& m, std::vector<int>& starts, std::vector<int>& ends);
-
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/MaximalSublineMatcher.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/MaximalSublineMatcher.h
@@ -59,6 +59,8 @@ public:
   virtual void setMinSplitSize(Meters minSplitSize) override { _minSplitSize = minSplitSize; }
   virtual void setHeadingDelta(Meters /*headingDelta*/) override {}
 
+  void setMaxRecursionComplexity(int maxRecursions) { _maxRecursionComplexity = maxRecursions; }
+
   virtual QString getDescription() const
   { return "Matches lines based on the longest matching subline found"; }
 
@@ -66,6 +68,9 @@ private:
 
   Radians _maxAngle;
   Meters _minSplitSize;
+
+  // See MaximalSubline::__maxRecursionComplexity
+  int _maxRecursionComplexity;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/SublineMatcher.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/SublineMatcher.h
@@ -45,7 +45,6 @@ public:
   static std::string className() { return "hoot::SublineMatcher"; }
 
   SublineMatcher() = default;
-
   virtual ~SublineMatcher() = default;
 
   /**
@@ -57,10 +56,8 @@ public:
     const ConstWayPtr& way2, double& score, Meters maxRelevantDistance = -1) const = 0;
 
   virtual void setMaxRelevantAngle(Radians r) = 0;
-
   virtual void setMinSplitSize(Meters minSplitSize) = 0;
-
-  virtual void setHeadingDelta(Meters headingDelta)  = 0;
+  virtual void setHeadingDelta(Meters headingDelta) = 0;
 };
 
 typedef std::shared_ptr<SublineMatcher> SublineMatcherPtr;

--- a/hoot-core/src/main/cpp/hoot/core/cmd/NodeDensityTilesCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/NodeDensityTilesCmd.cpp
@@ -177,6 +177,15 @@ public:
     }
     LOG_VARD(pixelSizeAutoReductionFactor);
 
+    bool alwaysFailWithNoSolution = false;
+    if (args.contains("--alwaysFailWithNoSolution"))
+    {
+      const int optionNameIndex = args.indexOf("--alwaysFailWithNoSolution");
+      alwaysFailWithNoSolution = true;
+      args.removeAt(optionNameIndex);
+    }
+    LOG_VARD(pixelSizeAutoReductionFactor);
+
     int randomSeed = -1;
     if (args.contains("--random") && args.contains("--randomSeed"))
     { 
@@ -204,6 +213,7 @@ public:
     tileCalc.setMaxNumTries(maxAttempts);
     tileCalc.setMaxTimePerAttempt(maxTimePerAttempt);
     tileCalc.setPixelSizeRetryReductionFactor(pixelSizeAutoReductionFactor);
+    tileCalc.setFailWithNoSolution(alwaysFailWithNoSolution);
     tileCalc.calculateTiles(inputMap);
     const std::vector<std::vector<geos::geom::Envelope>> tiles = tileCalc.getTiles();
     const std::vector<std::vector<long>> nodeCounts = tileCalc.getNodeCounts();

--- a/hoot-core/src/main/cpp/hoot/core/cmd/NodeDensityTilesCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/NodeDensityTilesCmd.cpp
@@ -259,6 +259,7 @@ private:
     for (int i = 0; i < inputs.size(); i++)
     {
       const QString input = inputs.at(i);
+      // has to be loaded with Unknown1 in order for the calculation to work
       std::shared_ptr<OsmMapReader> reader =
         OsmMapReaderFactory::createReader(input, true, Status::Unknown1);
 
@@ -275,10 +276,10 @@ private:
         std::dynamic_pointer_cast<ApiDbReader>(reader);
       if (apiDbReader)
       {
-        //the tiles calculation is only concerned with nodes, and the only readers capable of
-        //filtering down to nodes up front right now are the api db readers; more importantly,
-        //setting this to true also prevents any features from being returned outside of
-        //convert.bounding.box, if it was specified (ways partially inside the bounds, etc.)
+        // The tiles calculation is only concerned with nodes, and the only readers capable of
+        // filtering down to nodes up front right now are the api db readers. More importantly,
+        // setting this to true also prevents any features from being returned outside of
+        // convert.bounding.box, if it was specified (ways partially inside the bounds, etc.)
         apiDbReader->setReturnNodesOnly(true);
       }
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/NodeDensityTilesCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/NodeDensityTilesCmd.cpp
@@ -177,15 +177,6 @@ public:
     }
     LOG_VARD(pixelSizeAutoReductionFactor);
 
-    bool alwaysFailWithNoSolution = false;
-    if (args.contains("--alwaysFailWithNoSolution"))
-    {
-      const int optionNameIndex = args.indexOf("--alwaysFailWithNoSolution");
-      alwaysFailWithNoSolution = true;
-      args.removeAt(optionNameIndex);
-    }
-    LOG_VARD(pixelSizeAutoReductionFactor);
-
     int randomSeed = -1;
     if (args.contains("--random") && args.contains("--randomSeed"))
     { 
@@ -213,7 +204,6 @@ public:
     tileCalc.setMaxNumTries(maxAttempts);
     tileCalc.setMaxTimePerAttempt(maxTimePerAttempt);
     tileCalc.setPixelSizeRetryReductionFactor(pixelSizeAutoReductionFactor);
-    tileCalc.setFailWithNoSolution(alwaysFailWithNoSolution);
     tileCalc.calculateTiles(inputMap);
     const std::vector<std::vector<geos::geom::Envelope>> tiles = tileCalc.getTiles();
     const std::vector<std::vector<long>> nodeCounts = tileCalc.getNodeCounts();

--- a/hoot-core/src/main/cpp/hoot/core/cmd/NodeDensityTilesCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/NodeDensityTilesCmd.cpp
@@ -259,7 +259,7 @@ private:
     for (int i = 0; i < inputs.size(); i++)
     {
       const QString input = inputs.at(i);
-      // has to be loaded with Unknown1 in order for the calculation to work
+      // IMPORTANT: has to be loaded as Unknown1 in order for the calculation to work
       std::shared_ptr<OsmMapReader> reader =
         OsmMapReaderFactory::createReader(input, true, Status::Unknown1);
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/MultipleSublineMatcherSnapMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/MultipleSublineMatcherSnapMerger.cpp
@@ -24,7 +24,7 @@
  *
  * @copyright Copyright (C) 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
-#include "RiverSnapMerger.h"
+#include "MultipleSublineMatcherSnapMerger.h"
 
 // hoot
 #include <hoot/core/algorithms/subline-matching/SublineStringMatcher.h>
@@ -35,14 +35,14 @@
 namespace hoot
 {
 
-HOOT_FACTORY_REGISTER(Merger, RiverSnapMerger)
+HOOT_FACTORY_REGISTER(Merger, MultipleSublineMatcherSnapMerger)
 
-RiverSnapMerger::RiverSnapMerger() :
+MultipleSublineMatcherSnapMerger::MultipleSublineMatcherSnapMerger() :
 HighwaySnapMerger()
 {
 }
 
-RiverSnapMerger::RiverSnapMerger(
+MultipleSublineMatcherSnapMerger::MultipleSublineMatcherSnapMerger(
   const std::set<std::pair<ElementId, ElementId>>& pairs,
   const std::shared_ptr<SublineStringMatcher>& sublineMatcher,
   const std::shared_ptr<SublineStringMatcher>& sublineMatcher2) :
@@ -52,7 +52,8 @@ _sublineMatcher2(sublineMatcher2)
   // The subline matchers have already been initialized by the conflate script by this point.
 }
 
-WaySublineMatchString RiverSnapMerger::_matchSubline(OsmMapPtr map, ElementPtr e1, ElementPtr e2)
+WaySublineMatchString MultipleSublineMatcherSnapMerger::_matchSubline(
+  OsmMapPtr map, ElementPtr e1, ElementPtr e2)
 {
   WaySublineMatchString match;
   if (e1->getElementType() != ElementType::Node && e2->getElementType() != ElementType::Node)

--- a/hoot-core/src/main/cpp/hoot/core/conflate/MultipleSublineMatcherSnapMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/MultipleSublineMatcherSnapMerger.h
@@ -24,8 +24,8 @@
  *
  * @copyright Copyright (C) 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
-#ifndef RIVER_SNAP_MERGER_H
-#define RIVER_SNAP_MERGER_H
+#ifndef MULTIPLE_SUBLINE_MATCHER_SNAP_MERGER_H
+#define MULTIPLE_SUBLINE_MATCHER_SNAP_MERGER_H
 
 // Hoot
 #include <hoot/core/conflate/highway/HighwaySnapMerger.h>
@@ -36,26 +36,26 @@ namespace hoot
 class WaySublineMatchString;
 
 /**
- * Merges river features
+ * Merges way features potentially using multiple subline matcher
  *
  * This class primarily exists so that we can select a subline matcher based on properties of the
  * input data for runtime performance reasons.
  */
-class RiverSnapMerger : public HighwaySnapMerger
+class MultipleSublineMatcherSnapMerger : public HighwaySnapMerger
 {
 
 public:
 
-  static std::string className() { return "hoot::RiverSnapMerger"; }
+  static std::string className() { return "hoot::MultipleSublineMatcherSnapMerger"; }
 
-  RiverSnapMerger();
-  RiverSnapMerger(
+  MultipleSublineMatcherSnapMerger();
+  MultipleSublineMatcherSnapMerger(
     const std::set<std::pair<ElementId, ElementId>>& pairs,
     const std::shared_ptr<SublineStringMatcher>& sublineMatcher,
     const std::shared_ptr<SublineStringMatcher>& sublineMatcher2);
-  virtual ~RiverSnapMerger() = default;
+  virtual ~MultipleSublineMatcherSnapMerger() = default;
 
-  virtual QString getDescription() const { return "Merges rivers"; }
+  virtual QString getDescription() const { return "Merges ways with one or more subline matchers"; }
 
   virtual QString getName() const { return QString::fromStdString(className()); }
 
@@ -73,8 +73,8 @@ private:
   std::shared_ptr<SublineStringMatcher> _sublineMatcher2;
 };
 
-typedef std::shared_ptr<RiverSnapMerger> RiverSnapMergerPtr;
+typedef std::shared_ptr<MultipleSublineMatcherSnapMerger> MultipleSublineMatcherSnapMergerPtr;
 
 }
 
-#endif // HIGHWAYSNAPMERGER_H
+#endif // MULTIPLE_SUBLINE_MATCHER_SNAP_MERGER_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/river/RiverSnapMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/river/RiverSnapMerger.h
@@ -29,8 +29,6 @@
 
 // Hoot
 #include <hoot/core/conflate/highway/HighwaySnapMerger.h>
-#include <hoot/core/elements/Way.h>
-#include <hoot/core/util/Configurable.h>
 
 namespace hoot
 {
@@ -43,7 +41,7 @@ class WaySublineMatchString;
  * This class primarily exists so that we can select a subline matcher based on properties of the
  * input data for runtime performance reasons.
  */
-class RiverSnapMerger : public HighwaySnapMerger, public Configurable
+class RiverSnapMerger : public HighwaySnapMerger
 {
 
 public:
@@ -57,27 +55,6 @@ public:
     const std::shared_ptr<SublineStringMatcher>& sublineMatcher2);
   virtual ~RiverSnapMerger() = default;
 
-  /**
-   * @see Configurable
-   */
-  virtual void setConfiguration(const Settings& conf);
-
-  /**
-   * Determines if either of two features is considered "long" by the standards of River Conflation.
-   * Both way length and node count are examined.
-   *
-   * Note that relations are allowed here to despite the fact relation isn't an element type
-   * conflatable by River Conflation. This is due to the fact that relations are passed to matching
-   * during match conflict resolution and trying to prevent that causes regression test failures
-   * for an unknown reason. See comments in ScriptMatch::_isOrderedConflicting.
-   *
-   * @param map map owning the input elements
-   * @param element1 the first input element
-   * @param element2 the second input element
-   * @return true if either of the elements is considered "long"; false otherwise
-   */
-  bool isLongPair(ConstOsmMapPtr map, ConstElementPtr element1, ConstElementPtr element2);
-
   virtual QString getDescription() const { return "Merges rivers"; }
 
   virtual QString getName() const { return QString::fromStdString(className()); }
@@ -90,11 +67,6 @@ protected:
   virtual WaySublineMatchString _matchSubline(OsmMapPtr map, ElementPtr e1, ElementPtr e2);
 
 private:
-
-  // way node count above which an element is considered "long"
-  int _nodeCountThreshold;
-  // way length above  which an elementis considered "long"
-  int _lengthThreshold;
 
   // This is our backup matcher to use for long ways for runtime performance reasons. It may be
   // a little less accurate but prevents extremely long ways from slowing things down too much.

--- a/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.cpp
@@ -55,7 +55,6 @@ _maxNodeCountInOneTile(0),
 _minNodeCountInOneTile(LONG_MAX),
 _pixelSizeRetryReductionFactor(10),
 _maxNumTries(3),
-_failWithNoSolution(false),
 _maxTimePerAttempt(-1),
 _tileCount(0)
 {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.cpp
@@ -62,9 +62,19 @@ _tileCount(0)
 
 void NodeDensityTileBoundsCalculator::calculateTiles(const ConstOsmMapPtr& map)
 {  
-  if (!map || map->getNodeCount() == 0 || _maxNodesPerTile == 0)
+  if (!map)
   {
-    throw IllegalArgumentException("TODO");
+    throw IllegalArgumentException("Invalid map passed to node density tile calculator.");
+  }
+  else if (map->getNodeCount() == 0)
+  {
+    throw IllegalArgumentException("Empty map passed to node density tile calculator.");
+  }
+  else if (_maxNodesPerTile == 0)
+  {
+    throw IllegalArgumentException(
+      "Invalid maximum nodes per tile requirement equal to zero passed to node density tile " +
+      "calculator.");
   }
 
   // TODO: throw exception if no input data is Unknown1

--- a/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.cpp
@@ -73,8 +73,8 @@ void NodeDensityTileBoundsCalculator::calculateTiles(const ConstOsmMapPtr& map)
   else if (_maxNodesPerTile == 0)
   {
     throw IllegalArgumentException(
-      "Invalid maximum nodes per tile requirement equal to zero passed to node density tile " +
-      "calculator.");
+      QString("Invalid maximum nodes per tile requirement equal to zero passed to node density " ) +
+      QString("tile calculator."));
   }
 
   // TODO: throw exception if no input data is Unknown1

--- a/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.cpp
@@ -55,7 +55,8 @@ _maxNodeCountInOneTile(0),
 _minNodeCountInOneTile(LONG_MAX),
 _pixelSizeRetryReductionFactor(10),
 _maxNumTries(3),
-_maxTimePerAttempt(-1)
+_maxTimePerAttempt(-1),
+_tileCount(0)
 {
 }
 
@@ -268,6 +269,7 @@ void NodeDensityTileBoundsCalculator::_calculateTiles()
 
     _checkForTimeout();
   }
+  _tileCount = width * width;
 
   if (_maxNodeCountInOneTile == 0)
   {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.cpp
@@ -68,6 +68,8 @@ void NodeDensityTileBoundsCalculator::calculateTiles(const ConstOsmMapPtr& map)
     throw IllegalArgumentException("TODO");
   }
 
+  // TODO: throw exception if no input data is Unknown1
+
   LOG_VARD(map->getNodeCount());
   if (map->getNodeCount() <= _maxNodesPerTile)
   {
@@ -104,7 +106,7 @@ void NodeDensityTileBoundsCalculator::calculateTiles(const ConstOsmMapPtr& map)
 
       QString msg =
         "Running node density tiles calculation attempt " + QString::number(tryCtr) + " / " +
-         QString::number(_maxNumTries) << " with pixel size: " << QString::number(_pixelSize) +
+         QString::number(_maxNumTries) + " with pixel size: " + QString::number(_pixelSize) +
          ", max allowed nodes: " + StringUtils::formatLargeNumber(_maxNodesPerTile) +
          ", total input node size: " + StringUtils::formatLargeNumber(map->getNodeCount());
       if (_maxTimePerAttempt == -1)
@@ -131,19 +133,12 @@ void NodeDensityTileBoundsCalculator::calculateTiles(const ConstOsmMapPtr& map)
       {
         QString msg =
           "Tile calculation attempt " + QString::number(tryCtr) + " / " +
-          QString::number(_maxNumTries) + " failed: " + e.getWhat();
+          QString::number(_maxNumTries) + " failed with error: \"" + e.getWhat() + "\"";
         if (tryCtr == _maxNumTries)
         {
-          //if (_failWithNoSolution)
-          //{
-            msg += " Aborting calculation.";
-            LOG_ERROR(msg);
-            throw e;
-//          }
-//          else
-//          {
-//            _calculateUniformSolution(map);
-//          }
+          msg += " Aborting calculation.";
+          LOG_ERROR(msg);
+          throw e;
         }
         else
         {
@@ -161,27 +156,6 @@ void NodeDensityTileBoundsCalculator::calculateTiles(const ConstOsmMapPtr& map)
       }
     }
   }
-}
-
-void NodeDensityTileBoundsCalculator::_calculateUniformSolution(const ConstOsmMapPtr& map)
-{
-  // TODO: finish
-
-  if (!map || map->getNodeCount() == 0 || _maxNodesPerTile == 0)
-  {
-    throw IllegalArgumentException("TODO");
-  }
-
-  const int numCells = 1 / (_maxNodesPerTile / map->getNodeCount());
-  const geos::geom::Envelope bounds = CalculateMapBoundsVisitor::getGeosBounds(map);
-  const double boundsWidth = bounds.getWidth();
-  const cellWidth = boundsWidth / numCells;
-  const double boundsLength = bounds.getLength();
-  const cellLength = boundsLength / numCells;
-
-  // starting at the upper left corner of the original bounds, draw a rectangular way with width =
-  // cellWidth and length = cellLength. move to the next cell.
-
 }
 
 void NodeDensityTileBoundsCalculator::_calculateMin()

--- a/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.h
@@ -170,6 +170,8 @@ public:
 
   std::vector<std::vector<geos::geom::Envelope>> getTiles() const { return _tiles; }
 
+  int getTileCount() const { return _tileCount; }
+
   /**
    * Returns the node counts for each computed tile bounding box
    *
@@ -233,6 +235,7 @@ private:
 
   std::vector<std::vector<long>> _nodeCounts;
   std::vector<std::vector<geos::geom::Envelope>> _tiles;
+  int _tileCount;
 
   /*
    * Calculates a set of rectangular bounding boxes that at most contain a configured set of nodes;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.h
@@ -164,7 +164,7 @@ public:
    *
    * @param map the map containing the nodes
    */
-  void calculateTiles(OsmMapPtr map);
+  void calculateTiles(const ConstOsmMapPtr& map);
 
   static QString tilesToString(const std::vector<std::vector<geos::geom::Envelope>>& tiles);
 
@@ -203,6 +203,7 @@ public:
   void setMaxNumTries(int numTries) { _maxNumTries = numTries; }
   void setMaxTimePerAttempt(int seconds) { _maxTimePerAttempt = seconds; }
   void setEnvelope(const OGREnvelope& e) { _envelope = e; }
+  void setFailWithNoSolution(bool fail) { _failWithNoSolution = fail; }
 
 private:
 
@@ -228,6 +229,8 @@ private:
   int _pixelSizeRetryReductionFactor;
   // allows for multiple calc attempts
   int _maxNumTries;
+  // TODO
+  bool _failWithNoSolution;
 
   // timeout in seconds; -1 is unlimited
   int _maxTimePerAttempt;
@@ -243,8 +246,8 @@ private:
    */
   void _calculateTiles();
 
-  void _renderImage(const std::shared_ptr<OsmMap>& map);
-  void _renderImage(const std::shared_ptr<OsmMap>& map, cv::Mat& r1, cv::Mat& r2);
+  void _renderImage(const ConstOsmMapPtr& map);
+  void _renderImage(const ConstOsmMapPtr& map, cv::Mat& r1, cv::Mat& r2);
   void _setImages(const cv::Mat& r1, const cv::Mat& r2);
 
   void _calculateMin();
@@ -263,6 +266,8 @@ private:
 
   long _sumPixels(const PixelBox& pb, cv::Mat& r);
   long _sumPixels(const PixelBox& pb);
+
+  void _calculateUniformSolution(const ConstOsmMapPtr& map);
 
   geos::geom::Envelope _toEnvelope(const PixelBox& pb);
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.h
@@ -267,8 +267,6 @@ private:
   long _sumPixels(const PixelBox& pb, cv::Mat& r);
   long _sumPixels(const PixelBox& pb);
 
-  void _calculateUniformSolution(const ConstOsmMapPtr& map);
-
   geos::geom::Envelope _toEnvelope(const PixelBox& pb);
 
   void _checkForTimeout();

--- a/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.h
@@ -203,7 +203,6 @@ public:
   void setMaxNumTries(int numTries) { _maxNumTries = numTries; }
   void setMaxTimePerAttempt(int seconds) { _maxTimePerAttempt = seconds; }
   void setEnvelope(const OGREnvelope& e) { _envelope = e; }
-  void setFailWithNoSolution(bool fail) { _failWithNoSolution = fail; }
 
 private:
 
@@ -229,8 +228,6 @@ private:
   int _pixelSizeRetryReductionFactor;
   // allows for multiple calc attempts
   int _maxNumTries;
-  // TODO
-  bool _failWithNoSolution;
 
   // timeout in seconds; -1 is unlimited
   int _maxTimePerAttempt;

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementDeduplicator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementDeduplicator.cpp
@@ -81,13 +81,13 @@ void ElementDeduplicator::dedupe(OsmMapPtr map)
   }
 
   LOG_DEBUG(map->getName() << " size after de-duping: " << map->size());
-  LOG_STATUS(
+  LOG_DEBUG(
     "Removed " << nodesBefore - map->getNodeCount() << " duplicate nodes from " <<
     map->getName());
-  LOG_STATUS(
+  LOG_DEBUG(
     "Removed " << waysBefore - map->getWayCount() << " duplicate ways from " <<
     map->getName());
-  LOG_STATUS(
+  LOG_DEBUG(
     "Removed " << relationsBefore - map->getRelationCount() << " duplicate relations from " <<
     map->getName());
 }
@@ -169,22 +169,22 @@ void ElementDeduplicator::dedupe(OsmMapPtr map1, OsmMapPtr map2)
 
   LOG_DEBUG(map1->getName() << " size after de-duping: " << map1->size());
   LOG_DEBUG(map2->getName() << " size after de-duping: " << map2->size());
-  LOG_STATUS(
+  LOG_DEBUG(
     "Removed " << map1NodesBefore - map1->getNodeCount() << " duplicate nodes from " <<
     map1->getName());
-  LOG_STATUS(
+  LOG_DEBUG(
     "Removed " << map1WaysBefore - map1->getWayCount() << " duplicate ways from " <<
     map1->getName());
-  LOG_STATUS(
+  LOG_DEBUG(
     "Removed " << map1RelationsBefore - map1->getRelationCount() << " duplicate relations from " <<
     map1->getName());
-  LOG_STATUS(
+  LOG_DEBUG(
     "Removed " << map2NodesBefore - map2->getNodeCount() << " duplicate nodes from " <<
     map2->getName());
-  LOG_STATUS(
+  LOG_DEBUG(
     "Removed " << map2WaysBefore - map2->getWayCount() << " duplicate ways from " <<
     map2->getName());
-  LOG_STATUS(
+  LOG_DEBUG(
     "Removed " << map2RelationsBefore - map2->getRelationCount() << " duplicate relations from " <<
     map2->getName());
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDb.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDb.cpp
@@ -657,7 +657,7 @@ std::shared_ptr<QSqlQuery> ApiDb::selectWayIdsByWayNodeIds(const QSet<QString>& 
   sql += " node_id IN (" + QStringList(nodeIds.toList()).join(",") + ")";
   //sql += " ORDER BY way_id desc";
   _selectWayIdsByWayNodeIds->prepare(sql);
-  LOG_VARD(_selectWayIdsByWayNodeIds->lastQuery());
+  LOG_VARD(_selectWayIdsByWayNodeIds->lastQuery().right(100));
 
   if (_selectWayIdsByWayNodeIds->exec() == false)
   {
@@ -723,7 +723,7 @@ std::shared_ptr<QSqlQuery> ApiDb::selectElementsByElementIdList(const QSet<QStri
   sql += " AND id IN (" + QStringList(elementIds.toList()).join(",") + ")";
   sql += " ORDER BY id DESC";
   _selectElementsByElementIdList->prepare(sql);
-  LOG_VARD(_selectElementsByElementIdList->lastQuery());
+  LOG_VARD(_selectElementsByElementIdList->lastQuery().right(100));
 
   if (_selectElementsByElementIdList->exec() == false)
   {
@@ -752,7 +752,7 @@ std::shared_ptr<QSqlQuery> ApiDb::selectWayNodeIdsByWayIds(const QSet<QString>& 
   sql += " way_id IN (" + QStringList(wayIds.toList()).join(",") + ")";
   //sql += " ORDER BY sequence_id";
   _selectWayNodeIdsByWayIds->prepare(sql);
-  LOG_VARD(_selectWayNodeIdsByWayIds->lastQuery());
+  LOG_VARD(_selectWayNodeIdsByWayIds->lastQuery().right(100));
 
   if (_selectWayNodeIdsByWayIds->exec() == false)
   {
@@ -792,7 +792,7 @@ std::shared_ptr<QSqlQuery> ApiDb::selectRelationIdsByMemberIds(const QSet<QStrin
   {
     _selectRelationIdsByMemberIds->bindValue(":elementType", memberElementType.toString());
   }
-  LOG_VARD(_selectRelationIdsByMemberIds->lastQuery());
+  LOG_VARD(_selectRelationIdsByMemberIds->lastQuery().right(100));
   LOG_VARD(_selectRelationIdsByMemberIds->boundValues());
 
   if (_selectRelationIdsByMemberIds->exec() == false)

--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.cpp
@@ -269,6 +269,7 @@ void ApiDbReader::_readWaysByNodeIds(OsmMapPtr map, const QSet<QString>& nodeIds
                                      long& nodeCount, long& wayCount)
 {
   LOG_DEBUG("Retrieving way IDs referenced by the selected nodes...");
+  // TODO: This is extremely slow for large numbers of node IDs.
   std::shared_ptr<QSqlQuery> wayIdItr = _getDatabase()->selectWayIdsByWayNodeIds(nodeIds);
   while (wayIdItr->next())
   {
@@ -385,7 +386,6 @@ void ApiDbReader::_readByBounds(OsmMapPtr map, const Envelope& bounds)
         map, nodeIds, wayIds, additionalWayNodeIds, boundedNodeCount, boundedWayCount);
       nodeIds.unite(additionalWayNodeIds);
       LOG_VARD(nodeIds.size());
-      LOG_VARD(wayIds);
       LOG_VARD(wayIds.size());
 
       LOG_DEBUG("Retrieving relation IDs referenced by the selected ways and nodes...");

--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.cpp
@@ -352,6 +352,8 @@ void ApiDbReader::_readWaysByNodeIds(OsmMapPtr map, const QSet<QString>& nodeIds
 
 void ApiDbReader::_readByBounds(OsmMapPtr map, const Envelope& bounds)
 {
+  // TODO: This proves very slow for AOI's with a lot of data. Need something better.
+
   long boundedNodeCount = 0;
   long boundedWayCount = 0;
   long boundedRelationCount = 0;

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
@@ -475,22 +475,22 @@ void HootApiDb::_flushBulkInserts()
 
   if (_nodeBulkInsert != 0)
   {
-    LOG_VARD(_nodeBulkInsert->getPendingCount());
+    LOG_VART(_nodeBulkInsert->getPendingCount());
     _nodeBulkInsert->flush();
   }
   if (_wayBulkInsert != 0)
   {
-    LOG_VARD(_wayBulkInsert->getPendingCount());
+    LOG_VART(_wayBulkInsert->getPendingCount());
     _wayBulkInsert->flush();
   }
   if (_wayNodeBulkInsert != 0)
   {
-    LOG_VARD(_wayNodeBulkInsert->getPendingCount());
+    LOG_VART(_wayNodeBulkInsert->getPendingCount());
     _wayNodeBulkInsert->flush();
   }
   if (_relationBulkInsert != 0)
   {
-    LOG_VARD(_relationBulkInsert->getPendingCount());
+    LOG_VART(_relationBulkInsert->getPendingCount());
     _relationBulkInsert->flush();
   }
 }
@@ -501,7 +501,7 @@ void HootApiDb::_flushBulkDeletes()
 
   if (_nodeBulkDelete != 0)
   {
-    LOG_VARD(_nodeBulkDelete->getPendingCount());
+    LOG_VART(_nodeBulkDelete->getPendingCount());
     _nodeBulkDelete->flush();
   }
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbReader.h
@@ -57,7 +57,7 @@ public:
 
   virtual void open(const QString& urlStr) override;
 
-  virtual void read(const OsmMapPtr &map) override;
+  virtual void read(const OsmMapPtr& map) override;
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbReader.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef HOOTAPIDBREADER_H
 #define HOOTAPIDBREADER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/IoUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/IoUtils.cpp
@@ -216,7 +216,7 @@ void IoUtils::cropToBounds(OsmMapPtr& map, const geos::geom::Envelope& bounds,
   cropper.setInclusionCriterion(inclusionCrit);
 
   LOG_VARD(StringUtils::formatLargeNumber(map->getElementCount()));
-  LOG_INFO(cropper.getInitStatusMessage());
+  LOG_STATUS(cropper.getInitStatusMessage());
   cropper.apply(map);
   LOG_DEBUG(cropper.getCompletedStatusMessage());
   LOG_VARD(StringUtils::formatLargeNumber(map->getElementCount()));

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetApplier.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetApplier.cpp
@@ -68,6 +68,7 @@ void OsmApiDbSqlChangesetApplier::_initChangesetStats()
 void OsmApiDbSqlChangesetApplier::write(const QString& sql)
 {
   LOG_DEBUG("Executing changeset SQL queries against OSM API database...");
+  LOG_VARD(sql.length());
 
   _db.transaction();
 
@@ -75,11 +76,13 @@ void OsmApiDbSqlChangesetApplier::write(const QString& sql)
   QString elementSqlStatements = "";
 
   const QStringList sqlParts = sql.split(";");
+  LOG_VARD(sqlParts.length());
 
   if (!sqlParts[0].toUpper().startsWith("INSERT INTO CHANGESETS"))
   {
     throw HootException(
-      "The first SQL statement in a changeset SQL file must create a changeset.");
+      "The first SQL statement in a changeset SQL file must create a changeset. Found: " +
+      sqlParts[0].left(25));
   }
 
   for (int i = 0; i < sqlParts.size(); i++)

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetApplier.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetApplier.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "OsmApiDbSqlChangesetApplier.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetFileWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetFileWriter.cpp
@@ -380,9 +380,11 @@ void OsmApiDbSqlChangesetFileWriter::_deleteExistingElement(ConstElementPtr elem
   const long currentVersion = changeElement->getVersion();
   if (currentVersion < 1)
   {
+    // TODO: re-enable; this is not good
     throw HootException(
       "Elements being deleted in an .osc.sql changeset must always have a version greater than one: " +
       element->getElementId().toString());
+    //currentVersion = 1;
   }
   const long newVersion = currentVersion + 1;
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetFileWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetFileWriter.cpp
@@ -380,11 +380,9 @@ void OsmApiDbSqlChangesetFileWriter::_deleteExistingElement(ConstElementPtr elem
   const long currentVersion = changeElement->getVersion();
   if (currentVersion < 1)
   {
-    // TODO: re-enable; this is not good
     throw HootException(
       "Elements being deleted in an .osc.sql changeset must always have a version greater than one: " +
       element->getElementId().toString());
-    //currentVersion = 1;
   }
   const long newVersion = currentVersion + 1;
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.cpp
@@ -210,7 +210,7 @@ void OsmMapReaderFactory::_read(const OsmMapPtr& map,
     }
   }
   VALIDATE(map->validate(true));
-  LOG_STATUS(
+  LOG_INFO(
     "Read " << StringUtils::formatLargeNumber(map->getElementCount()) <<
     " elements from input in: " << StringUtils::millisecondsToDhms(timer.elapsed()) << ".");
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.h
@@ -67,7 +67,7 @@ public:
 
   static void read(const std::shared_ptr<OsmMap>& map, const QString& url, bool useFileId = true,
                    Status defaultStatus = Status::Invalid);
-  //see note for createReader
+  // see note for createReader
   static void read(const std::shared_ptr<OsmMap>& map, bool useFileId, bool useFileStatus,
                    const QString& url);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapWriterFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapWriterFactory.cpp
@@ -148,7 +148,7 @@ void OsmMapWriterFactory::write(const std::shared_ptr<OsmMap>& map, const QStrin
     writer->open(url);
     // We could pass a progress in here to get more granular write status feedback.
     writer->write(map);
-    LOG_STATUS(
+    LOG_INFO(
       "Wrote " << StringUtils::formatLargeNumber(map->getElementCount()) <<
       " elements to output in: " << StringUtils::millisecondsToDhms(timer.elapsed()) << ".");
   }

--- a/hoot-core/src/main/cpp/hoot/core/ops/SearchRadiusCalculator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/SearchRadiusCalculator.cpp
@@ -173,7 +173,7 @@ std::vector<double> SearchRadiusCalculator::_getTiePointDistances(OsmMapPtr& map
   }
   catch (const HootException&)
   {
-    //unrecoverable error...we'll end up using the default search distance instead
+    // unrecoverable error...we'll end up using the default search distance instead
   }
   return tiePointDistances;
 }

--- a/hoot-core/src/main/cpp/hoot/core/ops/UnconnectedWaySnapper.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/UnconnectedWaySnapper.cpp
@@ -442,7 +442,7 @@ void UnconnectedWaySnapper::_createFeatureIndex(const ElementCriterionPtr& featu
                                                 std::deque<ElementId>& featureIndexToEid,
                                                 const ElementType& elementType)
 {
-  LOG_INFO("Creating feature index of type: " << elementType << "...");
+  LOG_DEBUG("Creating feature index of type: " << elementType << "...");
 
   // TODO: tune these indexes? - see #3054
   std::shared_ptr<Tgs::MemoryPageStore> mps(new Tgs::MemoryPageStore(728));

--- a/hoot-core/src/main/cpp/hoot/core/schema/OverwriteTagMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OverwriteTagMerger.cpp
@@ -45,9 +45,9 @@ OverwriteTagMerger::OverwriteTagMerger(bool swap)
 
 Tags OverwriteTagMerger::mergeTags(const Tags& t1, const Tags& t2, ElementType /*et*/) const
 {
-  LOG_VARD(_overwriteExcludeTagKeys);
-  LOG_VARD(_accumulateValuesTagKeys);
-  LOG_VARD(_caseSensitive);
+  LOG_VART(_overwriteExcludeTagKeys);
+  LOG_VART(_accumulateValuesTagKeys);
+  LOG_VART(_caseSensitive);
 
   if (_swap)
   {

--- a/hoot-core/src/main/cpp/hoot/core/util/DbUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/DbUtils.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2019 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2017, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "DbUtils.h"

--- a/hoot-core/src/main/cpp/hoot/core/util/DbUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/DbUtils.cpp
@@ -47,7 +47,7 @@ QSqlQuery DbUtils::execNoPrepare(const QSqlDatabase& database, const QString& sq
   if (q.exec(sql) == false)
   {
     throw HootException(
-      QString("Error executing query: %1 (%2)").arg(q.lastError().text().left(500)).arg(sql));
+      QString("Error executing query: %1 (%2)").arg(q.lastError().text().left(50)).arg(sql));
   }
   LOG_VART(q.numRowsAffected());
 

--- a/hoot-core/src/main/cpp/hoot/core/util/GeometryUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/GeometryUtils.h
@@ -147,6 +147,7 @@ public:
 
   /**
    * Creates a bounding rectangle within the specified map
+   *
    * @param map the map to insert the bounding rectangle in
    * @param bounds bounding box
    * @return ElementId of the way created

--- a/hoot-core/src/main/cpp/hoot/core/util/HootException.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/HootException.h
@@ -47,15 +47,10 @@ public:
   static std::string className() { return "hoot::HootException"; }
 
   HootException() { }
-
   HootException(const char* str) { _what = QString::fromUtf8(str); }
-
   HootException(const std::string& str) { _what = QString::fromStdString(str); }
-
   HootException(QString str) { _what = str; }
-
   HootException(const HootException& e) { _what = e._what; }
-
   virtual ~HootException() throw() {}
 
   virtual HootException* clone() const { return new HootException(*this); }
@@ -63,7 +58,6 @@ public:
   virtual std::string getClassName() const { return className(); }
 
   const QString& getWhat() const { return _what; }
-
   virtual const char* what() const throw() { _tmp = _what.toLatin1(); return _tmp.constData(); }
 
 private:
@@ -189,6 +183,7 @@ HOOT_DEFINE_EXCEPTION(InternalErrorException)
 HOOT_DEFINE_EXCEPTION(IoException)
 HOOT_DEFINE_EXCEPTION(NeedsReviewException)
 HOOT_DEFINE_EXCEPTION(UnsupportedException)
+HOOT_DEFINE_EXCEPTION_STR(RecursiveComplexityException, "RecursiveComplexityException")
 HOOT_DEFINE_EXCEPTION_STR(NotImplementedException, "Not Implemented")
 
 }

--- a/hoot-js/src/main/cpp/hoot/js/algorithms/subline-matching/SublineStringMatcherJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/algorithms/subline-matching/SublineStringMatcherJs.cpp
@@ -35,7 +35,6 @@
 #include <hoot/core/ops/CopyMapSubsetOp.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/Settings.h>
-#include <hoot/core/schema/MetadataTags.h>
 #include <hoot/js/JsRegistrar.h>
 #include <hoot/js/elements/OsmMapJs.h>
 #include <hoot/js/algorithms/linearreference/WaySublineMatchStringJs.h>

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/HighwaySnapMergerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/HighwaySnapMergerJs.cpp
@@ -29,7 +29,7 @@
 // hoot
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/conflate/highway/HighwayTagOnlyMerger.h>
-#include <hoot/core/conflate/river/RiverSnapMerger.h>
+#include <hoot/core/conflate/MultipleSublineMatcherSnapMerger.h>
 
 #include <hoot/js/JsRegistrar.h>
 #include <hoot/js/elements/OsmMapJs.h>
@@ -112,12 +112,12 @@ void HighwaySnapMergerJs::apply(const FunctionCallbackInfo<Value>& args)
   if (args.Length() > 5)
   {
     // This is little unusual, but we're allowing an extra subline matcher to be passed info for
-    // river conflation only and the actual one used will be determined based on the input data.
-    // See RiverSnapMerger for more info.
-    if (matchedBy != "Waterway")
+    // certain conflation types, and the actual one used will be determined based how the matcher
+    // performs against the input data. See WaySnapMerger for more info.
+    if (matchedBy != "Waterway" && matchedBy != "Line")
     {
       throw IllegalArgumentException(
-        "Only river merging allows passing in multiple subline matchers.");
+        "Only river or generic line merging allows passing in multiple subline matchers.");
     }
     sublineMatcher2 = toCpp<SublineStringMatcherPtr>(args[5]);
   }
@@ -130,10 +130,10 @@ void HighwaySnapMergerJs::apply(const FunctionCallbackInfo<Value>& args)
     // HighwayTagOnlyMerger inherits from HighwaySnapMerger, so this works.
     snapMerger.reset(new HighwayTagOnlyMerger(pairs, sublineMatcher));
   }
-  else if (matchedBy == "Waterway")
+  else if (matchedBy == "Waterway" || matchedBy == "Line")
   {
     // see note above about multiple subline matchers here
-    snapMerger.reset(new RiverSnapMerger(pairs, sublineMatcher, sublineMatcher2));
+    snapMerger.reset(new MultipleSublineMatcherSnapMerger(pairs, sublineMatcher, sublineMatcher2));
   }
   else
   {

--- a/hoot-js/src/main/cpp/hoot/js/elements/ElementJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/ElementJs.cpp
@@ -77,6 +77,8 @@ void ElementJs::_addBaseFunctions(Local<FunctionTemplate> tpl)
       FunctionTemplate::New(current, toString));
   tpl->PrototypeTemplate()->Set(String::NewFromUtf8(current, "toString"),
       FunctionTemplate::New(current, toString));
+  tpl->PrototypeTemplate()->Set(String::NewFromUtf8(current, "removeTag"),
+      FunctionTemplate::New(current, removeTag));
 }
 
 void ElementJs::getCircularError(const FunctionCallbackInfo<Value>& args)
@@ -264,6 +266,27 @@ void ElementJs::setTag(const FunctionCallbackInfo<Value>& args)
     const QString tagKey = toCpp<QString>(args[0]);
     const QString tagVal = toCpp<QString>(args[1]);
     e->setTag(tagKey, tagVal);
+    args.GetReturnValue().SetUndefined();
+  }
+}
+
+void ElementJs::removeTag(const FunctionCallbackInfo<Value>& args)
+{
+  Isolate* current = args.GetIsolate();
+  HandleScope scope(current);
+
+  ElementPtr e = ObjectWrap::Unwrap<ElementJs>(args.This())->getElement();
+  if (!e)
+  {
+    args.GetReturnValue().Set(
+      current->ThrowException(
+        HootExceptionJs::create(
+          IllegalArgumentException("Unable to remove tag on a const Element."))));
+  }
+  else
+  {
+    const QString tagKey = toCpp<QString>(args[0]);
+    e->removeTag(tagKey);
     args.GetReturnValue().SetUndefined();
   }
 }

--- a/hoot-js/src/main/cpp/hoot/js/elements/ElementJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/elements/ElementJs.h
@@ -75,6 +75,7 @@ protected:
   static void setStatusString(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void setTags(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void setTag(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void removeTag(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void toString(const v8::FunctionCallbackInfo<v8::Value>& args);
 
 private:

--- a/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.cpp
@@ -121,8 +121,6 @@ void OsmSchemaJs::Init(Handle<Object> exports)
               FunctionTemplate::New(current, hasName)->GetFunction());
   schema->Set(String::NewFromUtf8(current, "isSpecificallyConflatable"),
               FunctionTemplate::New(current, isSpecificallyConflatable)->GetFunction());
-  schema->Set(String::NewFromUtf8(current, "isLongRiverPair"),
-              FunctionTemplate::New(current, isLongRiverPair)->GetFunction());
 }
 
 void OsmSchemaJs::getAllTags(const FunctionCallbackInfo<Value>& args)
@@ -456,19 +454,6 @@ void OsmSchemaJs::mostSpecificType(const FunctionCallbackInfo<Value>& args)
   ConstElementPtr element = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject())->getConstElement();
   const QString kvp = OsmSchema::getInstance().mostSpecificType(element->getTags());
   args.GetReturnValue().Set(String::NewFromUtf8(current, kvp.toUtf8().data()));
-}
-
-void OsmSchemaJs::isLongRiverPair(const FunctionCallbackInfo<Value>& args)
-{
-  Isolate* current = args.GetIsolate();
-  HandleScope scope(current);
-
-  OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject());
-  ConstElementPtr e1 = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject())->getConstElement();
-  ConstElementPtr e2 = ObjectWrap::Unwrap<ElementJs>(args[2]->ToObject())->getConstElement();
-
-  args.GetReturnValue().Set(
-    Boolean::New(current, RiverSnapMerger().isLongPair(mapJs->getConstMap(), e1, e2)));
 }
 
 }

--- a/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.cpp
@@ -42,7 +42,6 @@
 #include <hoot/core/criterion/NonConflatableCriterion.h>
 #include <hoot/core/criterion/NonBuildingAreaCriterion.h>
 #include <hoot/core/criterion/CollectionRelationCriterion.h>
-#include <hoot/core/conflate/river/RiverSnapMerger.h>
 
 #include <hoot/js/elements/TagsJs.h>
 #include <hoot/js/JsRegistrar.h>

--- a/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.h
@@ -88,8 +88,6 @@ private:
   static void isSpecificallyConflatable(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static void hasName(const v8::FunctionCallbackInfo<v8::Value>& args);
-
-  static void isLongRiverPair(const v8::FunctionCallbackInfo<v8::Value>& args);
 };
 
 inline v8::Handle<v8::Value> toV8(const SchemaVertex& tv)

--- a/hoot-rnd/src/main/cpp/hoot/rnd/ops/RandomMapCropper.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/ops/RandomMapCropper.cpp
@@ -77,7 +77,6 @@ void RandomMapCropper::setTileFootprintOutputPath(QString path)
 
 void RandomMapCropper::apply(OsmMapPtr& map)
 {
-  //LOG_VARD(_maxNodeCount);
   if (_maxNodeCount < 1 || _maxNodeCount > (int)map->size())
   {
     throw IllegalArgumentException("Invalid max node count: " + _maxNodeCount);

--- a/rules/River.js
+++ b/rules/River.js
@@ -30,7 +30,7 @@ var sublineMatcher = // default subline matcher
   new hoot.MaximalSublineStringMatcher(
     { "way.matcher.max.angle": hoot.get("waterway.matcher.max.angle"),
       "way.subline.matcher": sublineMatcherName,
-      "maximal.subline.max.recursive.complexity": hoot.get("waterway.maximal.subline.max.recursive.complexity")/*50*/ });
+      "maximal.subline.max.recursive.complexity": hoot.get("waterway.maximal.subline.max.recursive.complexity") });
 var frechetSublineMatcher = // we'll switch over to this one if the default matcher runs too slowly
   new hoot.MaximalSublineStringMatcher(
     { "way.matcher.max.angle": hoot.get("waterway.matcher.max.angle"),
@@ -158,7 +158,7 @@ function geometryMismatch(map, e1, e2)
     // If receive the specfic string above from the matching routine, we know our subline matcher
     // hit the cap on the number of recursive calls we allow for it 
     // (see waterway.maximal.subline.max.recursive.complexity above; A little kludgy, but not sure 
-    // how to handle hoot exceptions in a js script at this point). So now we'll try a backup matcher
+    // how to handle hoot exceptions in a js script at this point). So, now we'll try a backup matcher
     // that may be a little less accurate but much faster. Previously tried tweaking the configuration 
     // of MaximalSublineMatcher for performance instead of using this approach, but it didn't help.
     hoot.trace("Extracting sublines with Frechet...");
@@ -274,7 +274,7 @@ exports.mergeSets = function(map, pairs, replaced)
   // original subline matcher used during matching, pass in both of the possible subline matchers 
   // that could have been used and use the same internal core logic that was used during matching to 
   // determine which one to use now.
-  return snapRivers(sublineMatcher, map, pairs, replaced, exports.baseFeatureType, frechetSublineMatcher);
+  return snapWays2(sublineMatcher, map, pairs, replaced, exports.baseFeatureType, frechetSublineMatcher);
 };
 
 exports.getMatchFeatureDetails = function(map, e1, e2)

--- a/rules/River.js
+++ b/rules/River.js
@@ -161,7 +161,7 @@ function geometryMismatch(map, e1, e2)
     // how to handle hoot exceptions in a js script at this point). So now we'll try a backup matcher
     // that may be a little less accurate but much faster. Previously tried tweaking the configuration 
     // of MaximalSublineMatcher for performance instead of using this approach, but it didn't help.
-    hoot.debug("Extracting sublines with Frechet...");
+    hoot.trace("Extracting sublines with Frechet...");
     sublines = frechetSublineMatcher.extractMatchingSublines(map, e1, e2);
   }
 

--- a/rules/lib/HootLib.js
+++ b/rules/lib/HootLib.js
@@ -386,9 +386,9 @@ function snapWays(sublineMatcher, map, pairs, replaced, matchedBy)
 }
 
 /**
- * Merges rivers together
+ * Another approach to snapping ways, which allows for using multiple subline matchers. See notes in ?
  */
-function snapRivers(sublineMatcher, map, pairs, replaced, matchedBy, sublineMatcher2)
+function snapWays2(sublineMatcher, map, pairs, replaced, matchedBy, sublineMatcher2)
 {
   return new hoot.HighwaySnapMerger().apply(sublineMatcher, map, pairs, replaced, matchedBy, sublineMatcher2);
 }

--- a/rules/lib/HootLib.js
+++ b/rules/lib/HootLib.js
@@ -394,14 +394,6 @@ function snapRivers(sublineMatcher, map, pairs, replaced, matchedBy, sublineMatc
 }
 
 /**
- * Determines if a river is considered "long" by River Conflation standards
- */
-function isLongRiverPair(map, e1, e2)
-{
-  return hoot.OsmSchema.isLongRiverPair(map, e1, e2);
-}
-
-/**
  * Uses the SearchRadiusCalculator to automatically calculate a search radius based on tie points found
  * in the two input datasets.
  *

--- a/test-files/cmd/glacial/serial/ServiceChangesetReplacementAdjacentCellsTest.sh.off
+++ b/test-files/cmd/glacial/serial/ServiceChangesetReplacementAdjacentCellsTest.sh.off
@@ -5,16 +5,16 @@ set -e
 # won't work unless you use the two osmapidb bulk inserter options specified (#4171).
 
 # southern task 52
-test-files/cmd/glacial/serial/ServiceChangesetReplacement.sh.off "ServiceChangesetReplacementAdjacentGridsTest-south" "/home/vagrant/hoot/tmp/4158/SouthernTask52/task_52_inputdata/NOME_d5a6dc.osm" "/home/vagrant/hoot/tmp/4158/SouthernTask52/task_52_inputdata/OSM_d5a6dc.osm" "-115.048828,36.244273,-115.004883,36.279709" "-180,-90,180,90" "true" "lenient" "" "" "false" "" "" "" "" "xml" "5.0" "0.5" "true" "true" "true" "-D osmapidb.bulk.inserter.reserve.record.ids.before.writing.data=true -D apidb.bulk.inserter.validate.data=true"
+test-files/cmd/glacial/serial/ServiceChangesetReplacement.sh.off "ServiceChangesetReplacementAdjacentCellsTest-south" "/home/vagrant/hoot/tmp/4158/SouthernTask52/task_52_inputdata/NOME_d5a6dc.osm" "/home/vagrant/hoot/tmp/4158/SouthernTask52/task_52_inputdata/OSM_d5a6dc.osm" "-115.048828,36.244273,-115.004883,36.279709" "-180,-90,180,90" "true" "lenient" "" "" "false" "" "" "" "" "xml" "5.0" "0.5" "true" "true" "true" "-D osmapidb.bulk.inserter.reserve.record.ids.before.writing.data=true -D apidb.bulk.inserter.validate.data=true"
 
 # northern task 53
-test-files/cmd/glacial/serial/ServiceChangesetReplacement.sh.off "ServiceChangesetReplacementAdjacentGridsTest-north" "/home/vagrant/hoot/tmp/4158/NorthernTask53/NOME_849248_OSM_849248/NOME_849248.osm" "/home/vagrant/hoot/tmp/4158/NorthernTask53/NOME_849248_OSM_849248/OSM_849248.osm" "-115.048828,36.279707,-115.004883,36.315127" "-180,-90,180,90" "true" "lenient" "" "" "false" "" "" "" "" "xml" "5.0" "0.5" "true" "true" "false" "-D osmapidb.bulk.inserter.reserve.record.ids.before.writing.data=true -D apidb.bulk.inserter.validate.data=true"
+test-files/cmd/glacial/serial/ServiceChangesetReplacement.sh.off "ServiceChangesetReplacementAdjacentCellsTest-north" "/home/vagrant/hoot/tmp/4158/NorthernTask53/NOME_849248_OSM_849248/NOME_849248.osm" "/home/vagrant/hoot/tmp/4158/NorthernTask53/NOME_849248_OSM_849248/OSM_849248.osm" "-115.048828,36.279707,-115.004883,36.315127" "-180,-90,180,90" "true" "lenient" "" "" "false" "" "" "" "" "xml" "5.0" "0.5" "true" "true" "false" "-D osmapidb.bulk.inserter.reserve.record.ids.before.writing.data=true -D apidb.bulk.inserter.validate.data=true"
 
 # read out both cells
 source conf/database/DatabaseConfig.sh
 export OSM_API_DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
 export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
-COMBINED_OUT_DIR=test-output/cmd/glacial/serial/ServiceChangesetReplacementAdjacentGridsTest-combined
+COMBINED_OUT_DIR=test-output/cmd/glacial/serial/ServiceChangesetReplacementAdjacentCellsTest-combined
 mkdir -p $COMBINED_OUT_DIR
 hoot convert --status -C UnifyingAlgorithm.conf -C Testing.conf -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D convert.bounding.box.remove.missing.elements=false -D log.warnings.for.missing.elements=false -D debug.maps.write=false -D debug.maps.remove.missing.elements=true -D element.hash.visitor.non.metadata.ignore.keys=note -D osmapidb.bulk.inserter.reserve.record.ids.before.writing.data=true -D apidb.bulk.inserter.validate.data=true -D log.class.filter="" -D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1 -D changeset.max.size=999999 -D convert.ops="hoot::RemoveMissingElementsVisitor" -D debug.maps.filename=$COMBINED_OUT_DIR/final-write-xml.osm $OSM_API_DB_URL $COMBINED_OUT_DIR/ServiceChangesetReplacementAdjacentGridsTest-replaced-combined.osm

--- a/test-files/cmd/slow/ConflateCmdStatsGenericRiversTest.sh.stdout
+++ b/test-files/cmd/slow/ConflateCmdStatsGenericRiversTest.sh.stdout
@@ -1,28 +1,28 @@
-21:34:51.194 INFO   ...ore/io/OsmMapReaderFactory.cpp( 171) Loading map from ...d/slow/ConflateCmdStatsTest/generic-rivers-out.osm...
-21:34:51.196 INFO   .../hoot/core/io/OsmXmlReader.cpp( 890) Read 0 elements from input.        21:34:51.196 INFO   .../hoot/core/io/OsmXmlReader.cpp( 890) Read 0 elements from input.        21:34:51.232 INFO   .../hoot/core/io/OsmXmlReader.cpp( 476) 	Reporting missing elements...
-21:34:51.233 STATUS ...ore/io/OsmMapReaderFactory.cpp( 203) Read 461 elements from input in: 00:00.
-21:34:51.233 INFO   ...ore/io/OsmMapReaderFactory.cpp( 171) Loading map from ...d/slow/ConflateCmdStatsTest/generic-rivers-out.osm...
-21:34:51.235 INFO   .../hoot/core/io/OsmXmlReader.cpp( 890) Read 0 elements from input.        21:34:51.235 INFO   .../hoot/core/io/OsmXmlReader.cpp( 890) Read 0 elements from input.        21:34:51.265 INFO   .../hoot/core/io/OsmXmlReader.cpp( 476) 	Reporting missing elements...
-21:34:51.266 STATUS ...ore/io/OsmMapReaderFactory.cpp( 203) Read 461 elements from input in: 00:00.
-21:34:51.271 STATUS .../cpp/hoot/core/cmd/DiffCmd.cpp( 145) Map difference calculated in 00:00 total.
+18:14:23.161 INFO   ...ore/io/OsmMapReaderFactory.cpp( 171) Loading map from ...d/slow/ConflateCmdStatsTest/generic-rivers-out.osm...
+18:14:23.163 INFO   .../hoot/core/io/OsmXmlReader.cpp( 890) Read 0 elements from input.        18:14:23.163 INFO   .../hoot/core/io/OsmXmlReader.cpp( 890) Read 0 elements from input.        18:14:23.180 INFO   .../hoot/core/io/OsmXmlReader.cpp( 476) 	Reporting missing elements...
+18:14:23.180 INFO   ...ore/io/OsmMapReaderFactory.cpp( 215) Read 451 elements from input in: 00:00.
+18:14:23.180 INFO   ...ore/io/OsmMapReaderFactory.cpp( 171) Loading map from ...d/slow/ConflateCmdStatsTest/generic-rivers-out.osm...
+18:14:23.181 INFO   .../hoot/core/io/OsmXmlReader.cpp( 890) Read 0 elements from input.        18:14:23.181 INFO   .../hoot/core/io/OsmXmlReader.cpp( 890) Read 0 elements from input.        18:14:23.196 INFO   .../hoot/core/io/OsmXmlReader.cpp( 476) 	Reporting missing elements...
+18:14:23.196 INFO   ...ore/io/OsmMapReaderFactory.cpp( 215) Read 451 elements from input in: 00:00.
+18:14:23.200 STATUS .../cpp/hoot/core/cmd/DiffCmd.cpp( 145) Map difference calculated in 00:00 total.
 stats = (stat) OR (input map 1 stat) (input map 2 stat) (output map stat)
-Nodes	338	176	407	
-Ways	14	15	52	
+Nodes	338	176	408	
+Ways	14	15	41	
 Relations	0	0	2	
 Least Nodes in a Way	3	2	2	
 Most Nodes in a Way	66	26	68	
-Average Nodes Per Way	24	12	9	
-Total Way Nodes	348	187	488	
+Average Nodes Per Way	24	12	11	
+Total Way Nodes	348	187	466	
 Least Members in a Relation	0	0	2	
 Most Members in a Relation	0	0	3	
 Average Members Per Relation	0	0	2	
 Total Relation Members	0	0	5	
 Least Tags on a Feature	4	3	3	
 Most Tags on a Feature	6	4	9	
-Average Tags Per Feature	5	3	4	
+Average Tags Per Feature	5	3	5	
 Least Information Tags on a Feature	3	3	3	
 Most Information Tags on a Feature	5	4	8	
-Average Information Tags Per Feature	4.142857142857143	3.133333333333333	4.627450980392157	
+Average Information Tags Per Feature	4.142857142857143	3.133333333333333	5.075	
 Features with Names	4	2	17	
 Bridges	0	0	0	
 Tunnels	0	0	0	
@@ -44,7 +44,7 @@ Features with Addresses	0	0	0
 Total Addresses	0	0	0	
 Features with Phone Numbers	0	0	0	
 Total Phone Numbers	0	0	0	
-Total Features	14	15	51	
+Total Features	14	15	40	
 Total Conflatable Features	14	15	0	
 Percentage of Total Features Conflatable	100	100	0	
 Untagged Features	0	0	0	
@@ -53,12 +53,12 @@ Percentage of Total Features Unconflatable	0	0	0
 Match Creators	1	1	1	
 Features Conflatable by: hoot::ScriptMatchCreator,River.js	14	15	0	
 Total Conflated Features	0	0	11	
-Percentage of Total Features Conflated	0	0	21.56862745098039	
+Percentage of Total Features Conflated	0	0	27.5	
 Total Features Marked for Review	0	0	0	
 Percentage of Total Features Marked for Review	0	0	0	
 Total Reviews to be Made	0	0	0	
-Total Unmatched Features	14	15	40	
-Percentage of Total Features Unmatched	100	100	78.43137254901961	
+Total Unmatched Features	14	15	29	
+Percentage of Total Features Unmatched	100	100	72.5	
 POIs	0	0	0	
 Conflatable POIs	0	0	0	
 Conflated POIs	0	0	0	
@@ -86,16 +86,16 @@ Unmatched Buildings	0	0	0
 Percentage of Buildings Conflated	0	0	0	
 Percentage of Buildings Marked for Review	0	0	0	
 Percentage of Unmatched Buildings	0	0	0	
-Waterways	14	15	49	
+Waterways	14	15	38	
 Conflatable Waterways	14	15	0	
 Conflated Waterways	0	0	11	
 Waterways Marked for Review	0	0	0	
 Waterway Reviews to be Made	0	0	0	
-Unmatched Waterways	14	15	38	
+Unmatched Waterways	14	15	27	
 Meters of Waterway Processed by Conflation	0	0	11178.11346457614	
-Percentage of Waterways Conflated	0	0	22.44897959183674	
+Percentage of Waterways Conflated	0	0	28.94736842105263	
 Percentage of Waterways Marked for Review	0	0	0	
-Percentage of Unmatched Waterways	100	100	77.55102040816327	
+Percentage of Unmatched Waterways	100	100	71.05263157894737	
 Polygon Conflatable POIs	0	0	0	
 Conflatable Polygon Conflatable POIs	0	0	0	
 Conflated Polygon Conflatable POIs	0	0	0	
@@ -153,16 +153,16 @@ Unmatched Points	0	0	0
 Percentage of Points Conflated	0	0	0	
 Percentage of Points Marked for Review	0	0	0	
 Percentage of Unmatched Points	0	0	0	
-Lines	14	15	51	
+Lines	14	15	40	
 Conflatable Lines	0	0	0	
 Conflated Lines	0	0	11	
 Lines Marked for Review	0	0	0	
 Line Reviews to be Made	0	0	0	
-Unmatched Lines	14	15	40	
+Unmatched Lines	14	15	29	
 Meters of Line Processed by Conflation	0	0	11178.11346457614	
-Percentage of Lines Conflated	0	0	21.56862745098039	
+Percentage of Lines Conflated	0	0	27.5	
 Percentage of Lines Marked for Review	0	0	0	
-Percentage of Unmatched Lines	100	100	78.43137254901961	
+Percentage of Unmatched Lines	100	100	72.5	
 Collection Relations	0	0	2	
 Conflatable Collection Relations	0	0	0	
 Conflated Collection Relations	0	0	0	
@@ -173,13 +173,13 @@ Meters Squared of Collection Relations Processed by Conflation	0	0	0
 Percentage of Collection Relations Conflated	0	0	0	
 Percentage of Collection Relations Marked for Review	0	0	0	
 Percentage of Unmatched Collection Relations	0	0	100	
-Translated Populated Tags	14	107	390	
-Difference Between Total Features in Output and Total Features in Inputs			22	
-Percentage Difference Between Total Features in Output and Total Features in Inputs			75.86206896551724	
-Calculate Stats for Input 1 Time (sec)				9.368013858795166
-Calculate Stats for Input 2 Time (sec)				0.9662771224975586
-Apply Pre-Conflate Ops Time (sec)				0.03362679481506348
-Apply Post-Conflate Ops Time (sec)				0.02557897567749023
-Calculate Stats for Output Time (sec)				1.019593000411987
+Translated Populated Tags	14	107	313	
+Difference Between Total Features in Output and Total Features in Inputs			11	
+Percentage Difference Between Total Features in Output and Total Features in Inputs			37.93103448275862	
+Calculate Stats for Input 1 Time (sec)				8.90753698348999
+Calculate Stats for Input 2 Time (sec)				0.9806530475616455
+Apply Pre-Conflate Ops Time (sec)				0.0322258472442627
+Apply Post-Conflate Ops Time (sec)				0.04191303253173828
+Calculate Stats for Output Time (sec)				1.013443946838379
 
-21:34:50.731 STATUS ...pp/hoot/core/util/Progress.cpp(  85) Conflate (100%): Conflation job completed in 00:12 for reference map: ...NIGS_Rivers_REF1-cropped-2.osm and secondary map: ...waterway_ss_REF2-cropped-2.osm and written to output: ...atsTest/generic-rivers-out.osm
+18:14:22.716 STATUS ...pp/hoot/core/util/Progress.cpp(  85) Conflate (100%): Conflation job completed in 00:11 for reference map: ...NIGS_Rivers_REF1-cropped-2.osm and secondary map: ...waterway_ss_REF2-cropped-2.osm and written to output: ...atsTest/generic-rivers-out.osm

--- a/test-files/cmd/slow/ConflateCmdStatsTest/generic-rivers-out.osm
+++ b/test-files/cmd/slow/ConflateCmdStatsTest/generic-rivers-out.osm
@@ -1,73 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326" schema="TDSv61">
     <bounds minlat="19.6980449" minlon="-73.4219114" maxlat="19.73796707204734" maxlon="-73.38699879999999"/>
-    <node visible="true" id="-480066" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.6994991760221616" lon="-73.3933846980588669">
+    <node visible="true" id="-479945" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.6994991760221616" lon="-73.3933846980588669">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-480066"/>
+        <tag k="hoot:id" v="-479945"/>
     </node>
-    <node visible="true" id="-480058" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7279836325002762" lon="-73.4089407582260662">
+    <node visible="true" id="-479940" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7274595926663601" lon="-73.3932290620836056">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-480058"/>
+        <tag k="hoot:id" v="-479940"/>
     </node>
-    <node visible="true" id="-480052" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7274595926663601" lon="-73.3932290620836056">
+    <node visible="true" id="-479933" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7030752505836766" lon="-73.3982112141141840">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-480052"/>
+        <tag k="hoot:id" v="-479933"/>
     </node>
-    <node visible="true" id="-480045" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7030752505836766" lon="-73.3982112141141840">
+    <node visible="true" id="-479931" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7124219918126649" lon="-73.4112052584136165">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-480045"/>
+        <tag k="hoot:id" v="-479931"/>
     </node>
-    <node visible="true" id="-480043" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7124219918126649" lon="-73.4112052584136165">
+    <node visible="true" id="-479924" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7304297416032668" lon="-73.4020398532708498">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-480043"/>
+        <tag k="hoot:id" v="-479924"/>
     </node>
-    <node visible="true" id="-480036" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7304297416032668" lon="-73.4020398532708498">
+    <node visible="true" id="-479916" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7170062380533295" lon="-73.4084258301079302">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-480036"/>
+        <tag k="hoot:id" v="-479916"/>
     </node>
-    <node visible="true" id="-480028" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7186775252212172" lon="-73.3972667928966871">
+    <node visible="true" id="-479915" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7213854495491958" lon="-73.4074200710885520">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-480028"/>
+        <tag k="hoot:id" v="-479915"/>
     </node>
-    <node visible="true" id="-480027" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7236511670933012" lon="-73.3945854314300448">
+    <node visible="true" id="-479914" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7236015318273132" lon="-73.4069399501377262">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-480027"/>
+        <tag k="hoot:id" v="-479914"/>
     </node>
-    <node visible="true" id="-480022" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7170062380533295" lon="-73.4084258301079302">
+    <node visible="true" id="-479912" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7276055282247178" lon="-73.4057729792037748">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-480022"/>
+        <tag k="hoot:id" v="-479912"/>
     </node>
-    <node visible="true" id="-480021" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7213854495491958" lon="-73.4074200710885520">
+    <node visible="true" id="-479911" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7266701088075713" lon="-73.4061323805427577">
         <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-480021"/>
-    </node>
-    <node visible="true" id="-480020" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7236015318273132" lon="-73.4069399501377262">
-        <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-480020"/>
-    </node>
-    <node visible="true" id="-480018" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7276055282247178" lon="-73.4057729792037748">
-        <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-480018"/>
-    </node>
-    <node visible="true" id="-480017" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7266701088075713" lon="-73.4061323805427577">
-        <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-480017"/>
-    </node>
-    <node visible="true" id="-480000" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7169843160962621" lon="-73.4150386842183309">
-        <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-480000"/>
-    </node>
-    <node visible="true" id="-479999" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7145746641901241" lon="-73.4173728418958973">
-        <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-479999"/>
-    </node>
-    <node visible="true" id="-479998" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7217388443527888" lon="-73.4105866149356103">
-        <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-479998"/>
-    </node>
-    <node visible="true" id="-479997" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7248637092459624" lon="-73.4099459752040531">
-        <tag k="hoot:status" v="1"/>
-        <tag k="hoot:id" v="-479997"/>
+        <tag k="hoot:id" v="-479911"/>
     </node>
     <node visible="true" id="-479744" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7379670720473399" lon="-73.4010317258709790">
         <tag k="hoot:status" v="2"/>
@@ -89,6 +61,10 @@
         <tag k="hoot:status" v="2"/>
         <tag k="hoot:id" v="-479733"/>
     </node>
+    <node visible="true" id="-479732" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7099604091077616" lon="-73.4022592995623882">
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="-479732"/>
+    </node>
     <node visible="true" id="-479731" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7226142047099664" lon="-73.4076015942581108">
         <tag k="hoot:status" v="2"/>
         <tag k="hoot:id" v="-479731"/>
@@ -109,6 +85,10 @@
         <tag k="hoot:status" v="2"/>
         <tag k="hoot:id" v="-479722"/>
     </node>
+    <node visible="true" id="-479720" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7265912417800351" lon="-73.4086026451352041">
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="-479720"/>
+    </node>
     <node visible="true" id="-479717" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7289893386070183" lon="-73.4070888926443956">
         <tag k="hoot:status" v="2"/>
         <tag k="hoot:id" v="-479717"/>
@@ -120,6 +100,10 @@
     <node visible="true" id="-479713" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7371380378382320" lon="-73.3944494515571648">
         <tag k="hoot:status" v="2"/>
         <tag k="hoot:id" v="-479713"/>
+    </node>
+    <node visible="true" id="-479709" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7161853620274776" lon="-73.4000756883653196">
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="-479709"/>
     </node>
     <node visible="true" id="-479704" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7200183615178410" lon="-73.3971540543445684">
         <tag k="hoot:status" v="2"/>
@@ -145,6 +129,10 @@
         <tag k="hoot:status" v="2"/>
         <tag k="hoot:id" v="-479684"/>
     </node>
+    <node visible="true" id="-479683" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7236451531296844" lon="-73.3945879245015362">
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="-479683"/>
+    </node>
     <node visible="true" id="-479678" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7181665843241696" lon="-73.4149431073827827">
         <tag k="hoot:status" v="2"/>
         <tag k="hoot:id" v="-479678"/>
@@ -168,6 +156,10 @@
     <node visible="true" id="-479668" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7236335132776048" lon="-73.4070848198715993">
         <tag k="hoot:status" v="2"/>
         <tag k="hoot:id" v="-479668"/>
+    </node>
+    <node visible="true" id="-479664" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7249631923574711" lon="-73.4101408797990018">
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="-479664"/>
     </node>
     <node visible="true" id="-479662" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7298651085950816" lon="-73.4041429546084316">
         <tag k="hoot:status" v="2"/>
@@ -205,6 +197,10 @@
         <tag k="hoot:status" v="2"/>
         <tag k="hoot:id" v="-479629"/>
     </node>
+    <node visible="true" id="-479627" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7217443994541242" lon="-73.4105988323422167">
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="-479627"/>
+    </node>
     <node visible="true" id="-479625" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7097240007310646" lon="-73.3967626082888671">
         <tag k="hoot:status" v="2"/>
         <tag k="hoot:id" v="-479625"/>
@@ -221,6 +217,10 @@
         <tag k="hoot:status" v="2"/>
         <tag k="hoot:id" v="-479618"/>
     </node>
+    <node visible="true" id="-479616" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7281472183186750" lon="-73.4089341238693720">
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="-479616"/>
+    </node>
     <node visible="true" id="-479615" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7034507580082412" lon="-73.3882964410185821">
         <tag k="hoot:status" v="2"/>
         <tag k="hoot:id" v="-479615"/>
@@ -233,13 +233,13 @@
         <tag k="hoot:status" v="2"/>
         <tag k="hoot:id" v="-479611"/>
     </node>
-    <node visible="true" id="-479609" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7245759168708155" lon="-73.3939286502971129">
-        <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-479609"/>
-    </node>
     <node visible="true" id="-479607" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7360148110154796" lon="-73.4016456358886984">
         <tag k="hoot:status" v="2"/>
         <tag k="hoot:id" v="-479607"/>
+    </node>
+    <node visible="true" id="-479606" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7143641832959347" lon="-73.4002195383174438">
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="-479606"/>
     </node>
     <node visible="true" id="-479603" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7187381535356785" lon="-73.3975119434570331">
         <tag k="hoot:status" v="2"/>
@@ -260,6 +260,10 @@
     <node visible="true" id="-479582" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7170018156522033" lon="-73.4083667028120459">
         <tag k="hoot:status" v="2"/>
         <tag k="hoot:id" v="-479582"/>
+    </node>
+    <node visible="true" id="-479577" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7170607938462297" lon="-73.4151999571369487">
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:id" v="-479577"/>
     </node>
     <node visible="true" id="-479576" timestamp="1970-01-01T00:00:00Z" version="1" lat="19.7335390369078922" lon="-73.3927354659950595">
         <tag k="hoot:status" v="2"/>
@@ -1629,7 +1633,7 @@
         <tag k="hoot:status" v="1"/>
         <tag k="hoot:id" v="-10142"/>
     </node>
-    <way visible="true" id="-13400" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13279" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-479561"/>
         <nd ref="-477660"/>
         <nd ref="-479562"/>
@@ -1637,7 +1641,7 @@
         <tag k="source" v="CNIGS"/>
         <tag k="hoot:status" v="3"/>
         <tag k="river_type" v="secondary"/>
-        <tag k="hoot:id" v="-13400"/>
+        <tag k="hoot:id" v="-13279"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF1" v="000042"/>
         <tag k="REF2" v="000042"/>
@@ -1645,7 +1649,7 @@
         <tag k="intermittent" v="yes"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13399" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13278" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-391135"/>
         <nd ref="-479722"/>
         <nd ref="-479661"/>
@@ -1653,23 +1657,23 @@
         <nd ref="-479716"/>
         <nd ref="-479741"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13399"/>
+        <tag k="hoot:id" v="-13278"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="0010da"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13398" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13277" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-391141"/>
-        <nd ref="-480066"/>
+        <nd ref="-479945"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13398"/>
+        <tag k="hoot:id" v="-13277"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="0010da"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13394" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13273" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-479563"/>
         <nd ref="-391126"/>
         <nd ref="-391127"/>
@@ -1685,7 +1689,7 @@
         <nd ref="-391137"/>
         <nd ref="-391138"/>
         <nd ref="-391139"/>
-        <nd ref="-480066"/>
+        <nd ref="-479945"/>
         <nd ref="-391140"/>
         <nd ref="-391141"/>
         <nd ref="-479564"/>
@@ -1694,7 +1698,7 @@
         <tag k="hoot:status" v="1"/>
         <tag k="name" v="Ravine Solage"/>
         <tag k="river_type" v="secondary"/>
-        <tag k="hoot:id" v="-13394"/>
+        <tag k="hoot:id" v="-13273"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF1" v="0010da"/>
         <tag k="REF2" v="0010da"/>
@@ -1702,50 +1706,31 @@
         <tag k="intermittent" v="yes"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13391" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-185983"/>
+    <way visible="true" id="-13270" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-185976"/>
+        <nd ref="-479616"/>
         <nd ref="-479717"/>
-        <nd ref="-185986"/>
+        <nd ref="-185987"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13391"/>
+        <tag k="hoot:id" v="-13270"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="001f4a"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13390" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-480058"/>
-        <nd ref="-185982"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13390"/>
-        <tag k="waterway" v="stream"/>
-        <tag k="REF2" v="001f4a"/>
-        <tag k="z_order" v="0"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-13389" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-185968"/>
-        <nd ref="-479675"/>
-        <nd ref="-185969"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13389"/>
-        <tag k="waterway" v="stream"/>
-        <tag k="REF2" v="001f4a"/>
-        <tag k="z_order" v="0"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-13388" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-185966"/>
+    <way visible="true" id="-13269" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-185965"/>
         <nd ref="-479574"/>
-        <nd ref="-185967"/>
+        <nd ref="-479675"/>
+        <nd ref="-185970"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13388"/>
+        <tag k="hoot:id" v="-13269"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="001f4a"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13375" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13263" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-479566"/>
         <nd ref="-185958"/>
         <nd ref="-185959"/>
@@ -1770,7 +1755,6 @@
         <nd ref="-185978"/>
         <nd ref="-185979"/>
         <nd ref="-185980"/>
-        <nd ref="-480058"/>
         <nd ref="-185981"/>
         <nd ref="-185982"/>
         <nd ref="-185983"/>
@@ -1782,7 +1766,7 @@
         <tag k="river_flow" v="temporary"/>
         <tag k="hoot:status" v="1"/>
         <tag k="river_type" v="secondary"/>
-        <tag k="hoot:id" v="-13375"/>
+        <tag k="hoot:id" v="-13263"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF1" v="001f4a"/>
         <tag k="REF2" v="001f4a"/>
@@ -1790,7 +1774,7 @@
         <tag k="intermittent" v="yes"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13373" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13254" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-77198"/>
         <nd ref="-479576"/>
         <nd ref="-479677"/>
@@ -1799,37 +1783,37 @@
         <nd ref="-479743"/>
         <tag k="hoot:status" v="2"/>
         <tag k="name" v="Ravine Christ"/>
-        <tag k="hoot:id" v="-13373"/>
+        <tag k="hoot:id" v="-13254"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="002876"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13372" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13253" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-77203"/>
         <nd ref="-479684"/>
         <nd ref="-479618"/>
         <nd ref="-77199"/>
         <tag k="hoot:status" v="2"/>
         <tag k="name" v="Ravine Christ"/>
-        <tag k="hoot:id" v="-13372"/>
+        <tag k="hoot:id" v="-13253"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="002876"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13371" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-480052"/>
+    <way visible="true" id="-13252" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-479940"/>
         <nd ref="-77204"/>
         <tag k="hoot:status" v="2"/>
         <tag k="name" v="Ravine Christ"/>
-        <tag k="hoot:id" v="-13371"/>
+        <tag k="hoot:id" v="-13252"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="002876"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13358" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13239" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-170479"/>
         <nd ref="-170480"/>
         <nd ref="-170481"/>
@@ -1849,7 +1833,7 @@
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Ravine Pichomblaise"/>
         <tag k="river_type" v="secondary"/>
-        <tag k="hoot:id" v="-13358"/>
+        <tag k="hoot:id" v="-13239"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF1" v="0020fa"/>
         <tag k="REF2" v="0020fa"/>
@@ -1857,7 +1841,7 @@
         <tag k="intermittent" v="yes"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13357" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13238" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-302250"/>
         <nd ref="-479697"/>
         <nd ref="-479638"/>
@@ -1868,50 +1852,49 @@
         <nd ref="-479744"/>
         <tag k="hoot:status" v="2"/>
         <tag k="name" v="Ravine Pichomblaise"/>
-        <tag k="hoot:id" v="-13357"/>
+        <tag k="hoot:id" v="-13238"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="001952"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13356" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13237" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-302247"/>
         <nd ref="-479662"/>
         <nd ref="-302249"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13356"/>
+        <tag k="hoot:id" v="-13237"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13349" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13230" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-77216"/>
-        <nd ref="-480027"/>
-        <nd ref="-479609"/>
+        <nd ref="-479683"/>
         <nd ref="-77213"/>
         <tag k="hoot:status" v="2"/>
         <tag k="name" v="Ravine Christ"/>
-        <tag k="hoot:id" v="-13349"/>
+        <tag k="hoot:id" v="-13230"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="002876"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13348" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13229" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-77237"/>
         <nd ref="-479625"/>
         <nd ref="-479725"/>
         <nd ref="-77232"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13348"/>
+        <tag k="hoot:id" v="-13229"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13347" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13228" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-77249"/>
-        <nd ref="-480045"/>
+        <nd ref="-479933"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13347"/>
+        <tag k="hoot:id" v="-13228"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13341" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13222" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-479568"/>
         <nd ref="-77191"/>
         <nd ref="-77192"/>
@@ -1929,7 +1912,7 @@
         <nd ref="-77204"/>
         <nd ref="-77205"/>
         <nd ref="-77206"/>
-        <nd ref="-480052"/>
+        <nd ref="-479940"/>
         <nd ref="-77207"/>
         <nd ref="-77208"/>
         <nd ref="-77209"/>
@@ -1971,7 +1954,7 @@
         <nd ref="-77245"/>
         <nd ref="-77246"/>
         <nd ref="-77247"/>
-        <nd ref="-480045"/>
+        <nd ref="-479933"/>
         <nd ref="-77248"/>
         <nd ref="-77249"/>
         <nd ref="-77250"/>
@@ -1985,7 +1968,7 @@
         <tag k="hoot:status" v="1"/>
         <tag k="name" v="Ravine Christ"/>
         <tag k="river_type" v="secondary"/>
-        <tag k="hoot:id" v="-13341"/>
+        <tag k="hoot:id" v="-13222"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF1" v="002876"/>
         <tag k="REF2" v="002876"/>
@@ -1993,17 +1976,17 @@
         <tag k="intermittent" v="yes"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13337" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-480043"/>
+    <way visible="true" id="-13218" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-479931"/>
         <nd ref="-170472"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13337"/>
+        <tag k="hoot:id" v="-13218"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="000766"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13332" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13213" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-363529"/>
         <nd ref="-363530"/>
         <nd ref="-363531"/>
@@ -2015,7 +1998,7 @@
         <tag k="source" v="CNIGS"/>
         <tag k="hoot:status" v="3"/>
         <tag k="river_type" v="secondary"/>
-        <tag k="hoot:id" v="-13332"/>
+        <tag k="hoot:id" v="-13213"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF1" v="00165b"/>
         <tag k="REF2" v="00165b"/>
@@ -2023,7 +2006,7 @@
         <tag k="intermittent" v="yes"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13330" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13211" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-355324"/>
         <nd ref="-355325"/>
         <nd ref="-355326"/>
@@ -2035,7 +2018,7 @@
         <tag k="source" v="CNIGS"/>
         <tag k="hoot:status" v="3"/>
         <tag k="river_type" v="secondary"/>
-        <tag k="hoot:id" v="-13330"/>
+        <tag k="hoot:id" v="-13211"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF1" v="001710"/>
         <tag k="REF2" v="001710"/>
@@ -2043,57 +2026,57 @@
         <tag k="intermittent" v="yes"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13329" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-480036"/>
+    <way visible="true" id="-13210" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-479924"/>
         <nd ref="-479733"/>
         <nd ref="-479697"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13329"/>
+        <tag k="hoot:id" v="-13210"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="001f4e"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13328" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13209" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-185819"/>
         <nd ref="-479593"/>
         <nd ref="-479597"/>
         <nd ref="-185817"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13328"/>
+        <tag k="hoot:id" v="-13209"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="001f4e"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13327" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13208" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-185830"/>
         <nd ref="-479695"/>
         <nd ref="-479629"/>
         <nd ref="-479728"/>
         <nd ref="-185826"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13327"/>
+        <tag k="hoot:id" v="-13208"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="001f4e"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13326" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13207" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-185839"/>
         <nd ref="-479646"/>
         <nd ref="-185837"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13326"/>
+        <tag k="hoot:id" v="-13207"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="001f4e"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13318" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13199" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-185814"/>
         <nd ref="-185815"/>
-        <nd ref="-480036"/>
+        <nd ref="-479924"/>
         <nd ref="-185816"/>
         <nd ref="-185817"/>
         <nd ref="-185818"/>
@@ -2130,7 +2113,7 @@
         <tag k="river_flow" v="temporary"/>
         <tag k="hoot:status" v="1"/>
         <tag k="river_type" v="secondary"/>
-        <tag k="hoot:id" v="-13318"/>
+        <tag k="hoot:id" v="-13199"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF1" v="001f4e"/>
         <tag k="REF2" v="001f4e"/>
@@ -2138,57 +2121,39 @@
         <tag k="intermittent" v="yes"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13311" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-185915"/>
+    <way visible="true" id="-13192" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-185922"/>
+        <nd ref="-479606"/>
+        <nd ref="-479709"/>
+        <nd ref="-479643"/>
+        <nd ref="-479603"/>
         <nd ref="-479704"/>
         <nd ref="-479637"/>
         <nd ref="-479570"/>
         <nd ref="-479649"/>
         <nd ref="-479583"/>
-        <nd ref="-185910"/>
+        <nd ref="-479683"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13311"/>
+        <tag k="hoot:id" v="-13192"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="001f4b"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13310" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-185919"/>
-        <nd ref="-479643"/>
-        <nd ref="-479603"/>
-        <nd ref="-480028"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13310"/>
-        <tag k="waterway" v="stream"/>
-        <tag k="REF2" v="001f4b"/>
-        <tag k="z_order" v="0"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-13309" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-185922"/>
-        <nd ref="-185920"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13309"/>
-        <tag k="waterway" v="stream"/>
-        <tag k="REF2" v="001f4b"/>
-        <tag k="z_order" v="0"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-13308" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-185928"/>
+    <way visible="true" id="-13191" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-185929"/>
+        <nd ref="-479732"/>
         <nd ref="-479669"/>
-        <nd ref="-185926"/>
+        <nd ref="-185925"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13308"/>
+        <tag k="hoot:id" v="-13191"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="001f4b"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13298" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13187" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-77215"/>
-        <nd ref="-480027"/>
         <nd ref="-185909"/>
         <nd ref="-185910"/>
         <nd ref="-185911"/>
@@ -2196,7 +2161,6 @@
         <nd ref="-185913"/>
         <nd ref="-185914"/>
         <nd ref="-185915"/>
-        <nd ref="-480028"/>
         <nd ref="-185916"/>
         <nd ref="-185917"/>
         <nd ref="-185918"/>
@@ -2235,7 +2199,7 @@
         <tag k="river_flow" v="temporary"/>
         <tag k="hoot:status" v="3"/>
         <tag k="river_type" v="secondary"/>
-        <tag k="hoot:id" v="-13298"/>
+        <tag k="hoot:id" v="-13187"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF1" v="001f4b"/>
         <tag k="REF2" v="001f4b"/>
@@ -2243,7 +2207,7 @@
         <tag k="intermittent" v="yes"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13291" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13171" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-10142"/>
         <nd ref="-10143"/>
         <nd ref="-10144"/>
@@ -2256,14 +2220,14 @@
         <tag k="source" v="CNIGS"/>
         <tag k="hoot:status" v="3"/>
         <tag k="river_type" v="secondary"/>
-        <tag k="hoot:id" v="-13291"/>
+        <tag k="hoot:id" v="-13171"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF1" v="002fc1"/>
         <tag k="REF2" v="002fc1"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13287" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13167" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-170479"/>
         <nd ref="-185659"/>
         <nd ref="-185660"/>
@@ -2289,7 +2253,7 @@
         <tag k="river_flow" v="temporary"/>
         <tag k="hoot:status" v="3"/>
         <tag k="river_type" v="secondary"/>
-        <tag k="hoot:id" v="-13287"/>
+        <tag k="hoot:id" v="-13167"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF1" v="001f53"/>
         <tag k="REF2" v="001f53;0020fa"/>
@@ -2297,7 +2261,7 @@
         <tag k="intermittent" v="yes"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13285" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13165" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-170472"/>
         <nd ref="-170473"/>
         <nd ref="-170474"/>
@@ -2311,7 +2275,7 @@
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Ravine Pichomblaise"/>
         <tag k="river_type" v="secondary"/>
-        <tag k="hoot:id" v="-13285"/>
+        <tag k="hoot:id" v="-13165"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF1" v="0020fa"/>
         <tag k="REF2" v="001f53;0020fa"/>
@@ -2319,45 +2283,45 @@
         <tag k="intermittent" v="yes"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13282" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-480021"/>
+    <way visible="true" id="-13162" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-479915"/>
         <nd ref="-479731"/>
         <nd ref="-479668"/>
-        <nd ref="-480020"/>
+        <nd ref="-479914"/>
         <tag k="hoot:status" v="2"/>
         <tag k="name" v="Ravine Pichomblaise"/>
-        <tag k="hoot:id" v="-13282"/>
+        <tag k="hoot:id" v="-13162"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="001952"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13281" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13161" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-170466"/>
         <nd ref="-479624"/>
         <nd ref="-479582"/>
-        <nd ref="-480022"/>
+        <nd ref="-479916"/>
         <tag k="hoot:status" v="2"/>
         <tag k="name" v="Ravine Pichomblaise"/>
-        <tag k="hoot:id" v="-13281"/>
+        <tag k="hoot:id" v="-13161"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="001952"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13273" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13153" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-53419"/>
         <nd ref="-170456"/>
         <nd ref="-170457"/>
-        <nd ref="-480020"/>
+        <nd ref="-479914"/>
         <nd ref="-170458"/>
         <nd ref="-170459"/>
-        <nd ref="-480021"/>
+        <nd ref="-479915"/>
         <nd ref="-170460"/>
         <nd ref="-170461"/>
         <nd ref="-170462"/>
         <nd ref="-170463"/>
-        <nd ref="-480022"/>
+        <nd ref="-479916"/>
         <nd ref="-170464"/>
         <nd ref="-170465"/>
         <nd ref="-170466"/>
@@ -2372,7 +2336,7 @@
         <tag k="hoot:status" v="1"/>
         <tag k="name" v="Ravine Pichomblaise"/>
         <tag k="river_type" v="secondary"/>
-        <tag k="hoot:id" v="-13273"/>
+        <tag k="hoot:id" v="-13153"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF1" v="0020fa"/>
         <tag k="REF2" v="001952"/>
@@ -2380,34 +2344,34 @@
         <tag k="intermittent" v="yes"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13272" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-480018"/>
+    <way visible="true" id="-13152" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-479912"/>
         <nd ref="-185987"/>
         <tag k="hoot:status" v="2"/>
         <tag k="name" v="Ravine Pichomblaise"/>
-        <tag k="hoot:id" v="-13272"/>
+        <tag k="hoot:id" v="-13152"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="001952"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13271" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-480017"/>
+    <way visible="true" id="-13151" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-479911"/>
         <nd ref="-302243"/>
         <tag k="hoot:status" v="2"/>
         <tag k="name" v="Ravine Pichomblaise"/>
-        <tag k="hoot:id" v="-13271"/>
+        <tag k="hoot:id" v="-13151"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="001952"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13265" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13145" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-170454"/>
-        <nd ref="-480017"/>
+        <nd ref="-479911"/>
         <nd ref="-302242"/>
         <nd ref="-302243"/>
-        <nd ref="-480018"/>
+        <nd ref="-479912"/>
         <nd ref="-302244"/>
         <nd ref="-302245"/>
         <nd ref="-185987"/>
@@ -2429,7 +2393,7 @@
         <tag k="river_flow" v="temporary"/>
         <tag k="hoot:status" v="1"/>
         <tag k="name" v="Ravine Pichomblaise"/>
-        <tag k="hoot:id" v="-13265"/>
+        <tag k="hoot:id" v="-13145"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF1" v="001952"/>
         <tag k="REF2" v="001952"/>
@@ -2437,7 +2401,7 @@
         <tag k="intermittent" v="yes"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13262" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13142" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-170454"/>
         <nd ref="-53419"/>
         <tag k="river_flow" v="temporary"/>
@@ -2445,7 +2409,7 @@
         <tag k="hoot:status" v="3"/>
         <tag k="name" v="Ravine Pichomblaise"/>
         <tag k="river_type" v="secondary"/>
-        <tag k="hoot:id" v="-13262"/>
+        <tag k="hoot:id" v="-13142"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF1" v="0020fa"/>
         <tag k="REF2" v="001952"/>
@@ -2453,105 +2417,37 @@
         <tag k="intermittent" v="yes"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13261" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-479997"/>
-        <nd ref="-479619"/>
-        <nd ref="-53422"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13261"/>
-        <tag k="waterway" v="stream"/>
-        <tag k="REF2" v="002a64"/>
-        <tag k="z_order" v="0"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-13260" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-53426"/>
-        <nd ref="-479726"/>
-        <nd ref="-53424"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13260"/>
-        <tag k="waterway" v="stream"/>
-        <tag k="REF2" v="002a64"/>
-        <tag k="z_order" v="0"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-13259" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-53429"/>
-        <nd ref="-479693"/>
-        <nd ref="-479998"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13259"/>
-        <tag k="waterway" v="stream"/>
-        <tag k="REF2" v="002a64"/>
-        <tag k="z_order" v="0"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-13258" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-53432"/>
-        <nd ref="-53430"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13258"/>
-        <tag k="waterway" v="stream"/>
-        <tag k="REF2" v="002a64"/>
-        <tag k="z_order" v="0"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-13257" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-53434"/>
-        <nd ref="-479612"/>
-        <nd ref="-53433"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13257"/>
-        <tag k="waterway" v="stream"/>
-        <tag k="REF2" v="002a64"/>
-        <tag k="z_order" v="0"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-13256" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-480000"/>
-        <nd ref="-479678"/>
-        <nd ref="-53435"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13256"/>
-        <tag k="waterway" v="stream"/>
-        <tag k="REF2" v="002a64"/>
-        <tag k="z_order" v="0"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-13255" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-53439"/>
-        <nd ref="-479644"/>
-        <nd ref="-53437"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13255"/>
-        <tag k="waterway" v="stream"/>
-        <tag k="REF2" v="002a64"/>
-        <tag k="z_order" v="0"/>
-        <tag k="error:circular" v="15"/>
-    </way>
-    <way visible="true" id="-13254" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-53444"/>
+    <way visible="true" id="-13141" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-53446"/>
         <nd ref="-479685"/>
-        <nd ref="-479999"/>
+        <nd ref="-479644"/>
+        <nd ref="-479577"/>
+        <nd ref="-479678"/>
+        <nd ref="-479612"/>
+        <nd ref="-479693"/>
+        <nd ref="-479627"/>
+        <nd ref="-479726"/>
+        <nd ref="-479664"/>
+        <nd ref="-479619"/>
+        <nd ref="-479720"/>
+        <nd ref="-53421"/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-13254"/>
+        <tag k="hoot:id" v="-13141"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="002a64"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <way visible="true" id="-13228" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-13136" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-53419"/>
         <nd ref="-53420"/>
         <nd ref="-53421"/>
         <nd ref="-53422"/>
         <nd ref="-53423"/>
-        <nd ref="-479997"/>
         <nd ref="-53424"/>
         <nd ref="-53425"/>
         <nd ref="-53426"/>
         <nd ref="-53427"/>
-        <nd ref="-479998"/>
         <nd ref="-53428"/>
         <nd ref="-53429"/>
         <nd ref="-53430"/>
@@ -2561,13 +2457,11 @@
         <nd ref="-53434"/>
         <nd ref="-53435"/>
         <nd ref="-53436"/>
-        <nd ref="-480000"/>
         <nd ref="-53437"/>
         <nd ref="-53438"/>
         <nd ref="-53439"/>
         <nd ref="-53440"/>
         <nd ref="-53441"/>
-        <nd ref="-479999"/>
         <nd ref="-53442"/>
         <nd ref="-53443"/>
         <nd ref="-53444"/>
@@ -2583,7 +2477,7 @@
         <tag k="river_flow" v="temporary"/>
         <tag k="hoot:status" v="3"/>
         <tag k="river_type" v="secondary"/>
-        <tag k="hoot:id" v="-13228"/>
+        <tag k="hoot:id" v="-13136"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF1" v="002a64"/>
         <tag k="REF2" v="002a64"/>
@@ -2608,7 +2502,7 @@
         <nd ref="-436830"/>
         <nd ref="-436831"/>
         <nd ref="-436832"/>
-        <nd ref="-480043"/>
+        <nd ref="-479931"/>
         <nd ref="-436833"/>
         <nd ref="-170472"/>
         <tag k="source" v="CNIGS"/>
@@ -2623,24 +2517,24 @@
         <tag k="intermittent" v="yes"/>
         <tag k="error:circular" v="15"/>
     </way>
-    <relation visible="true" id="-124" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-13356" role=""/>
-        <member type="way" ref="-13357" role=""/>
+    <relation visible="true" id="-114" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="way" ref="-13237" role=""/>
+        <member type="way" ref="-13238" role=""/>
         <tag k="hoot:status" v="2"/>
         <tag k="name" v="Ravine Pichomblaise"/>
-        <tag k="hoot:id" v="-124"/>
+        <tag k="hoot:id" v="-114"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="001952"/>
         <tag k="z_order" v="0"/>
         <tag k="error:circular" v="15"/>
         <tag k="type" v="multilinestring"/>
     </relation>
-    <relation visible="true" id="-120" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-13347" role=""/>
-        <member type="way" ref="-13348" role=""/>
-        <member type="way" ref="-13349" role=""/>
+    <relation visible="true" id="-110" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="way" ref="-13228" role=""/>
+        <member type="way" ref="-13229" role=""/>
+        <member type="way" ref="-13230" role=""/>
         <tag k="hoot:status" v="2"/>
-        <tag k="hoot:id" v="-120"/>
+        <tag k="hoot:id" v="-110"/>
         <tag k="waterway" v="stream"/>
         <tag k="REF2" v="002876"/>
         <tag k="z_order" v="0"/>


### PR DESCRIPTION
Maximal subline matching performance suffers greatly for certain input data. Previously, this was only seen with rivers but now also with generic lines (in this case possibly untagged rivers). Since it often performs very well, the current solution was to use it by default and then kick over to Frechet matching if rivers were over a certain size or node count, since it isn't always as accurate but is much faster in general. 

Size/node count has proven not to be the best metric for this, and this has been reworked to kick out of maximal matching after a configurable recursive matching call limit is reached. This capability has been added to both rivers and generic lines (haven't seen any need to do it for roads yet). This has taken the runtime for a conflate job that was seen running for 48 hours with no apparent finishing time down to ~30 minutes. 

Out of the two river regression tests we have, one was slightly negatively affected (-1%) and the other was significantly positively affected (+5%).

Unrelated: code for doing adjacent C&R operations, as well as some node density tile calc bug fixes are included.