### PR TITLE
Prevent repeated changeset statements for the same element when using multiple changeset providers

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ServiceChangesetReplacementGridTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ServiceChangesetReplacementGridTest.cpp
@@ -53,15 +53,15 @@ static const QString REPLACEMENT_DATA_URL =
   ServicesDbTestUtils::getDbModifyUrl(TEST_NAME).toString();
 static const QString REPLACEMENT_DATA_FILE = "OSMData.osm";
 
-// all - fails on 3rd changeset
+// all - ? changesets; fails on 3rd changeset
 //static const QString CROP_INPUT_BOUNDS = "";
 //static const QString REPLACEMENT_BOUNDS = "-115.3528,36.0919,-114.9817,36.3447";
 
-// 4 sq blocks - good
+// 4 sq blocks - ? changesets; completes in ?
 //static const QString CROP_INPUT_BOUNDS = "-115.3314,36.2825,-115.2527,36.3387";
 //static const QString REPLACEMENT_BOUNDS = "-115.3059,36.2849,-115.2883,36.2991";
 
-// 1/4 of city - fails with zero alpha shape
+// 1/4 of city - 64 changesets; fails on application of 12th changeset at 9.5min
 static const QString CROP_INPUT_BOUNDS = "-115.3441,36.2012,-115.1942,36.3398";
 static const QString REPLACEMENT_BOUNDS = "-115.3332,36.2178,-115.1837,36.3400";
 
@@ -77,7 +77,7 @@ static const QString TASK_GRID_FILE = ROOT_DIR + "/bounds.osm";
 class ServiceChangesetReplacementGridTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ServiceChangesetReplacementGridTest);
-  // FOR DEBUGGING ONLY
+  // ENABLE FOR DEBUGGING ONLY
   //CPPUNIT_TEST(runGridCellTest);
   CPPUNIT_TEST_SUITE_END();
 
@@ -144,7 +144,6 @@ private:
     conf().set(ConfigOptions::getReaderAddSourceDatetimeKey(), false);
     conf().set(ConfigOptions::getWriterIncludeCircularErrorTagsKey(), false);
     conf().set(ConfigOptions::getConvertBoundingBoxRemoveMissingElementsKey(), false);
-    conf().set(ConfigOptions::getDebugMapsWriteKey(), false);
     conf().set(ConfigOptions::getDebugMapsRemoveMissingElementsKey(), true);
     conf().set(ConfigOptions::getMapReaderAddChildRefsWhenMissingKey(), true);
     conf().set(ConfigOptions::getApiDbEmailKey(), USER_EMAIL);
@@ -154,7 +153,7 @@ private:
     conf().set(ConfigOptions::getChangesetMaxSizeKey(), 999999);
     conf().set(ConfigOptions::getSnapUnconnectedWaysExistingWayNodeToleranceKey(), 0.5);
     conf().set(ConfigOptions::getSnapUnconnectedWaysSnapToleranceKey(), 5.0);
-    conf().set(ConfigOptions::getDebugMapsWriteKey(), true);
+    conf().set(ConfigOptions::getDebugMapsWriteKey(), false);
     conf().set(ConfigOptions::getDebugMapsFilenameKey(), ROOT_DIR + "/debug.osm");
   }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator.cpp
@@ -460,6 +460,8 @@ void ChangesetReplacementCreator::create(
         "Adding ref map of size: " << refMap->size() << " and conflated map of size: " <<
         conflatedMap->size() << " to changeset derivation queue for geometry type: " <<
         GeometryTypeCriterion::typeToString(itr.key()) << "...");
