### PR TITLE
FilteredVisitor memory leaks

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "BuildingMerger.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
@@ -348,7 +348,8 @@ ElementId BuildingMerger::_getIdOfMoreComplexBuilding(
     LOG_VART(building1);
     nodeCount1 =
       (int)FilteredVisitor::getStat(
-        new NodeCriterion(), new ElementCountVisitor(), map, building1);
+        ElementCriterionPtr(new NodeCriterion()),
+        ElementVisitorPtr(new ElementCountVisitor()), map, building1);
   }
   LOG_VART(nodeCount1);
 
@@ -358,7 +359,8 @@ ElementId BuildingMerger::_getIdOfMoreComplexBuilding(
     LOG_VART(building2);
     nodeCount2 =
       (int)FilteredVisitor::getStat(
-        new NodeCriterion(), new ElementCountVisitor(), map, building2);
+        ElementCriterionPtr(new NodeCriterion()),
+        ElementVisitorPtr(new ElementCountVisitor()), map, building2);
   }
   LOG_VART(nodeCount2);
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/VersionUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/VersionUtils.cpp
@@ -41,12 +41,12 @@ namespace hoot
 
 int VersionUtils::versionLessThanOneCount(const OsmMapPtr& map)
 {
-  std::shared_ptr<AttributeValueCriterion> attrCrit(
-    new AttributeValueCriterion(
-      ElementAttributeType(ElementAttributeType::Version), 1, NumericComparisonType::LessThan));
   return
     (int)FilteredVisitor::getStat(
-      attrCrit, std::shared_ptr<ElementCountVisitor>(new ElementCountVisitor()), map);
+      ElementCriterionPtr(
+        new AttributeValueCriterion(
+          ElementAttributeType(ElementAttributeType::Version), 1, NumericComparisonType::LessThan)),
+      ElementVisitorPtr(new ElementCountVisitor()), map);
 }
 
 bool VersionUtils::checkVersionLessThanOneCountAndLogWarning(const OsmMapPtr& map)

--- a/hoot-core/src/main/cpp/hoot/core/elements/VersionUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/VersionUtils.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2020, 2021 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "VersionUtils.h"

--- a/hoot-core/src/main/cpp/hoot/core/ops/AddHilbertReviewSortOrderOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/AddHilbertReviewSortOrderOp.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "AddHilbertReviewSortOrderOp.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/AddHilbertReviewSortOrderOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/AddHilbertReviewSortOrderOp.cpp
@@ -140,7 +140,7 @@ int64_t AddHilbertReviewSortOrderOp::_calculateHilbertValue(
     ConstElementPtr element = map->getElement(*it);
     if (element)
     {
-      Envelope::AutoPtr te(element->getEnvelope(map));
+      std::unique_ptr<Envelope> te(element->getEnvelope(map));
       LOG_VART(env.get());
       if (env.get() == 0)
       {

--- a/hoot-core/src/main/cpp/hoot/core/ops/FindStreetIntersectionsByName.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/FindStreetIntersectionsByName.cpp
@@ -69,8 +69,8 @@ void FindStreetIntersectionsByName::apply(OsmMapPtr& map)
   // Use the total number of roads in the map as the total feature being processed.
   _numProcessed =
     (int)FilteredVisitor::getStat(
-      std::shared_ptr<HighwayCriterion>(new HighwayCriterion(map)),
-      std::shared_ptr<ElementCountVisitor>(new ElementCountVisitor()),
+      ElementCriterionPtr(new HighwayCriterion(map)),
+      ElementVisitorPtr(new ElementCountVisitor()),
       map);
   LOG_VARD(_numProcessed);
   _numAffected = 0;

--- a/hoot-core/src/main/cpp/hoot/core/ops/FindStreetIntersectionsByName.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/FindStreetIntersectionsByName.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C)  2020 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2020, 2021 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "FindStreetIntersectionsByName.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/SchemaUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/SchemaUtils.cpp
@@ -40,8 +40,8 @@ bool SchemaUtils::anyElementsHaveType(const ConstOsmMapPtr& map)
 {
   return
     (int)FilteredVisitor::getStat(
-      std::shared_ptr<HasTypeCriterion>(new HasTypeCriterion()),
-      std::shared_ptr<ElementCountVisitor>(new ElementCountVisitor()), map) > 0;
+      ElementCriterionPtr(new HasTypeCriterion()),
+      ElementVisitorPtr(new ElementCountVisitor()), map) > 0;
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/schema/SchemaUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/SchemaUtils.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2020, 2021 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "SchemaUtils.h"

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.cpp
@@ -131,6 +131,12 @@ double FilteredVisitor::getStat(ElementCriterionPtr criterion, ElementVisitorPtr
   return stat->getStat();
 }
 
+double FilteredVisitor::getStat(ElementCriterionPtr criterion, ElementVisitorPtr visitor,
+                                const ConstOsmMapPtr& map, const ElementPtr& element)
+{
+  return getStat(criterion.get(), visitor.get(), map, element);
+}
+
 double FilteredVisitor::getStat(ElementCriterion* criterion, ElementVisitor* visitor,
                                 const ConstOsmMapPtr& map, const ElementPtr& element)
 {

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "FilteredVisitor.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef FILTEREDVISITOR_H
 #define FILTEREDVISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.h
@@ -66,8 +66,8 @@ public:
 
   /**
    * Similar to above but this is convenient if you want to pass in a temporary criterion and
-   * visitor. In this case FilteredVisitor will take ownership of the criterion and visitor and
-   * delete it when destructed.
+   * visitor. WARNING: FilteredVisitor DOES NOT take ownership of the criterion and visitor and
+   * WON'T delete them when destructed.
    */
   FilteredVisitor(ElementCriterion* criterion, ElementVisitor* visitor);
 
@@ -84,6 +84,8 @@ public:
 
   static double getStat(ElementCriterionPtr criterion, ElementVisitorPtr visitor,
                         const ConstOsmMapPtr& map);
+  static double getStat(ElementCriterionPtr criterion, ElementVisitorPtr visitor,
+                        const ConstOsmMapPtr& map, const ElementPtr& element);
   static double getStat(ElementCriterion* criterion, ElementVisitor* visitor,
                         const ConstOsmMapPtr& map, const ElementPtr& element);
 


### PR DESCRIPTION
The documentation of the `FilteredVisitor::getStat` says that the pointer ownership is passed to the class but it wasn't.  Updated the documentation and created/used the shared pointer version of that function where the leaks were happening.

Closes #4458 