### PR TITLE
Remove logic that prevents POIs with conflated status from being merged with polys

### DIFF
--- a/hoot-js/src/test/cpp/hoot/js/conflate/merging/ElementMergerJsTest.cpp
+++ b/hoot-js/src/test/cpp/hoot/js/conflate/merging/ElementMergerJsTest.cpp
@@ -74,72 +74,71 @@ class ElementMergerJsTest : public HootTestFixture
   CPPUNIT_TEST_SUITE(ElementMergerJsTest);
 
   // POI TO POLYGON
-  CPPUNIT_TEST(poiToPolyMergeWayAsPolyTest);
-  CPPUNIT_TEST(poiToPolyMergeWayAsPolyNoConstituentsTest);
-  CPPUNIT_TEST(poiToPolyMergeRelationAsPolyTest);
-  CPPUNIT_TEST(poiToPolyMergeRelationAsPolyNoConstituentsTest);
-  CPPUNIT_TEST(poiToPolyMergeMissingPoiInputTest);
-  CPPUNIT_TEST(poiToPolyMergeMissingPolyInputTest);
-  CPPUNIT_TEST(poiToPolyMergeMoreThanOnePolyInputTest);
-  CPPUNIT_TEST(poiToPolyMergeMoreThanOnePoiInputTest);
-  CPPUNIT_TEST(poiToPolyMergeExtraNonPolyWayTest);
-  CPPUNIT_TEST(poiToPolyMergeExtraNonPolyRelationTest);
-  CPPUNIT_TEST(poiToPolyMergeExtraNonPoiNodeTest);
-  // TODO: fix
-  //CPPUNIT_TEST(poiToPolyPolyInputWithConflatedStatusTest);
-  // TODO: fix
-  //CPPUNIT_TEST(poiToPolyPoiInputWithConflatedStatusTest);
+  // TODO: re-enable
+//  CPPUNIT_TEST(poiToPolyMergeWayAsPolyTest);
+//  CPPUNIT_TEST(poiToPolyMergeWayAsPolyNoConstituentsTest);
+//  CPPUNIT_TEST(poiToPolyMergeRelationAsPolyTest);
+//  CPPUNIT_TEST(poiToPolyMergeRelationAsPolyNoConstituentsTest);
+//  CPPUNIT_TEST(poiToPolyMergeMissingPoiInputTest);
+//  CPPUNIT_TEST(poiToPolyMergeMissingPolyInputTest);
+//  CPPUNIT_TEST(poiToPolyMergeMoreThanOnePolyInputTest);
+//  CPPUNIT_TEST(poiToPolyMergeMoreThanOnePoiInputTest);
+//  CPPUNIT_TEST(poiToPolyMergeExtraNonPolyWayTest);
+//  CPPUNIT_TEST(poiToPolyMergeExtraNonPolyRelationTest);
+//  CPPUNIT_TEST(poiToPolyMergeExtraNonPoiNodeTest);
+  CPPUNIT_TEST(poiToPolyPolyInputWithConflatedStatusTest);
+  CPPUNIT_TEST(poiToPolyPoiInputWithConflatedStatusTest);
 
-  // POI TO POI
-  CPPUNIT_TEST(poiToPoiMergeTwoPoisTest);
-  CPPUNIT_TEST(poiToPoiMergeMoreThanTwoPoisTest);
-  CPPUNIT_TEST(poiToPoiMergeTooFewPoisTest);
-  CPPUNIT_TEST(poiToPoiMergeMissingTargetTagTest);
-  CPPUNIT_TEST(poiToPoiMergeDuplicateTargetTagTest);
-  CPPUNIT_TEST(poiToPoiMergeExtraNonPoiNodeTest);
-  CPPUNIT_TEST(poiToPoiInputWithConflatedStatusTest);
+//  // POI TO POI
+//  CPPUNIT_TEST(poiToPoiMergeTwoPoisTest);
+//  CPPUNIT_TEST(poiToPoiMergeMoreThanTwoPoisTest);
+//  CPPUNIT_TEST(poiToPoiMergeTooFewPoisTest);
+//  CPPUNIT_TEST(poiToPoiMergeMissingTargetTagTest);
+//  CPPUNIT_TEST(poiToPoiMergeDuplicateTargetTagTest);
+//  CPPUNIT_TEST(poiToPoiMergeExtraNonPoiNodeTest);
+//  CPPUNIT_TEST(poiToPoiInputWithConflatedStatusTest);
 
