### PR TITLE
Allow admins to export other users private data

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ServiceChangesetReplacementGridTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ServiceChangesetReplacementGridTest.cpp
@@ -305,13 +305,17 @@ private:
       StringUtils::millisecondsToDhms(_subTaskTimer.elapsed()));
     _subTaskTimer.restart();
 
-//    LOG_STATUS("Cleaning up the replacement data db at: " << _replacementDataUrl << "...");
-//    ServicesDbTestUtils::deleteUser(USER_EMAIL);
-//    HootApiDbWriter().deleteMap(_testName);
-//    LOG_STATUS(
-//      "Replacement data cleaned in: " <<
-//      StringUtils::millisecondsToDhms(_subTaskTimer.elapsed()));
-//    _subTaskTimer.restart();
+    LOG_STATUS("Cleaning up the replacement data db at: " << _replacementDataUrl << "...");
+    HootApiDb database;
+    database.open(ServicesDbTestUtils::getDbModifyUrl(_testName).toString());
+    database.deleteMap(database.getMapIdByName(_testName));
+    database.close();
+
+    ServicesDbTestUtils::deleteUser(USER_EMAIL);
+    LOG_STATUS(
+      "Replacement data cleaned in: " <<
+      StringUtils::millisecondsToDhms(_subTaskTimer.elapsed()));
+    _subTaskTimer.restart();
   }
 };
 

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ServiceChangesetReplacementGridTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ServiceChangesetReplacementGridTest.cpp
@@ -86,7 +86,7 @@ public:
     _cleanupDataToReplace();
   }
 
