### PR TITLE
Fix Version Mismatch handling in OsmApiMatchFailure class

### DIFF
--- a/conf/core/AttributeConflation.conf
+++ b/conf/core/AttributeConflation.conf
@@ -9,6 +9,7 @@
   "duplicate.name.preserve.original.name": "true",
   "highway.corner.splitter.rounded.split": "true",
   "highway.merge.tags.only": "true",
+  "hootapi.db.writer.preserve.version.on.insert": "true",
   "poi.polygon.allow.cross.conflation.merging": "true",
   "poi.polygon.auto.merge.many.poi.to.one.poly.matches": "true",
   "poi.polygon.tag.merger": "hoot::OverwriteTag1Merger",

--- a/conf/core/DifferentialConflation.conf
+++ b/conf/core/DifferentialConflation.conf
@@ -1,5 +1,6 @@
 {
   "#": "Only add entries here that different default values than the options in ConfigOptions.asciidoc",
+  "hootapi.db.writer.preserve.version.on.insert": "true",
   "snap.unconnected.ways.snap.way.criterion" : "hoot::HighwayCriterion",
   "snap.unconnected.ways.snap.to.way.criterion" : "hoot::HighwayCriterion",
   "snap.unconnected.ways.snap.to.way.node.criterion" : "hoot::HighwayWayNodeCriterion",

--- a/conf/core/GrailDifferentialConflation.conf
+++ b/conf/core/GrailDifferentialConflation.conf
@@ -4,6 +4,7 @@
   "element.cache.size.node": "10000000",
   "element.cache.size.relation": "2000000",
   "element.cache.size.way": "2000000",
+  "hootapi.db.writer.preserve.version.on.insert": "true",
   "map.cleaner.transforms": "hoot::ReprojectToPlanarOp;hoot::DuplicateWayRemover;hoot::SuperfluousWayRemover;hoot::IntersectionSplitter;hoot::UnlikelyIntersectionRemover;hoot::DualHighwaySplitter;hoot::HighwayImpliedDividedMarker;hoot::DuplicateNameRemover;hoot::SmallHighwayMerger;hoot::RemoveEmptyAreasVisitor;hoot::RemoveDuplicateAreaVisitor;hoot::NoInformationElementRemover;hoot::HighwayCornerSplitter;hoot::RubberSheet",
   "match.creators": "hoot::HighwayMatchCreator;hoot::ScriptMatchCreator,Area.js;hoot::BuildingMatchCreator;hoot::ScriptMatchCreator,Poi.js;hoot::PoiPolygonMatchCreator;hoot::ScriptMatchCreator,PowerLine.js;hoot::ScriptMatchCreator,Railway.js;hoot::ScriptMatchCreator,River.js",
   "merger.creators": "hoot::HighwaySnapMergerCreator;hoot::ScriptMergerCreator;hoot::BuildingMergerCreator;hoot::PoiPolygonMergerCreator",

--- a/conf/core/HorizontalConflation.conf
+++ b/conf/core/HorizontalConflation.conf
@@ -2,5 +2,6 @@
   "#": "Only add entries here that different default values than the options in ConfigOptions.asciidoc",
   "conflate.pre.ops": "$(conflate.pre.ops);hoot::CookieCutterOp",
   "cookie.cutter.alpha": "2500",
+  "hootapi.db.writer.preserve.version.on.insert": "true",
   "#": "end"
 }

