### PR TITLE
Fix UI tests in Jenkins with dynamic session timestamps.

### DIFF
--- a/test-files/ui/Makefile
+++ b/test-files/ui/Makefile
@@ -141,7 +141,7 @@ load-data: clean
 		VALUES ( \
 		'ff47f751-c831-41ee-800f-5ef8b9371ee3', \
 		extract(epoch from now()), \
-		extract(epoch from now()), \
+		extract(epoch from (now() + interval '1 second')), \
 		31536000, \
 		'', \
 		-1541432234)"

--- a/test-files/ui/Makefile
+++ b/test-files/ui/Makefile
@@ -140,8 +140,8 @@ load-data: clean
 		\
 		VALUES ( \
 		'ff47f751-c831-41ee-800f-5ef8b9371ee3', \
-		1568933324000, \
-		1568933325000, \
+		extract(epoch from now()), \
+		extract(epoch from now()), \
 		31536000, \
 		'', \
 		-1541432234)"


### PR DESCRIPTION
Dynamic session dates so that next year we don't have the same failure in UI tests.