### PR TITLE
Update and delete same element in changeset

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -455,8 +455,21 @@ private:
    * @return _errorPathname with "error" replaced by "remaining"
    */
   QString getRemainingFilename();
-
+  /**
+   * @brief fixOrphanedNodesSplit
+   * @param changeset
+   * @param split
+   * @return
+   */
   ChangesetInfoPtr fixOrphanedNodesSplit(const ChangesetInfoPtr& changeset, const ChangesetInfoPtr& split);
+  /**
+   * @brief insertElement
+   * @param element
+   * @param type
+   * @param elementMap
+   * @param all
+   */
+  void insertElement(const ChangesetElementPtr& element, ChangesetType type, ChangesetTypeMap& elementMap, ChangesetElementMap& all);
   /** Sorted map of all nodes, original node ID and a pointer to the element object */
   ChangesetElementMap _allNodes;
   /** Sorted map of all ways, original node ID and a pointer to the element object */

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -456,18 +456,19 @@ private:
    */
   QString getRemainingFilename();
   /**
-   * @brief fixOrphanedNodesSplit
-   * @param changeset
-   * @param split
-   * @return
+   * @brief fixOrphanedNodesSplit When a changeset info object is split it may produce orphaned nodes, this
+   *   function splits them out to the `_cleanup` object
+   * @param changeset Changeset info with one half of the data and any potential orphaned nodes
+   * @param split Changeset info with the other half of the data split off
+   * @return Split object to push back on queue
    */
   ChangesetInfoPtr fixOrphanedNodesSplit(const ChangesetInfoPtr& changeset, const ChangesetInfoPtr& split);
   /**
-   * @brief insertElement
-   * @param element
-   * @param type
-   * @param elementMap
-   * @param all
+   * @brief insertElement Insert an element into the changeset in a generic function
+   * @param element Element to insert
+   * @param type Changeset type (create/modify/delete)
+   * @param elementMap List of elements for the changeset types (_nodes/_ways/_relations)
+   * @param all List of all elements in the changeset (_allNodes/_allWays/_allRelations)
    */
   void insertElement(const ChangesetElementPtr& element, ChangesetType type, ChangesetTypeMap& elementMap, ChangesetElementMap& all);
   /** Sorted map of all nodes, original node ID and a pointer to the element object */

--- a/test-files/io/OsmChangesetElementTest/ModifyAndDelete-Expected.osc
+++ b/test-files/io/OsmChangesetElementTest/ModifyAndDelete-Expected.osc
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+	<modify>
+		<node id="1" version="1" lat="38.8549321261880536" lon="-104.8979050333482093" timestamp="" changeset="1"/>
+		<way id="2" version="1" timestamp="" changeset="1">
+			<nd ref="10"/>
+			<nd ref="11"/>
+			<nd ref="12"/>
+			<tag k="note" v="1"/>
+			<tag k="highway" v="road"/>
+		</way>
+		<relation id="3" version="1" timestamp="" changeset="1">
+			<member type="way" ref="4" role=""/>
+			<member type="way" ref="5" role=""/>
+			<tag k="name" v="Test Highway"/>
+			<tag k="highway" v="secondary"/>
+			<tag k="type" v="multilinestring"/>
+		</relation>
+	</modify>
+</osmChange>

--- a/test-files/io/OsmChangesetElementTest/ModifyAndDelete.osc
+++ b/test-files/io/OsmChangesetElementTest/ModifyAndDelete.osc
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny">
+    <modify>
+        <node id="1" version="1" lat="38.8549321261880536" lon="-104.8979050333482093" timestamp=""/>
+        <way id="2" version="1" timestamp="">
+            <nd ref="10"/>
+            <nd ref="11"/>
+            <nd ref="12"/>
+            <tag k="note" v="1"/>
+            <tag k="highway" v="road"/>
+        </way>
+    </modify>
+    <delete>
+        <node id="1" version="1" lat="38.8549321261880536" lon="-104.8979050333482093" timestamp=""/>
+        <way id="2" version="1" timestamp="">
+            <nd ref="10"/>
+            <nd ref="11"/>
+            <nd ref="12"/>
+            <tag k="note" v="1"/>
+            <tag k="highway" v="road"/>
+        </way>
+        <relation id="3" version="1" timestamp="">
+            <member type="way" ref="4" role=""/>
+            <member type="way" ref="5" role=""/>
+            <tag k="name" v="Test Highway"/>
+            <tag k="highway" v="secondary"/>
+            <tag k="type" v="multilinestring"/>
+        </relation>
+    </delete>
+    <modify>
+        <relation id="3" version="1" timestamp="">
+            <member type="way" ref="4" role=""/>
+            <member type="way" ref="5" role=""/>
+            <tag k="name" v="Test Highway"/>
+            <tag k="highway" v="secondary"/>
+            <tag k="type" v="multilinestring"/>
+        </relation>
+    </modify>
+</osmChange>


### PR DESCRIPTION
Updating changeset-apply for OSC files that contain both modifies and deletes of the same element.