### PR TITLE
Add bounds to derive changeset if task bbox is set

### DIFF
--- a/hoot-services/src/main/java/hoot/services/controllers/grail/DeriveChangesetCommand.java
+++ b/hoot-services/src/main/java/hoot/services/controllers/grail/DeriveChangesetCommand.java
@@ -53,12 +53,13 @@ class DeriveChangesetCommand extends GrailCommand {
         Map<String, Object> substitutionMap = new HashMap<>();
         substitutionMap.put("INPUT1", params.getInput1());
         substitutionMap.put("INPUT2", params.getInput2());
+        substitutionMap.put("BOUNDS", params.getBounds());
         substitutionMap.put("OSC_FILE", params.getOutput());
         substitutionMap.put("HOOT_OPTIONS", hootOptions);
         substitutionMap.put("DEBUG_LEVEL", debugLevel);
         substitutionMap.put("STATS_FILE", new File(params.getWorkDir(), "stats.json").getPath());
 
-        String command = "hoot.bin changeset-derive --${DEBUG_LEVEL} -C DeriveChangeset.conf ${HOOT_OPTIONS} ${INPUT1} ${INPUT2} ${OSC_FILE} --stats ${STATS_FILE}";
+        String command = "hoot.bin changeset-derive --${DEBUG_LEVEL} -C DeriveChangeset.conf ${HOOT_OPTIONS} ${INPUT1} ${INPUT2} ${BOUNDS} ${OSC_FILE} --stats ${STATS_FILE}";
 
         super.configureCommand(command, substitutionMap, caller);
     }

--- a/hoot-services/src/main/java/hoot/services/controllers/grail/DeriveChangesetCommand.java
+++ b/hoot-services/src/main/java/hoot/services/controllers/grail/DeriveChangesetCommand.java
@@ -48,18 +48,22 @@ class DeriveChangesetCommand extends GrailCommand {
             options.add("changeset.allow.deleting.reference.features=false");
         }
 
+        if (params.getBounds() != null) {
+            //Add TASK_BBOX as a convert.bounding.box
+            options.add("convert.bounding.box=" + params.getBounds());
+        }
+
         List<String> hootOptions = toHootOptions(options);
 
         Map<String, Object> substitutionMap = new HashMap<>();
         substitutionMap.put("INPUT1", params.getInput1());
         substitutionMap.put("INPUT2", params.getInput2());
-        substitutionMap.put("BOUNDS", params.getBounds());
         substitutionMap.put("OSC_FILE", params.getOutput());
         substitutionMap.put("HOOT_OPTIONS", hootOptions);
         substitutionMap.put("DEBUG_LEVEL", debugLevel);
         substitutionMap.put("STATS_FILE", new File(params.getWorkDir(), "stats.json").getPath());
 
-        String command = "hoot.bin changeset-derive --${DEBUG_LEVEL} -C DeriveChangeset.conf ${HOOT_OPTIONS} ${INPUT1} ${INPUT2} ${BOUNDS} ${OSC_FILE} --stats ${STATS_FILE}";
+        String command = "hoot.bin changeset-derive --${DEBUG_LEVEL} -C DeriveChangeset.conf ${HOOT_OPTIONS} ${INPUT1} ${INPUT2} ${OSC_FILE} --stats ${STATS_FILE}";
 
         super.configureCommand(command, substitutionMap, caller);
     }

