### PR TITLE
Output the last element uploaded in `changeset-apply` status message

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetApplyCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetApplyCmd.cpp
@@ -143,7 +143,9 @@ public:
         "Changeset(s) applied to: " + printableUrl.left(maxFilePrintLength) + "...");
 
       //  Output the last changeset ID in a status message
-      LOG_STATUS("Last changeset pushed ID: " << writer.getLastChangesetId());
+      LastElementInfo last = writer.getLastElementInfo();
+      if (!last._id.isNull())
+        LOG_STATUS("Last element pushed: " << last);
 
       //  Write out the failed changeset if there is one
       if (writer.containsFailed())

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
@@ -43,6 +43,18 @@ bool id_sort_order(long lhs, long rhs)
   else                          return lhs < rhs; //  Negative numbers come before positive
 }
 
+/** Function to convert ChangesetType to a string */
+std::string toString(ChangesetType type)
+{
+  switch(type)
+  {
+  case ChangesetType::TypeCreate:   return "create";
+  case ChangesetType::TypeModify:   return "modify";
+  case ChangesetType::TypeDelete:   return "delete";
+  default:                          return "Invalid Changeset Type";
+  }
+}
+
 /**  Global regular expression for truncating tag keys/values at max tag length */
 QRegularExpression truncateTags("&[^;]+$", QRegularExpression::UseUnicodePropertiesOption);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
@@ -63,6 +63,8 @@ enum ChangesetType : int
   TypeDelete,
   TypeMax
 };
+/** Function to convert ChangesetType to a string */
+std::string toString(ChangesetType type);
 
 /** Changeset element abstraction for simplified nodes, ways, and relations */
 class ChangesetElement

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -145,10 +145,10 @@ public:
    */
   bool writeErrorFile() { return _changeset.writeErrorFile(); }
   /**
-   * @brief getLastChangesetId Get the ID of the last changeset uploaded
-   * @return ID of last changeset closed
+   * @brief getLastChangesetId Get the element information of the last element uploaded
+   * @return information of last element uploaded
    */
-  long getLastChangesetId() { return _lastChangesetId; }
+  LastElementInfo getLastElementInfo() { return _lastElement; }
 
 private:
   /**
@@ -157,8 +157,11 @@ private:
   struct OsmApiFailureInfo
   {
     OsmApiFailureInfo() : success(false), status(0), response("") { }
+    /** Success flag */
     bool success;
+    /** HTTP response code */
     int status;
+    /** HTTP response body */
     QString response;
   };
   typedef std::shared_ptr<OsmApiFailureInfo> OsmApiFailureInfoPtr;
@@ -178,10 +181,10 @@ private:
    * @brief _closeChangeset End the changeset
    *  see: https://wiki.openstreetmap.org/wiki/API_v0.6#Close:_PUT_.2Fapi.2F0.6.2Fchangeset.2F.23id.2Fclose
    * @param request - Network request object initialized with OSM API URL
-   * @param id - ID of the changeset to close
-   * @param size - Size of the changeset to close, empty changesets don't update last changeset ID
+   * @param changeset_id - ID of the changeset to close
+   * @param last_element - Last element info
    */
-  void _closeChangeset(HootNetworkRequestPtr request, long id, long size);
+  void _closeChangeset(HootNetworkRequestPtr request, long changeset_id, const LastElementInfo& last_element);
   /**
    * @brief _uploadChangeset Upload a changeset to the OSM API
    *  see: https://wiki.openstreetmap.org/wiki/API_v0.6#Diff_upload:_POST_.2Fapi.2F0.6.2Fchangeset.2F.23id.2Fupload
@@ -355,11 +358,18 @@ private:
    */
   void _updateThreadStatus(int thread_index, ThreadStatus status);
   /**
-   * @brief _statusMessage
-   * @param info
-   * @param changesetId
+   * @brief _statusMessage Conver the HTTP error response into human readable format
+   * @param info Failure information structure
+   * @param changesetId Current changeset ID
    */
   void _statusMessage(OsmApiFailureInfoPtr info, long changesetId);
+  /**
+   * @brief _extractLastElement Get the last element uploaded in this changeset and
+   *  extract the actual ID (if created) and the version
+   * @param workInfo Last set of elements in the current changeset
+   * @return LastElementInfo object completely filled out
+   */
+  LastElementInfo _extractLastElement(const ChangesetInfoPtr& workInfo);
   /** Vector of statuses for each running thread */
   std::vector<ThreadStatus> _threadStatus;
   /** Mutex protecting status vector */
@@ -410,8 +420,8 @@ private:
   QString _secretToken;
   /** Number of changesets written to API */
   int _changesetCount;
-  /** Last changeset ID pushed for synchonization */
-  long _lastChangesetId;
+  /** Last element infomation pushed for synchonization */
+  LastElementInfo _lastElement;
   /** Mutex for changeset count */
   std::mutex _changesetCountMutex;
   /** Output requests and responses for debugging  */


### PR DESCRIPTION
Updated changeset-apply to report the ID, Type, Version, and Upload Type of the last element uploaded.

Here is a sample output STATUS message:
```
STATUS ...core/cmd/ChangesetApplyCmd.cpp( 148) Last element pushed: Type(create) Relation(84) Version(1)
```
Type can be `create`, `modify`, `delete` and `Relation` can be `Node` or `Way` like these.
```
STATUS ...core/cmd/ChangesetApplyCmd.cpp( 148) Last element pushed: Type(create) Relation(84) Version(1)
STATUS ...core/cmd/ChangesetApplyCmd.cpp( 148) Last element pushed: Type(modify) Way(190) Version(4)
STATUS ...core/cmd/ChangesetApplyCmd.cpp( 148) Last element pushed: Type(delete) Node(1234) Version(2)
```
Closes #4310 