-  // AREA TO AREA
-  CPPUNIT_TEST(areaToAreaMergeTwoWaysTest);
-  CPPUNIT_TEST(areaToAreaMergeTwoWaysNoConstituentsTest);
-  CPPUNIT_TEST(areaToAreaMergeTwoRelationsTest);
-  CPPUNIT_TEST(areaToAreaMergeTwoRelationsNoConstituentsTest);
-  CPPUNIT_TEST(areaToAreaMergeOneWayOneRelationTargetAsWayTest);
-  CPPUNIT_TEST(areaToAreaMergeOneWayOneRelationTargetAsWayNoConstituentsTest);
-  CPPUNIT_TEST(areaToAreaMergeOneWayOneRelationTargetAsRelationTest);
-  CPPUNIT_TEST(areaToAreaMergeOneWayOneRelationTargetAsRelationNoConstituentsTest);
-  CPPUNIT_TEST(areaToAreaMergeMoreThanTwoAreasTest);
-  CPPUNIT_TEST(areaToAreaMergeMoreThanTwoAreasNoConstituentsTest);
-  CPPUNIT_TEST(areaToAreaMergeTooFewAreasTest);
-  CPPUNIT_TEST(areaToAreaMergeMissingTargetTagTest);
-  CPPUNIT_TEST(areaToAreaMergeDuplicateTargetTagTest);
-  CPPUNIT_TEST(areaToAreaMergeExtraNonAreaWayTest);
-  CPPUNIT_TEST(areaToAreaMergeExtraNonAreaRelationTest);
-  CPPUNIT_TEST(areaToAreaInputWithConflatedStatusTest);
+//  // AREA TO AREA
+//  CPPUNIT_TEST(areaToAreaMergeTwoWaysTest);
+//  CPPUNIT_TEST(areaToAreaMergeTwoWaysNoConstituentsTest);
+//  CPPUNIT_TEST(areaToAreaMergeTwoRelationsTest);
+//  CPPUNIT_TEST(areaToAreaMergeTwoRelationsNoConstituentsTest);
+//  CPPUNIT_TEST(areaToAreaMergeOneWayOneRelationTargetAsWayTest);
+//  CPPUNIT_TEST(areaToAreaMergeOneWayOneRelationTargetAsWayNoConstituentsTest);
+//  CPPUNIT_TEST(areaToAreaMergeOneWayOneRelationTargetAsRelationTest);
+//  CPPUNIT_TEST(areaToAreaMergeOneWayOneRelationTargetAsRelationNoConstituentsTest);
+//  CPPUNIT_TEST(areaToAreaMergeMoreThanTwoAreasTest);
+//  CPPUNIT_TEST(areaToAreaMergeMoreThanTwoAreasNoConstituentsTest);
+//  CPPUNIT_TEST(areaToAreaMergeTooFewAreasTest);
+//  CPPUNIT_TEST(areaToAreaMergeMissingTargetTagTest);
+//  CPPUNIT_TEST(areaToAreaMergeDuplicateTargetTagTest);
+//  CPPUNIT_TEST(areaToAreaMergeExtraNonAreaWayTest);
+//  CPPUNIT_TEST(areaToAreaMergeExtraNonAreaRelationTest);
+//  CPPUNIT_TEST(areaToAreaInputWithConflatedStatusTest);
 
