### PR TITLE
Minor sonar rules to fix - Inherited functions should not be hidden

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbBulkInserter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbBulkInserter.h
@@ -59,15 +59,15 @@ public:
   HootApiDbBulkInserter();
   virtual ~HootApiDbBulkInserter();
 
-  virtual bool isSupported(const QString& url) override;
-  virtual void open(const QString& url) override;
+  bool isSupported(const QString& url) override;
+  void open(const QString& url) override;
 
-  virtual void finalizePartial();
-  virtual void writePartial(const ConstNodePtr& node) override;
-  virtual void writePartial(const ConstWayPtr& way) override;
-  virtual void writePartial(const ConstRelationPtr& relation) override;
+  void finalizePartial();
+  void writePartial(const ConstNodePtr& node) override;
+  void writePartial(const ConstWayPtr& way) override;
+  void writePartial(const ConstRelationPtr& relation) override;
 
-  virtual void setConfiguration(const Settings& conf) override;
+  void setConfiguration(const Settings& conf) override;
 
   long getMapId() const { return _database.getMapId(); }
 
@@ -76,42 +76,42 @@ public:
   void setOverwriteMap(bool overwriteMap) { _overwriteMap = overwriteMap; }
   void setCopyBulkInsertActivated(bool activated) { _copyBulkInsertActivated = activated; }
 
-  virtual QString supportedFormats() override { return MetadataTags::HootApiDbScheme() + "://"; }
+  QString supportedFormats() override { return MetadataTags::HootApiDbScheme() + "://"; }
 
 protected:
 
-  virtual unsigned int _numberOfFileDataPasses() const;
+  unsigned int _numberOfFileDataPasses() const override;
 
-  virtual unsigned long _getTotalRecordsWritten() const;
-  virtual unsigned long _getTotalFeaturesWritten() const;
+  unsigned long _getTotalRecordsWritten() const override;
+  unsigned long _getTotalFeaturesWritten() const override;
 
   //creates the output files containing the data
-  virtual void _createNodeOutputFiles();
-  virtual QStringList _createSectionNameList() override;
-  virtual void _createWayOutputFiles();
-  virtual void _createRelationOutputFiles();
+  void _createNodeOutputFiles() override;
+  QStringList _createSectionNameList() override;
+  void _createWayOutputFiles() override;
+  void _createRelationOutputFiles() override;
 