--- a/hoot-services/src/main/java/hoot/services/controllers/grail/DeriveChangesetReplacementCommand.java
+++ b/hoot-services/src/main/java/hoot/services/controllers/grail/DeriveChangesetReplacementCommand.java
@@ -72,10 +72,6 @@ class DeriveChangesetReplacementCommand extends GrailCommand {
         options.add("reader.add.source.datetime=false");
         options.add("writer.include.circular.error.tags=false");
         options.add("convert.bounding.box.remove.missing.elements=false");
-        if (params.getBounds() != null) {
-            //Add TASK_BBOX as a convert.bounding.box
-            options.add("convert.bounding.box=" + params.getBounds());
-        }
 
         List<String> hootOptions = toHootOptions(options);
 
@@ -93,13 +89,14 @@ class DeriveChangesetReplacementCommand extends GrailCommand {
         Map<String, Object> substitutionMap = new HashMap<>();
         substitutionMap.put("INPUT1", params.getInput1());
         substitutionMap.put("INPUT2", params.getInput2());
+        substitutionMap.put("BOUNDS", params.getBounds());
         substitutionMap.put("OSC_FILE", params.getOutput());
         substitutionMap.put("HOOT_OPTIONS", hootOptions);
         substitutionMap.put("DEBUG_LEVEL", debugLevel);
         substitutionMap.put("ADV_OPTIONS", advancedOptions);
         substitutionMap.put("STATS_FILE", new File(params.getWorkDir(), "stats.json").getPath());
 
-        String command = "hoot.bin changeset-derive-replacement --${DEBUG_LEVEL} -C DeriveChangeset.conf ${HOOT_OPTIONS} ${INPUT1} ${INPUT2} ${OSC_FILE} ${ADV_OPTIONS} --stats ${STATS_FILE}";
+        String command = "hoot.bin changeset-derive-replacement --${DEBUG_LEVEL} -C DeriveChangeset.conf ${HOOT_OPTIONS} ${INPUT1} ${INPUT2} ${BOUNDS} ${OSC_FILE} ${ADV_OPTIONS} --stats ${STATS_FILE}";
 
         super.configureCommand(command, substitutionMap, caller);
     }

--- a/hoot-services/src/main/java/hoot/services/controllers/grail/DeriveChangesetReplacementCommand.java
+++ b/hoot-services/src/main/java/hoot/services/controllers/grail/DeriveChangesetReplacementCommand.java
@@ -72,6 +72,10 @@ class DeriveChangesetReplacementCommand extends GrailCommand {
         options.add("reader.add.source.datetime=false");
         options.add("writer.include.circular.error.tags=false");
         options.add("convert.bounding.box.remove.missing.elements=false");
+        if (params.getBounds() != null) {
+            //Add TASK_BBOX as a convert.bounding.box
+            options.add("convert.bounding.box=" + params.getBounds());
+        }
 
         List<String> hootOptions = toHootOptions(options);
 
@@ -89,14 +93,13 @@ class DeriveChangesetReplacementCommand extends GrailCommand {
         Map<String, Object> substitutionMap = new HashMap<>();
         substitutionMap.put("INPUT1", params.getInput1());
         substitutionMap.put("INPUT2", params.getInput2());
-        substitutionMap.put("BOUNDS", params.getBounds());
         substitutionMap.put("OSC_FILE", params.getOutput());
         substitutionMap.put("HOOT_OPTIONS", hootOptions);
         substitutionMap.put("DEBUG_LEVEL", debugLevel);
         substitutionMap.put("ADV_OPTIONS", advancedOptions);
         substitutionMap.put("STATS_FILE", new File(params.getWorkDir(), "stats.json").getPath());
 
-        String command = "hoot.bin changeset-derive-replacement --${DEBUG_LEVEL} -C DeriveChangeset.conf ${HOOT_OPTIONS} ${INPUT1} ${INPUT2} ${BOUNDS} ${OSC_FILE} ${ADV_OPTIONS} --stats ${STATS_FILE}";
+        String command = "hoot.bin changeset-derive-replacement --${DEBUG_LEVEL} -C DeriveChangeset.conf ${HOOT_OPTIONS} ${INPUT1} ${INPUT2} ${OSC_FILE} ${ADV_OPTIONS} --stats ${STATS_FILE}";
 
         super.configureCommand(command, substitutionMap, caller);
     }


### PR DESCRIPTION
This prevents connected out-of-bounds ways in the reference layer (needed for cut&replace) from being deleted in the derive changeset of a reference conflation merged output