-  // BUILDING TO BUILDING
-  CPPUNIT_TEST(buildingToBuildingMergeTwoWaysTest);
-  CPPUNIT_TEST(buildingToBuildingMergeTwoWaysNoConstituentsTest);
-  CPPUNIT_TEST(buildingToBuildingMergeTwoRelationsTest);
-  CPPUNIT_TEST(buildingToBuildingMergeTwoRelationsNoConstituentsTest);
-  CPPUNIT_TEST(buildingToBuildingMergeOneWayOneRelationTargetAsWayTest);
-  CPPUNIT_TEST(buildingToBuildingMergeOneWayOneRelationTargetAsWayNoConstituentsTest);
-  CPPUNIT_TEST(buildingToBuildingMergeOneWayOneRelationTargetAsRelationTest);
-  CPPUNIT_TEST(buildingToBuildingMergeOneWayOneRelationTargetAsRelationNoConstituentsTest);
-  CPPUNIT_TEST(buildingToBuildingMergeMoreThanTwoBuildingsTest);
-  CPPUNIT_TEST(buildingToBuildingMergeMoreThanTwoBuildingsNoConstituentsTest);
-  CPPUNIT_TEST(buildingToBuildingMergeTooFewBuildingsTest);
-  CPPUNIT_TEST(buildingToBuildingMergeMissingTargetTagTest);
-  CPPUNIT_TEST(buildingToBuildingMergeDuplicateTargetTagTest);
-  CPPUNIT_TEST(buildingToBuildingMergeExtraNonBuildingWayTest);
-  CPPUNIT_TEST(buildingToBuildingMergeExtraNonBuildingRelationTest);
-  CPPUNIT_TEST(buildingToBuildingInputWithConflatedStatusTest);
+//  // BUILDING TO BUILDING
+//  CPPUNIT_TEST(buildingToBuildingMergeTwoWaysTest);
+//  CPPUNIT_TEST(buildingToBuildingMergeTwoWaysNoConstituentsTest);
+//  CPPUNIT_TEST(buildingToBuildingMergeTwoRelationsTest);
+//  CPPUNIT_TEST(buildingToBuildingMergeTwoRelationsNoConstituentsTest);
+//  CPPUNIT_TEST(buildingToBuildingMergeOneWayOneRelationTargetAsWayTest);
+//  CPPUNIT_TEST(buildingToBuildingMergeOneWayOneRelationTargetAsWayNoConstituentsTest);
+//  CPPUNIT_TEST(buildingToBuildingMergeOneWayOneRelationTargetAsRelationTest);
+//  CPPUNIT_TEST(buildingToBuildingMergeOneWayOneRelationTargetAsRelationNoConstituentsTest);
+//  CPPUNIT_TEST(buildingToBuildingMergeMoreThanTwoBuildingsTest);
+//  CPPUNIT_TEST(buildingToBuildingMergeMoreThanTwoBuildingsNoConstituentsTest);
+//  CPPUNIT_TEST(buildingToBuildingMergeTooFewBuildingsTest);
+//  CPPUNIT_TEST(buildingToBuildingMergeMissingTargetTagTest);
+//  CPPUNIT_TEST(buildingToBuildingMergeDuplicateTargetTagTest);
+//  CPPUNIT_TEST(buildingToBuildingMergeExtraNonBuildingWayTest);
+//  CPPUNIT_TEST(buildingToBuildingMergeExtraNonBuildingRelationTest);
+//  CPPUNIT_TEST(buildingToBuildingInputWithConflatedStatusTest);
 
-  // INVALID FEATURE COMBOS
-  CPPUNIT_TEST(invalidFeatureCombinationTest1);
-  CPPUNIT_TEST(invalidFeatureCombinationTest2);
-  CPPUNIT_TEST(invalidFeatureCombinationTest3);
-  CPPUNIT_TEST(invalidFeatureCombinationTest4);
+//  // INVALID FEATURE COMBOS
+//  CPPUNIT_TEST(invalidFeatureCombinationTest1);
+//  CPPUNIT_TEST(invalidFeatureCombinationTest2);
+//  CPPUNIT_TEST(invalidFeatureCombinationTest3);
+//  CPPUNIT_TEST(invalidFeatureCombinationTest4);
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -268,8 +267,7 @@ public:
   void poiToPolyPoiInputWithConflatedStatusTest()
   {
     testMerge(
-      "poi-poly-way-poly-conflated-2-in.osm", "poi-poly-way-poly-out.osm",
-      "POI being merged with polygon cannot must have an Unknown1 or Unknown2 status");
+      "poi-poly-way-poly-conflated-2-in.osm", "poi-poly-way-poly-out.osm");
   }
 
   //POI TO POI

