### PR TITLE
SONAR: Minor sonar rules to fix - Inherited functions should not be hidden

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/TestOsmChangesetProvider.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/TestOsmChangesetProvider.h
@@ -67,16 +67,16 @@ public:
 
   ~TestOsmChangesetProvider() { }
 
-  std::shared_ptr<OGRSpatialReference> getProjection() const
+  std::shared_ptr<OGRSpatialReference> getProjection() const override
   {
     return std::shared_ptr<OGRSpatialReference>();
   }
 
-  void close() { }
+  void close() override { }
 
-  bool hasMoreChanges() { return _ctr < _max; }
+  bool hasMoreChanges() override { return _ctr < _max; }
 
-  Change readNextChange()
+  Change readNextChange() override
   {
     Change change;
     Change::ChangeType changeType = _getRandomType();

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetCleaner.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetCleaner.h
@@ -63,52 +63,52 @@ public:
   /**
    * @see ChangeSetProvider
    */
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const override;
+  std::shared_ptr<OGRSpatialReference> getProjection() const override;
 
   /**
    * @see ChangeSetProvider
    */
-  virtual void close() override;
+  void close() override;
 
   /**
    * @see ChangeSetProvider
    */
-  virtual bool hasMoreChanges() override;
+  bool hasMoreChanges() override;
 
   /**
    * @see ChangeSetProvider
    */
-  virtual Change readNextChange() override;
+  Change readNextChange() override;
 
   /**
    * @see ChangeSetProvider
    */
-  virtual int getNumFromElementsParsed() const override;
+  int getNumFromElementsParsed() const override;
 
   /**
    * @see ChangeSetProvider
    */
-  virtual int getNumToElementsParsed() const override;
+  int getNumToElementsParsed() const override;
 
   /**
    * @see ChangeSetProvider
    */
-  virtual int getNumCreateChanges() const override;
+  int getNumCreateChanges() const override;
 
   /**
    * @see ChangeSetProvider
    */
-  virtual int getNumModifyChanges() const override;
+  int getNumModifyChanges() const override;
 
   /**
    * @see ChangeSetProvider
    */
-  virtual int getNumDeleteChanges() const override;
+  int getNumDeleteChanges() const override;
 
   /**
    * @see ChangeSetProvider
    */
-  virtual int getNumChanges() const override;
+  int getNumChanges() const override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetDeriver.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetDeriver.h
@@ -49,35 +49,35 @@ public:
   /**
    * @see ChangeSetProvider
    */
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const override;
+  std::shared_ptr<OGRSpatialReference> getProjection() const override;
 
   virtual ~ChangesetDeriver();
 
   /**
    * @see ChangeSetProvider
    */
-  virtual void close();
+  void close() override;
 
   /**
    * @see ChangeSetProvider
    */
-  virtual bool hasMoreChanges();
+  bool hasMoreChanges() override;
 
   /**
    * @see ChangeSetProvider
    */
-  virtual Change readNextChange() override;
+  Change readNextChange() override;
 
-  virtual int getNumFromElementsParsed() const override { return _numFromElementsParsed; }
-  virtual int getNumToElementsParsed() const override { return _numToElementsParsed; }
+  int getNumFromElementsParsed() const override { return _numFromElementsParsed; }
+  int getNumToElementsParsed() const override { return _numToElementsParsed; }
 
-  virtual int getNumCreateChanges() const override
+  int getNumCreateChanges() const override
   { return _changesByType[Change::ChangeType::Create]; }
-  virtual int getNumModifyChanges() const override
+  int getNumModifyChanges() const override
   { return _changesByType[Change::ChangeType::Modify]; }
-  virtual int getNumDeleteChanges() const override
+  int getNumDeleteChanges() const override
   { return _changesByType[Change::ChangeType::Delete]; }
-  virtual int getNumChanges() const override
+  int getNumChanges() const override
   { return getNumCreateChanges() + getNumModifyChanges() + getNumDeleteChanges(); }
 
   void setAllowDeletingReferenceFeatures(bool allow) { _allowDeletingReferenceFeatures = allow; }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetProvider.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetProvider.h
@@ -31,8 +31,8 @@
 #include <ogr_spatialref.h>
 
 // hoot
-#include <hoot/core/elements/Element.h>
 #include <hoot/core/algorithms/changeset/Change.h>
+#include <hoot/core/elements/Element.h>
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/MemChangesetProvider.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/MemChangesetProvider.cpp
@@ -60,7 +60,7 @@ void MemChangesetProvider::addChange(Change newChange)
 
 int MemChangesetProvider::getNumChanges() const
 {
-  return _changes.size();
+  return static_cast<int>(_changes.size());
 }
 
 bool MemChangesetProvider::containsChange(ElementId eID)

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/MemChangesetProvider.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/MemChangesetProvider.cpp
@@ -58,7 +58,7 @@ void MemChangesetProvider::addChange(Change newChange)
   _changes.push_back(newChange);
 }
 
-size_t MemChangesetProvider::getNumChanges()
+int MemChangesetProvider::getNumChanges() const
 {
   return _changes.size();
 }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/MemChangesetProvider.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/MemChangesetProvider.h
@@ -49,26 +49,29 @@ public:
   /**
    * @see ChangeSetProvider
    */
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const override;
+  std::shared_ptr<OGRSpatialReference> getProjection() const override;
 
   /**
    * @see ChangeSetProvider
    */
-  virtual void close();
+  void close() override;
 
   /**
    * @see ChangeSetProvider
    */
-  virtual bool hasMoreChanges();
+  bool hasMoreChanges() override;
 
   /**
    * @see ChangeSetProvider
    */
-  virtual Change readNextChange() override;
+  Change readNextChange() override;
+
+  /**
+   * @see ChangeSetProvider
+   */
+  int getNumChanges() const override;
 
   void addChange(Change newChange);
-
-  size_t getNumChanges();
 
   bool containsChange(ElementId eID);
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/MultipleChangesetProvider.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/MultipleChangesetProvider.h
@@ -46,22 +46,22 @@ public:
 
   virtual ~MultipleChangesetProvider() = default;
 
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const override;
+  std::shared_ptr<OGRSpatialReference> getProjection() const override;
 
   /**
    * @see ChangeSetProvider
    */
-  virtual void close();
+  void close() override;
 
   /**
    * @see ChangeSetProvider
    */
-  virtual bool hasMoreChanges();
+  bool hasMoreChanges() override;
 
   /**
    * @see ChangeSetProvider
    */
-  virtual Change readNextChange() override;
+  Change readNextChange() override;
 
   void addChangesetProvider(ChangesetProviderPtr newChangeset);
 

--- a/hoot-rnd/src/main/cpp/hoot/rnd/io/MultiaryIngestChangesetReader.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/io/MultiaryIngestChangesetReader.h
@@ -53,24 +53,24 @@ public:
   /**
    * @see ChangesetProvider
    */
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const;
+  std::shared_ptr<OGRSpatialReference> getProjection() const override;
 
   void open(QString fileName);
 
   /**
    * @see ChangesetProvider
    */
-  virtual void close();
+  void close() override;
 
   /**
    * @see ChangesetProvider
    */
-  virtual bool hasMoreChanges();
+  bool hasMoreChanges() override;
 
   /**
    * @see ChangesetProvider
    */
-  virtual Change readNextChange();
+  Change readNextChange() override;
 
 private:
 


### PR DESCRIPTION
Fixed MemChangesetProvider::getNumChanges() hiding function and updated all related classes.

Refs #4570 