+      // TODO: move set name here to inside _getMapsForGeometryType, so we can see the geometry type
+      // in the name??
       refMap->setName(refMap->getName() + "-" + GeometryTypeCriterion::typeToString(itr.key()));
       refMaps.append(refMap);
       conflatedMap->setName(

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetApplier.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetApplier.cpp
@@ -92,7 +92,7 @@ void OsmApiDbSqlChangesetApplier::write(const QString& sql)
     QString changesetStatType;
     if (sqlStatement.toUpper().startsWith("INSERT INTO CHANGESETS"))
     {
-      //flush
+      // flush
       if (!changesetInsertStatement.isEmpty())
       {
         if (elementSqlStatements.trimmed().isEmpty())

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetFileWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetFileWriter.cpp
@@ -83,7 +83,7 @@ void OsmApiDbSqlChangesetFileWriter::write(const QString& path,
 
   _remappedIds.clear();
   _changesetBounds.init();
-  _parsedChanges.clear();
+  _parsedChangeIds.clear();
 
   _outputSql.setFileName(path);
   if (_outputSql.open(QIODevice::WriteOnly | QIODevice::Text) == false)
@@ -108,9 +108,9 @@ void OsmApiDbSqlChangesetFileWriter::write(const QString& path,
       Change change = changesetProvider->readNextChange();
 
       // See related note in OsmXmlChangesetFileWriter::write.
-      if (_parsedChanges.contains(change))
+      if (_parsedChangeIds.contains(change.getElement()->getElementId()))
       {
-        LOG_TRACE("Skipping adding duplicated change: " << change << "...");
+        LOG_TRACE("Skipping change for element ID already having change: " << change << "...");
         continue;
       }
 
@@ -140,7 +140,7 @@ void OsmApiDbSqlChangesetFileWriter::write(const QString& path,
           ConstNodePtr node = std::dynamic_pointer_cast<const Node>(change.getElement());
           _changesetBounds.expandToInclude(node->getX(), node->getY());
         }
-        _parsedChanges.append(change);
+        _parsedChangeIds.append(change.getElement()->getElementId());
         changes++;
       }
     }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetFileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetFileWriter.h
@@ -140,7 +140,8 @@ private:
   // id mappings for created elements
   QMap<ElementId, ElementId> _remappedIds;
 
-  QList<Change> _parsedChanges;
+  // element IDs associated with a changes encountered
+  QList<ElementId> _parsedChangeIds;
 
   // list of metadata tag keys allowed to be written to the changeset
   QStringList _metadataAllowKeys;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlChangesetFileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlChangesetFileWriter.h
@@ -88,7 +88,8 @@ private:
   int _precision;
 
   Change _change;
-  QList<Change> _parsedChanges;
+  // element IDs associated with a changes encountered
+  QList<ElementId> _parsedChangeIds;
 
   bool _addTimestamp;
   bool _includeDebugTags;

--- a/hoot-core/src/main/cpp/hoot/core/util/DbUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/DbUtils.cpp
@@ -47,7 +47,9 @@ QSqlQuery DbUtils::execNoPrepare(const QSqlDatabase& database, const QString& sq
   if (q.exec(sql) == false)
   {
     throw HootException(
-      QString("Error executing query: %1 (%2)").arg(q.lastError().text().left(50)).arg(sql));
+      QString("Error executing query. Error: %1 ...\nSQL: %2 ...")
+        .arg(q.lastError().text().left(200))
+        .arg(sql.left(200)));
   }
   LOG_VART(q.numRowsAffected());
 

--- a/test-files/cmd/glacial/serial/ServiceChangesetReplacement.sh.off
+++ b/test-files/cmd/glacial/serial/ServiceChangesetReplacement.sh.off
@@ -229,8 +229,8 @@ REF_DB_INPUT=$OSM_API_DB_URL
 
 LOG_LEVEL="--warn"
 GENERAL_OPTS="-C UnifyingAlgorithm.conf -C Testing.conf -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D convert.bounding.box.remove.missing.elements=false -D log.warnings.for.missing.elements=false -D debug.maps.write=false -D debug.maps.remove.missing.elements=true -D element.hash.visitor.non.metadata.ignore.keys=note $EXTRA_PARAMS -D log.class.filter= "
-# Holding onto missing child element refs does not work yet with cropping, so disable it when cropping is specified...bug issue creation 
-# pending.
+# Holding onto missing child element refs does not work yet with cropping, so disable it when cropping is specified...TODO: bug issue creation 
+# pending. TODO: This needs to be only added for the initial write and not all convert ops in the script.
 if [ "$CROP_OPTS" == "" ]; then
   GENERAL_OPTS=$GENERAL_OPTS" -D map.reader.add.child.refs.when.missing=true"
 fi

--- a/test-files/cmd/glacial/serial/ServiceChangesetReplacementAdjacentCellsTest.sh.off
+++ b/test-files/cmd/glacial/serial/ServiceChangesetReplacementAdjacentCellsTest.sh.off
@@ -11,12 +11,40 @@ HOOT_DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
 REF_DB_INPUT=$OSM_API_DB_URL
 SEC_DB_INPUT="$HOOT_DB_URL/ServiceChangesetReplacementAdjacentCellsTest-sec"
 
-LOG_LEVEL="--warn"
-GENERAL_OPTS="-C UnifyingAlgorithm.conf -C Testing.conf -D uuid.helper.repeatable=true -D writer.include.debug.tags=false -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D convert.bounding.box.remove.missing.elements=false -D log.warnings.for.missing.elements=false -D debug.maps.write=false -D debug.maps.remove.missing.elements=false -D log.class.filter= "
+CROP_AOI="" # leave empty to avoid cropping
+# 4183
+#CROP_AOI="-115.1083193,36.0045951,-115.0225009,36.0811562" # leave empty to avoid cropping
+LOG_LEVEL="--status"
+GENERAL_OPTS="-C UnifyingAlgorithm.conf -C Testing.conf -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D convert.bounding.box.remove.missing.elements=false -D log.warnings.for.missing.elements=false -D debug.maps.write=false -D debug.maps.remove.missing.elements=true -D log.class.filter= "
 DB_OPTS="-D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1 -D changeset.max.size=999999"
 
-SOURCE_FILE_1="/home/vagrant/hoot/tmp/4182/329_ReferenceNOMEData_31JULY2020.osm"
-SOURCE_FILE_2="/home/vagrant/hoot/tmp/4182/329_SecondaryOSMData_31JULY2020.osm"
+# 4182
+#SOURCE_FILE_1="/home/vagrant/hoot/tmp/4182/329_ReferenceNOMEData_31JULY2020.osm"
+#SOURCE_FILE_2="/home/vagrant/hoot/tmp/4182/329_SecondaryOSMData_31JULY2020.osm"
+# 4183
+SOURCE_FILE_1="/home/vagrant/hoot/tmp/4183/NOME_ReferenceData.osm"
+SOURCE_FILE_2="/home/vagrant/hoot/tmp/4183/OSM_SecondaryData.osm"
+#SOURCE_FILE_CROP_1="/home/vagrant/hoot/tmp/4183/NOME_ReferenceData-cropped.osm"
+#SOURCE_FILE_CROP_2="/home/vagrant/hoot/tmp/4183/OSM_SecondaryData-cropped.osm"
+#SOURCE_FILE_1="/home/vagrant/hoot/tmp/4183/NOME_ReferenceData-cropped.osm"
+#SOURCE_FILE_2="/home/vagrant/hoot/tmp/4183/OSM_SecondaryData-cropped.osm"
+
+if [[ "$CROP_AOI" == "" ]]; then
+  echo ""
+  echo "No cropping being performed on inputs..."
+  echo ""
+else
+  echo ""
+  echo "Cropping the reference dataset from: $SOURCE_FILE_1 at bounds: $CROP_AOI..."
+  echo ""
+  hoot crop $LOG_LEVEL $GENERAL_OPTS -D debug.maps.filename=$OUT_DIR/data-crop-ref-db.osm -D reader.use.data.source.ids=true -D map.reader.add.child.refs.when.missing=false $SOURCE_FILE_1 $SOURCE_FILE_CROP_1 $CROP_AOI
+  SOURCE_FILE_1=$SOURCE_FILE_CROP_1
+  echo ""
+  echo "Cropping the secondary dataset from: $SOURCE_FILE_2 at bounds: $CROP_AOI..."
+  echo ""
+  hoot crop $LOG_LEVEL $GENERAL_OPTS -D debug.maps.filename=$OUT_DIR/data-crop-ref-db.osm -D reader.use.data.source.ids=true -D map.reader.add.child.refs.when.missing=false $SOURCE_FILE_2 $SOURCE_FILE_CROP_2 $CROP_AOI
+  SOURCE_FILE_2=$SOURCE_FILE_CROP_2
+fi
 
 scripts/database/CleanAndInitializeOsmApiDb.sh
 
@@ -30,9 +58,9 @@ echo "Writing the secondary dataset from: $SOURCE_FILE_2 to a hoot api db (conta
 echo ""
 hoot convert $LOG_LEVEL $GENERAL_OPTS $DB_OPTS -D debug.maps.filename=$OUT_DIR/data-prep-sec-db.osm -D reader.use.data.source.ids=true $SOURCE_FILE_2 $SEC_DB_INPUT
 
-# southern task 14
+# TASK 1
 
-TEST_NAME="ServiceChangesetReplacementAdjacentCellsTest-south"
+TEST_NAME="ServiceChangesetReplacementAdjacentCellsTest-task1"
 
 IN_DIR=test-files/cmd/glacial/serial/$TEST_NAME
 OUT_DIR=test-output/cmd/glacial/serial/$TEST_NAME
@@ -44,7 +72,10 @@ CHANGESET_DB=$OUT_DIR/$TEST_NAME-changeset-db.osc.sql
 CHANGESET_DB_DEBUG=$OUT_DIR/$TEST_NAME-changeset-db.osc
 OUT_DB=$TEST_NAME-db-replaced.osm
 
+# southern task 14 - 4182
 REPLACEMENT_AOI="-119.750977,39.0447859,-119.7399904,39.0533182"
+# 4183
+#REPLACEMENT_AOI="-115.0927735,36.0313319,-115.0488281,36.0668621"
 
 echo ""
 echo "Deriving a changeset between the osm api db and the hoot api db layers over: $REPLACEMENT_AOI, to file: $CHANGESET_DB that replaces features in the reference dataset with those from a secondary dataset..."
@@ -61,9 +92,12 @@ echo "Reading the entire reference dataset out of the osm api db to: $OUT_DB for
 echo ""
 hoot convert $LOG_LEVEL $GENERAL_OPTS $DB_OPTS -D debug.maps.filename=$OUT_DIR/final-write-db.osm $OSM_API_DB_URL $OUT_DIR/$OUT_DB
 
-# northern task 15
+# for replacing a single cell
+#exit
 
-TEST_NAME="ServiceChangesetReplacementAdjacentCellsTest-north"
+# TASK 2
+
+TEST_NAME="ServiceChangesetReplacementAdjacentCellsTest-task2"
 
 IN_DIR=test-files/cmd/glacial/serial/$TEST_NAME
 OUT_DIR=test-output/cmd/glacial/serial/$TEST_NAME
@@ -75,6 +109,7 @@ CHANGESET_DB=$OUT_DIR/$TEST_NAME-changeset-db.osc.sql
 CHANGESET_DB_DEBUG=$OUT_DIR/$TEST_NAME-changeset-db.osc
 OUT_DB=$TEST_NAME-db-replaced.osm
 
+# northern task 15 - 4182
 REPLACEMENT_AOI="-119.7509766,39.0533178,-119.7399902,39.0618491"
 
 echo ""

--- a/test-files/cmd/glacial/serial/ServiceChangesetReplacementAdjacentCellsTest.sh.off
+++ b/test-files/cmd/glacial/serial/ServiceChangesetReplacementAdjacentCellsTest.sh.off
@@ -1,25 +1,98 @@
 #!/bin/bash
 set -e
 
-# This tests the replacement effects at the replacement boundary when replacing data in adjacent task grids. Note that re-using the database for 
-# subsequent tasks won't work unless you use the two osmapidb bulk inserter options that have been added here (#4171). Also, make sure the 
-# target db is only cleaned before the initial task and not subsequent ones (option that can be passed into the replacement script).
+# This tests the replacement effects at the replacement boundary when replacing data in adjacent task grids.
 
-# southern task 52
-#test-files/cmd/glacial/serial/ServiceChangesetReplacement.sh.off "ServiceChangesetReplacementAdjacentCellsTest-south" "/home/vagrant/hoot/tmp/4158/SouthernTask52/task_52_inputdata/NOME_d5a6dc.osm" "/home/vagrant/hoot/tmp/4158/SouthernTask52/task_52_inputdata/OSM_d5a6dc.osm" "-115.048828,36.244273,-115.004883,36.279709" "-180,-90,180,90" "true" "lenient" "" "" "false" "" "" "" "" "xml" "5.0" "0.5" "true" "true" "true" "-D osmapidb.bulk.inserter.reserve.record.ids.before.writing.data=true -D apidb.bulk.inserter.validate.data=true"
-# northern task 53
-#test-files/cmd/glacial/serial/ServiceChangesetReplacement.sh.off "ServiceChangesetReplacementAdjacentCellsTest-north" "/home/vagrant/hoot/tmp/4158/NorthernTask53/NOME_849248_OSM_849248/NOME_849248.osm" "/home/vagrant/hoot/tmp/4158/NorthernTask53/NOME_849248_OSM_849248/OSM_849248.osm" "-115.048828,36.279707,-115.004883,36.315127" "-180,-90,180,90" "true" "lenient" "" "" "false" "" "" "" "" "xml" "5.0" "0.5" "true" "true" "false" "-D osmapidb.bulk.inserter.reserve.record.ids.before.writing.data=true -D apidb.bulk.inserter.validate.data=true"
-
-# southern task 14
-test-files/cmd/glacial/serial/ServiceChangesetReplacement.sh.off "ServiceChangesetReplacementAdjacentCellsTest-south" "/home/vagrant/hoot/tmp/4182/329_ReferenceNOMEData_31JULY2020.osm" "/home/vagrant/hoot/tmp/4182/329_SecondaryOSMData_31JULY2020.osm" "-119.750977,39.0447859,-119.7399904,39.0533182" "-180,-90,180,90" "true" "lenient" "" "" "false" "" "" "" "" "xml" "5.0" "0.5" "true" "true" "true" "-D osmapidb.bulk.inserter.reserve.record.ids.before.writing.data=true -D apidb.bulk.inserter.validate.data=true"
-# northern task 15
-test-files/cmd/glacial/serial/ServiceChangesetReplacement.sh.off "ServiceChangesetReplacementAdjacentCellsTest-north" "/home/vagrant/hoot/tmp/4182/329_ReferenceNOMEData_31JULY2020.osm" "/home/vagrant/hoot/tmp/4182/329_SecondaryOSMData_31JULY2020.osm" "-119.7509766,39.0533178,-119.7399902,39.0618491" "-180,-90,180,90" "true" "lenient" "" "" "false" "" "" "" "" "xml" "5.0" "0.5" "true" "true" "false" "-D osmapidb.bulk.inserter.reserve.record.ids.before.writing.data=true -D apidb.bulk.inserter.validate.data=true"
-
-# read out both cells
 source conf/database/DatabaseConfig.sh
 export OSM_API_DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
 export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
-COMBINED_OUT_DIR=test-output/cmd/glacial/serial/ServiceChangesetReplacementAdjacentCellsTest-combined
-mkdir -p $COMBINED_OUT_DIR
-hoot convert --info -C UnifyingAlgorithm.conf -C Testing.conf -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D convert.bounding.box.remove.missing.elements=false -D log.warnings.for.missing.elements=false -D debug.maps.write=false -D debug.maps.remove.missing.elements=true -D element.hash.visitor.non.metadata.ignore.keys=note -D osmapidb.bulk.inserter.reserve.record.ids.before.writing.data=true -D apidb.bulk.inserter.validate.data=true -D log.class.filter="" -D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1 -D changeset.max.size=999999 -D convert.ops="hoot::RemoveMissingElementsVisitor" -D debug.maps.filename=$COMBINED_OUT_DIR/final-write-xml.osm $OSM_API_DB_URL $COMBINED_OUT_DIR/ServiceChangesetReplacementAdjacentGridsTest-replaced-combined.osm
+HOOT_DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
+REF_DB_INPUT=$OSM_API_DB_URL
+SEC_DB_INPUT="$HOOT_DB_URL/ServiceChangesetReplacementAdjacentCellsTest-sec"
+
+LOG_LEVEL="--warn"
+GENERAL_OPTS="-C UnifyingAlgorithm.conf -C Testing.conf -D uuid.helper.repeatable=true -D writer.include.debug.tags=false -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D convert.bounding.box.remove.missing.elements=false -D log.warnings.for.missing.elements=false -D debug.maps.write=false -D debug.maps.remove.missing.elements=false -D log.class.filter= "
+DB_OPTS="-D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1 -D changeset.max.size=999999"
+
+SOURCE_FILE_1="/home/vagrant/hoot/tmp/4182/329_ReferenceNOMEData_31JULY2020.osm"
+SOURCE_FILE_2="/home/vagrant/hoot/tmp/4182/329_SecondaryOSMData_31JULY2020.osm"
+
+scripts/database/CleanAndInitializeOsmApiDb.sh
+
+echo ""
+echo "Writing reference dataset from: $SOURCE_FILE_1 to an osm api db (contains features to be replaced)..."
+echo ""
+hoot convert $LOG_LEVEL $GENERAL_OPTS $DB_OPTS -D debug.maps.filename=$OUT_DIR/data-prep-ref-db.osm -D reader.use.data.source.ids=true $SOURCE_FILE_1 $REF_DB_INPUT 
+
+echo ""
+echo "Writing the secondary dataset from: $SOURCE_FILE_2 to a hoot api db (contains features to replace with)..."
+echo ""
+hoot convert $LOG_LEVEL $GENERAL_OPTS $DB_OPTS -D debug.maps.filename=$OUT_DIR/data-prep-sec-db.osm -D reader.use.data.source.ids=true $SOURCE_FILE_2 $SEC_DB_INPUT
+
+# southern task 14
+
+TEST_NAME="ServiceChangesetReplacementAdjacentCellsTest-south"
+
+IN_DIR=test-files/cmd/glacial/serial/$TEST_NAME
+OUT_DIR=test-output/cmd/glacial/serial/$TEST_NAME
+rm -rf $OUT_DIR
+mkdir -p $OUT_DIR
+
+CHANGESET_DERIVE_OPTS="-D changeset.user.id=1 -D bounds.output.file=$OUT_DIR/$TEST_NAME-bounds.osm -D snap.unconnected.ways.existing.way.node.tolerance=5.0 -D snap.unconnected.ways.snap.tolerance=0.5"
+CHANGESET_DB=$OUT_DIR/$TEST_NAME-changeset-db.osc.sql
+CHANGESET_DB_DEBUG=$OUT_DIR/$TEST_NAME-changeset-db.osc
+OUT_DB=$TEST_NAME-db-replaced.osm
+
+REPLACEMENT_AOI="-119.750977,39.0447859,-119.7399904,39.0533182"
+
+echo ""
+echo "Deriving a changeset between the osm api db and the hoot api db layers over: $REPLACEMENT_AOI, to file: $CHANGESET_DB that replaces features in the reference dataset with those from a secondary dataset..."
+echo ""
+hoot changeset-derive-replacement $LOG_LEVEL $GENERAL_OPTS $DB_OPTS $CHANGESET_DERIVE_OPTS -D debug.maps.filename=$OUT_DIR/changeset-derive-db.osm $REF_DB_INPUT $SEC_DB_INPUT $REPLACEMENT_AOI $CHANGESET_DB $REF_DB_INPUT --full-replacement --write-bounds --disable-conflation --disable-cleaning
+
+echo ""
+echo "Applying the changeset: $CHANGESET_DB to the reference data in the osm api db..."
+echo ""
+hoot changeset-apply $LOG_LEVEL $GENERAL_OPTS $DB_OPTS $CHANGESET_DERIVE_OPTS -D debug.maps.filename=$OUT_DIR/changeset-apply-db.osm $CHANGESET_DB $OSM_API_DB_URL
+
+echo ""
+echo "Reading the entire reference dataset out of the osm api db to: $OUT_DB for verification..."
+echo ""
+hoot convert $LOG_LEVEL $GENERAL_OPTS $DB_OPTS -D debug.maps.filename=$OUT_DIR/final-write-db.osm $OSM_API_DB_URL $OUT_DIR/$OUT_DB
+
+# northern task 15
+
+TEST_NAME="ServiceChangesetReplacementAdjacentCellsTest-north"
+
+IN_DIR=test-files/cmd/glacial/serial/$TEST_NAME
+OUT_DIR=test-output/cmd/glacial/serial/$TEST_NAME
+rm -rf $OUT_DIR
+mkdir -p $OUT_DIR
+
+CHANGESET_DERIVE_OPTS="-D changeset.user.id=1 -D bounds.output.file=$OUT_DIR/$TEST_NAME-bounds.osm -D snap.unconnected.ways.existing.way.node.tolerance=5.0 -D snap.unconnected.ways.snap.tolerance=0.5"
+CHANGESET_DB=$OUT_DIR/$TEST_NAME-changeset-db.osc.sql
+CHANGESET_DB_DEBUG=$OUT_DIR/$TEST_NAME-changeset-db.osc
+OUT_DB=$TEST_NAME-db-replaced.osm
+
+REPLACEMENT_AOI="-119.7509766,39.0533178,-119.7399902,39.0618491"
+
+echo ""
+echo "Deriving a changeset between the osm api db and the hoot api db layers over: $REPLACEMENT_AOI, to file: $CHANGESET_DB that replaces features in the reference dataset with those from a secondary dataset..."
+echo ""
+hoot changeset-derive-replacement $LOG_LEVEL $GENERAL_OPTS $DB_OPTS $CHANGESET_DERIVE_OPTS -D debug.maps.filename=$OUT_DIR/changeset-derive-db.osm $REF_DB_INPUT $SEC_DB_INPUT $REPLACEMENT_AOI $CHANGESET_DB $REF_DB_INPUT --full-replacement --write-bounds --disable-conflation --disable-cleaning
+
+echo ""
+echo "Applying the changeset: $CHANGESET_DB to the reference data in the osm api db..."
+echo ""
+hoot changeset-apply $LOG_LEVEL $GENERAL_OPTS $DB_OPTS $CHANGESET_DERIVE_OPTS -D debug.maps.filename=$OUT_DIR/changeset-apply-db.osm $CHANGESET_DB $OSM_API_DB_URL
+
+echo ""
+echo "Reading the entire reference dataset out of the osm api db to: $OUT_DB for verification..."
+echo ""
+hoot convert $LOG_LEVEL $GENERAL_OPTS $DB_OPTS -D debug.maps.filename=$OUT_DIR/final-write-db.osm $OSM_API_DB_URL $OUT_DIR/$OUT_DB
+
+echo ""
+echo "Removing data from secondary input..."
+echo ""
+hoot db-delete-map $LOG_LEVEL $GENERAL_OPTS $DB_OPTS -D debug.maps.filename=$OUT_DIR/cleanup-db.osm $SEC_DB_INPUT


### PR DESCRIPTION
This helps prevent SQL errors when trying to apply some changesets. May have other benefits with real world data. I think the C&R workflow is the only one deriving and then combining multiple changesets. If arbitrarily throwing out subsequent statements ends up causing any problems, then we may have to come with a more robust way to handle the duplication of statements.