### PR TITLE
Reduce the number of relations per chunck to keep 503 errors at bay

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator6.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreator6.cpp
@@ -585,7 +585,6 @@ void ChangesetReplacementCreator6::_synchronizeIds(
   // changeset modifications from being generated. Its possible we could do this earlier in the
   // replacement process, however that has proven difficult to accomplish so far.
 
-  assert(mapsBeingReplaced.size() == replacementMaps.size());
   ChangesetReplacementElementIdSynchronizer idSync;
   OsmMapWriterFactory::writeDebugMap(
     mapBeingReplaced, _changesetId + "-" + mapBeingReplaced->getName() +

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.cpp
@@ -859,6 +859,9 @@ bool XmlChangeset::addRelations(const ChangesetInfoPtr& changeset, ChangesetType
     //  Add relations up until the max changeset
     if (changeset->size() < (size_t)_maxPushSize)
       added |= addRelation(changeset, type, dynamic_cast<ChangesetRelation*>(it->second.get()));
+    //  Don't allow too many relations
+    if (changeset->size(ElementType::Relation) >= 2)
+      return added;
   }
   //  Return true if something was added
   return added;
@@ -2467,6 +2470,15 @@ ChangesetInfo::iterator ChangesetInfo::end(ElementType::Type element_type, Chang
 size_t ChangesetInfo::size(ElementType::Type elementType, ChangesetType changesetType)
 {
   return _changeset[elementType][changesetType].size();
+}
+
+size_t ChangesetInfo::size(ElementType::Type elementType)
+{
+  size_t s = 0;
+  //  Sum up all counts for each changeset type
+  for (int j = 0; j < ChangesetType::TypeMax; ++j)
+    s += _changeset[elementType][j].size();
+  return s;
 }
 
 size_t ChangesetInfo::size()

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -590,6 +590,13 @@ public:
    */
   size_t size(ElementType::Type elementType, ChangesetType changesetType);
   /**
+   * @brief size Total number of ElementType::Type elements (node/way/relation) of all changeset types within
+   *  this subset
+   * @param elementType Describes the type (node/way/relation) to count
+   * @return count based on the type
+   */
+  size_t size(ElementType::Type elementType);
+  /**
    * @brief size Total number of elements in the subset
    * @return total count
    */


### PR DESCRIPTION
All testing has shown that this doesn't slow down `changeset-apply`.