### PR TITLE
Remove duplicated code from PoiPolygonInfoCache

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonDistanceExtractor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonDistanceExtractor.cpp
@@ -57,7 +57,8 @@ double PoiPolygonDistanceExtractor::extract(const OsmMap& /*map*/, const ConstEl
   LOG_VART(poi->getElementId());
   LOG_VART(poly->getElementId());
 
-  //to suppress the ElementToGeometryConverter poly warnings...warnings worth looking into at some point
+  // to suppress the ElementToGeometryConverter poly warnings...warnings worth looking into at some
+  // point
   //DisableLog dl(Log::Warn);
 
   return _infoCache->getDistance(poly, poi);

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonDistanceExtractor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonDistanceExtractor.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2016, 2017, 2019, 2020, 2021 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "PoiPolygonDistanceExtractor.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/ConflateInfoCache.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/ConflateInfoCache.cpp
@@ -1,0 +1,489 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2021 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+#include "ConflateInfoCache.h"
+
+// geos
+#include <geos/util/TopologyException.h>
+
+// hoot
+#include <hoot/core/geometry/ElementToGeometryConverter.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/StringUtils.h>
+#include <hoot/core/util/Factory.h>
+#include <hoot/core/geometry/GeometryUtils.h>
+#include <hoot/core/algorithms/extractors/AddressScoreExtractor.h>
+
+// Std
+#include <float.h>
+
+// Qt
+#include <QStringBuilder>
+
+namespace hoot
+{
+
+ConflateInfoCache::ConflateInfoCache(const ConstOsmMapPtr& map) :
+_map(map),
+_cacheEnabled(true),
+_elementIntersectsCache(CACHE_SIZE_DEFAULT),
+_hasCriterionCache(CACHE_SIZE_DEFAULT),
+_numAddressesCache(CACHE_SIZE_DEFAULT)
+{
+  _geometryCache.reset(
+    new Tgs::LruCache<ElementId, std::shared_ptr<geos::geom::Geometry>>(CACHE_SIZE_DEFAULT));
+}
+
+void ConflateInfoCache::setConfiguration(const Settings& conf)
+{
+  _addressParser.setConfiguration(conf);
+
+  const int maxCacheSize = ConfigOptions(conf).getPoiPolygonMaxSizePerCache();
+  if (maxCacheSize > 0)
+  {
+    _elementIntersectsCache.setMaxCost(maxCacheSize);
+    _hasCriterionCache.setMaxCost(maxCacheSize);
+    _numAddressesCache.setMaxCost(maxCacheSize);
+    _geometryCache.reset(
+        new Tgs::LruCache<ElementId, std::shared_ptr<geos::geom::Geometry>>(maxCacheSize));
+  }
+  else
+  {
+    _cacheEnabled = false;
+  }
+}
+
+void ConflateInfoCache::clear()
+{
+  if (_cacheEnabled)
+  {
+    LOG_DEBUG("Clearing cache...");
+
+    _numCacheHitsByCacheType.clear();
+    _numCacheEntriesByCacheType.clear();
+
+    _hasCriterionCache.clear();
+    _criterionCache.clear();
+    _geometryCache->clear();
+    _numAddressesCache.clear();
+    _elementIntersectsCache.clear();
+    _numAddressesCache.clear();
+  }
+}
+
+void ConflateInfoCache::printCacheInfo()
+{
+  if (_cacheEnabled)
+  {
+    // Add one for the address cache on AddressScoreExtractor.
+    LOG_VARD(_numCacheHitsByCacheType.size());
+    LOG_DEBUG("Conflate caches used: " <<  (_numCacheHitsByCacheType.size() + 1));
+    for (QMap<QString, int>::const_iterator numCacheHitsByCacheTypeItr = _numCacheHitsByCacheType.begin();
+         numCacheHitsByCacheTypeItr != _numCacheHitsByCacheType.end(); ++numCacheHitsByCacheTypeItr)
+    {
+      const QString line =
+        QString("%1:\t%2 hits     entries: %3")
+          .arg(numCacheHitsByCacheTypeItr.key())
+          .arg(StringUtils::formatLargeNumber(numCacheHitsByCacheTypeItr.value()))
+          .arg(
+            StringUtils::formatLargeNumber(
+              _numCacheEntriesByCacheType[numCacheHitsByCacheTypeItr.key()]));
+      LOG_DEBUG(line);
+    }
+    const QString line =
+      QString("%1:\t%2 hits     entries: %3")
+        .arg("address")
+        .arg(StringUtils::formatLargeNumber(AddressScoreExtractor::getNumAddressCacheHits()))
+        .arg(StringUtils::formatLargeNumber(AddressScoreExtractor::getAddressCacheSize()));
+    LOG_DEBUG(line);
+  }
+  else
+  {
+    LOG_DEBUG("POI/Polygon caching disabled.")
+  }
+}
+
+void ConflateInfoCache::_incrementCacheHitCount(const QString& cacheTypeKey)
+{
+  if (!_numCacheHitsByCacheType.contains(cacheTypeKey))
+  {
+    _numCacheHitsByCacheType[cacheTypeKey] = 1;
+  }
+  else
+  {
+    _numCacheHitsByCacheType[cacheTypeKey] = _numCacheHitsByCacheType[cacheTypeKey] + 1;
+  }
+}
+
+void ConflateInfoCache::_incrementCacheSizeCount(const QString& cacheTypeKey)
+{
+  if (!_numCacheEntriesByCacheType.contains(cacheTypeKey))
+  {
+    _numCacheEntriesByCacheType[cacheTypeKey] = 1;
+  }
+  else
+  {
+    _numCacheEntriesByCacheType[cacheTypeKey] = _numCacheEntriesByCacheType[cacheTypeKey] + 1;
+  }
+}
+
+std::shared_ptr<geos::geom::Geometry> ConflateInfoCache::_getGeometry(
+  const ConstElementPtr& element)
+{
+  if (!element)
+  {
+    throw IllegalArgumentException("The input element is null.");
+  }
+
+  std::shared_ptr<geos::geom::Geometry> cachedVal;
+  if (_cacheEnabled && _geometryCache->get(element->getElementId(), cachedVal))
+  {
+    _incrementCacheHitCount("geometry");
+    return cachedVal;
+  }
+
+  std::shared_ptr<geos::geom::Geometry> newGeom;
+  QString errorMsg =
+    "Feature passed to PoiPolygonInfoCache caused topology exception on conversion to a geometry: ";
+  try
+  {
+    newGeom = ElementToGeometryConverter(_map).convertToGeometry(element);
+  }
+  catch (const geos::util::TopologyException& e)
+  {
+    // try to clean it
+    newGeom.reset(GeometryUtils::validateGeometry(newGeom.get()));
+    if (_badGeomCount <= Log::getWarnMessageLimit())
+    {
+      LOG_TRACE(errorMsg << element->toString() << "\n" << e.what());
+      _badGeomCount++;
+    }
+  }
+  catch (const HootException& e)
+  {
+    if (_badGeomCount <= Log::getWarnMessageLimit())
+    {
+      LOG_TRACE(errorMsg << element->toString() << "\n" << e.what());
+      _badGeomCount++;
+    }
+  }
+  if (newGeom.get() &&
+      QString::fromStdString(newGeom->toString()).toUpper().contains("EMPTY"))
+  {
+    if (_badGeomCount <= Log::getWarnMessageLimit())
+    {
+      LOG_TRACE("Invalid element passed: " << newGeom->toString());
+      _badGeomCount++;
+    }
+    newGeom.reset();
+  }
+
+  if (_cacheEnabled)
+  {
+    _geometryCache->insert(element->getElementId(), newGeom);
+    _incrementCacheSizeCount("geometry");
+  }
+
+  return newGeom;
+}
+
+bool ConflateInfoCache::elementContains(const ConstElementPtr& containingElement,
+                                        const ConstElementPtr& containedElement)
+{
+  if (!containingElement || !containedElement)
+  {
+    throw IllegalArgumentException("One of the input elements is null.");
+  }
+  if (containingElement->getElementType() != ElementType::Way &&
+      containingElement->getElementType() != ElementType::Relation)
+  {
+    throw IllegalArgumentException("One of the input elements is of the wrong type.");
+  }
+  LOG_VART(containedElement->getElementId());
+  LOG_VART(containingElement->getElementId());
+
+  std::shared_ptr<geos::geom::Geometry> containingElementGeom = _getGeometry(containingElement);
+  std::shared_ptr<geos::geom::Geometry> containedElementGeom = _getGeometry(containedElement);
+  bool contains = false;
+  if (containingElementGeom && containedElementGeom)
+  {
+    contains = containingElementGeom->contains(containedElementGeom.get());
+    LOG_TRACE(
+      "Calculated contains: " << contains << " for containing element: " <<
+      containingElement->getElementId() <<
+      " and contained element: " << containedElement->getElementId() << ".");
+  }
+  else
+  {
+    LOG_TRACE(
+      "Unable to calculate contains for containing element: " <<
+      containingElement->getElementId() << " and contained element: " <<
+      containedElement->getElementId() << ".");
+  }
+  return contains;
+}
+
+int ConflateInfoCache::numAddresses(const ConstElementPtr& element)
+{
+  if (!element)
+  {
+    throw IllegalArgumentException("The input element is null.");
+  }
+
+  if (_cacheEnabled)
+  {
+    const int* cachedVal = _numAddressesCache[element->getElementId()];
+    if (cachedVal != 0)
+    {
+      _incrementCacheHitCount("numAddresses");
+      return *cachedVal;
+    }
+  }
+
+  const int numAddresses = _addressParser.numAddressesRecursive(element, *_map);
+
+  if (_cacheEnabled)
+  {
+    _numAddressesCache.insert(element->getElementId(), new int(numAddresses));
+    _incrementCacheSizeCount("numAddresses");
+  }
+
+  return numAddresses;
+}
+
+bool ConflateInfoCache::containsMember(const ConstElementPtr& parent, const ElementId& memberId)
+{
+  if (!parent ||
+      (parent->getElementType() != ElementType::Way &&
+       parent->getElementType() != ElementType::Relation))
+  {
+    throw IllegalArgumentException("The parent element is null or of the wrong element type.");
+  }
+  if (parent->getElementType() != ElementType::Way && memberId.getType() != ElementType::Node)
+  {
+    throw IllegalArgumentException("The inputs are of the wrong element type.");
+  }
+  if (parent->getElementType() != ElementType::Relation &&
+      memberId.getType() == ElementType::Unknown)
+  {
+    throw IllegalArgumentException("The inputs are of the wrong element type.");
+  }
+
+  bool containsMember = false;
+  if (parent->getElementType() == ElementType::Way)
+  {
+    containsMember =
+      (std::dynamic_pointer_cast<const Way>(parent))->containsNodeId(memberId.getId());
+  }
+  else
+  {
+    containsMember =
+      (std::dynamic_pointer_cast<const Relation>(parent))->contains(memberId);
+  }
+  return containsMember;
+}
+
+bool ConflateInfoCache::elementsIntersect(
+  const ConstElementPtr& element1, const ConstElementPtr& element2)
+{
+  if (!element1 || !element2)
+  {
+    throw IllegalArgumentException("One of the input elements is null.");
+  }
+
+  QString key1;
+  QString key2;
+
+  if (_cacheEnabled)
+  {
+    key1 = element1->getElementId().toString() % ";" % element2->getElementId().toString();
+    key2 = element2->getElementId().toString() % ";" % element1->getElementId().toString();
+
+    bool* cachedVal = _elementIntersectsCache[key1];
+    if (cachedVal != 0)
+    {
+      _incrementCacheHitCount("intersects");
+      const bool intersects = *cachedVal;
+      LOG_TRACE("Found cached intersects: " << intersects << " for key: " << key1);
+      return intersects;
+    }
+    cachedVal = _elementIntersectsCache[key2];
+    if (cachedVal != 0)
+    {
+      _incrementCacheHitCount("intersects");
+      const bool intersects = *cachedVal;
+      LOG_TRACE("Found cached intersects: " << intersects << " for key: " << key2);
+      return intersects;
+    }
+  }
+
+  std::shared_ptr<geos::geom::Geometry> geom1 = _getGeometry(element1);
+  std::shared_ptr<geos::geom::Geometry> geom2 = _getGeometry(element2);
+  bool intersects = false;
+  if (geom1 && geom2)
+  {
+    intersects = geom1->intersects(geom2.get());
+
+    LOG_TRACE(
+      "Calculated intersects: " << intersects << " for elements: " <<
+      element1->getElementId() << " and " << element2->getElementId() << ".");
+  }
+  else
+  {
+    LOG_TRACE(
+      "Unable to calculate intersects for: " << element1->getElementId() <<
+      " and: " << element2->getElementId() << ".");
+  }
+
+  if (_cacheEnabled)
+  {
+    _elementIntersectsCache.insert(key1, new bool(intersects));
+    _incrementCacheSizeCount("intersects");
+  }
+
+  return intersects;
+}
+
+double ConflateInfoCache::getDistance(
+  const ConstElementPtr& element1, const ConstElementPtr& element2)
+{
+  if (!element1 || !element2)
+  {
+    throw IllegalArgumentException("One of the input elements is null.");
+  }
+  LOG_VART(element1->getElementId());
+  LOG_VART(element2->getElementId());
+
+  double distance = -1.0;
+
+  std::shared_ptr<geos::geom::Geometry> element1Geom = _getGeometry(element1);
+  std::shared_ptr<geos::geom::Geometry> element2Geom = _getGeometry(element2);
+  if (element1Geom && element2Geom)
+  {
+    distance = element1Geom->distance(element2Geom.get());
+    LOG_TRACE(
+      "Calculated distance: " << distance << " for: " << element1->getElementId() <<
+      " and: " << element2->getElementId() << ".");
+  }
+  else
+  {
+    LOG_TRACE(
+      "Unable to calculate distance for: " << element1->getElementId() <<
+      " and: " << element2->getElementId() << ".");
+  }
+
+  return distance;
+}
+
+double ConflateInfoCache::getArea(const ConstElementPtr& element)
+{
+  if (!element)
+  {
+    throw IllegalArgumentException("The input element is null.");
+  }
+
+  std::shared_ptr<geos::geom::Geometry> geom = _getGeometry(element);
+  double area = -1.0;
+  if (geom)
+  {
+    area = geom->getArea();
+  }
+  else
+  {
+    LOG_TRACE("Unable to calculate area for: " << element->getElementId() << ".");
+  }
+  return area;
+}
+
+bool ConflateInfoCache::hasCriterion(const ConstElementPtr& element,
+                                     const QString& criterionClassName)
+{
+  if (!element || criterionClassName.trimmed().isEmpty())
+  {
+    throw IllegalArgumentException(
+      "The input element is null or the criterion class name is empty.");
+  }
+
+  QString key;
+
+  if (_cacheEnabled)
+  {
+    key = element->getElementId().toString() % ";" % criterionClassName;
+    const bool* cachedVal = _hasCriterionCache[key];
+    if (cachedVal != 0)
+    {
+      _incrementCacheHitCount("hasCrit");
+      return *cachedVal;
+    }
+  }
+
+  ElementCriterionPtr crit = _getCrit(criterionClassName);
+  const bool hasCrit = crit->isSatisfied(element);
+
+  if (_cacheEnabled)
+  {
+    _hasCriterionCache.insert(key, new bool(hasCrit));
+    _incrementCacheSizeCount("hasCrit");
+  }
+
+  return hasCrit;
+}
+
+ElementCriterionPtr ConflateInfoCache::_getCrit(const QString& criterionClassName)
+{
+  if (criterionClassName.trimmed().isEmpty())
+  {
+    throw IllegalArgumentException("The criterion class name is empty.");
+  }
+
+  if (_cacheEnabled)
+  {
+    QHash<QString, ElementCriterionPtr>::const_iterator itr =
+      _criterionCache.find(criterionClassName);
+    if (itr != _criterionCache.end())
+    {
+      return itr.value();
+    }
+  }
+
+  ElementCriterionPtr crit =
+    ElementCriterionPtr(
+      Factory::getInstance().constructObject<ElementCriterion>(criterionClassName));
+  if (!crit)
+  {
+    throw IllegalArgumentException(
+      "Invalid criterion passed to PoiPolygonInfoCache::hasCriterion: " + criterionClassName);
+  }
+
+  if (_cacheEnabled)
+  {
+     _criterionCache[criterionClassName] = crit;
+  }
+
+  return crit;
+}
+
+}

--- a/hoot-core/src/main/cpp/hoot/core/conflate/ConflateInfoCache.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/ConflateInfoCache.h
@@ -1,0 +1,217 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. DigitalGlobe
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2021 DigitalGlobe (http://www.digitalglobe.com/)
+ */
+#ifndef CONFLATE_INFO_CACHE_H
+#define CONFLATE_INFO_CACHE_H
+
+// geos
+#include <geos/geom/Geometry.h>
+
+// Hoot
+#include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/criterion/ElementCriterion.h>
+#include <hoot/core/schema/OsmSchema.h>
+#include <hoot/core/util/Configurable.h>
+#include <hoot/core/conflate/address/AddressParser.h>
+
+// Tgs
+#include <tgs/LruCache.h>
+
+// Qt
+#include <QCache>
+
+namespace hoot
+{
+
+/**
+ * Caches data about elements and their relationships that may in speeding up conflation jobs.
+ *
+ * This is generally expected to be initialized only once by each match creator. It is done this way
+ * rather than implementing a Singleton, since case tests are launched as multiple threads within
+ * the same process, which would result in a conflicted cache state. Also, since different match
+ * creators deal with different data types and shouldn't have too much cache overlap between
+ * different caches. Currently, this cache is only used by POI/Polygon conflation.
+ *
+ * The caches used in this class (and in PoiPolygonInfoCache) were determined on 9/30/18 running
+ * POI/Polygon conflation against the regression test
+ * unifying-tests.child/somalia.child/somalia-test3.child and also on 1/7/20 against the data in
+ * africom/somalia/229_Mogadishu_SOM_Translated. Further caching could be deemed necessary given
+ * performance with other datasets.
+ *
+ * Its worth noting that if you are doing performance tweaks on a Vagrant VM, the runtimes may vary
+ * with subsequent executions of the exact same conflate job. So in that case, its best to look for
+ * tweaks with fairly large improvements and ignore the smaller performance improvements.
+ *
+ * WARNING: This class can get very memory hungry depending on how the cache size is configured.
+ */
+class ConflateInfoCache : public Configurable
+{
+
+public:
+
+  ConflateInfoCache(const ConstOsmMapPtr& map);
+  virtual ~ConflateInfoCache() = default;
+
+  virtual void setConfiguration(const Settings& conf) override;
+
+  /**
+   * Returns the distance between two elements; backed by a cache
+   *
+   * @param element1 the first element to measure distance from
+   * @param element2 the second element to measure distance from
+   * @return the distance between the two elements or -1.0 if the distance could not be calculated
+   */
+  double getDistance(const ConstElementPtr& element1, const ConstElementPtr& element2);
+
+  /**
+   * Calculates the area of an element; backed by a cache
+   *
+   * @param element the feature to calculate the area of
+   * @return the area of the feature or -1.0 if the area could not be calculated
+   */
+  double getArea(const ConstElementPtr& element);
+
+  /**
+   * Determines if an element contains another element geographically
+   *
+   * Unlike ElementGeometryUtils::haveGeometricRelationship, this backs the element to geometry
+   * conversion with a cache. This will contribute to increased runtime performance if the same
+   * elements are being used in a comparison many times within the same conflate job.
+   *
+   * @param containingElement the element to check for containing containedElement
+   * @param containedElement the element to check if contained by containingElement
+   * @return true if containingElement contains the containedElement geographicaly; false otherwise
+   * or if the containment could not be calculated
+   */
+  bool elementContains(const ConstElementPtr& containingElement,
+                       const ConstElementPtr& containedElement);
+
+  /**
+   * Determines if an element intersects another element; backed by a cache
+   *
+   * Unlike ElementGeometryUtils::haveGeometricRelationship, this backs the element to geometry
+   * conversion with a cache. This will contribute to increased runtime performance if the same
+   * elements are being used in a comparison many times within the same conflate job.
+   *
+   * @param element1 the first element to examine
+   * @param element2 the second element to examine
+   * @return true if the two elements intersect; false otherwise or if the intersection could not
+   * be calculated
+   */
+  bool elementsIntersect(const ConstElementPtr& element1, const ConstElementPtr& element2);
+
+  /**
+   * Determines if an element has a given criterion; backed by a cache
+   *
+   * Unlike CriterionUtils::hasCriterion, this backs the criterion creation with a cache. This will
+   * contribute to increased runtime performance if the same elements are being used in a comparison
+   * many times within the same conflate job.
+   *
+   * @param element the element to examine
+   * @param criterionClassName class name of the ElementCriterion to determine membership of
+   * @return true if the element has the criterion; false otherwise
+   * @throws if the criterion class name is invalid
+   */
+  bool hasCriterion(const ConstElementPtr& element, const QString& criterionClassName);
+
+  /**
+   * Returns the number of addresses contained by an element; backed by a cache
+   *
+   * @param element the element to examine
+   * @return a number of addresses
+   */
+  int numAddresses(const ConstElementPtr& element);
+
+  /**
+   * Determines if one element a child of another; e.g. way node or relation member; backed by a
+   * cache
+   *
+   * @param parent the parent element
+   * @param memberId the element ID of the child
+   * @return true if parent has the element with memberId as a child; false otherwise
+   */
+  bool containsMember(const ConstElementPtr& parent, const ElementId& memberId);
+
+  /**
+   * Clears the contents of the cache
+   */
+  virtual void clear();
+
+  /**
+   * Prints information about the caches used by this class
+   */
+  void printCacheInfo();
+
+protected:
+
+  static const int CACHE_SIZE_DEFAULT = 10000;
+
+  ConstOsmMapPtr _map;
+  bool _cacheEnabled;
+
+  void _incrementCacheHitCount(const QString& cacheTypeKey);
+  void _incrementCacheSizeCount(const QString& cacheTypeKey);
+
+private:
+
+  // TODO: should this be static?
+  int _badGeomCount;
+
+  AddressParser _addressParser;
+
+  // Didn't see any performance improvement by reserving initial sizes for these caches.
+
+  // key is "elementID 1;elementID 2"; ordering of the ID keys doesn't matter here, since we check
+  // in both directions
+  QCache<QString, bool> _elementIntersectsCache;
+
+  // key is "elementId;criterion class name"
+  QCache<QString, bool> _hasCriterionCache;
+
+  // key is element criterion class name; leaving this as a hash, since it shouldn't ever get big
+  // enough to require any cache size management
+  QHash<QString, ElementCriterionPtr> _criterionCache;
+
+  // QCache doesn't play nicely with shared pointers created elsewhere...tried using them with it
+  // for _geometryCache but failed. Another alternative was to modify ElementToGeometryConverter to
+  // also allow for returing Geometry raw pointers in addition to shared pointers...tried that and
+  // failed as well. Decided to use LruCache for this one instead.
+  std::shared_ptr<Tgs::LruCache<ElementId, std::shared_ptr<geos::geom::Geometry>>> _geometryCache;
+
+  QCache<ElementId, int> _numAddressesCache;
+
+  QMap<QString, int> _numCacheHitsByCacheType;
+  QMap<QString, int> _numCacheEntriesByCacheType;
+
+  //static const int CACHE_SIZE_UPDATE_INTERVAL = 100000;
+
+  std::shared_ptr<geos::geom::Geometry> _getGeometry(const ConstElementPtr& element);
+  ElementCriterionPtr _getCrit(const QString& criterionClassName);
+};
+
+}
+
+#endif // CONFLATE_INFO_CACHE_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonInfoCache.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonInfoCache.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2019, 2020, 2021 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #include "PoiPolygonInfoCache.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonInfoCache.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonInfoCache.cpp
@@ -159,8 +159,6 @@ void PoiPolygonInfoCache::_incrementCacheSizeCount(const QString& cacheTypeKey)
   }
 }
 