-  virtual void takeDown()
+  virtual void tearDown()
   {
     _cleanupDataToReplace();
     _cleanupReplacementData();

--- a/hoot-core-test/src/test/cpp/hoot/core/auth/ServicesHootServicesLoginManagerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/auth/ServicesHootServicesLoginManagerTest.cpp
@@ -108,15 +108,18 @@ public:
   void getAccessTokensTest()
   {
     const QString sessionId = UuidHelper::createUuid().toString().replace("{", "").replace("}", "");
+    QString testName = "ServicesHootServicesLoginManagerTest_getAccessTokensTest";
+    QString email = testName + "@hoottestcpp.org";
     const long userId =
       ServicesDbTestUtils::insertTestUser(
-        "ServicesHootServicesLoginManagerTest::getAccessTokensTest",
-        "ServicesHootServicesLoginManagerTest::getAccessTokensTest@hoot.com",
+        testName, email,
         sessionId, "testAccessToken", "testAccessTokenSecret");
 
     QString accessToken;
     QString accessTokenSecret;
     HootServicesLoginManager().getAccessTokens(userId, accessToken, accessTokenSecret);
+
+    ServicesDbTestUtils::deleteUser(email);
 
     HOOT_STR_EQUALS("testAccessToken", accessToken);
     HOOT_STR_EQUALS("testAccessTokenSecret", accessTokenSecret);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServiceHootApiDbTest.cpp
@@ -461,7 +461,8 @@ public:
 
   void runAvailableMapNamesTest()
   {
-    setUpTest("runAvailableMapNamesTest");
+    QString test_name = "runAvailableMapNamesTest";
+    setUpTest(test_name);
     const QString differentUserEmail = userEmail().replace(testName, testName + "-different-user");
     ServicesDbTestUtils::deleteUser(differentUserEmail);
 
@@ -478,9 +479,9 @@ public:
     const long currentUserId = database.getOrCreateUser(userEmail(), userName());
     LOG_VART(currentUserId);
     database.setUserId(currentUserId);
+    QString currentUser = testName + "-current-user";
     const long currentUserPrivateFolderId =
-      database.insertFolder(
-        testName.replace(testName, testName + "-current-user"), -1, currentUserId, false);
+      database.insertFolder(currentUser, -1, currentUserId, false);
     long testMapId = database.insertMap("runAvailableMapNamesTest-1");
     database.insertFolderMapMapping(testMapId, currentUserPrivateFolderId);
     testMapId = database.insertMap("runAvailableMapNamesTest-2");
@@ -488,14 +489,14 @@ public:
 
     // insert a couple of public maps owned by a different user; these should be returned by
     // selectMapNamesAvailableToCurrentUser
+    QString differentUser = testName + "-different-user";
     const long differentUserId =
-      database.getOrCreateUser(
-        differentUserEmail, userName().replace(testName, testName + "-different-user"));
+      database.getOrCreateUser(differentUserEmail, differentUser);
     LOG_VART(differentUserId);
     database.setUserId(differentUserId);
+    QString differentUser1 = testName + "-different-user-1";
     const long differentUserPublicFolderId =
-      database.insertFolder(
-        testName.replace(testName, testName + "-different-user-1"), -1, differentUserId, true);
+      database.insertFolder(differentUser1, -1, differentUserId, true);
     testMapId = database.insertMap("runAvailableMapNamesTest-3");
     database.insertFolderMapMapping(testMapId, differentUserPublicFolderId);
     testMapId = database.insertMap("runAvailableMapNamesTest-4");
@@ -503,10 +504,9 @@ public:
 
     // insert a couple of private maps owned by a different user; these should *not* be returned by
     // selectMapNamesAvailableToCurrentUser
-
+    QString differentUser2 = testName + "-different-user-2";
     const long differentUserPrivateFolderId =
-      database.insertFolder(
-        testName.replace(testName, testName + "-different-user-2"), -1, differentUserId, false);
+      database.insertFolder(differentUser2, -1, differentUserId, false);
     testMapId = database.insertMap("runAvailableMapNamesTest-5");
     database.insertFolderMapMapping(testMapId, differentUserPrivateFolderId);
     testMapId = database.insertMap("runAvailableMapNamesTest-6");

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.cpp
@@ -328,11 +328,11 @@ OsmMapPtr ServicesDbTestUtils::createServiceTestMap()
 
 long ServicesDbTestUtils::insertTestUser(const QString& userName, const QString& email,
                                          const QString& sessionId, const QString& accessToken,
-                                         const QString& accessTokenSecret)
+                                         const QString& accessTokenSecret, bool isAdmin)
 {
   HootApiDb db;
   db.open(QUrl(HootApiDb::getBaseUrl().toString() + "/blah"));
-  const long userId = db.insertUser(email, userName);
+  const long userId = db.getOrCreateUser(email, userName, isAdmin);
   db.insertUserSession(userId, sessionId);
   db.updateUserAccessTokens(userId, accessToken, accessTokenSecret);
   db.close();

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ServicesDbTestUtils.h
@@ -94,7 +94,7 @@ public:
   static OsmMapPtr createServiceTestMap();
 
   static long insertTestUser(const QString& userName, const QString& email, const QString& sessionId,
-                             const QString& accessToken, const QString& accessTokenSecret);
+                             const QString& accessToken, const QString& accessTokenSecret, bool isAdmin = false);
 
   static bool deleteUserByUserName(const QString& userName);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
@@ -310,6 +310,10 @@ void HootApiDb::createPendingMapIndexes()
 
 void HootApiDb::deleteMap(long mapId)
 {
+  //  Don't try to delete an invalid map ID
+  if (mapId == -1)
+    return;
+
   LOG_STATUS("Deleting map: " << mapId << "...");
 
   // Drop related sequences

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
@@ -968,19 +968,38 @@ bool HootApiDb::insertRelationMember(const long relationId, const ElementType& t
 
   if (!_insertRelationMembers->exec())
   {
-    throw HootException("Error inserting relation memeber: " +
+    throw HootException("Error inserting relation member: " +
       _insertRelationMembers->lastError().text());
   }
   return true;
 }
 
-long HootApiDb::getOrCreateUser(QString email, QString displayName)
+long HootApiDb::getOrCreateUser(QString email, QString displayName, bool admin)
 {
   long result = getUserId(email, false);
 
   if (result == -1)
   {
     result = insertUser(email, displayName);
+    if (admin)
+    {
+      if (!_setUserAsAdmin)
+      {
+        _setUserAsAdmin.reset(new QSqlQuery(_db));
+        _setUserAsAdmin->prepare(
+          "UPDATE " + this->getUsersTableName() +
+          " SET privileges = privileges || '\"admin\"=>\"true\"' :: hstore"
+          " WHERE id=:id;");
+      }
+      //  Add the "admin => true" value to the HSTORE
+      _setUserAsAdmin->bindValue(":id", (qlonglong)result);
+
+      if (!_setUserAsAdmin->exec())
+      {
+        throw HootException("Error setting user as admin: " +
+          _setUserAsAdmin->lastError().text());
+      }
+    }
   }
 
   return result;
@@ -1196,6 +1215,8 @@ void HootApiDb::_resetQueries()
   _wayIdReserver.reset();
 
   _updateIdSequence.reset();
+  _setUserAsAdmin.reset();
+  _isUserAdmin.reset();
 }
 
 long HootApiDb::getMapIdFromUrl(const QUrl& url)
@@ -1307,6 +1328,7 @@ bool HootApiDb::currentUserCanAccessMap(const long mapId, const bool write)
 
   long userId = -1;
   bool isPublic = false;
+  bool isAdmin = false;
   if (_getMapPermissionsById->next())
   {
     bool ok;
@@ -1319,15 +1341,33 @@ bool HootApiDb::currentUserCanAccessMap(const long mapId, const bool write)
     isPublic = _getMapPermissionsById->value(1).toBool();
     LOG_VART(isPublic);
   }
+  //  Only query for admin permissions if the map isn't owned by the current user
+  if (_currUserId != userId)
+  {
+    //  Create the admin query if it doesn't exist
+    if (!_isUserAdmin)
+    {
+      _isUserAdmin.reset(new QSqlQuery(_db));
+      _isUserAdmin->prepare(
+        "SELECT (u.privileges -> 'admin')::boolean AS is_admin FROM users u WHERE id=:id;");
+    }
+    //  Query for the admin privileges of the current user
+    _isUserAdmin->bindValue(":id", (qlonglong)_currUserId);
+    if (!_isUserAdmin->exec())
+      throw HootException(_isUserAdmin->lastError().text());
+    else if (_isUserAdmin->next())
+      isAdmin = _isUserAdmin->value(0).toBool();
+    _isUserAdmin->finish();
+  }
   _getMapPermissionsById->finish();
 
   if (write)
   {
-    return _currUserId == userId;
+    return _currUserId == userId || isAdmin;
   }
   else
   {
-    return isPublic || _currUserId == userId;
+    return isPublic || _currUserId == userId || isAdmin;
   }
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
@@ -137,7 +137,7 @@ public:
    */
   void createPendingMapIndexes();
 
-  long getOrCreateUser(QString email, QString displayName);
+  long getOrCreateUser(QString email, QString displayName, bool admin = false);
 
   /**
    * Set user ID for current session, will be passed to DB in all places user ID is required
@@ -626,6 +626,8 @@ private:
   std::shared_ptr<QSqlQuery> _deleteJobById;
   std::shared_ptr<QSqlQuery> _getJobStatusResourceId;
   std::shared_ptr<QSqlQuery> _updateIdSequence;
+  std::shared_ptr<QSqlQuery> _setUserAsAdmin;
+  std::shared_ptr<QSqlQuery> _isUserAdmin;
 
   /** Ignore any insertion conflicts and continue with the rest */
   bool _ignoreInsertConflicts;

--- a/scripts/core/archive/ServiceOsmApiDbHootApiDbConflate.sh
+++ b/scripts/core/archive/ServiceOsmApiDbHootApiDbConflate.sh
@@ -51,11 +51,11 @@ RUN_DEBUG_STEPS=false
 LOAD_REF_DATA=true
 LOAD_SEC_DATA=true
 CONFLATE_DATA=true
-HOOT_EMAIL=OsmApiDbHootApiDbConflate@hoottestcpp.org
+HOOT_EMAIL="$TEST_NAME@hoottestcpp.org"
 
 source conf/database/DatabaseConfig.sh
 export OSM_API_DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
-export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
 HOOT_DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
 # generic debugging options applicable to multiple commands
@@ -235,3 +235,6 @@ if [ "$CONFLATE_DATA" == "true" ]; then
   hoot db-delete-map -D api.db.email=$HOOT_EMAIL "$HOOT_DB_URL/8a-conflated-$TEST_NAME"
   hoot db-delete-map -D api.db.email=$HOOT_EMAIL "$HOOT_DB_URL/8b-conflated-$TEST_NAME"
 fi
+
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null

--- a/test-files/cmd/glacial/RndServiceMultiaryPoiIngestCmdTest.sh
+++ b/test-files/cmd/glacial/RndServiceMultiaryPoiIngestCmdTest.sh
@@ -9,8 +9,11 @@ mkdir -p $OUTPUT_DIR
 
 source conf/database/DatabaseConfig.sh
 HOOT_DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
+PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
+PGPASSWORD=$DB_PASSWORD_OSMAPI
+HOOT_EMAIL="RndServiceMultiaryPoiIngestCmdTest@hoottestcpp.org"
 # set the max elements per map in such a way that the partial reading occurs
-HOOT_OPTS="--warn -C Testing.conf -D uuid.helper.repeatable=true -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D max.elements.per.partial.map=2"
+HOOT_OPTS="--warn -C Testing.conf -D uuid.helper.repeatable=true -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D api.db.email=$HOOT_EMAIL -D hootapi.db.writer.create.user=true -D max.elements.per.partial.map=2"
 
 GOLD_OUTPUT=$REF_DIR/allCountries-geonames-output.osm
 GOLD_ADD_CHANGESET=$REF_DIR/allCountries-geonames-changeset-add.spark.1
@@ -188,3 +191,5 @@ echo "MULTIARY INGEST - DELETING REFERENCE LAYER..."
 echo ""
 hoot db-delete-map $HOOT_OPTS "$HOOT_DB_URL/MultiaryIngest-ReferenceLayer"
 
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null

--- a/test-files/cmd/glacial/ServiceDbEmptyTagsTest.sh
+++ b/test-files/cmd/glacial/ServiceDbEmptyTagsTest.sh
@@ -4,9 +4,12 @@ set -e
 # This script recreates the problem in https://github.com/ngageoint/hootenanny/issues/168
 source $HOOT_HOME/conf/database/DatabaseConfig.sh
 
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD
 
-export HOOT_OPTS="--warn -C Testing.conf -D hootapi.db.writer.create.user=true -D api.db.email=ApiDbTest@hoottestcpp.org -D hootapi.db.writer.overwrite.map=true -D writer.include.debug.tags=true -D match.creators=hoot::HighwayMatchCreator -D merger.creators=hoot::HighwayMergerCreator"
+export HOOT_EMAIL="ApiDbTest@hoottestcpp.org"
+
+export HOOT_OPTS="--warn -C Testing.conf -D hootapi.db.writer.create.user=true -D api.db.email=$HOOT_EMAIL -D hootapi.db.writer.overwrite.map=true -D writer.include.debug.tags=true -D match.creators=hoot::HighwayMatchCreator -D merger.creators=hoot::HighwayMergerCreator"
 
 export DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
 
@@ -20,4 +23,7 @@ export TB_COUNT=`psql -A -t -h $DB_HOST -p $DB_PORT -d $DB_NAME -U $DB_USER -c "
 echo "Tunnel or bridge count (should be zero): " $TB_COUNT
 
 # Clean up the map from the database
-hoot db-delete-map $HOOT_OPTS -D api.db.email=ApiDbTest@hoottestcpp.org $DB_URL/HootApiDbEmptyTagTest
+hoot db-delete-map $HOOT_OPTS -D api.db.email=$HOOT_EMAIL $DB_URL/HootApiDbEmptyTagTest
+
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null

--- a/test-files/cmd/glacial/ServiceExportOsm.sh
+++ b/test-files/cmd/glacial/ServiceExportOsm.sh
@@ -4,6 +4,7 @@ set -e
 source $HOOT_HOME/conf/database/DatabaseConfig.sh
 
 export DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD
 export outputname=service-export-test
 export outputfolder=$HOOT_HOME/tmp/$outputname
@@ -38,3 +39,6 @@ hoot db-delete-map $HOOT_OPTS $DB_URL/$input
 
 # Remove file output
 rm -rf $outputfolder
+
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='test@test.com';" > /dev/null

--- a/test-files/cmd/glacial/serial/ServiceChangesetReplacement.sh.off
+++ b/test-files/cmd/glacial/serial/ServiceChangesetReplacement.sh.off
@@ -213,9 +213,11 @@ mkdir -p $OUT_DIR
 
 source conf/database/DatabaseConfig.sh
 export OSM_API_DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
-export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
 REF_DB_INPUT=$OSM_API_DB_URL
+
+HOOT_EMAIL="${TEST_NAME}@hoottestcpp.org"
 
 # SET UP HOOT CONFIGURATION
 
@@ -235,7 +237,7 @@ GENERAL_OPTS="-C UnifyingAlgorithm.conf -C Testing.conf -D uuid.helper.repeatabl
 if [ "$CROP_OPTS" == "" ]; then
   GENERAL_OPTS=$GENERAL_OPTS" -D map.reader.add.child.refs.when.missing=true"
 fi
-DB_OPTS="-D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1 -D changeset.max.size=999999 $EXTRA_PARAMS"
+DB_OPTS="-D api.db.email=$HOOT_EMAIL -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1 -D changeset.max.size=999999 $EXTRA_PARAMS"
 PERTY_OPTS="-D random.seed=1 -D perty.systematic.error.x=15 -D perty.systematic.error.y=15 $EXTRA_PARAMS -D perty.ops= "
 CHANGESET_DERIVE_OPTS="-D changeset.user.id=1 -D bounds.output.file=$OUT_DIR/$TEST_NAME-bounds.osm -D snap.unconnected.ways.existing.way.node.tolerance=$EXISTING_WAY_NODE_TOLERANCE -D snap.unconnected.ways.snap.tolerance=$WAY_SNAP_TOLERANCE $EXTRA_PARAMS "
 CUSTOM_TAG_KEY="note"
@@ -451,3 +453,7 @@ if [[ $SOURCE_FORMATS == *"json"* ]]; then
   hoot diff $LOG_LEVEL $GENERAL_OPTS $IN_DIR/$OUT_XML $OUT_DIR/$OUT_JSON
 
 fi
+
+# Delete the user
+psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null
+

--- a/test-files/cmd/glacial/serial/ServiceChangesetReplacementAdjacentCellsTest.sh.off
+++ b/test-files/cmd/glacial/serial/ServiceChangesetReplacementAdjacentCellsTest.sh.off
@@ -5,18 +5,19 @@ set -e
 
 source conf/database/DatabaseConfig.sh
 export OSM_API_DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
-export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
 HOOT_DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
 REF_DB_INPUT=$OSM_API_DB_URL
 SEC_DB_INPUT="$HOOT_DB_URL/ServiceChangesetReplacementAdjacentCellsTest-sec"
+HOOT_EMAIL="ServiceChangesetReplacementAdjacentCellsTest@hoottestcpp.org"
 
 CROP_AOI="" # leave empty to avoid cropping
 # 4183
 #CROP_AOI="-115.1083193,36.0045951,-115.0225009,36.0811562" # leave empty to avoid cropping
 LOG_LEVEL="--status"
 GENERAL_OPTS="-C UnifyingAlgorithm.conf -C Testing.conf -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D convert.bounding.box.remove.missing.elements=false -D log.warnings.for.missing.elements=false -D debug.maps.write=false -D debug.maps.remove.missing.elements=true -D log.class.filter= "
-DB_OPTS="-D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1 -D changeset.max.size=999999"
+DB_OPTS="-D api.db.email=$HOOT_EMAIL -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1 -D changeset.max.size=999999"
 
 # 4182
 #SOURCE_FILE_1="/home/vagrant/hoot/tmp/4182/329_ReferenceNOMEData_31JULY2020.osm"
@@ -131,3 +132,6 @@ echo ""
 echo "Removing data from secondary input..."
 echo ""
 hoot db-delete-map $LOG_LEVEL $GENERAL_OPTS $DB_OPTS -D debug.maps.filename=$OUT_DIR/cleanup-db.osm $SEC_DB_INPUT
+
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null

--- a/test-files/cmd/glacial/serial/ServiceConflateDiffTest.sh.off
+++ b/test-files/cmd/glacial/serial/ServiceConflateDiffTest.sh.off
@@ -9,7 +9,9 @@ IN_DIR=/home/vagrant/hoot/tmp/3895
 OUT_DIR=$IN_DIR
 CROP_BOUNDS="-94.5395,39.1037,-94.5379,39.1046"
 
-CONFIG="--info -C ReferenceConflation.conf -C UnifyingAlgorithm.conf -C Testing.conf -D writer.include.debug.tags=true -D uuid.helper.repeatable=true -D debug.maps.write=false -D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
+HOOT_EMAIL="ServiceConflateDiffTest@hoottestcpp.org"
+
+CONFIG="--info -C ReferenceConflation.conf -C UnifyingAlgorithm.conf -C Testing.conf -D writer.include.debug.tags=true -D uuid.helper.repeatable=true -D debug.maps.write=false -D api.db.email=$HOOT_EMAIL -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
 #-D reader.keep.status.tag=true -D reader.use.file.status=true -D reader.add.source.datetime=false
 #CONFIG+="-D log.class.filter=RemoveEmptyAreasVisitor"
 CONFIG+=" -D match.creators=hoot::HighwayMatchCreator -D merger.creators=hoot::HighwayMergerCreator"
@@ -24,7 +26,7 @@ rm -f $OUT_DIR/changeset-applied.osm
 echo "Creating the OSM API DB..."
 source conf/database/DatabaseConfig.sh
 export OSM_API_DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
-export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
 REF_DB_INPUT=$OSM_API_DB_URL
 scripts/database/CleanAndInitializeOsmApiDb.sh
@@ -78,3 +80,6 @@ hoot changeset-apply $CONFIG -D debug.maps.filename=$IN_DIR/debug-changeset-appl
 echo "Reading out the final map for comparison with expected map..."
 hoot convert $CONFIG -D debug.maps.filename=$IN_DIR/debug-final-map.osm $OSM_API_DB_URL $OUT_DIR/changeset-applied.osm
 #hoot diff $CONFIG $IN_DIR/changeset-applied.osm $OUT_DIR/changeset-applied.osm
+
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null

--- a/test-files/cmd/glacial/serial/ServiceGrailDiffTest.sh.off
+++ b/test-files/cmd/glacial/serial/ServiceGrailDiffTest.sh.off
@@ -8,7 +8,8 @@ IN_DIR=/home/vagrant/hoot/tmp/3923
 OUT_DIR=$IN_DIR
 #CROP_BOUNDS="-94.5466,39.0990,-94.5357,39.1097"
 
-CONFIG="--info -C DifferentialConflation.conf -C NetworkAlgorithm.conf -D differential.snap.unconnected.roads=true -D writer.include.debug.tags=true -D uuid.helper.repeatable=true -D debug.maps.write=false -D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
+HOOT_EMAIL="ServiceGrailDiffTest@hoottestcpp.org"
+CONFIG="--info -C DifferentialConflation.conf -C NetworkAlgorithm.conf -D differential.snap.unconnected.roads=true -D writer.include.debug.tags=true -D uuid.helper.repeatable=true -D debug.maps.write=false -D api.db.email=$HOOT_EMAIL -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
 # -C Testing.conf
 #-D reader.keep.status.tag=true -D reader.use.file.status=true -D reader.add.source.datetime=false
 #CONFIG+="-D log.class.filter=RemoveEmptyAreasVisitor"
@@ -25,7 +26,7 @@ rm -f $OUT_DIR/changeset-applied.osm
 echo "Creating the OSM API DB..."
 source conf/database/DatabaseConfig.sh
 export OSM_API_DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
-export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
 REF_DB_INPUT=$OSM_API_DB_URL
 scripts/database/CleanAndInitializeOsmApiDb.sh
@@ -81,3 +82,6 @@ hoot changeset-apply $CONFIG -D debug.maps.filename=$IN_DIR/debug-changeset-appl
 echo "Reading out the final map for comparison with expected map..."
 hoot convert $CONFIG -D debug.maps.filename=$IN_DIR/debug-final-map.osm $OSM_API_DB_URL $OUT_DIR/changeset-applied.osm
 #hoot diff $CONFIG $IN_DIR/changeset-applied.osm $OUT_DIR/changeset-applied.osm
+
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null

--- a/test-files/cmd/glacial/serial/ServiceStreamingApiDbTest.sh
+++ b/test-files/cmd/glacial/serial/ServiceStreamingApiDbTest.sh
@@ -8,10 +8,11 @@ mkdir -p $OUTPUT_DIR
 
 source conf/database/DatabaseConfig.sh
 export OSM_API_DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
-export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
+export HOOT_EMAIL="ServiceStreamingApiDbTest@hoottestcpp.org"
 HOOT_DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
-HOOT_OPTS="--warn -C Testing.conf -D uuid.helper.repeatable=true -D reader.add.source.datetime=false  -D writer.include.circular.error.tags=false -D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D changeset.user.id=1 -D osmapidb.bulk.inserter.reserve.record.ids.before.writing.data=false -D apidb.bulk.inserter.validate.data=true -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D api.db.email=ServiceStreamingApiDbTest@test.com"
+HOOT_OPTS="--warn -C Testing.conf -D uuid.helper.repeatable=true -D reader.add.source.datetime=false  -D writer.include.circular.error.tags=false -D changeset.user.id=1 -D osmapidb.bulk.inserter.reserve.record.ids.before.writing.data=false -D apidb.bulk.inserter.validate.data=true -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D api.db.email=$HOOT_EMAIL"
 
 echo "streaming hoot api db --> osm api db..."
 echo ""
@@ -86,6 +87,9 @@ hoot convert $HOOT_OPTS $OUTPUT_DIR/Poi1-cropped-osmapidb/poi.shp $OUTPUT_DIR/Po
 hoot diff $HOOT_OPTS $GOLD_DIR/Poi1-cropped-2.osm $OUTPUT_DIR/Poi1-cropped-osmapidb-ogr.osm
 
 # Cleanup the database
-hoot db-delete-map -D api.db.email=ServiceStreamingApiDbTest@test.com "$HOOT_DB_URL/ToyTestA"
-hoot db-delete-map -D api.db.email=ServiceStreamingApiDbTest@test.com "$HOOT_DB_URL/Poi1"
+hoot db-delete-map -D api.db.email=$HOOT_EMAIL "$HOOT_DB_URL/ToyTestA"
+hoot db-delete-map -D api.db.email=$HOOT_EMAIL "$HOOT_DB_URL/Poi1"
 scripts/database/CleanAndInitializeOsmApiDb.sh
+
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null

--- a/test-files/cmd/glacial/serial/replacement-test-archive/ServiceBuildingReplacementTest.sh.off
+++ b/test-files/cmd/glacial/serial/replacement-test-archive/ServiceBuildingReplacementTest.sh.off
@@ -15,9 +15,11 @@ mkdir -p $OUT_DIR
 
 source conf/database/DatabaseConfig.sh
 export OSM_API_DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
-export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
 HOOT_DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
+
+HOOT_EMAIL="$TEST_NAME@hoottestcpp.org"
 
 REF_LAYER_FILE=$OUT_DIR/BostonSubsetRoadBuilding_FromOsm-perturbed.osm
 REF_LAYER=$OSM_API_DB_URL
@@ -27,7 +29,7 @@ AOI="-71.4698,42.4866,-71.4657,42.4902"
 
 #ChangesetCreator;MapCropper;OsmMap;OsmMapWriterFactory
 GENERAL_OPTS="--warn -D log.class.filter= -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D changeset.xml.writer.add.timestamp=false -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D debug.maps.write=false"
-DB_OPTS="-D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
+DB_OPTS="-D api.db.email=$HOOT_EMAIL -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
 PERTY_OPTS="-D perty.seed=1 -D perty.systematic.error.x=15 -D perty.systematic.error.y=15 -D perty.ops="
 PRUNE_AND_CROP_OPTS="-D reader.use.data.source.ids=true -D convert.bounding.box.keep.entire.features.crossing.bounds=true -D convert.bounding.box.keep.only.features.inside.bounds=false -D convert.ops=hoot::RemoveElementsVisitor -D convert.bounding.box=$AOI -D remove.elements.visitor.element.criteria=hoot::BuildingCriterion -D remove.elements.visitor.recursive=true -D element.criterion.negate=true"
 COOKIE_CUT_OPTS="-D reader.use.data.source.ids=true -D crop.keep.entire.features.crossing.bounds=true -D crop.keep.only.features.inside.bounds=false -D debug.maps.filename=$OUT_DIR/cookie-cut.osm"
@@ -98,3 +100,6 @@ hoot diff $GENERAL_OPTS $IN_DIR/$TEST_NAME-replaced.osm $OUT_DIR/$TEST_NAME-repl
 # CLEANUP
 
 hoot delete-db-map $HOOT_OPTS $DB_OPTS -D debug.maps.filename=$OUT_DIR/cleanup.osm $SEC_LAYER
+
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null

--- a/test-files/cmd/glacial/serial/replacement-test-archive/ServiceBuildingStrictReplacementTest.sh.off
+++ b/test-files/cmd/glacial/serial/replacement-test-archive/ServiceBuildingStrictReplacementTest.sh.off
@@ -15,9 +15,11 @@ mkdir -p $OUT_DIR
 
 source conf/database/DatabaseConfig.sh
 export OSM_API_DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
-export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
 HOOT_DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
+
+HOOT_EMAIL="$TEST_NAME@hoottestcpp.org"
 
 REF_LAYER_FILE=$OUT_DIR/BostonSubsetRoadBuilding_FromOsm-perturbed.osm
 REF_LAYER=$OSM_API_DB_URL
@@ -26,7 +28,7 @@ SEC_LAYER="$HOOT_DB_URL/$TEST_NAME-sec"
 AOI="-71.4698,42.4866,-71.4657,42.4902"
 
 GENERAL_OPTS="--warn -D log.class.filter= -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D changeset.xml.writer.add.timestamp=false -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D debug.maps.write=false"
-DB_OPTS="-D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
+DB_OPTS="-D api.db.email=$HOOT_EMAIL -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
 PERTY_OPTS="-D perty.seed=1 -D perty.systematic.error.x=15 -D perty.systematic.error.y=15 -D perty.ops= "
 PRUNE_AND_CROP_OPTS="-D reader.use.data.source.ids=true -D convert.ops=hoot::RemoveElementsVisitor -D convert.bounding.box=$AOI -D remove.elements.visitor.element.criteria=hoot::BuildingCriterion -D remove.elements.visitor.recursive=true -D element.criterion.negate=true"
 COOKIE_CUT_OPTS="-D reader.use.data.source.ids=true -D crop.keep.entire.features.crossing.bounds=true -D crop.keep.only.features.inside.bounds=false -D debug.maps.filename=$OUT_DIR/cookie-cut.osm"
@@ -100,3 +102,6 @@ hoot diff $GENERAL_OPTS $IN_DIR/$TEST_NAME-replaced.osm $OUT_DIR/$TEST_NAME-repl
 # CLEANUP
 
 hoot delete-db-map $HOOT_OPTS $DB_OPTS -D debug.maps.filename=$OUT_DIR/cleanup.osm $SEC_LAYER
+
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null

--- a/test-files/cmd/glacial/serial/replacement-test-archive/ServicePoiStrictReplacementTest.sh.off
+++ b/test-files/cmd/glacial/serial/replacement-test-archive/ServicePoiStrictReplacementTest.sh.off
@@ -15,9 +15,11 @@ mkdir -p $OUT_DIR
 
 source conf/database/DatabaseConfig.sh
 export OSM_API_DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
-export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
 HOOT_DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
+
+HOOT_EMAIL="$TEST_NAME@hoottestcpp.org"
 
 REF_LAYER_FILE=$IN_DIR/PoiPolygon1.osm
 REF_LAYER=$OSM_API_DB_URL
@@ -26,7 +28,7 @@ SEC_LAYER="$HOOT_DB_URL/$TEST_NAME-sec"
 AOI="-122.43204,37.7628,-122.4303457,37.76437"
 
 GENERAL_OPTS="--warn -D log.class.filter= -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D changeset.xml.writer.add.timestamp=false -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D debug.maps.write=false"
-DB_OPTS="-D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
+DB_OPTS="-D api.db.email=$HOOT_EMAIL -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
 PRUNE_AND_CROP_OPTS="-D reader.use.data.source.ids=true -D convert.bounding.box.keep.entire.features.crossing.bounds=false -D convert.bounding.box.keep.only.features.inside.bounds=false -D convert.ops=hoot::RemoveElementsVisitor -D convert.bounding.box=$AOI -D remove.elements.visitor.element.criteria=hoot::PoiCriterion -D remove.elements.visitor.recursive=true -D element.criterion.negate=true"
 COOKIE_CUT_OPTS="-D reader.use.data.source.ids=true -D crop.keep.entire.features.crossing.bounds=false -D crop.keep.only.features.inside.bounds=false -D debug.maps.filename=$OUT_DIR/cookie-cut.osm"
 CONFLATE_OPTS="-D debug.maps.filename=$OUT_DIR/conflate.osm -D conflate.use.data.source.ids.1=true -D conflate.use.data.source.ids.2=false -D debug.maps.filename=$OUT_DIR/conflated.osm"
@@ -88,3 +90,6 @@ hoot diff $GENERAL_OPTS $IN_DIR_2/$TEST_NAME-replaced.osm $OUT_DIR/$TEST_NAME-re
 # CLEANUP
 
 hoot delete-db-map $HOOT_OPTS $DB_OPTS -D debug.maps.filename=$OUT_DIR/cleanup.osm $SEC_LAYER
+
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null

--- a/test-files/cmd/glacial/serial/replacement-test-archive/ServiceRoadReplacementTest.sh.off
+++ b/test-files/cmd/glacial/serial/replacement-test-archive/ServiceRoadReplacementTest.sh.off
@@ -15,9 +15,11 @@ mkdir -p $OUT_DIR
 
 source conf/database/DatabaseConfig.sh
 export OSM_API_DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
-export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
 HOOT_DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
+
+HOOT_EMAIL="$TEST_NAME@hoottestcpp.org"
 
 REF_LAYER_FILE=$OUT_DIR/BostonSubsetRoadBuilding_FromOsm-perturbed.osm
 REF_LAYER=$OSM_API_DB_URL
@@ -26,7 +28,7 @@ SEC_LAYER="$HOOT_DB_URL/$TEST_NAME-sec"
 AOI="-71.4698,42.4866,-71.4657,42.4902"
 
 GENERAL_OPTS="--warn -D log.class.filter= -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D changeset.xml.writer.add.timestamp=false -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D debug.maps.write=false"
-DB_OPTS="-D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
+DB_OPTS="-D api.db.email=$HOOT_EMAIL -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
 PERTY_OPTS="-D perty.seed=1 -D perty.systematic.error.x=15 -D perty.systematic.error.y=15 -D perty.ops="
 PRUNE_AND_CROP_OPTS="-D reader.use.data.source.ids=true -D convert.bounding.box.keep.entire.features.crossing.bounds=true -D convert.bounding.box.keep.only.features.inside.bounds=false -D convert.ops=hoot::RemoveElementsVisitor -D convert.bounding.box=$AOI -D remove.elements.visitor.element.criteria=hoot::HighwayCriterion -D remove.elements.visitor.recursive=true -D element.criterion.negate=true"
 COOKIE_CUT_OPTS="-D reader.use.data.source.ids=true -D crop.keep.entire.features.crossing.bounds=false -D crop.keep.only.features.inside.bounds=false -D debug.maps.filename=$OUT_DIR/cookie-cut.osm"
@@ -94,3 +96,6 @@ hoot diff $GENERAL_OPTS $IN_DIR/$TEST_NAME-replaced.osm $OUT_DIR/$TEST_NAME-repl
 # CLEANUP
 
 hoot delete-db-map $HOOT_OPTS $DB_OPTS -D debug.maps.filename=$OUT_DIR/cleanup.osm $SEC_LAYER
+
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null

--- a/test-files/cmd/glacial/serial/replacement-test-archive/ServiceRoadStrictReplacementTest.sh.off
+++ b/test-files/cmd/glacial/serial/replacement-test-archive/ServiceRoadStrictReplacementTest.sh.off
@@ -15,9 +15,11 @@ mkdir -p $OUT_DIR
 
 source conf/database/DatabaseConfig.sh
 export OSM_API_DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
-export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
 HOOT_DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
+
+HOOT_EMAIL="$TEST_NAME@hoottestcpp.org"
 
 REF_LAYER_FILE=$OUT_DIR/BostonSubsetRoadBuilding_FromOsm-perturbed.osm
 REF_LAYER=$OSM_API_DB_URL
@@ -26,7 +28,7 @@ SEC_LAYER="$HOOT_DB_URL/$TEST_NAME-sec"
 AOI="-71.4698,42.4866,-71.4657,42.4902"
 
 GENERAL_OPTS="--warn -D log.class.filter= -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D changeset.xml.writer.add.timestamp=false -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false -D debug.maps.write=false"
-DB_OPTS="-D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
+DB_OPTS="-D api.db.email=$HOOT_EMAIL -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
 PERTY_OPTS="-D perty.seed=1 -D perty.systematic.error.x=15 -D perty.systematic.error.y=15 -D perty.ops= "
 PRUNE_AND_CROP_OPTS="-D convert.bounding.box.keep.only.features.inside.bounds=false -D reader.use.data.source.ids=true -D convert.ops=hoot::RemoveElementsVisitor -D convert.bounding.box=$AOI -D remove.elements.visitor.element.criteria=hoot::HighwayCriterion -D remove.elements.visitor.recursive=true -D element.criterion.negate=true"
 COOKIE_CUT_OPTS="-D reader.use.data.source.ids=true -D crop.keep.entire.features.crossing.bounds=false -D crop.keep.only.features.inside.bounds=false -D debug.maps.filename=$OUT_DIR/cookie-cut.osm"
@@ -103,3 +105,6 @@ hoot diff $GENERAL_OPTS $IN_DIR/$TEST_NAME-replaced.osm $OUT_DIR/$TEST_NAME-repl
 # CLEANUP
 
 hoot delete-db-map $HOOT_OPTS $DB_OPTS -D debug.maps.filename=$OUT_DIR/cleanup.osm $SEC_LAYER
+
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null

--- a/test-files/cmd/quick/ServiceDbListMapsCmdTest.sh
+++ b/test-files/cmd/quick/ServiceDbListMapsCmdTest.sh
@@ -1,19 +1,24 @@
 #!/bin/bash
 set -e
 
-EMAIL=DbListMapsCmdTest@hoottestcpp.org
 source conf/database/DatabaseConfig.sh
-HOOT_DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
+export HOOT_DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 
-CONFIG="-C Testing.conf"
+export HOOT_EMAIL="DbListMapsCmdTest@hoottestcpp.org"
+
+export CONFIG="-C Testing.conf"
 
 # add some maps for this user (delete any pre-existing)
-hoot convert --warn $CONFIG -D api.db.email=$EMAIL -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true test-files/ToyTestA.osm $HOOT_DB_URL/DbListMapsCmdTest1
-hoot convert --warn $CONFIG -D api.db.email=$EMAIL -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true test-files/ToyTestB.osm $HOOT_DB_URL/DbListMapsCmdTest2
+hoot convert --warn $CONFIG -D api.db.email=$HOOT_EMAIL -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true test-files/ToyTestA.osm $HOOT_DB_URL/DbListMapsCmdTest1
+hoot convert --warn $CONFIG -D api.db.email=$HOOT_EMAIL -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true test-files/ToyTestB.osm $HOOT_DB_URL/DbListMapsCmdTest2
 
 # list the maps (not dealing with public maps here; see ServiceHootApiDbTest)
-hoot db-list-maps --warn $CONFIG -D api.db.email=$EMAIL $HOOT_DB_URL
+hoot db-list-maps --warn $CONFIG -D api.db.email=$HOOT_EMAIL $HOOT_DB_URL
 
 # clean-up the databases
-hoot db-delete-map --warn $CONFIG -D api.db.email=$EMAIL $HOOT_DB_URL/DbListMapsCmdTest1
-hoot db-delete-map --warn $CONFIG -D api.db.email=$EMAIL $HOOT_DB_URL/DbListMapsCmdTest2
+hoot db-delete-map --warn $CONFIG -D api.db.email=$HOOT_EMAIL $HOOT_DB_URL/DbListMapsCmdTest1
+hoot db-delete-map --warn $CONFIG -D api.db.email=$HOOT_EMAIL $HOOT_DB_URL/DbListMapsCmdTest2
+
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null

--- a/test-files/cmd/slow/ServiceHootApiDbConflateTest.sh
+++ b/test-files/cmd/slow/ServiceHootApiDbConflateTest.sh
@@ -2,8 +2,10 @@
 set -e
 
 source $HOOT_HOME/conf/database/DatabaseConfig.sh
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
+export HOOT_EMAIL="ServiceHootApiDbConflateTest@hoottestcpp.org"
 
-export HOOT_OPTS="-C Testing.conf -D hootapi.db.writer.create.user=true -D api.db.email=ServiceHootApiDbConflateTest@hoottestcpp.org -D hootapi.db.writer.overwrite.map=true -D writer.include.debug.tags=true --warn"
+export HOOT_OPTS="-C Testing.conf -D hootapi.db.writer.create.user=true -D api.db.email=$HOOT_EMAIL -D hootapi.db.writer.overwrite.map=true -D writer.include.debug.tags=true --warn"
 export CONFLATE_OPTS="-C UnifyingAlgorithm.conf -C ReferenceConflation.conf"
 
 export DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
@@ -58,5 +60,5 @@ export PGPASSWORD=$DB_PASSWORD
 psql -U $DB_USER -h $DB_HOST -p $DB_PORT -d $DB_NAME -c "select display_name from maps;" | grep -qw DcGisRoads-ServiceHootApiDbConflateTest && echo "Error: db-delete-map did not remove DcGisRoads-ServiceHootApiDbConflateTest dataset"
 psql -U $DB_USER -h $DB_HOST -p $DB_PORT -d $DB_NAME -c "select display_name from maps;" | grep -qw DcTigerRoads-ServiceHootApiDbConflateTest && echo "Error: db-delete-map did not remove DcTigerRoads-ServiceHootApiDbConflateTest dataset"
 
-
-
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null

--- a/test-files/cmd/slow/ServiceHootApiDbReaderCmdTest.sh
+++ b/test-files/cmd/slow/ServiceHootApiDbReaderCmdTest.sh
@@ -3,7 +3,8 @@ set -e
 
 source conf/database/DatabaseConfig.sh
 export HOOT_DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
-export EMAIL=ServiceHootApiDbReaderCmdTest.sh@hoottestcpp.org
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
+export HOOT_EMAIL="ServiceHootApiDbReaderCmdTest@hoottestcpp.org"
 
 OUTPUT_DIR=test-output/cmd/slow/ServiceHootApiDbReaderCmdTest
 rm -rf $OUTPUT_DIR
@@ -12,15 +13,18 @@ mkdir -p $OUTPUT_DIR
 CONFIG="-C Testing.conf"
 
 echo "initial data load"
-hoot convert --warn $CONFIG -D hootapi.db.writer.create.user=true -D api.db.email=$EMAIL -D hootapi.db.writer.overwrite.map=true test-files/DcGisRoads.osm "$HOOT_DB_URL/DcGisRoads-ServiceHootApiDbReaderCmdTest"
+hoot convert --warn $CONFIG -D hootapi.db.writer.create.user=true -D api.db.email=$HOOT_EMAIL -D hootapi.db.writer.overwrite.map=true test-files/DcGisRoads.osm "$HOOT_DB_URL/DcGisRoads-ServiceHootApiDbReaderCmdTest"
 
 echo "unbounded query"
-hoot convert --warn $CONFIG -D api.db.email=$EMAIL -D convert.ops="hoot::RemoveTagsVisitor;hoot::RemoveAttributesVisitor" -D tag.filter.keys="source:datetime" -D remove.attributes.visitor.types="changeset;timestamp" "$HOOT_DB_URL/DcGisRoads-ServiceHootApiDbReaderCmdTest" $OUTPUT_DIR/output1.osm
+hoot convert --warn $CONFIG -D api.db.email=$HOOT_EMAIL -D convert.ops="hoot::RemoveTagsVisitor;hoot::RemoveAttributesVisitor" -D tag.filter.keys="source:datetime" -D remove.attributes.visitor.types="changeset;timestamp" "$HOOT_DB_URL/DcGisRoads-ServiceHootApiDbReaderCmdTest" $OUTPUT_DIR/output1.osm
 hoot diff --warn $CONFIG test-files/cmd/slow/ServiceHootApiDbReaderTest/output1.osm $OUTPUT_DIR/output1.osm
 
 echo "bounded query"
-hoot convert --warn $CONFIG -D api.db.email=$EMAIL -D convert.ops="hoot::RemoveTagsVisitor;hoot::RemoveAttributesVisitor" -D tag.filter.keys="source:datetime" -D remove.attributes.visitor.types="changeset;timestamp" -D convert.bounding.box=-77.04,38.8916,-77.03324,38.8958 "$HOOT_DB_URL/DcGisRoads-ServiceHootApiDbReaderCmdTest" $OUTPUT_DIR/output2.osm
+hoot convert --warn $CONFIG -D api.db.email=$HOOT_EMAIL -D convert.ops="hoot::RemoveTagsVisitor;hoot::RemoveAttributesVisitor" -D tag.filter.keys="source:datetime" -D remove.attributes.visitor.types="changeset;timestamp" -D convert.bounding.box=-77.04,38.8916,-77.03324,38.8958 "$HOOT_DB_URL/DcGisRoads-ServiceHootApiDbReaderCmdTest" $OUTPUT_DIR/output2.osm
 hoot diff $CONFIG test-files/cmd/slow/ServiceHootApiDbReaderTest/output2.osm $OUTPUT_DIR/output2.osm
 
 echo "clean up database"
-hoot db-delete-map --warn $CONFIG -D api.db.email=$EMAIL "$HOOT_DB_URL/DcGisRoads-ServiceHootApiDbReaderCmdTest"
+hoot db-delete-map --warn $CONFIG -D api.db.email=$HOOT_EMAIL "$HOOT_DB_URL/DcGisRoads-ServiceHootApiDbReaderCmdTest"
+
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null

--- a/test-files/cmd/slow/serial/ServiceDiffRoadSnapTest.sh.off
+++ b/test-files/cmd/slow/serial/ServiceDiffRoadSnapTest.sh.off
@@ -25,12 +25,14 @@ mkdir -p $OUTPUT_DIR
 
 source conf/database/DatabaseConfig.sh
 export OSM_API_DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
-export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
 HOOT_DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
 
+HOOT_EMAIL="$TEST_NAME@hoottestcpp.org"
+
 GENERAL_OPTS=$CONFIG" -C "$ALG_CONFIG" -C DifferentialConflation.conf -C Testing.conf $MATCHERS $MERGERS -D uuid.helper.repeatable=true -D writer.include.debug.tags=true -D reader.add.source.datetime=false -D writer.include.circular.error.tags=false"
-DB_OPTS="-D api.db.email=OsmApiDbHootApiDbConflate@hoottestcpp.org -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
+DB_OPTS="-D api.db.email=$HOOT_EMAIL -D hootapi.db.writer.create.user=true -D hootapi.db.writer.overwrite.map=true -D changeset.user.id=1"
 CHANGESET_DERIVE_OPTS="-D changeset.user.id=1 -D changeset.allow.deleting.reference.features=false -D snap.unconnected.ways.mark.snapped.nodes=true -D snap.unconnected.ways.mark.snapped.ways=true"
 
 DEBUG=false
@@ -79,4 +81,5 @@ hoot diff $GENERAL_OPTS $GOLD_DIR/out.osm $OUTPUT_DIR/out.osm
 
 hoot db-delete-map $GENERAL_OPTS $DB_OPTS $SEC_DB_INPUT $HOOT_DB_URL/$TEST_NAME-sec
 
-
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null

--- a/test-files/cmd/slow/serial/ServiceNodeDensityTilesCmdTest.sh
+++ b/test-files/cmd/slow/serial/ServiceNodeDensityTilesCmdTest.sh
@@ -11,18 +11,22 @@ mkdir -p $HOOT_HOME/tmp
 
 source conf/database/DatabaseConfig.sh
 export OSM_API_DB_URL="osmapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME_OSMAPI"
-export OSM_API_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
+export PSQL_DB_AUTH="-h $DB_HOST -p $DB_PORT -U $DB_USER"
 export PGPASSWORD=$DB_PASSWORD_OSMAPI
 HOOT_DB_URL="hootapidb://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
+export HOOT_EMAIL="ServiceNodeDensityTilesCmdTest@hoottestcpp.org"
 
 CONFIG="-C Testing.conf"
 
 scripts/database/CleanAndInitializeOsmApiDb.sh
-hoot convert --warn $CONFIG -D api.db.email=test@test.com -D changeset.user.id=1 -D apidb.bulk.inserter.validate.data=true test-files/DcGisRoads.osm $OSM_API_DB_URL
-hoot convert --warn $CONFIG -D hootapi.db.writer.overwrite.map=true -D hootapi.db.writer.create.user=true -D api.db.email=test@test.com test-files/DcTigerRoads.osm $HOOT_DB_URL"/DcTigerRoads"
-hoot node-density-tiles --warn $CONFIG -D api.db.email=test@test.com -D convert.bounding.box="-77.04856,38.8855,-77.0292,38.899" $OSM_API_DB_URL";"$HOOT_DB_URL"/DcTigerRoads" $OUTPUT_DIR/output-cropped.geojson --maxNodeCountPerTile 1000
+hoot convert --warn $CONFIG -D api.db.email=$HOOT_EMAIL -D changeset.user.id=1 -D apidb.bulk.inserter.validate.data=true test-files/DcGisRoads.osm $OSM_API_DB_URL
+hoot convert --warn $CONFIG -D hootapi.db.writer.overwrite.map=true -D hootapi.db.writer.create.user=true -D api.db.email=$HOOT_EMAIL test-files/DcTigerRoads.osm $HOOT_DB_URL"/DcTigerRoads"
+hoot node-density-tiles --warn $CONFIG -D api.db.email=$HOOT_EMAIL -D convert.bounding.box="-77.04856,38.8855,-77.0292,38.899" $OSM_API_DB_URL";"$HOOT_DB_URL"/DcTigerRoads" $OUTPUT_DIR/output-cropped.geojson --maxNodeCountPerTile 1000
 hoot diff $CONFIG $GOLD_FILES_DIR/output-cropped.geojson $OUTPUT_DIR/output-cropped.geojson
 
 # Clean up the map from the database
-hoot db-delete-map --warn $CONFIG -D api.db.email=test@test.com $HOOT_DB_URL"/DcTigerRoads"
+hoot db-delete-map --warn $CONFIG -D api.db.email=$HOOT_EMAIL $HOOT_DB_URL"/DcTigerRoads"
 scripts/database/CleanAndInitializeOsmApiDb.sh > /dev/null
+
+# Delete the user
+PGPASSWORD=$DB_PASSWORD psql $PSQL_DB_AUTH -c "DELETE FROM users WHERE email='$HOOT_EMAIL';" > /dev/null


### PR DESCRIPTION
Allow admins to export other user's private data.  While working on this I noticed that there are quite a few unit tests that don't clean up after themselves.  So I updated C++ and script unit tests to clean up any users and maps used in testing.

Closes #4119 