--- a/hoot-js/src/test/cpp/hoot/js/conflate/merging/ElementMergerJsTest.cpp
+++ b/hoot-js/src/test/cpp/hoot/js/conflate/merging/ElementMergerJsTest.cpp
@@ -74,71 +74,70 @@ class ElementMergerJsTest : public HootTestFixture
   CPPUNIT_TEST_SUITE(ElementMergerJsTest);
 
   // POI TO POLYGON
-  // TODO: re-enable
-//  CPPUNIT_TEST(poiToPolyMergeWayAsPolyTest);
-//  CPPUNIT_TEST(poiToPolyMergeWayAsPolyNoConstituentsTest);
-//  CPPUNIT_TEST(poiToPolyMergeRelationAsPolyTest);
-//  CPPUNIT_TEST(poiToPolyMergeRelationAsPolyNoConstituentsTest);
-//  CPPUNIT_TEST(poiToPolyMergeMissingPoiInputTest);
-//  CPPUNIT_TEST(poiToPolyMergeMissingPolyInputTest);
-//  CPPUNIT_TEST(poiToPolyMergeMoreThanOnePolyInputTest);
-//  CPPUNIT_TEST(poiToPolyMergeMoreThanOnePoiInputTest);
-//  CPPUNIT_TEST(poiToPolyMergeExtraNonPolyWayTest);
-//  CPPUNIT_TEST(poiToPolyMergeExtraNonPolyRelationTest);
-//  CPPUNIT_TEST(poiToPolyMergeExtraNonPoiNodeTest);
+  CPPUNIT_TEST(poiToPolyMergeWayAsPolyTest);
+  CPPUNIT_TEST(poiToPolyMergeWayAsPolyNoConstituentsTest);
+  CPPUNIT_TEST(poiToPolyMergeRelationAsPolyTest);
+  CPPUNIT_TEST(poiToPolyMergeRelationAsPolyNoConstituentsTest);
+  CPPUNIT_TEST(poiToPolyMergeMissingPoiInputTest);
+  CPPUNIT_TEST(poiToPolyMergeMissingPolyInputTest);
+  CPPUNIT_TEST(poiToPolyMergeMoreThanOnePolyInputTest);
+  CPPUNIT_TEST(poiToPolyMergeMoreThanOnePoiInputTest);
+  CPPUNIT_TEST(poiToPolyMergeExtraNonPolyWayTest);
+  CPPUNIT_TEST(poiToPolyMergeExtraNonPolyRelationTest);
+  CPPUNIT_TEST(poiToPolyMergeExtraNonPoiNodeTest);
   CPPUNIT_TEST(poiToPolyPolyInputWithConflatedStatusTest);
   CPPUNIT_TEST(poiToPolyPoiInputWithConflatedStatusTest);
 
-//  // POI TO POI
-//  CPPUNIT_TEST(poiToPoiMergeTwoPoisTest);
-//  CPPUNIT_TEST(poiToPoiMergeMoreThanTwoPoisTest);
-//  CPPUNIT_TEST(poiToPoiMergeTooFewPoisTest);
-//  CPPUNIT_TEST(poiToPoiMergeMissingTargetTagTest);
-//  CPPUNIT_TEST(poiToPoiMergeDuplicateTargetTagTest);
-//  CPPUNIT_TEST(poiToPoiMergeExtraNonPoiNodeTest);
-//  CPPUNIT_TEST(poiToPoiInputWithConflatedStatusTest);
+  // POI TO POI
+  CPPUNIT_TEST(poiToPoiMergeTwoPoisTest);
+  CPPUNIT_TEST(poiToPoiMergeMoreThanTwoPoisTest);
+  CPPUNIT_TEST(poiToPoiMergeTooFewPoisTest);
+  CPPUNIT_TEST(poiToPoiMergeMissingTargetTagTest);
+  CPPUNIT_TEST(poiToPoiMergeDuplicateTargetTagTest);
+  CPPUNIT_TEST(poiToPoiMergeExtraNonPoiNodeTest);
+  CPPUNIT_TEST(poiToPoiInputWithConflatedStatusTest);
 