-/////////////////NOT POI/POLY SPECIFIC///////////////////
-
 std::shared_ptr<geos::geom::Geometry> PoiPolygonInfoCache::_getGeometry(
   const ConstElementPtr& element)
 {
@@ -496,8 +494,6 @@ ElementCriterionPtr PoiPolygonInfoCache::_getCrit(const QString& criterionClassN
 
   return crit;
 }
-
-/////////////////POI/POLY SPECIFIC/////////////////
 
 bool PoiPolygonInfoCache::isType(const ConstElementPtr& element, const PoiPolygonSchemaType& type)
 {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonInfoCache.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonInfoCache.cpp
@@ -26,20 +26,9 @@
  */
 #include "PoiPolygonInfoCache.h"
 
-// geos
-#include <geos/util/TopologyException.h>
-
 // hoot
 #include <hoot/core/conflate/poi-polygon/PoiPolygonSchema.h>
-#include <hoot/core/geometry/ElementToGeometryConverter.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/util/StringUtils.h>
-#include <hoot/core/util/Factory.h>
-#include <hoot/core/geometry/GeometryUtils.h>
-#include <hoot/core/algorithms/extractors/AddressScoreExtractor.h>
-
-// Std
-#include <float.h>
 
 // Qt
 #include <QStringBuilder>
@@ -48,34 +37,23 @@ namespace hoot
 {
 
 PoiPolygonInfoCache::PoiPolygonInfoCache(const ConstOsmMapPtr& map) :
-_map(map),
-_cacheEnabled(true),
-_elementIntersectsCache(CACHE_SIZE_DEFAULT),
+ConflateInfoCache(map),
 _isTypeCache(CACHE_SIZE_DEFAULT),
-_hasCriterionCache(CACHE_SIZE_DEFAULT),
 _hasMoreThanOneTypeCache(CACHE_SIZE_DEFAULT),
-_numAddressesCache(CACHE_SIZE_DEFAULT),
 _reviewDistanceCache(CACHE_SIZE_DEFAULT)
 {
-  _geometryCache.reset(
-    new Tgs::LruCache<ElementId, std::shared_ptr<geos::geom::Geometry>>(CACHE_SIZE_DEFAULT));
 }
 
 void PoiPolygonInfoCache::setConfiguration(const Settings& conf)
 {
-  _addressParser.setConfiguration(conf);
+  ConflateInfoCache::setConfiguration(conf);
 
   const int maxCacheSize = ConfigOptions(conf).getPoiPolygonMaxSizePerCache();
   if (maxCacheSize > 0)
   {
-    _elementIntersectsCache.setMaxCost(maxCacheSize);
     _isTypeCache.setMaxCost(maxCacheSize);
-    _hasCriterionCache.setMaxCost(maxCacheSize);
     _hasMoreThanOneTypeCache.setMaxCost(maxCacheSize);
-    _numAddressesCache.setMaxCost(maxCacheSize);
     _reviewDistanceCache.setMaxCost(maxCacheSize);
-    _geometryCache.reset(
-        new Tgs::LruCache<ElementId, std::shared_ptr<geos::geom::Geometry>>(maxCacheSize));
   }
   else
   {
@@ -85,414 +63,15 @@ void PoiPolygonInfoCache::setConfiguration(const Settings& conf)
 
 void PoiPolygonInfoCache::clear()
 {
+  ConflateInfoCache::clear();
+
   if (_cacheEnabled)
   {
     LOG_DEBUG("Clearing cache...");
 
-    _numCacheHitsByCacheType.clear();
-    _numCacheEntriesByCacheType.clear();
-
     _isTypeCache.clear();
-    _hasCriterionCache.clear();
-    _criterionCache.clear();
-    _geometryCache->clear();
     _hasMoreThanOneTypeCache.clear();
-    _numAddressesCache.clear();
-    _elementIntersectsCache.clear();
-    _numAddressesCache.clear();
   }
-}
-
-void PoiPolygonInfoCache::printCacheInfo()
-{
-  if (_cacheEnabled)
-  {
-    // Add one for the address cache on AddressScoreExtractor.
-    LOG_VARD(_numCacheHitsByCacheType.size());
-    LOG_DEBUG("POI/Polygon caches used: " <<  (_numCacheHitsByCacheType.size() + 1));
-    for (QMap<QString, int>::const_iterator numCacheHitsByCacheTypeItr = _numCacheHitsByCacheType.begin();
-         numCacheHitsByCacheTypeItr != _numCacheHitsByCacheType.end(); ++numCacheHitsByCacheTypeItr)
-    {
-      const QString line =
-        QString("%1:\t%2 hits     entries: %3")
-          .arg(numCacheHitsByCacheTypeItr.key())
-          .arg(StringUtils::formatLargeNumber(numCacheHitsByCacheTypeItr.value()))
-          .arg(
-            StringUtils::formatLargeNumber(
-              _numCacheEntriesByCacheType[numCacheHitsByCacheTypeItr.key()]));
-      LOG_DEBUG(line);
-    }
-    const QString line =
-      QString("%1:\t%2 hits     entries: %3")
-        .arg("address")
-        .arg(StringUtils::formatLargeNumber(AddressScoreExtractor::getNumAddressCacheHits()))
-        .arg(StringUtils::formatLargeNumber(AddressScoreExtractor::getAddressCacheSize()));
-    LOG_DEBUG(line);
-  }
-  else
-  {
-    LOG_DEBUG("POI/Polygon caching disabled.")
-  }
-}
-
-void PoiPolygonInfoCache::_incrementCacheHitCount(const QString& cacheTypeKey)
-{
-  if (!_numCacheHitsByCacheType.contains(cacheTypeKey))
-  {
-    _numCacheHitsByCacheType[cacheTypeKey] = 1;
-  }
-  else
-  {
-    _numCacheHitsByCacheType[cacheTypeKey] = _numCacheHitsByCacheType[cacheTypeKey] + 1;
-  }
-}
-
-void PoiPolygonInfoCache::_incrementCacheSizeCount(const QString& cacheTypeKey)
-{
-  if (!_numCacheEntriesByCacheType.contains(cacheTypeKey))
-  {
-    _numCacheEntriesByCacheType[cacheTypeKey] = 1;
-  }
-  else
-  {
-    _numCacheEntriesByCacheType[cacheTypeKey] = _numCacheEntriesByCacheType[cacheTypeKey] + 1;
-  }
-}
-
-std::shared_ptr<geos::geom::Geometry> PoiPolygonInfoCache::_getGeometry(
-  const ConstElementPtr& element)
-{
-  if (!element)
-  {
-    throw IllegalArgumentException("The input element is null.");
-  }
-
-  std::shared_ptr<geos::geom::Geometry> cachedVal;
-  if (_cacheEnabled && _geometryCache->get(element->getElementId(), cachedVal))
-  {
-    _incrementCacheHitCount("geometry");
-    return cachedVal;
-  }
-
-  std::shared_ptr<geos::geom::Geometry> newGeom;
-  QString errorMsg =
-    "Feature passed to PoiPolygonInfoCache caused topology exception on conversion to a geometry: ";
-  try
-  {
-    newGeom = ElementToGeometryConverter(_map).convertToGeometry(element);
-  }
-  catch (const geos::util::TopologyException& e)
-  {
-    // try to clean it
-    newGeom.reset(GeometryUtils::validateGeometry(newGeom.get()));
-    if (_badGeomCount <= Log::getWarnMessageLimit())
-    {
-      LOG_TRACE(errorMsg << element->toString() << "\n" << e.what());
-      _badGeomCount++;
-    }
-  }
-  catch (const HootException& e)
-  {
-    if (_badGeomCount <= Log::getWarnMessageLimit())
-    {
-      LOG_TRACE(errorMsg << element->toString() << "\n" << e.what());
-      _badGeomCount++;
-    }
-  }
-  if (newGeom.get() &&
-      QString::fromStdString(newGeom->toString()).toUpper().contains("EMPTY"))
-  {
-    if (_badGeomCount <= Log::getWarnMessageLimit())
-    {
-      LOG_TRACE("Invalid element passed: " << newGeom->toString());
-      _badGeomCount++;
-    }
-    newGeom.reset();
-  }
-
-  if (_cacheEnabled)
-  {
-    _geometryCache->insert(element->getElementId(), newGeom);
-    _incrementCacheSizeCount("geometry");
-  }
-
-  return newGeom;
-}
-
-bool PoiPolygonInfoCache::elementContains(const ConstElementPtr& containingElement,
-                                          const ConstElementPtr& containedElement)
-{
-  if (!containingElement || !containedElement)
-  {
-    throw IllegalArgumentException("One of the input elements is null.");
-  }
-  if (containingElement->getElementType() != ElementType::Way &&
-      containingElement->getElementType() != ElementType::Relation)
-  {
-    throw IllegalArgumentException("One of the input elements is of the wrong type.");
-  }
-  LOG_VART(containedElement->getElementId());
-  LOG_VART(containingElement->getElementId());
-
-  std::shared_ptr<geos::geom::Geometry> containingElementGeom = _getGeometry(containingElement);
-  std::shared_ptr<geos::geom::Geometry> containedElementGeom = _getGeometry(containedElement);
-  bool contains = false;
-  if (containingElementGeom && containedElementGeom)
-  {
-    contains = containingElementGeom->contains(containedElementGeom.get());
-    LOG_TRACE(
-      "Calculated contains: " << contains << " for containing element: " <<
-      containingElement->getElementId() <<
-      " and contained element: " << containedElement->getElementId() << ".");
-  }
-  else
-  {
-    LOG_TRACE(
-      "Unable to calculate contains for containing element: " <<
-      containingElement->getElementId() << " and contained element: " <<
-      containedElement->getElementId() << ".");
-  }
-  return contains;
-}
-
-int PoiPolygonInfoCache::numAddresses(const ConstElementPtr& element)
-{
-  if (!element)
-  {
-    throw IllegalArgumentException("The input element is null.");
-  }
-
-  if (_cacheEnabled)
-  {
-    const int* cachedVal = _numAddressesCache[element->getElementId()];
-    if (cachedVal != 0)
-    {
-      _incrementCacheHitCount("numAddresses");
-      return *cachedVal;
-    }
-  }
-
-  const int numAddresses = _addressParser.numAddressesRecursive(element, *_map);
-
-  if (_cacheEnabled)
-  {
-    _numAddressesCache.insert(element->getElementId(), new int(numAddresses));
-    _incrementCacheSizeCount("numAddresses");
-  }
-
-  return numAddresses;
-}
-
-bool PoiPolygonInfoCache::containsMember(const ConstElementPtr& parent, const ElementId& memberId)
-{
-  if (!parent ||
-      (parent->getElementType() != ElementType::Way &&
-       parent->getElementType() != ElementType::Relation))
-  {
-    throw IllegalArgumentException("The parent element is null or of the wrong element type.");
-  }
-  if (parent->getElementType() != ElementType::Way && memberId.getType() != ElementType::Node)
-  {
-    throw IllegalArgumentException("The inputs are of the wrong element type.");
-  }
-  if (parent->getElementType() != ElementType::Relation &&
-      memberId.getType() == ElementType::Unknown)
-  {
-    throw IllegalArgumentException("The inputs are of the wrong element type.");
-  }
-
-  bool containsMember = false;
-  if (parent->getElementType() == ElementType::Way)
-  {
-    containsMember =
-      (std::dynamic_pointer_cast<const Way>(parent))->containsNodeId(memberId.getId());
-  }
-  else
-  {
-    containsMember =
-      (std::dynamic_pointer_cast<const Relation>(parent))->contains(memberId);
-  }
-  return containsMember;
-}
-
-bool PoiPolygonInfoCache::elementsIntersect(
-  const ConstElementPtr& element1, const ConstElementPtr& element2)
-{
-  if (!element1 || !element2)
-  {
-    throw IllegalArgumentException("One of the input elements is null.");
-  }
-
-  QString key1;
-  QString key2;
-
-  if (_cacheEnabled)
-  {
-    key1 = element1->getElementId().toString() % ";" % element2->getElementId().toString();
-    key2 = element2->getElementId().toString() % ";" % element1->getElementId().toString();
-
-    bool* cachedVal = _elementIntersectsCache[key1];
-    if (cachedVal != 0)
-    {
-      _incrementCacheHitCount("intersects");
-      const bool intersects = *cachedVal;
-      LOG_TRACE("Found cached intersects: " << intersects << " for key: " << key1);
-      return intersects;
-    }
-    cachedVal = _elementIntersectsCache[key2];
-    if (cachedVal != 0)
-    {
-      _incrementCacheHitCount("intersects");
-      const bool intersects = *cachedVal;
-      LOG_TRACE("Found cached intersects: " << intersects << " for key: " << key2);
-      return intersects;
-    }
-  }
-
-  std::shared_ptr<geos::geom::Geometry> geom1 = _getGeometry(element1);
-  std::shared_ptr<geos::geom::Geometry> geom2 = _getGeometry(element2);
-  bool intersects = false;
-  if (geom1 && geom2)
-  {
-    intersects = geom1->intersects(geom2.get());
-
-    LOG_TRACE(
-      "Calculated intersects: " << intersects << " for elements: " <<
-      element1->getElementId() << " and " << element2->getElementId() << ".");
-  }
-  else
-  {
-    LOG_TRACE(
-      "Unable to calculate intersects for: " << element1->getElementId() <<
-      " and: " << element2->getElementId() << ".");
-  }
-
-  if (_cacheEnabled)
-  {
-    _elementIntersectsCache.insert(key1, new bool(intersects));
-    _incrementCacheSizeCount("intersects");
-  }
-
-  return intersects;
-}
-
-double PoiPolygonInfoCache::getDistance(
-  const ConstElementPtr& element1, const ConstElementPtr& element2)
-{
-  if (!element1 || !element2)
-  {
-    throw IllegalArgumentException("One of the input elements is null.");
-  }
-  LOG_VART(element1->getElementId());
-  LOG_VART(element2->getElementId());
-
-  double distance = -1.0;
-
-  std::shared_ptr<geos::geom::Geometry> element1Geom = _getGeometry(element1);
-  std::shared_ptr<geos::geom::Geometry> element2Geom = _getGeometry(element2);
-  if (element1Geom && element2Geom)
-  {
-    distance = element1Geom->distance(element2Geom.get());
-    LOG_TRACE(
-      "Calculated distance: " << distance << " for: " << element1->getElementId() <<
-      " and: " << element2->getElementId() << ".");
-  }
-  else
-  {
-    LOG_TRACE(
-      "Unable to calculate distance for: " << element1->getElementId() <<
-      " and: " << element2->getElementId() << ".");
-  }
-
-  return distance;
-}
-
-double PoiPolygonInfoCache::getArea(const ConstElementPtr& element)
-{
-  if (!element)
-  {
-    throw IllegalArgumentException("The input element is null.");
-  }
-
-  std::shared_ptr<geos::geom::Geometry> geom = _getGeometry(element);
-  double area = -1.0;
-  if (geom)
-  {
-    area = geom->getArea();
-  }
-  else
-  {
-    LOG_TRACE("Unable to calculate area for: " << element->getElementId() << ".");
-  }
-  return area;
-}
-
-bool PoiPolygonInfoCache::hasCriterion(const ConstElementPtr& element,
-                                       const QString& criterionClassName)
-{
-  if (!element || criterionClassName.trimmed().isEmpty())
-  {
-    throw IllegalArgumentException(
-      "The input element is null or the criterion class name is empty.");
-  }
-
-  QString key;
-
-  if (_cacheEnabled)
-  {
-    key = element->getElementId().toString() % ";" % criterionClassName;
-    const bool* cachedVal = _hasCriterionCache[key];
-    if (cachedVal != 0)
-    {
-      _incrementCacheHitCount("hasCrit");
-      return *cachedVal;
-    }
-  }
-
-  ElementCriterionPtr crit = _getCrit(criterionClassName);
-  const bool hasCrit = crit->isSatisfied(element);
-
-  if (_cacheEnabled)
-  {
-    _hasCriterionCache.insert(key, new bool(hasCrit));
-    _incrementCacheSizeCount("hasCrit");
-  }
-
-  return hasCrit;
-}
-
-ElementCriterionPtr PoiPolygonInfoCache::_getCrit(const QString& criterionClassName)
-{
-  if (criterionClassName.trimmed().isEmpty())
-  {
-    throw IllegalArgumentException("The criterion class name is empty.");
-  }
-
-  if (_cacheEnabled)
-  {
-    QHash<QString, ElementCriterionPtr>::const_iterator itr =
-      _criterionCache.find(criterionClassName);
-    if (itr != _criterionCache.end())
-    {
-      return itr.value();
-    }
-  }
-
-  ElementCriterionPtr crit =
-    ElementCriterionPtr(
-      Factory::getInstance().constructObject<ElementCriterion>(criterionClassName));
-  if (!crit)
-  {
-    throw IllegalArgumentException(
-      "Invalid criterion passed to PoiPolygonInfoCache::hasCriterion: " + criterionClassName);
-  }
-
-  if (_cacheEnabled)
-  {
-     _criterionCache[criterionClassName] = crit;
-  }
-
-  return crit;
 }
 
 bool PoiPolygonInfoCache::isType(const ConstElementPtr& element, const PoiPolygonSchemaType& type)

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonInfoCache.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonInfoCache.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2019, 2020, 2021 DigitalGlobe (http://www.digitalglobe.com/)
  */
 #ifndef POI_POLYGON_INFO_CACHE_H
 #define POI_POLYGON_INFO_CACHE_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonInfoCache.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonInfoCache.h
@@ -24,25 +24,12 @@
  *
  * @copyright Copyright (C) 2019, 2020 DigitalGlobe (http://www.digitalglobe.com/)
  */
-#ifndef POI_POLYGON_CACHE_H
-#define POI_POLYGON_CACHE_H
-
-// geos
-#include <geos/geom/Geometry.h>
+#ifndef POI_POLYGON_INFO_CACHE_H
+#define POI_POLYGON_INFO_CACHE_H
 
 // Hoot
-#include <hoot/core/elements/OsmMap.h>
-#include <hoot/core/criterion/ElementCriterion.h>
-#include <hoot/core/schema/OsmSchema.h>
-#include <hoot/core/util/Configurable.h>
-#include <hoot/core/conflate/address/AddressParser.h>
 #include <hoot/core/conflate/poi-polygon/PoiPolygonSchemaType.h>
-
-// Tgs
-#include <tgs/LruCache.h>
-
-// Qt
-#include <QCache>
+#include <hoot/core/conflate/ConflateInfoCache.h>
 
 namespace hoot
 {
@@ -52,23 +39,11 @@ class PoiPolygonInfoCache;
 typedef std::shared_ptr<PoiPolygonInfoCache> PoiPolygonInfoCachePtr;
 
 /**
- * Cached back class storing POI/Polygon feature comparison info
+ * Cached storing POI/Polygon feature comparison info
  *
- * This class is passed into PoiPolygonMatch as a one stop shop to get poi/poly comparison info
- * with a cache backing. It is done this way rather than implementing a Singleton, since case tests
- * are launched as multiple threads within the same process, which would result in a conflicted
- * cache state.
- *
- * The caches used in this class were determined on 9/30/18 running against the regression test
- * unifying-tests.child/somalia.child/somalia-test3.child and also on 1/7/20 against the data in
- * africom/somalia/229_Mogadishu_SOM_Translated. Further caching could be deemed necessary
- * given performance with other datasets.
- *
- * Its worth noting that if you are doing performance tweaks on a Vagrant VM, the runtimes may vary
- * with subsequent executions of the exact same conflate job. So in that case, its best to look for
- * tweaks with fairly large improvements and ignore the smaller performance improvements.
+ * @sa ConflateInfoCache.
  */
-class PoiPolygonInfoCache : public Configurable
+class PoiPolygonInfoCache : public ConflateInfoCache
 {
 
 public:
@@ -76,49 +51,7 @@ public:
   PoiPolygonInfoCache(const ConstOsmMapPtr& map);
   virtual ~PoiPolygonInfoCache() = default;
 
-  virtual void setConfiguration(const Settings& conf);
-
-  /**
-   * Returns the distance between two elements
-   *
-   * @param element1 the first element to measure distance from
-   * @param element2 the second element to measure distance from
-   * @return the distance between the two elements or -1.0 if the distance could not be calculated
-   * @todo move to ElementGeometryUtils backed with cache?
-   */
-  double getDistance(const ConstElementPtr& element1, const ConstElementPtr& element2);
-
-  /**
-   * Calculates the area of an element
-   *
-   * @param element the feature to calculate the area of
-   * @return the area of the feature or -1.0 if the area could not be calculated
-   * @todo move to ElementGeometryUtils backed with cache?
-   */
-  double getArea(const ConstElementPtr& element);
-
-  /**
-   * Determines if an element contains another element geographically
-   *
-   * @param containingElement the element to check for containing containedElement
-   * @param containedElement the element to check if contained by containingElement
-   * @return true if containingElement contains the containedElement geographicaly; false otherwise
-   * or if the containment could not be calculated
-   * @todo move to ElementGeometryUtils backed with cache?
-   */
-  bool elementContains(const ConstElementPtr& containingElement,
-                       const ConstElementPtr& containedElement);
-
-  /**
-   * Determines if an element intersects another element; backed by a cache
-   *
-   * @param element1 the first element to examine
-   * @param element2 the second element to examine
-   * @return true if the two elements intersect; false otherwise or if the intersection could not
-   * be calculated
-   * @todo move to ElementGeometryUtils backed with cache?
-   */
-  bool elementsIntersect(const ConstElementPtr& element1, const ConstElementPtr& element2);
+  virtual void setConfiguration(const Settings& conf) override;
 
   /**
    * Determines if an element is of the given type as defined by the poi/poly schema; backed by a
@@ -132,23 +65,11 @@ public:
   bool isType(const ConstElementPtr& element, const PoiPolygonSchemaType& type);
 
   /**
-   * Determines if an element has a given criterion; backed by a cache
-   *
-   * @param element the element to examine
-   * @param criterionClassName class name of the ElementCriterion to determine membership of
-   * @return true if the element has the criterion; false otherwise
-   * @throws if the criterion class name is invalid
-   * @todo same as CriterionUtils::hasCriterion with added cache?
-   */
-  bool hasCriterion(const ConstElementPtr& element, const QString& criterionClassName);
-
-  /**
    * Determines if an element has more than one type as defined by the poi/poly schema; backed by a
    * cache
    *
    * @param element the element to examine
    * @return true if the element has more than one type; false otherwise
-   * @todo same as OsmSchema::hasMoreThanOneType with added cache?
    */
   bool hasMoreThanOneType(const ConstElementPtr& element);
 
@@ -157,31 +78,12 @@ public:
    *
    * @param element the element to examine
    * @return true if the element has a poi/poly related type; false otherwise
-   * @todo simply wraps PoiPolygonSchema::hasRelatedType
    */
   bool hasRelatedType(const ConstElementPtr& element);
 
   /**
-   * Returns the number of addresses contained by an element; backed by a cache
-   *
-   * @param element the element to examine
-   * @return a number of addresses
-   * @todo simply wraps AddressParser method
-   */
-  int numAddresses(const ConstElementPtr& element);
-
-  /**
-   * Determines if one element a child of another; e.g. way node or relation memeber
-   *
-   * @param parent the parent element
-   * @param memberId the element ID of the child
-   * @return true if parent has the element with memberId as a child; false otherwise
-   * @todo move cache backing part to similar RelationMemberUtils method
-   */
-  bool containsMember(const ConstElementPtr& parent, const ElementId& memberId);
-
-  /**
-   * Determines the max distance to use for generating reviews during matching; backed by a cache
+   * Determines the max distance to use for generating reviews during poi/polygon matching; backed
+   * by a cache
    *
    * @param element the element to examine
    * @param polyTags the tags of the polygon involved in the current match
@@ -194,63 +96,17 @@ public:
   /**
    * Clears the contents of the cache
    */
-  void clear();
-
-  /**
-   * Prints information about the caches used by this class
-   */
-  void printCacheInfo();
+  virtual void clear() override;
 
 private:
-
-  ConstOsmMapPtr _map;
-
-  // TODO: should this be static?
-  int _badGeomCount;
-
-  AddressParser _addressParser;
-
-  bool _cacheEnabled;
-
-  // Didn't see any performance improvement by reserving initial sizes for these caches.
-
-  // key is "elementID 1;elementID 2"; ordering of the ID keys doesn't matter here, since we check
-  // in both directions
-  QCache<QString, bool> _elementIntersectsCache;
 
   // key is "elementId;type string"
   QCache<QString, bool> _isTypeCache;
 
-  // key is "elementId;criterion class name"
-  QCache<QString, bool> _hasCriterionCache;
-
-  // key is element criterion class name; leaving this as a hash, since it shouldn't ever get big
-  // enough to require any cache size management
-  QHash<QString, ElementCriterionPtr> _criterionCache;
-
-  // QCache doesn't play nicely with shared pointers created elsewhere...tried using them with it
-  // for _geometryCache but failed. Another alternative was to modify ElementToGeometryConverter to
-  // also allow for returing Geometry raw pointers in addition to shared pointers...tried that and
-  // failed as well. Decided to use LruCache for this one instead.
-  std::shared_ptr<Tgs::LruCache<ElementId, std::shared_ptr<geos::geom::Geometry>>> _geometryCache;
-
   QCache<ElementId, bool> _hasMoreThanOneTypeCache;
-  QCache<ElementId, int> _numAddressesCache;
   QCache<ElementId, double> _reviewDistanceCache;
-
-  QMap<QString, int> _numCacheHitsByCacheType;
-  QMap<QString, int> _numCacheEntriesByCacheType;
-
-  static const int CACHE_SIZE_UPDATE_INTERVAL = 100000;
-  static const int CACHE_SIZE_DEFAULT = 10000;
-
-  std::shared_ptr<geos::geom::Geometry> _getGeometry(const ConstElementPtr& element);
-  ElementCriterionPtr _getCrit(const QString& criterionClassName);
-
-  void _incrementCacheHitCount(const QString& cacheTypeKey);
-  void _incrementCacheSizeCount(const QString& cacheTypeKey);
 };
 
 }
 
-#endif // POIPOLYGONREVIEWREDUCER_H
+#endif // POI_POLYGON_INFO_CACHE_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonInfoCache.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonInfoCache.h
@@ -67,11 +67,6 @@ typedef std::shared_ptr<PoiPolygonInfoCache> PoiPolygonInfoCachePtr;
  * Its worth noting that if you are doing performance tweaks on a Vagrant VM, the runtimes may vary
  * with subsequent executions of the exact same conflate job. So in that case, its best to look for
  * tweaks with fairly large improvements and ignore the smaller performance improvements.
- *
- * Some of the geometry comparisons in this class could be abstracted out beyond poi/poly geoms and
- * moved into a class like OsmGeometryUtils if we ever need them to be used with other conflation
- * algs. If that's done there will be some work to make any caching being performed work across unit
- * tests.
  */
 class PoiPolygonInfoCache : public Configurable
 {
@@ -89,6 +84,7 @@ public:
    * @param element1 the first element to measure distance from
    * @param element2 the second element to measure distance from
    * @return the distance between the two elements or -1.0 if the distance could not be calculated
+   * @todo move to ElementGeometryUtils backed with cache?
    */
   double getDistance(const ConstElementPtr& element1, const ConstElementPtr& element2);
 
@@ -97,6 +93,7 @@ public:
    *
    * @param element the feature to calculate the area of
    * @return the area of the feature or -1.0 if the area could not be calculated
+   * @todo move to ElementGeometryUtils backed with cache?
    */
   double getArea(const ConstElementPtr& element);
 
@@ -107,6 +104,7 @@ public:
    * @param containedElement the element to check if contained by containingElement
    * @return true if containingElement contains the containedElement geographicaly; false otherwise
    * or if the containment could not be calculated
+   * @todo move to ElementGeometryUtils backed with cache?
    */
   bool elementContains(const ConstElementPtr& containingElement,
                        const ConstElementPtr& containedElement);
@@ -118,6 +116,7 @@ public:
    * @param element2 the second element to examine
    * @return true if the two elements intersect; false otherwise or if the intersection could not
    * be calculated
+   * @todo move to ElementGeometryUtils backed with cache?
    */
   bool elementsIntersect(const ConstElementPtr& element1, const ConstElementPtr& element2);
 
@@ -139,6 +138,7 @@ public:
    * @param criterionClassName class name of the ElementCriterion to determine membership of
    * @return true if the element has the criterion; false otherwise
    * @throws if the criterion class name is invalid
+   * @todo same as CriterionUtils::hasCriterion with added cache?
    */
   bool hasCriterion(const ConstElementPtr& element, const QString& criterionClassName);
 
@@ -148,6 +148,7 @@ public:
    *
    * @param element the element to examine
    * @return true if the element has more than one type; false otherwise
+   * @todo same as OsmSchema::hasMoreThanOneType with added cache?
    */
   bool hasMoreThanOneType(const ConstElementPtr& element);
 
@@ -156,6 +157,7 @@ public:
    *
    * @param element the element to examine
    * @return true if the element has a poi/poly related type; false otherwise
+   * @todo simply wraps PoiPolygonSchema::hasRelatedType
    */
   bool hasRelatedType(const ConstElementPtr& element);
 
@@ -164,6 +166,7 @@ public:
    *
    * @param element the element to examine
    * @return a number of addresses
+   * @todo simply wraps AddressParser method
    */
   int numAddresses(const ConstElementPtr& element);
 
@@ -173,6 +176,7 @@ public:
    * @param parent the parent element
    * @param memberId the element ID of the child
    * @return true if parent has the element with memberId as a child; false otherwise
+   * @todo move cache backing part to similar RelationMemberUtils method
    */
   bool containsMember(const ConstElementPtr& parent, const ElementId& memberId);
 
@@ -225,9 +229,9 @@ private:
   QHash<QString, ElementCriterionPtr> _criterionCache;
 
   // QCache doesn't play nicely with shared pointers created elsewhere...tried using them with it
-  // for _geometryCache but failed. Another alternative was to modify ElementToGeometryConverter to also
-  // allow for returing Geometry raw pointers in addition to shared pointers...tried that and failed
-  // as well. Decided to use LruCache for this one instead.
+  // for _geometryCache but failed. Another alternative was to modify ElementToGeometryConverter to
+  // also allow for returing Geometry raw pointers in addition to shared pointers...tried that and
+  // failed as well. Decided to use LruCache for this one instead.
   std::shared_ptr<Tgs::LruCache<ElementId, std::shared_ptr<geos::geom::Geometry>>> _geometryCache;
 
   QCache<ElementId, bool> _hasMoreThanOneTypeCache;

--- a/hoot-core/src/main/cpp/hoot/core/criterion/CriterionUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/CriterionUtils.cpp
@@ -57,7 +57,7 @@ ElementCriterionPtr CriterionUtils::_getCrit(const QString& criterionClassName)
   if (!crit)
   {
     throw IllegalArgumentException(
-      "Invalid criterion passed to PoiPolygonInfoCache::hasCriterion: " + criterionClassName);
+      "Invalid criterion passed to CriterionUtils::hasCriterion: " + criterionClassName);
   }
   return crit;
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/CriterionUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/CriterionUtils.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. DigitalGlobe
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020 DigitalGlobe (http://www.digitalglobe.com/)
+ * @copyright Copyright (C) 2020, 2021 DigitalGlobe (http://www.digitalglobe.com/)
  */
 
 #include "CriterionUtils.h"

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementGeometryUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementGeometryUtils.h
@@ -57,8 +57,6 @@ public:
    * @param map map owning the input elements
    * @return true if the two elements have the specified geometric relationship; false otherwise or
    * if the relationship could not be calculated
-   * @todo should eventually back this with a cache, as is done in PoiPolygonInfoCache (or merge
-   * the two)
    */
   static bool haveGeometricRelationship(
     const ConstElementPtr& element1, const ConstElementPtr& element2,


### PR DESCRIPTION
Moves non-poi/poly specific cache logic into a new `ConflateInfoCache` class.