--- a/conf/core/ReferenceConflation.conf
+++ b/conf/core/ReferenceConflation.conf
@@ -1,4 +1,5 @@
 {
   "#": "Only add entries here that different default values than the options in ConfigOptions.asciidoc. Generally, there won't be any.",
+  "hootapi.db.writer.preserve.version.on.insert": "true",
   "#": "end"
 }

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
@@ -135,7 +135,7 @@ bool RetryVersionTestServer::respond(HttpConnection::HttpConnectionPtr &connecti
     //  The first time through, the 'version' of element 1 should fail.
     if (!_has_error)
     {
-      response.reset(new HttpResponse(HttpResponseCode::HTTP_CONFLICT, "Changeset conflict: Version mismatch: Provided 2, server had: 1 of Way 1"));
+      response.reset(new HttpResponse(HttpResponseCode::HTTP_CONFLICT, "Version mismatch: Provided 2, server had: 1 of Way 1"));
       _has_error = true;
     }
     else
@@ -612,7 +612,7 @@ const char* OsmApiSampleRequestResponse::SAMPLE_CHANGESET_VERSION_FAILURE_CHANGE
     " </modify>\n"
     "</osmChange>";
 const char* OsmApiSampleRequestResponse::SAMPLE_CHANGESET_VERSION_FAILURE_RESPONSE =
-    "Changeset conflict: Version mismatch: Provided %1, server had: %2 of Way 1";
+    "Version mismatch: Provided %1, server had: %2 of Way 1";
 const char* OsmApiSampleRequestResponse::SAMPLE_CHANGESET_VERSION_FAILURE_GET_RESPONSE =
     "<?xml version='1.0' encoding='UTF-8'?>\n"
     "<osm version='0.6' generator='hootenanny'>\n"

--- a/hoot-core/hoot-core.pro
+++ b/hoot-core/hoot-core.pro
@@ -36,6 +36,10 @@ OTHER_FILES = \
     ../conf/core/ConfigOptions.asciidoc \
     ../conf/core/*Conflation.conf \
     ../conf/core/*Algorithm.conf \
+    ../conf/core/Grail*.conf \
+    ../conf/core/*Export.conf \
+    ../conf/core/*Import.conf \
+    ../conf/core/*Changeset.conf \
     ../scripts/jenkins/Jenkinsfile \
     $$files(../scripts/copyright/*, true) \
     ../sonar-project.properties \

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiMatchFailure.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiMatchFailure.cpp
@@ -49,9 +49,9 @@ OsmApiMatchFailure::OsmApiMatchFailure()
     _deletePreconditionFailure(
       "Precondition failed: (Node|Way|Relation) (-?[0-9]+) is still used by (node|way|relation)s ((-?[0-9]+,?)+)",
       QRegularExpression::CaseInsensitiveOption),
-    //  Changeset conflict: Version mismatch: Provided 2, server had: 1 of Node 4869875616
+    //  Version mismatch: Provided 2, server had: 1 of Node 4869875616
     _conflictVersionFailure(
-      "Changeset conflict: Version mismatch: Provided ([0-9]+), server had: ([0-9]+) of (Node|Way|Relation) ([0-9]+)",
+      "Version mismatch: Provided ([0-9]+), server had: ([0-9]+) of (Node|Way|Relation) ([0-9]+)",
       QRegularExpression::CaseInsensitiveOption),
     //  Changeset conflict: The changeset 49514098 was closed at 2020-01-08 16:28:56 UTC
     _changesetClosedFailure(
@@ -176,7 +176,7 @@ bool OsmApiMatchFailure::matchesChangesetConflictVersionMismatchFailure(
     long& element_id, ElementType::Type& element_type,
     long& version_old, long& version_new) const
 {
-  //  Changeset conflict: Version mismatch: Provided 2, server had: 1 of Node 4869875616
+  //  Version mismatch: Provided 2, server had: 1 of Node 4869875616
   QRegularExpressionMatch match = _conflictVersionFailure.match(hint);
   if (match.hasMatch())
   {

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiMatchFailure.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiMatchFailure.h
@@ -96,7 +96,7 @@ public:
                                                  std::vector<long>& member_ids, ElementType::Type& member_type) const;
   /**
    * @brief matchesChangesetConflictVersionMismatchFailure Checks the return from the API to see if it is similar to the following error message:
-   *        "Changeset conflict: Version mismatch: Provided 2, server had: 1 of Node 4869875616"
+   *        "Version mismatch: Provided 2, server had: 1 of Node 4869875616"
    * @param hint Error message from OSM API
    * @param member_id ID of the member element that caused the element to fail
    * @param member_type Type of the member element that caused the element to fail

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -222,7 +222,7 @@ private:
    */
   bool _resolveIssues(HootNetworkRequestPtr request, ChangesetInfoPtr changeset);
   /**
-   * @brief _fixConflict Try to fix the "Changeset conflict: Version mismatch" errors from the OSM API
+   * @brief _fixConflict Try to fix the "Version mismatch" errors from the OSM API
    * @param request Network request object initialized with OSM API URL
    * @param changeset Pointer to the failed changeset
    * @param conflictExplanation Error message from OSM API

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
@@ -249,12 +249,12 @@ void OsmXmlReader::_createWay(const QXmlAttributes& attributes)
   long version = ElementData::VERSION_EMPTY;
   if (attributes.value("version") != "")
   {
-    version = _parseDouble(attributes.value("version"));
+    version = _parseLong(attributes.value("version"));
   }
   long changeset = ElementData::CHANGESET_EMPTY;
   if (attributes.value("changeset") != "")
   {
-    changeset = _parseDouble(attributes.value("changeset"));
+    changeset = _parseLong(attributes.value("changeset"));
   }
   unsigned int timestamp = ElementData::TIMESTAMP_EMPTY;
   if (attributes.value("timestamp") != "")
@@ -269,7 +269,7 @@ void OsmXmlReader::_createWay(const QXmlAttributes& attributes)
   long uid = ElementData::UID_EMPTY;
   if (attributes.value("uid") != "")
   {
-    uid = _parseDouble(attributes.value("uid"));
+    uid = _parseLong(attributes.value("uid"));
   }
   LOG_VART(version);
   if (_warnOnVersionZeroElement && version == 0)


### PR DESCRIPTION
Refs #4333 

This PR fixes version mismatch handling in Hootenanny core but also requires a change in reference data handling in the UI.  See the issue for more info.