### PR TITLE
Random crash in GPKG translation

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OgrWriterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OgrWriterTest.cpp
@@ -130,6 +130,7 @@ public:
     uut.setSchemaTranslationScript(_inputPath + "SampleTranslation.js");
     uut.open(_outputPath + "OgrWriterShpTest.shp");
     uut.write(createTestMap());
+    uut.close();
     QStringList nameFilter;
     nameFilter << "*.shp";
 
@@ -145,6 +146,7 @@ public:
     uut.setSchemaTranslationScript(_inputPath + "SampleTranslation.js");
     uut.open(_outputPath + "OgrWriterTest.gdb");
     uut.write(createTestMap());
+    uut.close();
 
     FileUtils::makeDir("tmp");
     OsmMapWriterFactory::write(createTestMap(), "tmp/TestMap.osm");
@@ -174,6 +176,7 @@ public:
     uut.setSchemaTranslationScript(_inputPath + "SampleTranslation.js");
     uut.open(_outputPath + "OgrWriterRelationTest.gdb");
     uut.write(map);
+    uut.close();
 
     // make sure it created a bunch of files. We aren't testing for correct output.
     CPPUNIT_ASSERT(QDir(_outputPath + "OgrWriterRelationTest.gdb").entryList().size() > 10);

--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.cpp
@@ -502,6 +502,7 @@ void DataConverter::_convertToOgr(const QString& input, const QString& output)
     writer->setSchemaTranslationScript(_translation);
     writer->open(output);
     writer->write(map);
+    writer->close();
     currentStep++;
 
     LOG_INFO(

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
                 sh '''
                     git fetch --tags
                     git submodule update --init
-                    cp -R ../software.ubuntu1404 software
+                    ( [ -d ../software.ubuntu1404 ] && cp -R ../software.ubuntu1404 software ) || true
                     rm -rf ./test-files/ui/screenshot_*.png
                 '''
             }


### PR DESCRIPTION
Close `OgrWriter` before destroying it for GPKG files that sometimes don't close before destruction.