-//  // AREA TO AREA
-//  CPPUNIT_TEST(areaToAreaMergeTwoWaysTest);
-//  CPPUNIT_TEST(areaToAreaMergeTwoWaysNoConstituentsTest);
-//  CPPUNIT_TEST(areaToAreaMergeTwoRelationsTest);
-//  CPPUNIT_TEST(areaToAreaMergeTwoRelationsNoConstituentsTest);
-//  CPPUNIT_TEST(areaToAreaMergeOneWayOneRelationTargetAsWayTest);
-//  CPPUNIT_TEST(areaToAreaMergeOneWayOneRelationTargetAsWayNoConstituentsTest);
-//  CPPUNIT_TEST(areaToAreaMergeOneWayOneRelationTargetAsRelationTest);
-//  CPPUNIT_TEST(areaToAreaMergeOneWayOneRelationTargetAsRelationNoConstituentsTest);
-//  CPPUNIT_TEST(areaToAreaMergeMoreThanTwoAreasTest);
-//  CPPUNIT_TEST(areaToAreaMergeMoreThanTwoAreasNoConstituentsTest);
-//  CPPUNIT_TEST(areaToAreaMergeTooFewAreasTest);
-//  CPPUNIT_TEST(areaToAreaMergeMissingTargetTagTest);
-//  CPPUNIT_TEST(areaToAreaMergeDuplicateTargetTagTest);
-//  CPPUNIT_TEST(areaToAreaMergeExtraNonAreaWayTest);
-//  CPPUNIT_TEST(areaToAreaMergeExtraNonAreaRelationTest);
-//  CPPUNIT_TEST(areaToAreaInputWithConflatedStatusTest);
+  // AREA TO AREA
+  CPPUNIT_TEST(areaToAreaMergeTwoWaysTest);
+  CPPUNIT_TEST(areaToAreaMergeTwoWaysNoConstituentsTest);
+  CPPUNIT_TEST(areaToAreaMergeTwoRelationsTest);
+  CPPUNIT_TEST(areaToAreaMergeTwoRelationsNoConstituentsTest);
+  CPPUNIT_TEST(areaToAreaMergeOneWayOneRelationTargetAsWayTest);
+  CPPUNIT_TEST(areaToAreaMergeOneWayOneRelationTargetAsWayNoConstituentsTest);
+  CPPUNIT_TEST(areaToAreaMergeOneWayOneRelationTargetAsRelationTest);
+  CPPUNIT_TEST(areaToAreaMergeOneWayOneRelationTargetAsRelationNoConstituentsTest);
+  CPPUNIT_TEST(areaToAreaMergeMoreThanTwoAreasTest);
+  CPPUNIT_TEST(areaToAreaMergeMoreThanTwoAreasNoConstituentsTest);
+  CPPUNIT_TEST(areaToAreaMergeTooFewAreasTest);
+  CPPUNIT_TEST(areaToAreaMergeMissingTargetTagTest);
+  CPPUNIT_TEST(areaToAreaMergeDuplicateTargetTagTest);
+  CPPUNIT_TEST(areaToAreaMergeExtraNonAreaWayTest);
+  CPPUNIT_TEST(areaToAreaMergeExtraNonAreaRelationTest);
+  CPPUNIT_TEST(areaToAreaInputWithConflatedStatusTest);
 