-  virtual void _writeChangeset();
-  virtual void _writeRelation(const unsigned long relationDbId, const Tags& tags,
+  void _writeChangeset() override;
+  void _writeRelation(const unsigned long relationDbId, const Tags& tags,
                               const unsigned long version);
-  virtual void _writeRelationMember(const unsigned long sourceRelationDbId,
+  void _writeRelationMember(const unsigned long sourceRelationDbId,
                                     const RelationData::Entry& member,
                                     const unsigned long memberDbId,
                                     const unsigned int memberSequenceIndex,
                                     const unsigned long version) override;
-  virtual void _writeWay(const unsigned long wayDbId, const Tags& tags, const unsigned long version);
-  virtual void _writeWayNodes(const unsigned long wayId,
+  void _writeWay(const unsigned long wayDbId, const Tags& tags, const unsigned long version);
+  void _writeWayNodes(const unsigned long wayId,
                               const std::vector<long>& wayNodeIds,
                               const unsigned long version) override;
-  virtual void _writeNode(const ConstNodePtr& node, const unsigned long nodeDbId) override;
+  void _writeNode(const ConstNodePtr& node, const unsigned long nodeDbId) override;
 
-  virtual void _writeCombinedSqlFile();
-  virtual void _writeDataToDb();
-  virtual void _writeDataToDbPsql();
+  void _writeCombinedSqlFile() override;
+  void _writeDataToDb() override;
+  void _writeDataToDbPsql() override;
 
-  virtual bool _destinationIsDatabase() const { return true; }
+  bool _destinationIsDatabase() const  override{ return true; }
 
-  virtual void _incrementChangesInChangeset();
+  void _incrementChangesInChangeset() override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbBulkInserter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbBulkInserter.h
@@ -62,7 +62,7 @@ public:
   bool isSupported(const QString& url) override;
   void open(const QString& url) override;
 
-  void finalizePartial();
+  void finalizePartial() override;
   void writePartial(const ConstNodePtr& node) override;
   void writePartial(const ConstWayPtr& way) override;
   void writePartial(const ConstRelationPtr& relation) override;

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.h
@@ -48,19 +48,19 @@ public:
   HootApiDbWriter();
   virtual ~HootApiDbWriter();
 
-  void close();
+  void close() override;
 
-  virtual void finalizePartial();
+  void finalizePartial() override;
 
   long getMapId() const { return _hootdb.getMapId(); }
 
-  virtual bool isSupported(const QString& urlStr) override;
+  bool isSupported(const QString& urlStr) override;
 
-  virtual void open(const QString& urlStr) override;
+  void open(const QString& urlStr) override;
 
-  virtual void deleteMap(const QString& urlStr);
+  void deleteMap(const QString& urlStr);
 
-  virtual void setConfiguration(const Settings &conf) override;
+  void setConfiguration(const Settings &conf) override;
 
   void setCreateUser(bool createIfNotFound) { _createUserIfNotFound = createIfNotFound; }
   void setOverwriteMap(bool overwriteMap) { _overwriteMap = overwriteMap; }
@@ -77,19 +77,19 @@ public:
   void setJobId(const QString& id) { _jobId = id; }
   void setPreserveVersionOnInsert(bool preserve) { _preserveVersionOnInsert = preserve; }
 
-  virtual void writePartial(const ConstNodePtr& n) override;
-  virtual void writePartial(const ConstWayPtr& w) override;
-  virtual void writePartial(const ConstRelationPtr& r) override;
+  void writePartial(const ConstNodePtr& n) override;
+  void writePartial(const ConstWayPtr& w) override;
+  void writePartial(const ConstRelationPtr& r) override;
 
   /**
    * @see OsmChangeWriter
    */
-  virtual void writeChange(const Change& change) override;
-  virtual void setElementPayloadFormat(const QString& /*format*/) override {}
+  void writeChange(const Change& change) override;
+  void setElementPayloadFormat(const QString& /*format*/) override {}
 
   void setCopyBulkInsertActivated(bool activated) { _copyBulkInsertActivated = activated; }
 
-  virtual QString supportedFormats() override { return MetadataTags::HootApiDbScheme() + "://"; }
+  QString supportedFormats() override { return MetadataTags::HootApiDbScheme() + "://"; }
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -666,7 +666,7 @@ void OgrWriter::finalizePartial()
 {
 }
 
-void OgrWriter::writePartial(const std::shared_ptr<const hoot::Node>& newNode)
+void OgrWriter::writePartial(const ConstNodePtr& newNode)
 {
   LOG_TRACE("Writing node " << newNode->getId());
 
@@ -679,51 +679,51 @@ void OgrWriter::writePartial(const std::shared_ptr<const hoot::Node>& newNode)
   _writePartial(cacheProvider, newNode);
 }
 
-void OgrWriter::writePartial(const std::shared_ptr<const hoot::Way>& newWay)
+void OgrWriter::writePartial(const ConstWayPtr& way)
 {
-  LOG_TRACE("Writing way " << newWay->getId() );
+  LOG_TRACE("Writing way " << way->getId() );
 
   /*
    * Make sure this way has any hope of working (i.e., are there enough spots in the cache
    * for all its nodes?
    */
-  if ((unsigned long)newWay->getNodeCount() > _elementCache->getNodeCacheSize())
+  if ((unsigned long)way->getNodeCount() > _elementCache->getNodeCacheSize())
   {
-    throw HootException("Cannot do partial write of Way ID " + QString::number(newWay->getId()) +
-      " as it contains " + QString::number(newWay->getNodeCount()) + " nodes, but our cache can " +
+    throw HootException("Cannot do partial write of Way ID " + QString::number(way->getId()) +
+      " as it contains " + QString::number(way->getNodeCount()) + " nodes, but our cache can " +
       " only hold " + QString::number(_elementCache->getNodeCacheSize()) + ".  If you have enough " +
       " memory to load this way, you can increase the element.cache.size.node setting to " +
-      " an appropriate value larger than " + QString::number(newWay->getNodeCount()) +
+      " an appropriate value larger than " + QString::number(way->getNodeCount()) +
       " to allow for loading it.");
   }
 
   // Make sure all the nodes in the way are in our cache
-  const std::vector<long> wayNodeIds = newWay->getNodeIds();
+  const std::vector<long> wayNodeIds = way->getNodeIds();
   std::vector<long>::const_iterator nodeIdIterator;
 
   for (nodeIdIterator = wayNodeIds.begin(); nodeIdIterator != wayNodeIds.end(); ++nodeIdIterator)
   {
     if (_elementCache->containsNode(*nodeIdIterator) == false)
     {
-      throw HootException("Way " + QString::number(newWay->getId()) + " contains node " +
+      throw HootException("Way " + QString::number(way->getId()) + " contains node " +
         QString::number(*nodeIdIterator) + ", which is not present in the cache.  If you have the " +
           "memory to support this number of nodes, you can increase the element.cache.size.node " +
           "setting above: " + QString::number(_elementCache->getNodeCacheSize()) + ".");
     }
-    LOG_TRACE("Way " << newWay->getId() << " contains node " << *nodeIdIterator <<
+    LOG_TRACE("Way " << way->getId() << " contains node " << *nodeIdIterator <<
                  ": " << _elementCache->getNode(*nodeIdIterator)->getX() << ", " <<
                 _elementCache->getNode(*nodeIdIterator)->getY() );
   }
 
   // Add to the element cache
-  ConstElementPtr constWay(newWay);
+  ConstElementPtr constWay(way);
   _elementCache->addElement(constWay);
 
   ElementProviderPtr cacheProvider(_elementCache);
-  _writePartial(cacheProvider, newWay);
+  _writePartial(cacheProvider, way);
 }
 
-void OgrWriter::writePartial(const std::shared_ptr<const hoot::Relation>& newRelation)
+void OgrWriter::writePartial(const ConstRelationPtr& newRelation)
 {
   LOG_TRACE("Writing relation " << newRelation->getId());
 
@@ -833,11 +833,6 @@ void OgrWriter::writePartial(const std::shared_ptr<const hoot::Relation>& newRel
 
 void OgrWriter::writeElement(ElementPtr &element)
 {
-  writeElement(element, false);
-}
-
-void OgrWriter::writeElement(ElementPtr &element, bool debug)
-{
   //  Do not attempt to write empty elements
   if (!element)
     return;
@@ -852,11 +847,6 @@ void OgrWriter::writeElement(ElementPtr &element, bool debug)
   }
   // Now that all the empties are gone, update our element
   element->setTags(destTags);
-
-  if (debug == true)
-  {
-    LOG_TRACE(element->toString());
-  }
 
   PartialOsmMapWriter::writePartial(element);
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
@@ -79,7 +79,7 @@ public:
 
   void close();
 
-  virtual bool isSupported(const QString& url) override;
+  bool isSupported(const QString& url) override;
 
   // Init the translator
   void initTranslator();
@@ -92,9 +92,9 @@ public:
 
   void setCache(ElementCachePtr cachePtr) { _elementCache = cachePtr; }
 
-  virtual void open(const QString& url) override;
+  void open(const QString& url) override;
 
-  virtual void setConfiguration(const Settings& conf) override;
+  void setConfiguration(const Settings& conf) override;
 
   void setCreateAllLayers(bool createAll) { _createAllLayers = createAll; }
 
@@ -118,22 +118,20 @@ public:
   void writeTranslatedFeature(const std::shared_ptr<geos::geom::Geometry>& g,
                               const std::vector<ScriptToOgrSchemaTranslator::TranslatedFeature>& tf);
 
-  virtual void write(const ConstOsmMapPtr& map) override;
+  void write(const ConstOsmMapPtr& map) override;
 
-  virtual void finalizePartial() override;
+  void finalizePartial() override;
 
-  virtual void writePartial(const std::shared_ptr<const hoot::Node>&) override;
+  void writePartial(const ConstNodePtr& node) override;
 
-  virtual void writePartial(const std::shared_ptr<const hoot::Way>&) override;
+  void writePartial(const ConstWayPtr& way) override;
 
-  virtual void writePartial(const std::shared_ptr<const hoot::Relation>&) override;
+  void writePartial(const ConstRelationPtr& relation) override;
 
-  virtual void writeElement(ElementPtr& element) override;
-
-  virtual void writeElement(ElementPtr& element, bool debug);
+  void writeElement(ElementPtr& element) override;
 
   //leaving this empty for the time being
-  virtual QString supportedFormats() override { return ""; }
+  QString supportedFormats() override { return ""; }
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbBulkInserter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbBulkInserter.h
@@ -139,16 +139,16 @@ public:
   OsmApiDbBulkInserter();
   virtual ~OsmApiDbBulkInserter();
 
-  virtual bool isSupported(const QString& url) override;
-  virtual void open(const QString& url) override;
-  void close();
+  bool isSupported(const QString& url) override;
+  void open(const QString& url) override;
+  void close() override;
 
-  virtual void finalizePartial() override;
-  virtual void writePartial(const ConstNodePtr& node) override;
-  virtual void writePartial(const ConstWayPtr& way) override;
-  virtual void writePartial(const ConstRelationPtr& relation) override;
+  void finalizePartial() override;
+  void writePartial(const ConstNodePtr& node) override;
+  void writePartial(const ConstWayPtr& way) override;
+  void writePartial(const ConstRelationPtr& relation) override;
 
-  virtual void setConfiguration(const Settings& conf) override;
+  void setConfiguration(const Settings& conf) override;
 
   void setFileOutputElementBufferSize(long size) { _fileOutputElementBufferSize = size; }
   void setStatusUpdateInterval(long interval) { _statusUpdateInterval = interval; }
@@ -191,7 +191,7 @@ public:
   void setWriteIdSequenceUpdates(bool write)
   { _writeIdSequenceUpdates = write; }
 
-  virtual QString supportedFormats() { return MetadataTags::OsmApiDbScheme() + "://"; }
+  QString supportedFormats() { return MetadataTags::OsmApiDbScheme() + "://"; }
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbBulkInserter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbBulkInserter.h
@@ -191,7 +191,7 @@ public:
   void setWriteIdSequenceUpdates(bool write)
   { _writeIdSequenceUpdates = write; }
 
-  QString supportedFormats() { return MetadataTags::OsmApiDbScheme() + "://"; }
+  QString supportedFormats() override { return MetadataTags::OsmApiDbScheme() + "://"; }
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxXmlWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxXmlWriter.h
@@ -59,13 +59,13 @@ public:
   OsmGbdxXmlWriter();
   virtual ~OsmGbdxXmlWriter();
 
-  virtual bool isSupported(const QString& url) override { return url.toLower().endsWith(".gxml"); }
+  bool isSupported(const QString& url) override { return url.toLower().endsWith(".gxml"); }
 
-  virtual QString supportedFormats() override {return ".gxml";}
+  QString supportedFormats() override {return ".gxml";}
 
-  virtual void open(const QString& url) override;
+  void open(const QString& url) override;
 
-  void close();
+  void close() override;
 
   // Set the precision for writing coordinates
   void setPrecision(int p) { _precision = p; }
@@ -85,12 +85,12 @@ public:
    */
   void write(const ConstOsmMapPtr& map, const QString& path);
 
-  virtual void write(const ConstOsmMapPtr& map) override;
+  void write(const ConstOsmMapPtr& map) override;
 
-  virtual void writePartial(const ConstNodePtr& node) override;
-  virtual void writePartial(const ConstWayPtr& way) override;
-  virtual void writePartial(const ConstRelationPtr& relation) override;
-  virtual void finalizePartial();
+  void writePartial(const ConstNodePtr& node) override;
+  void writePartial(const ConstWayPtr& way) override;
+  void writePartial(const ConstRelationPtr& relation) override;
+  void finalizePartial();
 
   /**
    * Remove any invalid characters from the string s and print an error if one is found.

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxXmlWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxXmlWriter.h
@@ -90,7 +90,7 @@ public:
   void writePartial(const ConstNodePtr& node) override;
   void writePartial(const ConstWayPtr& way) override;
   void writePartial(const ConstRelationPtr& relation) override;
-  void finalizePartial();
+  void finalizePartial() override;
 
   /**
    * Remove any invalid characters from the string s and print an error if one is found.

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfWriter.h
@@ -79,7 +79,7 @@ public:
   /**
    * Used to finalize a call to writePartial.
    */
-  virtual void finalizePartial();
+  void finalizePartial() override;
 
   /**
    * Returns the number of elements written by this class since it was instantiated.
@@ -93,12 +93,12 @@ public:
 
   void initializePartial(std::ostream* strm);
 
-  virtual void initializePartial() override;
+  void initializePartial() override;
 
-  virtual bool isSupported(const QString& url) override { return url.toLower().endsWith("osm.pbf"); }
+  bool isSupported(const QString& url) override { return url.toLower().endsWith("osm.pbf"); }
 
-  virtual void open(const QString& url) override;
-  virtual void close();
+  void open(const QString& url) override;
+  void close() override;
 
   /**
    * Set the compression level to a value of -1 to 9. -1 is "default" or equivalent to about 7.
@@ -123,7 +123,7 @@ public:
   /**
    * The write command called after open.
    */
-  virtual void write(const ConstOsmMapPtr& map) override;
+  void write(const ConstOsmMapPtr& map) override;
 
   void write(const ConstOsmMapPtr& map, const QString& path);
 
@@ -139,11 +139,10 @@ public:
    * Write out a map in chunks. This may be called multiple times and must be precceded with a
    * call to initializePartial and finalized with a call to finalizePartial.
    */
-  virtual void writePartial(const ConstOsmMapPtr& map) override;
-
-  virtual void writePartial(const ConstNodePtr& n) override;
-  virtual void writePartial(const ConstWayPtr& w) override;
-  virtual void writePartial(const ConstRelationPtr& r) override;
+  void writePartial(const ConstOsmMapPtr& map) override;
+  void writePartial(const ConstNodePtr& n) override;
+  void writePartial(const ConstWayPtr& w) override;
+  void writePartial(const ConstRelationPtr& r) override;
 
   /**
    * Write out the map as a PrimitiveBlock to the specified stream. The size of the primitive
@@ -173,7 +172,7 @@ public:
   void writePb(const ConstRelationPtr& r, std::ostream* strm);
   void writePb(const RelationPtr& r, std::ostream* strm) { writePb((const ConstRelationPtr)r, strm); }
 
-  virtual QString supportedFormats() { return ".osm.pbf"; }
+  QString supportedFormats() override { return ".osm.pbf"; }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPgCsvWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPgCsvWriter.h
@@ -54,21 +54,21 @@ public:
    * @param url Filename ending in ".pgcsv"
    * @return
    */
-  virtual bool isSupported(const QString& url) override { return url.toLower().endsWith(".pgcsv"); }
+  bool isSupported(const QString& url) override { return url.toLower().endsWith(".pgcsv"); }
   /**
    * @brief supportedFormats
    * @return
    */
-  virtual QString supportedFormats() override { return ".pgcsv"; }
+  QString supportedFormats() override { return ".pgcsv"; }
   /**
    * @brief open
    * @param url
    */
-  virtual void open(const QString& url) override;
+  void open(const QString& url) override;
   /**
    * @brief close
    */
-  void close();
+  void close() override;
   /**
    * @brief toString Write map to one large string containing all PGCSV files,
    * @param map Pointer to map object to write PGCSV data to a string
@@ -79,23 +79,23 @@ public:
    * @brief write Write map to set of PGCSV files
    * @param map Pointer to map object to write to PGCSV
    */
-  virtual void write(const ConstOsmMapPtr& map) override;
+  void write(const ConstOsmMapPtr& map) override;
   /**
    * @brief writePartial Write a single node/way/relation to the correct stream
    * @param n/w/r - Pointer to the node/way/relation to write to PGCSV
    */
-  virtual void writePartial(const ConstNodePtr& n) override;
-  virtual void writePartial(const ConstWayPtr& w) override;
-  virtual void writePartial(const ConstRelationPtr& r) override;
+  void writePartial(const ConstNodePtr& n) override;
+  void writePartial(const ConstWayPtr& w) override;
+  void writePartial(const ConstRelationPtr& r) override;
   /**
    * @brief finalizePartial Finalize the map write
    */
-  virtual void finalizePartial();
+  void finalizePartial() override;
   /**
    * @brief setConfiguration allows configuration settings to override the defaults
    * @param conf Configuration settings object
    */
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
 private:
   /**

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.h
@@ -59,11 +59,11 @@ public:
   OsmXmlWriter();
   virtual ~OsmXmlWriter();
 
-  virtual bool isSupported(const QString& url) override { return url.toLower().endsWith(".osm"); }
+  bool isSupported(const QString& url) override { return url.toLower().endsWith(".osm"); }
 
-  virtual void open(const QString& url) override;
+  void open(const QString& url) override;
 
-  void close();
+  void close() override;
 
   /**
    * These tags can be included to allow Osmosis to read the files. There is no useful
@@ -100,17 +100,17 @@ public:
    */
   void write(const ConstOsmMapPtr& map, const QString& path);
 
-  virtual void write(const ConstOsmMapPtr& map) override;
+  void write(const ConstOsmMapPtr& map) override;
 
-  virtual void writePartial(const ConstNodePtr& node) override;
-  virtual void writePartial(const ConstWayPtr& way) override;
-  virtual void writePartial(const ConstRelationPtr& relation) override;
-  virtual void finalizePartial() override;
+  void writePartial(const ConstNodePtr& node) override;
+  void writePartial(const ConstWayPtr& way) override;
+  void writePartial(const ConstRelationPtr& relation) override;
+  void finalizePartial() override;
 
   bool getFormatXml() const { return _formatXml; }
   void setFormatXml(const bool format) { _formatXml = format; }
 
-  virtual QString supportedFormats() override { return ".osm"; }
+  QString supportedFormats() override { return ".osm"; }
 
   /**
    * Remove illegal XML characters from the string s and print an error if one is found.  These

--- a/hoot-core/src/main/cpp/hoot/core/io/PartialOsmMapWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/PartialOsmMapWriter.cpp
@@ -44,28 +44,28 @@ void PartialOsmMapWriter::writePartial(const ConstOsmMapPtr& map)
   const NodeMap& nm = map->getNodes();
   for (NodeMap::const_iterator it = nm.begin(); it != nm.end(); ++it)
   {
-    writePartial(it->second);
+    writePartial((ConstNodePtr)it->second);
   }
 
   const WayMap& wm = map->getWays();
   for (WayMap::const_iterator it = wm.begin(); it != wm.end(); ++it)
   {
-    writePartial(it->second);
+    writePartial((ConstWayPtr)it->second);
   }
 
   const RelationMap& rm = map->getRelations();
   for (RelationMap::const_iterator it = rm.begin(); it != rm.end(); ++it)
   {
-    writePartial(it->second);
+    writePartial((ConstRelationPtr)it->second);
   }
 }
-
+/*
 void PartialOsmMapWriter::writePartial(const OsmMapPtr& map)
 {
   writePartial((const ConstOsmMapPtr)map);
 }
-
-void PartialOsmMapWriter::writePartial(const std::shared_ptr<const Element>& e)
+*/
+void PartialOsmMapWriter::writePartial(const ConstElementPtr& e)
 {
   switch (e->getElementType().getEnum())
   {

--- a/hoot-core/src/main/cpp/hoot/core/io/PartialOsmMapWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/PartialOsmMapWriter.h
@@ -55,7 +55,7 @@ public:
   /**
    * The default writes the map and then calls finalizePartial();
    */
-  virtual void write(const ConstOsmMapPtr& map) override;
+  void write(const ConstOsmMapPtr& map) override;
 
   /**
    * Write all the entries in the OsmMap to the output. This does not guarantee that all data will
@@ -63,21 +63,12 @@ public:
    *
    * The default write function writes nodes, ways, then relations.
    */
-  virtual void writePartial(const std::shared_ptr<const Element>& e);
+  virtual void writePartial(const ConstElementPtr& e);
   virtual void writePartial(const ConstOsmMapPtr& map);
-  /**
-   * These silly non-const overloads are here to placate the old compiler in RHEL 5.8.
-   */
-  void writePartial(const OsmMapPtr& map);
 
   virtual void writePartial(const ConstNodePtr& n) = 0;
-  void writePartial(const NodePtr& n) { writePartial((const ConstNodePtr)n); }
-
   virtual void writePartial(const ConstWayPtr& w) = 0;
-  void writePartial(const WayPtr& w) { writePartial((const ConstWayPtr)w); }
-
   virtual void writePartial(const ConstRelationPtr& r) = 0;
-  void writePartial(const RelationPtr& r) { writePartial((const ConstRelationPtr)r); }
 
   virtual void writeElement(ElementPtr& element);
 };

--- a/hoot-rnd/src/main/cpp/hoot/rnd/io/SparkJsonWriter.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/io/SparkJsonWriter.h
@@ -56,40 +56,40 @@ public:
   /**
    * @see OsmMapWriter
    */
-  virtual void close() override { if (_fp.get()) { _fp->close(); _fp.reset(); } }
+  void close() override { if (_fp.get()) { _fp->close(); _fp.reset(); } }
 
   /**
    * @see PartialOsmMapWriter
    */
-  virtual void finalizePartial() override { close(); }
+  void finalizePartial() override { close(); }
 
   /**
    * @see OsmMapWriter
    */
-  virtual bool isSupported(const QString& url) override { return url.endsWith(".spark"); }
+  bool isSupported(const QString& url) override { return url.endsWith(".spark"); }
 
   /**
    * Open the specified filename for writing.
    */
-  virtual void open(const QString& fileName) override;
+  void open(const QString& fileName) override;
 
   /**
    * @see PartialOsmMapWriter
    */
-  virtual void writePartial(const ConstNodePtr& n) override;
+  void writePartial(const ConstNodePtr& n) override;
 
   /**
    * @see PartialOsmMapWriter
    */
-  virtual void writePartial(const ConstWayPtr&) override { throw NotImplementedException(); }
+  void writePartial(const ConstWayPtr&) override { throw NotImplementedException(); }
 
   /**
    * @see PartialOsmMapWriter
    */
-  virtual void writePartial(const ConstRelationPtr&) override { throw NotImplementedException(); }
+  void writePartial(const ConstRelationPtr&) override { throw NotImplementedException(); }
 
   //no point in showing this in the format list at this point, since its not actively maintained
-  virtual QString supportedFormats() override { return ""; }
+  QString supportedFormats() override { return ""; }
 
 private:
 


### PR DESCRIPTION
Fixed PartialOsmMapWriter::writePartial() function hiding and updated all derived classes

Refs #4570 