### PR TITLE
Update STATUS messages in changeset-apply

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -353,6 +353,12 @@ private:
    * @param status Status to update to
    */
   void _updateThreadStatus(int thread_index, ThreadStatus status);
+  /**
+   * @brief _statusMessage
+   * @param info
+   * @param changesetId
+   */
+  void _statusMessage(OsmApiFailureInfoPtr info, long changesetId);
   /** Vector of statuses for each running thread */
   std::vector<ThreadStatus> _threadStatus;
   /** Mutex protecting status vector */


### PR DESCRIPTION
Updated status messages for better UI logs during changeset-apply

```
WARN   Changeset precondition failed: Relation -2 requires the relations with id in 1707699,1707700, which either do not exist, or are not visible.
WARN   Changeset precondition failed: Relation -1 requires the relations with id in 1720067,1720068, which either do not exist, or are not visible.
WARN   Changeset precondition failed: Relation -5 requires the relations with id in 383909,383910, which either do not exist, or are not visible.
```

The `WARN` messages are equivalent to the following `STATUS` messages:

```
STATUS Required precondition not met in changeset 4, moving element to manual changeset.
STATUS Required precondition not met in changeset 4, moving element to manual changeset.
STATUS Required precondition not met in changeset 10, moving element to manual changeset.
```

Closes #4220 