-//  // BUILDING TO BUILDING
-//  CPPUNIT_TEST(buildingToBuildingMergeTwoWaysTest);
-//  CPPUNIT_TEST(buildingToBuildingMergeTwoWaysNoConstituentsTest);
-//  CPPUNIT_TEST(buildingToBuildingMergeTwoRelationsTest);
-//  CPPUNIT_TEST(buildingToBuildingMergeTwoRelationsNoConstituentsTest);
-//  CPPUNIT_TEST(buildingToBuildingMergeOneWayOneRelationTargetAsWayTest);
-//  CPPUNIT_TEST(buildingToBuildingMergeOneWayOneRelationTargetAsWayNoConstituentsTest);
-//  CPPUNIT_TEST(buildingToBuildingMergeOneWayOneRelationTargetAsRelationTest);
-//  CPPUNIT_TEST(buildingToBuildingMergeOneWayOneRelationTargetAsRelationNoConstituentsTest);
-//  CPPUNIT_TEST(buildingToBuildingMergeMoreThanTwoBuildingsTest);
-//  CPPUNIT_TEST(buildingToBuildingMergeMoreThanTwoBuildingsNoConstituentsTest);
-//  CPPUNIT_TEST(buildingToBuildingMergeTooFewBuildingsTest);
-//  CPPUNIT_TEST(buildingToBuildingMergeMissingTargetTagTest);
-//  CPPUNIT_TEST(buildingToBuildingMergeDuplicateTargetTagTest);
-//  CPPUNIT_TEST(buildingToBuildingMergeExtraNonBuildingWayTest);
-//  CPPUNIT_TEST(buildingToBuildingMergeExtraNonBuildingRelationTest);
-//  CPPUNIT_TEST(buildingToBuildingInputWithConflatedStatusTest);
+  // BUILDING TO BUILDING
+  CPPUNIT_TEST(buildingToBuildingMergeTwoWaysTest);
+  CPPUNIT_TEST(buildingToBuildingMergeTwoWaysNoConstituentsTest);
+  CPPUNIT_TEST(buildingToBuildingMergeTwoRelationsTest);
+  CPPUNIT_TEST(buildingToBuildingMergeTwoRelationsNoConstituentsTest);
+  CPPUNIT_TEST(buildingToBuildingMergeOneWayOneRelationTargetAsWayTest);
+  CPPUNIT_TEST(buildingToBuildingMergeOneWayOneRelationTargetAsWayNoConstituentsTest);
+  CPPUNIT_TEST(buildingToBuildingMergeOneWayOneRelationTargetAsRelationTest);
+  CPPUNIT_TEST(buildingToBuildingMergeOneWayOneRelationTargetAsRelationNoConstituentsTest);
+  CPPUNIT_TEST(buildingToBuildingMergeMoreThanTwoBuildingsTest);
+  CPPUNIT_TEST(buildingToBuildingMergeMoreThanTwoBuildingsNoConstituentsTest);
+  CPPUNIT_TEST(buildingToBuildingMergeTooFewBuildingsTest);
+  CPPUNIT_TEST(buildingToBuildingMergeMissingTargetTagTest);
+  CPPUNIT_TEST(buildingToBuildingMergeDuplicateTargetTagTest);
+  CPPUNIT_TEST(buildingToBuildingMergeExtraNonBuildingWayTest);
+  CPPUNIT_TEST(buildingToBuildingMergeExtraNonBuildingRelationTest);
+  CPPUNIT_TEST(buildingToBuildingInputWithConflatedStatusTest);
 
-//  // INVALID FEATURE COMBOS
-//  CPPUNIT_TEST(invalidFeatureCombinationTest1);
-//  CPPUNIT_TEST(invalidFeatureCombinationTest2);
-//  CPPUNIT_TEST(invalidFeatureCombinationTest3);
-//  CPPUNIT_TEST(invalidFeatureCombinationTest4);
+  // INVALID FEATURE COMBOS
+  CPPUNIT_TEST(invalidFeatureCombinationTest1);
+  CPPUNIT_TEST(invalidFeatureCombinationTest2);
+  CPPUNIT_TEST(invalidFeatureCombinationTest3);
+  CPPUNIT_TEST(invalidFeatureCombinationTest4);
 
   CPPUNIT_TEST_SUITE_END();
 


### PR DESCRIPTION
I think the original logic was based on the false assumption that POIs would always come in with a 1/2 status. If they are merged beforehand with a poly, that must be true b/c core requires that POIs must always be merged into polys. However, if a POI is immediately merged beforehand with another POI, it could come into poi/poly merging with a conflated status.