### PR TITLE
SONAR: Special member functions should not be defined unless a non standard behavior is required

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/BufferedLineSegmentIntersector.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/BufferedLineSegmentIntersector.cpp
@@ -113,10 +113,6 @@ private:
   const LineSegment& _ls;
 };
 
-BufferedLineSegmentIntersector::BufferedLineSegmentIntersector()
-{
-}
-
 inline double sgn(double x)
 {
   if (x < 0)

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/BufferedLineSegmentIntersector.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/BufferedLineSegmentIntersector.h
@@ -39,7 +39,7 @@ namespace hoot
 class BufferedLineSegmentIntersector
 {
 public:
-  BufferedLineSegmentIntersector();
+  BufferedLineSegmentIntersector() = default;
 
   /**
    * Buffer a and intersect it with b. The result is put into @a result. Return true if the line

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/Sparse2dMatrix.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/Sparse2dMatrix.cpp
@@ -31,10 +31,6 @@
 namespace hoot
 {
 
-Sparse2dMatrix::Sparse2dMatrix()
-{
-}
-
 QString Sparse2dMatrix::toString() const
 {
   QStringList sl;

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/Sparse2dMatrix.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/Sparse2dMatrix.h
@@ -81,7 +81,7 @@ public:
   typedef Sparse2dCellId CellId;
   typedef HashMap<CellId, double>::const_iterator const_iterator;
 
-  Sparse2dMatrix();
+  Sparse2dMatrix() = default;
   virtual ~Sparse2dMatrix() = default;
 
   double get(const CellId& cid) const;

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayMatchStringSplitter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayMatchStringSplitter.cpp
@@ -28,8 +28,8 @@
 
 // hoot
 #include <hoot/core/algorithms/splitter/WaySplitter.h>
-#include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/elements/ElementGeometryUtils.h>
+#include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/util/Log.h>
 
 using namespace std;
@@ -41,10 +41,6 @@ QString WayMatchStringSplitter::_overlyAggressiveMergeReviewText =
   "One or more ways in the merge are being removed. This is likely due to an inconsistent match. "
   "Please review the length of the review for overly aggressive merges and manually merge features "
   "using input data/imagery. There may also be one or more zero length ways at intersections.";
-
-WayMatchStringSplitter::WayMatchStringSplitter()
-{
-}
 
 void WayMatchStringSplitter::applySplits(OsmMapPtr map,
   vector<pair<ElementId, ElementId>> &replaced,

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayMatchStringSplitter.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayMatchStringSplitter.h
@@ -36,7 +36,7 @@ class WayMatchStringSplitter
 {
 public:
 
-  WayMatchStringSplitter();
+  WayMatchStringSplitter() = default;
 
   /**
    * Traverses all mappings, splits ways where appropriate and updates the subline mappings in

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetDeriver.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetDeriver.h
@@ -29,8 +29,8 @@
 
 // Hoot
 #include <hoot/core/algorithms/changeset/ChangesetProvider.h>
-#include <hoot/core/io/ElementInputStream.h>
 #include <hoot/core/elements/ElementComparer.h>
+#include <hoot/core/io/ElementInputStream.h>
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetProvider.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetProvider.h
@@ -53,7 +53,7 @@ public:
    * If the stream is open when the destructor is called, closeStream must be called in the
    * destructor
    */
-  virtual ~ChangesetProvider() {}
+  virtual ~ChangesetProvider() = default;
 
   /**
    * @brief closeStream

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/TaskGrid.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/TaskGrid.cpp
@@ -27,17 +27,13 @@
 #include "TaskGrid.h"
 
 // Hoot
-#include <hoot/core/util/Log.h>
 #include <hoot/core/geometry/GeometryUtils.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Log.h>
 #include <hoot/core/util/StringUtils.h>
 
 namespace hoot
 {
-
-TaskGrid::TaskGrid()
-{
-}
 
 geos::geom::Envelope TaskGrid::getBounds() const
 {

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/TaskGrid.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/TaskGrid.h
@@ -54,7 +54,7 @@ public:
     geos::geom::Envelope bounds;
   };
 
-  TaskGrid();
+  TaskGrid() = default;
 
   /**
    * Adds a task grid cell to this task grid; cell ordering will be maintainied

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/MultiLineStringLocation.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/MultiLineStringLocation.h
@@ -29,8 +29,8 @@
 #define __MULTI_LINE_STRING_LOCATION_H__
 
 // Hoot
-#include <hoot/core/algorithms/linearreference/WaySublineCollection.h>
 #include <hoot/core/algorithms/linearreference/WayLocation.h>
+#include <hoot/core/algorithms/linearreference/WaySublineCollection.h>
 
 namespace hoot
 {
@@ -47,7 +47,7 @@ public:
 
   // Don't like having a default constructor here, but its needed by PertyWaySplitVisitor
   // for now.
-  MultiLineStringLocation() {}
+  MultiLineStringLocation() = default;
 
   /**
    * Creates a location along the multi-line string

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayLocation.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayLocation.h
@@ -71,7 +71,7 @@ public:
 
   WayLocation(ConstOsmMapPtr map, ConstWayPtr way, int segmentIndex, double segmentFraction);
 
-  virtual ~WayLocation() {}
+  virtual ~WayLocation() = default;
 
   Meters calculateDistanceFromEnd() const;
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayMatchStringMappingConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayMatchStringMappingConverter.cpp
@@ -29,10 +29,6 @@
 namespace hoot
 {
 
-WayMatchStringMappingConverter::WayMatchStringMappingConverter()
-{
-}
-
 WaySublineMatchStringPtr WayMatchStringMappingConverter::toWaySublineMatchString(
   WayMatchStringMappingPtr mapping)
 {

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayMatchStringMappingConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayMatchStringMappingConverter.h
@@ -39,7 +39,7 @@ namespace hoot
 class WayMatchStringMappingConverter
 {
 public:
-  WayMatchStringMappingConverter();
+  WayMatchStringMappingConverter() = default;
 
   WaySublineMatchStringPtr toWaySublineMatchString(WayMatchStringMappingPtr mapping);
 };

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayString.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayString.cpp
@@ -41,10 +41,6 @@ int WayString::logWarnCount = 0;
 // if the difference is smaller than this we consider it to be equivalent.
 Meters WayString::_epsilon = 1e-9;
 
-WayString::WayString()
-{
-}
-
 Meters WayString::_aggregateCircularError() const
 {
   // I considered averaging the circular errors, but I think that could cause undesireable behaviour

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayString.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayString.h
@@ -52,7 +52,7 @@ public:
 
   static int logWarnCount;
 
-  WayString();
+  WayString() = default;
 
   void append(const WaySubline& subline);
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySubline.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySubline.cpp
@@ -30,8 +30,8 @@
 #include <geos/geom/LineString.h>
 
 // hoot
-#include <hoot/core/geometry/ElementToGeometryConverter.h>
 #include <hoot/core/algorithms/FindNodesInWayFactory.h>
+#include <hoot/core/geometry/ElementToGeometryConverter.h>
 #include <hoot/core/visitors/ConstElementVisitor.h>
 
 using namespace geos::geom;
@@ -39,10 +39,6 @@ using namespace std;
 
 namespace hoot
 {
-
-WaySubline::WaySubline()
-{
-}
 
 WaySubline::WaySubline(const WaySubline& from) :
   _start(from.getStart()),

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySubline.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySubline.h
@@ -27,8 +27,8 @@
 #ifndef WAYSUBLINE_H
 #define WAYSUBLINE_H
 
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/algorithms/linearreference/WayLocation.h>
+#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/geometry/GeometryToElementConverter.h>
 
 namespace hoot
@@ -46,7 +46,7 @@ class WaySubline
 {
 public:
 
-  WaySubline();
+  WaySubline() = default;
   WaySubline(const WayLocation& start, const WayLocation& end);
   WaySubline(const WaySubline& from);
   WaySubline(const WaySubline& from, const ConstOsmMapPtr &newMap);

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySublineCollection.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySublineCollection.cpp
@@ -33,10 +33,6 @@ namespace hoot
 
 int WaySublineCollection::logWarnCount = 0;
 
-WaySublineCollection::WaySublineCollection()
-{
-}
-
 void WaySublineCollection::addSubline(const WaySubline& subline)
 {
   if (_sublines.size() == 0)

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySublineCollection.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySublineCollection.h
@@ -54,7 +54,7 @@ public:
 
   typedef std::vector<WaySubline> SublineCollection;
 
-  WaySublineCollection();
+  WaySublineCollection() = default;
 
   void addSubline(const WaySubline& subline);
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySublineMatchString.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySublineMatchString.cpp
@@ -34,12 +34,6 @@ using namespace std;
 namespace hoot
 {
 
-WaySublineMatchString::WaySublineMatchString(const WaySublineMatchString& other)
-{
-  // no need to check for overlaps, the incoming object should already be consistent.
-  _matches = other._matches;
-}
-
 WaySublineMatchString::WaySublineMatchString(const MatchCollection& m)
 {
   for (size_t i = 0; i < m.size(); i++)

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySublineMatchString.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySublineMatchString.h
@@ -29,8 +29,8 @@
 
 
 // Hoot
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/algorithms/linearreference/WaySublineMatch.h>
+#include <hoot/core/elements/OsmMap.h>
 
 // Std
 #include <string>
@@ -55,8 +55,7 @@ public:
 
   typedef std::vector<WaySublineMatch> MatchCollection;
 
-  WaySublineMatchString() {}
-  WaySublineMatchString(const WaySublineMatchString& other);
+  WaySublineMatchString() = default;
   /**
    * Makes a new WaySublineMatchString where all the WayLocations are remapped to reference the
    * new map.

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheetApplier.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheetApplier.cpp
@@ -28,14 +28,14 @@
 #include "RubberSheetApplier.h"
 
 // Hoot
+#include <hoot/core/algorithms/rubber-sheet/RubberSheet.h>
 #include <hoot/core/elements/MapProjector.h>
 #include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/io/IoUtils.h>
+#include <hoot/core/ops/MapCleaner.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/io/IoUtils.h>
-#include <hoot/core/algorithms/rubber-sheet/RubberSheet.h>
-#include <hoot/core/ops/MapCleaner.h>
 #include <hoot/core/util/Settings.h>
 
 // Qt
@@ -43,10 +43,6 @@
 
 namespace hoot
 {
-
-RubberSheetApplier::RubberSheetApplier()
-{
-}
 
 void RubberSheetApplier::apply(const QString& transform, const QString& input, const QString& output)
 {

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheetApplier.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheetApplier.h
@@ -41,7 +41,7 @@ class RubberSheetApplier
 {
 public:
 
-  RubberSheetApplier();
+  RubberSheetApplier() = default;
 
   /**
    * Applies a rubber sheet transform to input and writes to output

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheetDeriver.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheetDeriver.cpp
@@ -28,14 +28,14 @@
 #include "RubberSheetDeriver.h"
 
 // Hoot
+#include <hoot/core/algorithms/rubber-sheet/RubberSheet.h>
 #include <hoot/core/elements/MapProjector.h>
 #include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/io/IoUtils.h>
+#include <hoot/core/ops/MapCleaner.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/io/IoUtils.h>
-#include <hoot/core/algorithms/rubber-sheet/RubberSheet.h>
-#include <hoot/core/ops/MapCleaner.h>
 #include <hoot/core/util/Settings.h>
 
 // Qt
@@ -43,10 +43,6 @@
 
 namespace hoot
 {
-
-RubberSheetDeriver::RubberSheetDeriver()
-{
-}
 
 void RubberSheetDeriver::derive(const QString& input1, const QString& input2,
                                 const QString& transform2To1, const QString& transform1To2,

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheetDeriver.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheetDeriver.h
@@ -41,7 +41,7 @@ class RubberSheetDeriver
 {
 public:
 
-  RubberSheetDeriver();
+  RubberSheetDeriver() = default;
 
   /**
    * Derives rubber sheet transforms for rubber sheeting either direction between two inputs

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheeter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheeter.cpp
@@ -28,22 +28,18 @@
 #include "RubberSheeter.h"
 
 // Hoot
+#include <hoot/core/algorithms/rubber-sheet/RubberSheet.h>
 #include <hoot/core/elements/MapProjector.h>
 #include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/io/IoUtils.h>
+#include <hoot/core/ops/MapCleaner.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/io/IoUtils.h>
-#include <hoot/core/algorithms/rubber-sheet/RubberSheet.h>
-#include <hoot/core/ops/MapCleaner.h>
 #include <hoot/core/util/Settings.h>
 
 namespace hoot
 {
-
-RubberSheeter::RubberSheeter()
-{
-}
 
 void RubberSheeter::rubberSheet(const QString& input1, const QString& input2, const QString& output)
 {

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheeter.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheeter.h
@@ -41,7 +41,7 @@ class RubberSheeter
 {
 public:
 
-  RubberSheeter();
+  RubberSheeter() = default;
 
   /**
    * Rubber sheets two inputs together

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/zindex/LongBox.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/zindex/LongBox.h
@@ -45,7 +45,7 @@ public:
 
   static QString className() { return "hoot::LongBox"; }
 
-  LongBox() {}
+  LongBox() = default;
 
   LongBox(std::vector<long int> min, std::vector<long int> max);
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/zindex/Range.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/zindex/Range.h
@@ -45,11 +45,11 @@ public:
 
   static QString className() { return "hoot::Range"; }
 
-  Range() {}
+  Range() = default;
 
   Range(long int min, long int max);
 
-  virtual ~Range() {}
+  virtual ~Range() = default;
 
   bool hashCode();
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/zindex/ZCurveRanger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/zindex/ZCurveRanger.cpp
@@ -53,7 +53,7 @@ class LongBoxContainer
 {
 public:
 
-  LongBoxContainer() {}
+  LongBoxContainer() = default;
 
   LongBoxContainer(LongBox box, long int excess)
     : _box(box), _excess(excess)

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/zindex/ZCurveRanger.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/zindex/ZCurveRanger.h
@@ -51,7 +51,7 @@ public:
 
   ZCurveRanger(const ZValue& zv);
 
-  ~ZCurveRanger() {}
+  ~ZCurveRanger() = default;
 
   /** Find a good break point for the given box based on major z-value breaks
    * and break the box into two children.

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/zindex/ZValue.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/zindex/ZValue.h
@@ -39,8 +39,6 @@ public:
 
   static QString className() { return "hoot::ZValue"; }
 
-  ZValue() {}
-
   ZValue(int dimensions, int depth, const std::vector<double>& min, const std::vector<double>& max);
 
   ~ZValue();

--- a/hoot-core/src/main/cpp/hoot/core/cmd/Command.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/Command.cpp
@@ -33,8 +33,4 @@
 namespace hoot
 {
 
-Command::Command()
-{
-}
-
 }

--- a/hoot-core/src/main/cpp/hoot/core/cmd/Command.h
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/Command.h
@@ -31,9 +31,6 @@
 // Qt
 #include <QString>
 
-// Standard
-#include <string>
-
 namespace hoot
 {
 
@@ -48,9 +45,9 @@ public:
 
   static QString className() { return "hoot::Command"; }
 
-  Command();
+  Command() = default;
 
-  virtual ~Command() {}
+  virtual ~Command() = default;
 
   /**
    * Returns true if the command should be displayed in the help list.

--- a/hoot-core/src/main/cpp/hoot/core/conflate/IdSwap.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/IdSwap.cpp
@@ -31,10 +31,6 @@
 namespace hoot
 {
 
-IdSwap::IdSwap()
-{
-}
-
 void IdSwap::add(ElementId id_1, ElementId id_2)
 {
   LOG_TRACE("Adding " << id_1.getType().toString() << " " << id_1.getId()

--- a/hoot-core/src/main/cpp/hoot/core/conflate/IdSwap.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/IdSwap.h
@@ -46,7 +46,7 @@ public:
   typedef typename container::iterator iterator;
   typedef typename container::const_iterator const_iterator;
 
-  IdSwap();
+  IdSwap() = default;
   IdSwap(ElementId id_1, ElementId id_2) { add(id_1, id_2); }
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.cpp
@@ -45,11 +45,11 @@
 #endif
 
 // hoot
+#include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/conflate/merging/MergerFactory.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/conflate/matching/Match.h>
 
 // Qt
 #include <QHash>
@@ -74,8 +74,8 @@ public:
     InvalidMatch
   } MatchType;
 
-  MatchEdge() : match(0), type(InvalidMatch) {}
-  MatchEdge(ConstMatchPtr m, MatchType t) : match(m), type(t) {}
+  MatchEdge() : match(0), type(InvalidMatch) { }
+  MatchEdge(ConstMatchPtr m, MatchType t) : match(m), type(t) { }
 
   ConstMatchPtr match;
   MatchType type;
@@ -85,8 +85,8 @@ class MatchVertex
 {
 public:
 
-  MatchVertex() {}
-  MatchVertex(ElementId e) : eid(e) {}
+  MatchVertex() = default;
+  MatchVertex(ElementId e) : eid(e) { }
 
   ElementId eid;
 };
@@ -109,7 +109,7 @@ class MatchGraphInternal
 {
 public:
 
-  MatchGraphInternal(const vector<ConstMatchPtr>& matches) : _matches(matches) {}
+  MatchGraphInternal(const vector<ConstMatchPtr>& matches) : _matches(matches) { }
 
   /**
    * Only return true for edges that are matches and meet the specified threshold.
@@ -120,11 +120,11 @@ public:
 
     MatchThresholdFilter() :
       _graph(0),
-      _threshold(-1) {}
+      _threshold(-1) { }
 
     MatchThresholdFilter(MatchBoostGraph& graph, double threshold) :
       _graph(&graph),
-      _threshold(threshold) {}
+      _threshold(threshold) { }
 
     bool operator()(const MatchEdgeId& edgeId) const
     {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.cpp
@@ -27,11 +27,11 @@
 #include "MergerFactory.h"
 
 // hoot
-#include <hoot/core/util/Factory.h>
-#include <hoot/core/elements/OsmMapConsumer.h>
 #include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/conflate/matching/MatchType.h>
+#include <hoot/core/elements/OsmMapConsumer.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Factory.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/StringUtils.h>
@@ -44,10 +44,6 @@ namespace hoot
 int MergerFactory::logWarnCount = 0;
 
 std::shared_ptr<MergerFactory> MergerFactory::_theInstance;
-
-MergerFactory::MergerFactory()
-{
-}
 
 MergerFactory::~MergerFactory()
 {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerFactory.h
@@ -28,9 +28,9 @@
 #define MERGEFACTORY_H
 
 // hoot
-#include <hoot/core/elements/OsmMap.h>
-#include <hoot/core/conflate/merging/MergerCreator.h>
 #include <hoot/core/conflate/matching/MatchSet.h>
+#include <hoot/core/conflate/merging/MergerCreator.h>
+#include <hoot/core/elements/OsmMap.h>
 
 // Qt
 #include <QString>
@@ -109,7 +109,7 @@ private:
   friend class AbstractConflator;
   friend class MultiaryUtilities;
 
-  MergerFactory();
+  MergerFactory() = default;
 
   static std::shared_ptr<MergerFactory> _theInstance;
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeString.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeString.cpp
@@ -62,26 +62,12 @@ bool operator==(const ConstEdgeStringPtr& es1, const ConstEdgeStringPtr& es2)
     }
   }
 
-//  bool strResult = es1->toString() == es2->toString();
-//  if (result != strResult)
-//  {
-//    LOG_VARE(result);
-//    LOG_VARE(strResult);
-//    LOG_VARE(es1);
-//    LOG_VARE(es2);
-//    throw HootException();
-//  }
-
   return result;
 }
 
 QString EdgeString::EdgeEntry::toString() const
 {
   return hoot::toString(_subline);
-}
-
-EdgeString::EdgeString()
-{
 }
 
 void EdgeString::addFirstEdge(const ConstNetworkEdgePtr& e)

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeString.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeString.h
@@ -49,9 +49,7 @@ public:
 
   struct EdgeEntry
   {
-    EdgeEntry(const ConstEdgeSublinePtr& subline) : _subline(subline)
-    {
-    }
+    EdgeEntry(const ConstEdgeSublinePtr& subline) : _subline(subline) { }
 
     const ConstNetworkEdgePtr& getEdge() const { return _subline->getEdge(); }
 
@@ -93,7 +91,7 @@ public:
 
   static int logWarnCount;
 
-  EdgeString();
+  EdgeString() = default;
 
   void addFirstEdge(const ConstNetworkEdgePtr& e);
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/OsmNetwork.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/OsmNetwork.cpp
@@ -31,10 +31,6 @@
 namespace hoot
 {
 
-OsmNetwork::OsmNetwork()
-{
-}
-
 void OsmNetwork::addEdge(NetworkEdgePtr edge)
 {
   if (_eidToVertex.contains(edge->getFrom()->getElementId()) == false ||

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/OsmNetwork.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/OsmNetwork.h
@@ -61,7 +61,7 @@ public:
   typedef QMultiHash<ElementId, ConstNetworkEdgePtr> EdgeMap;
   typedef QMultiHash<ConstNetworkVertexPtr, ConstNetworkEdgePtr> VertexToEdgeMap;
 
-  OsmNetwork();
+  OsmNetwork() = default;
 
   void addEdge(NetworkEdgePtr edge);
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.h
@@ -30,9 +30,9 @@
 
 
 // Hoot
-#include <hoot/core/util/OpenCv.h>
-#include <hoot/core/util/HootException.h>
 #include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/util/HootException.h>
+#include <hoot/core/util/OpenCv.h>
 
 // Qt
 #include <QString>
@@ -109,14 +109,6 @@ public:
     int maxX;
     int maxY;
 
-    PixelBox(const PixelBox& pb)
-    {
-      minX = pb.minX;
-      maxX = pb.maxX;
-      minY = pb.minY;
-      maxY = pb.maxY;
-    }
-
     PixelBox()
     {
       minX = -1;
@@ -140,15 +132,6 @@ public:
     PixelBox getRowBox(int row) const { return PixelBox(minX, maxX, row, row); }
 
     int getWidth() const { return maxX - minX + 1; }
-
-    PixelBox& operator=(const PixelBox& pb)
-    {
-      minX = pb.minX;
-      maxX = pb.maxX;
-      minY = pb.minY;
-      maxY = pb.maxY;
-      return *this;
-    }
 
     QString toString() const
     {

--- a/hoot-core/src/main/cpp/hoot/core/criterion/DisconnectedWayCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/DisconnectedWayCriterion.cpp
@@ -27,17 +27,13 @@
 #include "DisconnectedWayCriterion.h"
 
 // hoot
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/elements/WayUtils.h>
+#include <hoot/core/util/Factory.h>
 
 namespace hoot
 {
 
 HOOT_FACTORY_REGISTER(ElementCriterion, DisconnectedWayCriterion)
-
-DisconnectedWayCriterion::DisconnectedWayCriterion()
-{
-}
 
 DisconnectedWayCriterion::DisconnectedWayCriterion(ConstOsmMapPtr map) :
 _map(map)

--- a/hoot-core/src/main/cpp/hoot/core/criterion/DisconnectedWayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/DisconnectedWayCriterion.h
@@ -44,7 +44,7 @@ public:
 
   static QString className() { return "hoot::DisconnectedWayCriterion"; }
 
-  DisconnectedWayCriterion();
+  DisconnectedWayCriterion() = default;
   DisconnectedWayCriterion(ConstOsmMapPtr map);
   virtual ~DisconnectedWayCriterion() = default;
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ElementIdCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ElementIdCriterion.cpp
@@ -28,18 +28,14 @@
 #include "ElementIdCriterion.h"
 
 // hoot
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Log.h>
 
 namespace hoot
 {
 
 HOOT_FACTORY_REGISTER(ElementCriterion, ElementIdCriterion)
-
-ElementIdCriterion::ElementIdCriterion()
-{
-}
 
 ElementIdCriterion::ElementIdCriterion(const ElementId& id)
 {

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ElementIdCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ElementIdCriterion.h
@@ -44,7 +44,7 @@ public:
 
   static QString className() { return "hoot::ElementIdCriterion"; }
 
-  ElementIdCriterion();
+  ElementIdCriterion() = default;
   ElementIdCriterion(const ElementId& id);
   ElementIdCriterion(const std::set<ElementId>& ids);
   ElementIdCriterion(const ElementType& elementType, const std::set<long>& ids);

--- a/hoot-core/src/main/cpp/hoot/core/criterion/EmptyWayCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/EmptyWayCriterion.cpp
@@ -27,17 +27,13 @@
 #include "EmptyWayCriterion.h"
 
 // hoot
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/elements/Way.h>
+#include <hoot/core/util/Factory.h>
 
 namespace hoot
 {
 
 HOOT_FACTORY_REGISTER(ElementCriterion, EmptyWayCriterion)
-
-EmptyWayCriterion::EmptyWayCriterion()
-{
-}
 
 bool EmptyWayCriterion::isSatisfied(const ConstElementPtr& e) const
 {

--- a/hoot-core/src/main/cpp/hoot/core/criterion/EmptyWayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/EmptyWayCriterion.h
@@ -45,7 +45,7 @@ public:
 
   static QString className() { return "hoot::EmptyWayCriterion"; }
 
-  EmptyWayCriterion();
+  EmptyWayCriterion() = default;
   virtual ~EmptyWayCriterion() = default;
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/elements/NodeReplacements.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/NodeReplacements.cpp
@@ -45,10 +45,6 @@ using namespace std;
 namespace hoot
 {
 
-NodeReplacements::NodeReplacements()
-{
-}
-
 long NodeReplacements::_getFinalReplacement(long oldId)
 {
   set<long> touched;

--- a/hoot-core/src/main/cpp/hoot/core/elements/NodeReplacements.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/NodeReplacements.h
@@ -45,7 +45,7 @@ class NodeReplacements
 {
 public:
 
-  NodeReplacements();
+  NodeReplacements() = default;
 
   HashMap<long, long>& getReplacements() { return _r; }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMapListener.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMapListener.h
@@ -37,7 +37,7 @@ class OsmMapListener
 {
 public:
 
-  virtual ~OsmMapListener() {}
+  virtual ~OsmMapListener() = default;
 
   virtual std::shared_ptr<OsmMapListener> clone() const = 0;
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/RelationData.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/RelationData.h
@@ -46,7 +46,7 @@ public:
   {
     QString role;
 
-    Entry() {}
+    Entry() = default;
     Entry(QString r, ElementId eid) : role(r), _eid(eid)  { }
     Entry(ElementId eid) : _eid(eid) { }
 

--- a/hoot-core/src/main/cpp/hoot/core/geometry/PolygonCompare.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/PolygonCompare.cpp
@@ -27,14 +27,6 @@
 
 #include "PolygonCompare.h"
 
-// Hoot
-#include <hoot/core/elements/OsmMap.h>
-#include <hoot/core/io/OsmMapWriterFactory.h>
-#include <hoot/core/util/Log.h>
-#include <hoot/core/geometry/GeometryToElementConverter.h>
-#include <hoot/core/geometry/GeometryUtils.h>
-#include <hoot/core/util/StringUtils.h>
-
 // GEOS
 #include <geos/geom/CoordinateSequenceFactory.h>
 #include <geos/geom/GeometryFactory.h>
@@ -42,10 +34,19 @@
 #include <geos/geom/MultiPolygon.h>
 #include <geos/geom/Point.h>
 #include <geos/util/IllegalArgumentException.h>
-using namespace geos::geom;
 
 // TGS
 #include <tgs/RStarTree/HilbertCurve.h>
+
+// Hoot
+#include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/geometry/GeometryToElementConverter.h>
+#include <hoot/core/geometry/GeometryUtils.h>
+#include <hoot/core/io/OsmMapWriterFactory.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/StringUtils.h>
+
+using namespace geos::geom;
 using namespace Tgs;
 
 namespace hoot
@@ -56,13 +57,6 @@ PolygonCompare::PolygonCompare(Envelope e)
   _curve.reset(new HilbertCurve(2, 8));
   _e = e;
   _size = (1 << 8) - 1;
-}
-
-PolygonCompare::PolygonCompare(const PolygonCompare& other)
-{
-  _curve = other._curve;
-  _e = other._e;
-  _size = other._size;
 }
 
 bool PolygonCompare::operator()(const std::shared_ptr<geos::geom::Geometry>& p1,

--- a/hoot-core/src/main/cpp/hoot/core/geometry/PolygonCompare.h
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/PolygonCompare.h
@@ -49,14 +49,13 @@ class PolygonCompare
 public:
 
   PolygonCompare(geos::geom::Envelope e);
-  PolygonCompare(const PolygonCompare& other);
 
   bool operator()(const std::shared_ptr<geos::geom::Geometry>& p1,
                   const std::shared_ptr<geos::geom::Geometry>& p2);
 
 private:
 
-  PolygonCompare();
+  PolygonCompare() = default;
   PolygonCompare& operator=(PolygonCompare& other);
 
   geos::geom::Envelope _e;

--- a/hoot-core/src/main/cpp/hoot/core/index/ElementToRelationMap.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/index/ElementToRelationMap.cpp
@@ -27,19 +27,15 @@
 #include "ElementToRelationMap.h"
 
 // hoot
-#include <hoot/core/visitors/ConstElementVisitor.h>
-#include <hoot/core/elements/Relation.h>
 #include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/elements/Relation.h>
+#include <hoot/core/visitors/ConstElementVisitor.h>
 #include <hoot/core/util/Log.h>
 
 using namespace std;
 
 namespace hoot
 {
-
-ElementToRelationMap::ElementToRelationMap()
-{
-}
 
 void ElementToRelationMap::addRelation(const OsmMap& map,
                                        const std::shared_ptr<const Relation>& r)

--- a/hoot-core/src/main/cpp/hoot/core/index/ElementToRelationMap.h
+++ b/hoot-core/src/main/cpp/hoot/core/index/ElementToRelationMap.h
@@ -52,7 +52,7 @@ class ElementToRelationMap
 {
 public:
 
-  ElementToRelationMap();
+  ElementToRelationMap() = default;
 
   /**
    * Recursively traverses the relation and adds all child elements to the reference.

--- a/hoot-core/src/main/cpp/hoot/core/index/metric-hybrid/Node.h
+++ b/hoot-core/src/main/cpp/hoot/core/index/metric-hybrid/Node.h
@@ -44,7 +44,7 @@ class Node
 {
 public:
 
-  virtual ~Node() {}
+  virtual ~Node() = default;
 
   virtual const Node<KeyType, DataType>* getChild(size_t i) const = 0;
 

--- a/hoot-core/src/main/cpp/hoot/core/info/ApiEntityDisplayInfo.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/info/ApiEntityDisplayInfo.cpp
@@ -28,28 +28,28 @@
 #include "ApiEntityDisplayInfo.h"
 
 // Hoot
-#include <hoot/core/util/Log.h>
-#include <hoot/core/util/Factory.h>
-#include <hoot/core/info/SingleStatistic.h>
-#include <hoot/core/info/NumericStatistic.h>
-#include <hoot/core/ops/OsmMapOperation.h>
-#include <hoot/core/criterion/ElementCriterion.h>
-#include <hoot/core/visitors/ElementVisitor.h>
-#include <hoot/core/algorithms/extractors/FeatureExtractor.h>
-#include <hoot/core/conflate/matching/MatchCreator.h>
-#include <hoot/core/conflate/merging/MergerCreator.h>
-#include <hoot/core/schema/TagMerger.h>
-#include <hoot/core/algorithms/string/StringDistance.h>
+#include <hoot/core/algorithms/WayJoiner.h>
 #include <hoot/core/algorithms/aggregator/ValueAggregator.h>
-#include <hoot/core/info/ApiEntityInfo.h>
-#include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/algorithms/extractors/FeatureExtractor.h>
+#include <hoot/core/algorithms/string/StringDistance.h>
 #include <hoot/core/algorithms/subline-matching/SublineMatcher.h>
 #include <hoot/core/algorithms/subline-matching/SublineStringMatcher.h>
 #include <hoot/core/conflate/matching/Match.h>
+#include <hoot/core/conflate/matching/MatchCreator.h>
 #include <hoot/core/conflate/merging/Merger.h>
-#include <hoot/core/algorithms/WayJoiner.h>
+#include <hoot/core/conflate/merging/MergerCreator.h>
 #include <hoot/core/criterion/ConflatableElementCriterion.h>
+#include <hoot/core/criterion/ElementCriterion.h>
 #include <hoot/core/criterion/ElementCriterionConsumer.h>
+#include <hoot/core/info/ApiEntityInfo.h>
+#include <hoot/core/info/NumericStatistic.h>
+#include <hoot/core/info/SingleStatistic.h>
+#include <hoot/core/ops/OsmMapOperation.h>
+#include <hoot/core/schema/TagMerger.h>
+#include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Factory.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/visitors/ElementVisitor.h>
 
 //  Qt
 #include <QTextStream>
@@ -65,7 +65,7 @@ class ApiEntityNameComparator
 {
 public:
 
-  ApiEntityNameComparator() {}
+  ApiEntityNameComparator() = default;
 
   bool operator()(const QString& name1, const QString& name2)
   {

--- a/hoot-core/src/main/cpp/hoot/core/info/SingleStat.h
+++ b/hoot-core/src/main/cpp/hoot/core/info/SingleStat.h
@@ -40,9 +40,9 @@ public:
   QString name;
   double value;
 
-  SingleStat() {}
+  SingleStat() = default;
 
-  SingleStat(const QString& n, double v) : name(n), value(v) {}
+  SingleStat(const QString& n, double v) : name(n), value(v) { }
 
   QString toString() const
   {

--- a/hoot-core/src/main/cpp/hoot/core/io/BulkDelete.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/BulkDelete.h
@@ -40,7 +40,7 @@ class BulkDelete
 {
 public:
 
-  virtual ~BulkDelete() {}
+  virtual ~BulkDelete() = default;
 
   virtual void flush() = 0;
 

--- a/hoot-core/src/main/cpp/hoot/core/io/EnvelopeProvider.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/EnvelopeProvider.h
@@ -36,7 +36,7 @@ class EnvelopeProvider
 {
 public:
 
-  virtual ~EnvelopeProvider() {}
+  virtual ~EnvelopeProvider() = default;
 
   /**
    * Calculates the envelope and returns it. In some cases this may be pre-calculated, in others

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.cpp
@@ -73,17 +73,6 @@ ChangesetElement::ChangesetElement(const XmlObject& object, ElementIdToIdMap* id
   }
 }
 
-ChangesetElement::ChangesetElement(const ChangesetElement& element)
-  : _type(element._type),
-    _id(element._id),
-    _version(element._version),
-    _object(element._object),
-    _tags(element._tags),
-    _idMap(element._idMap),
-    _status(element._status)
-{
-}
-
 void ChangesetElement::addTag(const XmlObject& tag)
 {
   //  Make sure that the object is in fact a tag before adding it
@@ -291,11 +280,6 @@ ChangesetNode::ChangesetNode(const XmlObject& node, ElementIdToIdMap* idMap)
   _type = ElementType::Node;
 }
 
-ChangesetNode::ChangesetNode(const ChangesetNode &node)
-  : ChangesetElement(node)
-{
-}
-
 QString ChangesetNode::toString(long changesetId, ChangesetType type) const
 {
   QString buffer;
@@ -341,12 +325,6 @@ ChangesetWay::ChangesetWay(const XmlObject& way, ElementIdToIdMap* idMap)
 {
   //  Override the type
   _type = ElementType::Way;
-}
-
-ChangesetWay::ChangesetWay(const ChangesetWay &way)
-  : ChangesetElement(way),
-    _nodes(way._nodes)
-{
 }
 
 void ChangesetWay::removeNodes(int position, int count)
@@ -434,12 +412,6 @@ ChangesetRelation::ChangesetRelation(const XmlObject& relation, ElementIdToIdMap
 {
   //  Override the type
   _type = ElementType::Relation;
-}
-
-ChangesetRelation::ChangesetRelation(const ChangesetRelation &relation)
-  : ChangesetElement(relation),
-    _members(relation._members)
-{
 }
 
 bool ChangesetRelation::hasMember(ElementType::Type type, long id) const

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
@@ -76,11 +76,6 @@ public:
    * @param idMap ID to ID Map for updated IDs
    */
   ChangesetElement(const XmlObject& object, ElementIdToIdMap* idMap);
-  /**
-   * @brief XmlElement copy constructor
-   * @param element XmlElement object to copy
-   */
-  ChangesetElement(const ChangesetElement& element);
 
   virtual ~ChangesetElement() = default;
   /**
@@ -217,11 +212,6 @@ public:
    * @param idMap ID to ID Map for updated IDs
    */
   ChangesetNode(const XmlObject& node, ElementIdToIdMap* idMap);
-  /**
-   * @brief ChangesetNode copy constructor
-   * @param node ChangesetNode object to copy
-   */
-  ChangesetNode(const ChangesetNode& node);
   /** Virtual destructor */
   virtual ~ChangesetNode() = default;
   /**
@@ -252,11 +242,6 @@ public:
    * @param idMap ID to ID Map for updated IDs
    */
   ChangesetWay(const XmlObject& way, ElementIdToIdMap* idMap);
-  /**
-   * @brief ChangesetWay copy constructor
-   * @param way ChangesetWay object to copy
-   */
-  ChangesetWay(const ChangesetWay& way);
   /** Virtual destructor */
   virtual ~ChangesetWay() = default;
   /**
@@ -370,11 +355,6 @@ public:
    * @param idMap ID to ID Map for updated IDs
    */
   ChangesetRelation(const XmlObject& relation, ElementIdToIdMap* idMap);
-  /**
-   * @brief ChangesetRelation copy constructor
-   * @param relation ChangesetRelation object to copy
-   */
-  ChangesetRelation(const ChangesetRelation& relation);
   /** Virtual destructor */
   virtual ~ChangesetRelation() = default;
   /**

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -443,7 +443,7 @@ private:
   /** For white box testing */
   friend class OsmApiWriterTest;
   /** Default constructor for testing purposes only */
-  OsmApiWriter() {}
+  OsmApiWriter() = default;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/schema/FeatureDefinition.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/schema/FeatureDefinition.cpp
@@ -32,10 +32,6 @@
 namespace hoot
 {
 
-FeatureDefinition::FeatureDefinition()
-{
-}
-
 bool FeatureDefinition::hasField(const QString& name) const
 {
   for (size_t i = 0; i < _fields.size(); ++i)

--- a/hoot-core/src/main/cpp/hoot/core/io/schema/FeatureDefinition.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/schema/FeatureDefinition.h
@@ -42,7 +42,7 @@ class FieldDefinition;
 class FeatureDefinition
 {
 public:
-  FeatureDefinition();
+  FeatureDefinition() = default;
 
   void addField(const std::shared_ptr<FieldDefinition>& fd) { _fields.push_back(fd); }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/schema/FieldDefinition.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/schema/FieldDefinition.h
@@ -51,7 +51,7 @@ public:
     {
     }
 
-    virtual ~InvalidValueException() throw() {}
+    virtual ~InvalidValueException() throw() = default;
 
   private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/schema/Layer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/schema/Layer.cpp
@@ -29,8 +29,4 @@
 namespace hoot
 {
 
-Layer::Layer()
-{
-}
-
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/schema/Layer.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/schema/Layer.h
@@ -44,7 +44,7 @@ class FeatureDefinition;
 class Layer
 {
 public:
-  Layer();
+  Layer() = default;
 
   const std::shared_ptr<const FeatureDefinition>& getFeatureDefinition() const { return _definition; }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/schema/Schema.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/schema/Schema.cpp
@@ -31,10 +31,6 @@
 namespace hoot
 {
 
-Schema::Schema()
-{
-}
-
 void Schema::addLayer(const std::shared_ptr<Layer>& l)
 {
   _layers.push_back(l);

--- a/hoot-core/src/main/cpp/hoot/core/io/schema/Schema.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/schema/Schema.h
@@ -39,7 +39,7 @@ namespace hoot
 class Schema
 {
 public:
-  Schema();
+  Schema() = default;
 
   void addLayer(const std::shared_ptr<Layer>& l);
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/AttributeCoOccurrence.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/AttributeCoOccurrence.cpp
@@ -28,17 +28,17 @@
 #include "AttributeCoOccurrence.h"
 
 // Hoot
-#include <hoot/core/elements/ConstOsmMapConsumer.h>
+#include <hoot/core/algorithms/extractors/NameExtractor.h>
 #include <hoot/core/algorithms/string/LevenshteinDistance.h>
 #include <hoot/core/algorithms/string/MeanWordSetDistance.h>
-#include <hoot/core/algorithms/extractors/NameExtractor.h>
-#include <hoot/core/visitors/ConstElementVisitor.h>
-#include <hoot/core/schema/OsmSchema.h>
+#include <hoot/core/elements/ConstOsmMapConsumer.h>
 #include <hoot/core/language/ToEnglishTranslateStringDistance.h>
+#include <hoot/core/schema/MetadataTags.h>
+#include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/scoring/TextTable.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/schema/MetadataTags.h>
+#include <hoot/core/visitors/ConstElementVisitor.h>
 
 // tgs
 #include <tgs/HashMap.h>
@@ -57,7 +57,7 @@ public:
 
   typedef map<QString, set<ElementId>> RefToEid;
 
-  explicit RefToEidVisitor(QString ref) : _ref(ref) {}
+  explicit RefToEidVisitor(QString ref) : _ref(ref) { }
 
   virtual ~RefToEidVisitor() = default;
 
@@ -100,7 +100,7 @@ class CoOccurrenceVisitor : public ConstElementVisitor, public ConstOsmMapConsum
 public:
 
   CoOccurrenceVisitor(RefToEidVisitor::RefToEid refSet, AttributeCoOccurrence::CoOccurrenceHash& h) :
-  _refSet(refSet), _coOccurrence(h) {}
+  _refSet(refSet), _coOccurrence(h) { }
 
   virtual ~CoOccurrenceVisitor() = default;
 
@@ -237,8 +237,6 @@ private:
 
 };
 
-
-AttributeCoOccurrence::AttributeCoOccurrence() {}
 
 void AttributeCoOccurrence::addToMatrix(const ConstOsmMapPtr& in)
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/AttributeCoOccurrence.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/AttributeCoOccurrence.h
@@ -43,7 +43,7 @@ public:
 
   typedef HashMap<QString, HashMap<QString, int>> CoOccurrenceHash;
 
-  AttributeCoOccurrence();
+  AttributeCoOccurrence() = default;
 
   void addToMatrix(const ConstOsmMapPtr& in);
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
@@ -141,7 +141,7 @@ namespace hoot
 
 struct AverageResult
 {
-  AverageResult() {}
+  AverageResult() = default;
 
   AverageResult(VertexId vid, double score)
   {
@@ -157,9 +157,9 @@ class SimilarToOnly
 {
 public:
 
-  SimilarToOnly() : _graph(0) {}
+  SimilarToOnly() : _graph(0) { }
 
-  SimilarToOnly(TagGraph& graph) : _graph(&graph) {}
+  SimilarToOnly(TagGraph& graph) : _graph(&graph) { }
 
   bool operator()(const EdgeId& edge_id) const
   {
@@ -176,7 +176,7 @@ class VertexNameComparator
 {
 public:
 
-  VertexNameComparator(const TagGraph& graph) : _graph(graph) {}
+  VertexNameComparator(const TagGraph& graph) : _graph(graph) { }
 
   bool operator()(VertexId v1, VertexId v2)
   {

--- a/hoot-core/src/main/cpp/hoot/core/schema/SchemaChecker.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/SchemaChecker.cpp
@@ -28,9 +28,9 @@
 #include "SchemaChecker.h"
 
 // hoot
-#include <hoot/core/util/Log.h>
-#include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/schema/OsmSchema.h>
+#include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Log.h>
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/schema/SchemaChecker.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/SchemaChecker.h
@@ -52,7 +52,7 @@ public:
 
   SchemaChecker(OsmSchema& osmSchema);
 
-  ~SchemaChecker() {}
+  ~SchemaChecker() = default;
 
   /**
    * Print out error message if schemavertex is unkonw vertex type.

--- a/hoot-core/src/main/cpp/hoot/core/schema/ScoreMatrix.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/ScoreMatrix.h
@@ -57,7 +57,7 @@ class ScoreMatrix
 {
 public:
 
-  ScoreMatrix() { }
+  ScoreMatrix() = default;
   ScoreMatrix(int width, int height) { resize(width, height); }
 
   void resize(size_t i, size_t j);

--- a/hoot-core/src/main/cpp/hoot/core/scoring/DirectedGraph.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/DirectedGraph.cpp
@@ -31,17 +31,13 @@
 #include <geos/geom/LineString.h>
 
 // Hoot
+#include <hoot/core/criterion/OneWayCriterion.h>
+#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/geometry/ElementToGeometryConverter.h>
-#include <hoot/core/elements/OsmMap.h>
-#include <hoot/core/criterion/OneWayCriterion.h>
 
 namespace hoot
 {
-
-DirectedGraph::DirectedGraph()
-{
-}
 
 void DirectedGraph::addEdge(long from, long to, double weight)
 {

--- a/hoot-core/src/main/cpp/hoot/core/scoring/DirectedGraph.h
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/DirectedGraph.h
@@ -57,9 +57,9 @@ public:
     double weight;
   };
 
-  DirectedGraph();
+  DirectedGraph() = default;
 
-  virtual ~DirectedGraph() {}
+  virtual ~DirectedGraph() = default;
 
   void addEdge(long from, long to, double weight);
 

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MapMatchScoringUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MapMatchScoringUtils.cpp
@@ -32,11 +32,6 @@
 namespace hoot
 {
 
-MapMatchScoringUtils::MapMatchScoringUtils()
-{
-
-}
-
 QString MapMatchScoringUtils::getMatchScoringString(
   const std::shared_ptr<const MatchComparator>& matchComparator)
 {

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MapMatchScoringUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MapMatchScoringUtils.h
@@ -42,7 +42,7 @@ class MapMatchScoringUtils
 {
   public:
 
-    MapMatchScoringUtils();
+    MapMatchScoringUtils() = default;
 
     /**
       Returns a printable string with match scoring results

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MatchScoringMapPreparer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MatchScoringMapPreparer.cpp
@@ -27,10 +27,10 @@
 #include "MatchScoringMapPreparer.h"
 
 // hoot
-#include <hoot/core/ops/MapCleaner.h>
-#include <hoot/core/criterion/TagKeyCriterion.h>
 #include <hoot/core/criterion/ElementTypeCriterion.h>
 #include <hoot/core/criterion/TagCriterion.h>
+#include <hoot/core/criterion/TagKeyCriterion.h>
+#include <hoot/core/ops/MapCleaner.h>
 #include <hoot/core/schema/MetadataTags.h>
 #include <hoot/core/visitors/AddUuidVisitor.h>
 #include <hoot/core/visitors/FilteredVisitor.h>
@@ -47,7 +47,7 @@ public:
   ConvertUuidToRefVisitor() = default;
   virtual ~ConvertUuidToRefVisitor() = default;
 
-  virtual void visit(const std::shared_ptr<Element>& e)
+  void visit(const ElementPtr& e) override
   {
     if (!e->getTags().contains(MetadataTags::Ref1()) &&
         !e->getTags().contains(MetadataTags::Ref2()) && e->getTags().contains("uuid"))
@@ -64,14 +64,10 @@ public:
     }
   }
 
-  virtual QString getDescription() const { return ""; }
-  virtual QString getName() const { return ""; }
-  virtual QString getClassName() const override { return ""; }
+  QString getDescription() const override { return ""; }
+  QString getName() const override { return ""; }
+  QString getClassName() const override { return ""; }
 };
-
-MatchScoringMapPreparer::MatchScoringMapPreparer()
-{
-}
 
 void MatchScoringMapPreparer::prepMap(OsmMapPtr map, const bool removeNodes)
 {

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MatchScoringMapPreparer.h
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MatchScoringMapPreparer.h
@@ -40,7 +40,7 @@ class MatchScoringMapPreparer
 {
 public:
 
-  MatchScoringMapPreparer();
+  MatchScoringMapPreparer() = default;
 
   /**
     Prepares a map for match scoring

--- a/hoot-core/src/main/cpp/hoot/core/util/Assert.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/Assert.cpp
@@ -32,10 +32,6 @@
 namespace hoot
 {
 
-Assert::Assert()
-{
-}
-
 void Assert::isTrue(bool exp, QString s)
 {
   if (exp)

--- a/hoot-core/src/main/cpp/hoot/core/util/Assert.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Assert.h
@@ -37,7 +37,7 @@ namespace hoot
 class Assert
 {
 public:
-  Assert();
+  Assert() = default;
 
   static void isFalse(bool exp, QString s) { isTrue(!exp, s); }
   static void isTrue(bool exp, QString s);

--- a/hoot-core/src/main/cpp/hoot/core/util/AssertionFailedException.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/AssertionFailedException.h
@@ -41,9 +41,9 @@ class AssertionFailedException : public HootException
 {
 public:
 
-  AssertionFailedException(QString str) : HootException(str) {}
+  AssertionFailedException(QString str) : HootException(str) { }
 
-  virtual ~AssertionFailedException() throw() {}
+  virtual ~AssertionFailedException() throw() = default;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/util/ConfPath.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/ConfPath.cpp
@@ -46,10 +46,6 @@ using namespace std;
 namespace hoot
 {
 
-ConfPath::ConfPath()
-{
-}
-
 QStringList ConfPath::find(QStringList filters, QString searchDir)
 {
   QString hootHome = getHootHome();

--- a/hoot-core/src/main/cpp/hoot/core/util/ConfPath.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/ConfPath.h
@@ -45,7 +45,7 @@ namespace hoot
 class ConfPath
 {
 public:
-  ConfPath();
+  ConfPath() = default;
 
   /**
    * @brief Find all the files in the conf path that meet the requirements in filters.

--- a/hoot-core/src/main/cpp/hoot/core/util/Exception.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Exception.h
@@ -50,7 +50,7 @@ public:
     _error = error;
   }
 
-  virtual ~Exception() throw() {}
+  virtual ~Exception() throw() = default;
 
   virtual const char* what() const throw()
   {

--- a/hoot-core/src/main/cpp/hoot/core/util/HootException.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/HootException.h
@@ -46,12 +46,12 @@ public:
 
   static QString className() { return "hoot::HootException"; }
 
-  HootException() { }
+  HootException() = default;
   HootException(const char* str) { _what = QString::fromUtf8(str); }
   HootException(const std::string& str) { _what = QString::fromStdString(str); }
   HootException(QString str) { _what = str; }
   HootException(const HootException& e) { _what = e._what; }
-  virtual ~HootException() throw() {}
+  virtual ~HootException() throw() = default;
 
   virtual HootException* clone() const { return new HootException(*this); }
 

--- a/hoot-core/src/main/cpp/hoot/core/util/UuidHelper.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/UuidHelper.cpp
@@ -27,8 +27,8 @@
 #include "UuidHelper.h"
 
 // hoot
-#include <hoot/core/util/Log.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Log.h>
 
 // Qt
 #include <QCryptographicHash>
@@ -37,10 +37,6 @@ namespace hoot
 {
 
 int UuidHelper::_repeatableKey;
-
-UuidHelper::UuidHelper()
-{
-}
 
 QUuid UuidHelper::createUuid()
 {

--- a/hoot-core/src/main/cpp/hoot/core/util/UuidHelper.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/UuidHelper.h
@@ -43,7 +43,7 @@ class UuidHelper
 {
 public:
 
-  UuidHelper();
+  UuidHelper() = default;
 
   /**
    * Create a uuid using the global settings for defining the technique.

--- a/hoot-core/src/main/cpp/hoot/core/visitors/AddUserIdVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/AddUserIdVisitor.cpp
@@ -27,17 +27,13 @@
 #include "AddUserIdVisitor.h"
 
 // hoot
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/schema/MetadataTags.h>
+#include <hoot/core/util/Factory.h>
 
 namespace hoot
 {
 
 HOOT_FACTORY_REGISTER(ElementVisitor, AddUserIdVisitor)
-
-AddUserIdVisitor::AddUserIdVisitor()
-{
-}
 
 void AddUserIdVisitor::visit(const ElementPtr& pElement)
 {

--- a/hoot-core/src/main/cpp/hoot/core/visitors/AddUserIdVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/AddUserIdVisitor.h
@@ -43,7 +43,7 @@ public:
 
   static QString className() { return "hoot::AddUserIdVisitor"; }
 
-  AddUserIdVisitor();
+  AddUserIdVisitor() = default;
 
   /**
    * Adds the user name and user id as tags to all valid elements.

--- a/hoot-js/src/main/cpp/hoot/js/PluginContext.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/PluginContext.cpp
@@ -81,11 +81,6 @@ PluginContext::PluginContext()
   }
 }
 
-PluginContext::~PluginContext()
-{
-
-}
-
 Local<Value> PluginContext::call(Handle<Object> obj, QString name, QList<QVariant> args)
 {
   Isolate* current = obj->GetIsolate();

--- a/hoot-js/src/main/cpp/hoot/js/PluginContext.h
+++ b/hoot-js/src/main/cpp/hoot/js/PluginContext.h
@@ -49,7 +49,7 @@ public:
   static const double UNSPECIFIED_DEFAULT;
 
   PluginContext();
-  ~PluginContext();
+  ~PluginContext() = default;
 
   /**
    * Method that simplifies calling a function.

--- a/hoot-rnd/src/main/cpp/hoot/rnd/cmd/DeDuplicateCmd.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/cmd/DeDuplicateCmd.cpp
@@ -26,11 +26,11 @@
  */
 
 // Hoot
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/cmd/BaseCommand.h>
 #include <hoot/core/elements/ElementDeduplicator.h>
-#include <hoot/core/util/StringUtils.h>
 #include <hoot/core/io/IoUtils.h>
+#include <hoot/core/util/Factory.h>
+#include <hoot/core/util/StringUtils.h>
 
 // Qt
 #include <QElapsedTimer>
@@ -47,9 +47,7 @@ public:
 
   static QString className() { return "hoot::DeDuplicateCmd"; }
 
-  DeDuplicateCmd()
-  {
-  }
+  DeDuplicateCmd() = default;
 
   virtual QString getName() const override { return "de-duplicate"; }
 

--- a/hoot-rnd/src/main/cpp/hoot/rnd/cmd/SynchronizeElementIdsCmd.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/cmd/SynchronizeElementIdsCmd.cpp
@@ -26,11 +26,11 @@
  */
 
 // Hoot
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/cmd/BaseCommand.h>
 #include <hoot/core/elements/ElementIdSynchronizer.h>
-#include <hoot/core/util/StringUtils.h>
 #include <hoot/core/io/IoUtils.h>
+#include <hoot/core/util/Factory.h>
+#include <hoot/core/util/StringUtils.h>
 
 // Qt
 #include <QElapsedTimer>
@@ -47,9 +47,7 @@ public:
 
   static QString className() { return "hoot::SynchronizeElementIdsCmd"; }
 
-  SynchronizeElementIdsCmd()
-  {
-  }
+  SynchronizeElementIdsCmd() = default;
 
   virtual QString getName() const override { return "sync-element-ids"; }
 

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryUtilities.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryUtilities.h
@@ -52,12 +52,12 @@ class MultiarySimpleMatch
 
 public:
 
-  MultiarySimpleMatch() {}
+  MultiarySimpleMatch() = default;
 
-  MultiarySimpleMatch(int nIndex, double s) : neighborIndex(nIndex), score(s) {}
+  MultiarySimpleMatch(int nIndex, double s) : neighborIndex(nIndex), score(s) { }
 
-  QString toString() const { return QString("{neighborIndex: %1, score: %2}").arg(neighborIndex).
-        arg(score); }
+  QString toString() const
+  { return QString("{neighborIndex: %1, score: %2}").arg(neighborIndex).arg(score); }
 
   // The index of the elements that match in the provided vector.
   int neighborIndex;
@@ -72,7 +72,7 @@ class MultiaryElement
 
 public:
 
-  MultiaryElement() {}
+  MultiaryElement() = default;
 
 #ifndef SWIG
   MultiaryElement(QByteArray h, geos::geom::Envelope b, QByteArray p) :

--- a/hoot-rnd/src/main/cpp/hoot/rnd/io/MultiaryIngestChangesetReader.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/io/MultiaryIngestChangesetReader.h
@@ -28,8 +28,8 @@
 #define MULTIARY_INGEST_CHANGESET_READER_H
 
 // hoot
-#include <hoot/core/io/OsmJsonReader.h>
 #include <hoot/core/algorithms/changeset/ChangesetProvider.h>
+#include <hoot/core/io/OsmJsonReader.h>
 #include <hoot/core/io/OsmXmlReader.h>
 
 // Qt

--- a/hoot-rnd/src/main/cpp/hoot/rnd/io/WordCountWriter.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/io/WordCountWriter.cpp
@@ -27,8 +27,9 @@
 
 #include "WordCountWriter.h"
 
-// hoot
 #include <hoot/rnd/io/WordCount.h>
+
+// hoot
 #include <hoot/core/util/DbUtils.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>

--- a/hoot-rnd/src/main/cpp/hoot/rnd/io/WordCountWriter.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/io/WordCountWriter.h
@@ -48,7 +48,7 @@ public:
    */
   WordCountWriter(long maxFrequent) : _maxFrequent(maxFrequent) {}
 
-  virtual ~WordCountWriter() {}
+  virtual ~WordCountWriter() = default;
 
   void write(QString basePath, QVector<WordCount> words);
 

--- a/hoot-rnd/src/main/cpp/hoot/rnd/schema/ImplicitTagCustomRules.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/schema/ImplicitTagCustomRules.cpp
@@ -27,19 +27,15 @@
 #include "ImplicitTagCustomRules.h"
 
 // hoot
-#include <hoot/core/util/Log.h>
-#include <hoot/core/util/HootException.h>
 #include <hoot/core/schema/TagListReader.h>
+#include <hoot/core/util/HootException.h>
+#include <hoot/core/util/Log.h>
 
 // Qt
 #include <QFile>
 
 namespace hoot
 {
-
-ImplicitTagCustomRules::ImplicitTagCustomRules()
-{
-}
 
 void ImplicitTagCustomRules::init()
 {

--- a/hoot-rnd/src/main/cpp/hoot/rnd/schema/ImplicitTagCustomRules.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/schema/ImplicitTagCustomRules.h
@@ -42,7 +42,7 @@ class ImplicitTagCustomRules
 
 public:
 
-  ImplicitTagCustomRules();
+  ImplicitTagCustomRules() = default;
 
   void init();
 

--- a/tbs/src/main/cpp/tbs/stats/TDistribution.cpp
+++ b/tbs/src/main/cpp/tbs/stats/TDistribution.cpp
@@ -68,12 +68,6 @@ private:
   const vector<double>& _ELogH;
 };
 
-
-TDistribution::TDistribution()
-{
-
-}
-
 TDistribution::TDistribution(const Mat& m)
 {
   initialize(m);

--- a/tbs/src/main/cpp/tbs/stats/TDistribution.h
+++ b/tbs/src/main/cpp/tbs/stats/TDistribution.h
@@ -56,7 +56,7 @@ class TDistribution
 {
 public:
 
-  TDistribution();
+  TDistribution() = default;
 
   /**
    * Similar to calling initialize.

--- a/tgs/src/main/cpp/tgs/DelaunayTriangulation/DelaunayTriangulation.h
+++ b/tgs/src/main/cpp/tgs/DelaunayTriangulation/DelaunayTriangulation.h
@@ -66,9 +66,6 @@ public:
 
   Edge() { _ie = 0; }
   Edge(InternalEdge* ie);
-  Edge(const Edge& e) : _ie(e._ie) {}
-  Edge(Edge& e) : _ie(e._ie) {}
-  Edge& operator=(const Edge& e) { _ie = e._ie; return *this; }
   bool operator==(const Edge& e) const
   {
     if (_ie == e._ie)

--- a/tgs/src/main/cpp/tgs/DelaunayTriangulation/geom2d.h
+++ b/tgs/src/main/cpp/tgs/DelaunayTriangulation/geom2d.h
@@ -121,7 +121,7 @@ public:
 class Line
 {
 public:
-  Line()	{}
+  Line() : a(0.0), b(0.0), c(0.0) { }
   Line(const Point2d&, const Point2d&);
   Real eval(const Point2d&) const;
   int classify(const Point2d&) const;

--- a/tgs/src/main/cpp/tgs/Interpolation/BaseInterpolator.cpp
+++ b/tgs/src/main/cpp/tgs/Interpolation/BaseInterpolator.cpp
@@ -38,9 +38,9 @@
 
 // Tgs
 #include <tgs/StreamUtils.h>
+#include <tgs/RandomForest/DataFrame.h>
 #include <tgs/RStarTree/HilbertRTree.h>
 #include <tgs/RStarTree/MemoryPageStore.h>
-#include <tgs/RandomForest/DataFrame.h>
 
 using namespace std;
 

--- a/tgs/src/main/cpp/tgs/Interpolation/BaseInterpolator.h
+++ b/tgs/src/main/cpp/tgs/Interpolation/BaseInterpolator.h
@@ -41,7 +41,7 @@ public:
 
   BaseInterpolator();
 
-  virtual ~BaseInterpolator() {}
+  virtual ~BaseInterpolator() = default;
 
   virtual double estimateError();
 

--- a/tgs/src/main/cpp/tgs/Interpolation/DelaunayInterpolator.h
+++ b/tgs/src/main/cpp/tgs/Interpolation/DelaunayInterpolator.h
@@ -57,7 +57,7 @@ public:
 
   DelaunayInterpolator();
 
-  virtual ~DelaunayInterpolator() {}
+  virtual ~DelaunayInterpolator() = default;
 
   /**
    * Use k-fold cross validation to estimate the error.

--- a/tgs/src/main/cpp/tgs/Interpolation/IdwInterpolator.cpp
+++ b/tgs/src/main/cpp/tgs/Interpolation/IdwInterpolator.cpp
@@ -51,11 +51,6 @@ IdwInterpolator::IdwInterpolator(double p)
   _stopDelta = 0.1;
 }
 
-IdwInterpolator::~IdwInterpolator()
-{
-  //cout << "IdwInterpolator::~IdwInterpolator()" << endl << flush;
-}
-
 class IdwOptimizeFunction : public NelderMead::Function
 {
 public:

--- a/tgs/src/main/cpp/tgs/Interpolation/IdwInterpolator.h
+++ b/tgs/src/main/cpp/tgs/Interpolation/IdwInterpolator.h
@@ -52,7 +52,7 @@ public:
    */
   IdwInterpolator(double p = -1.0);
 
-  virtual ~IdwInterpolator();
+  virtual ~IdwInterpolator() = default;
 
   virtual QString getName() const { return className(); }
 

--- a/tgs/src/main/cpp/tgs/Interpolation/Interpolator.h
+++ b/tgs/src/main/cpp/tgs/Interpolation/Interpolator.h
@@ -45,7 +45,7 @@ public:
 
   static QString className() { return "Tgs::Interpolator"; }
 
-  virtual ~Interpolator() {}
+  virtual ~Interpolator() = default;
 
   virtual QString getName() const = 0;
 

--- a/tgs/src/main/cpp/tgs/Interpolation/KernelEstimationInterpolator.cpp
+++ b/tgs/src/main/cpp/tgs/Interpolation/KernelEstimationInterpolator.cpp
@@ -51,11 +51,6 @@ KernelEstimationInterpolator::KernelEstimationInterpolator(double sigma)
   _stopDelta = 1.0;
 }
 
-KernelEstimationInterpolator::~KernelEstimationInterpolator()
-{
-  //cout << "KernelEstimationInterpolator::~KernelEstimationInterpolator()" << endl << flush;
-}
-
 class OptimizeFunction : public NelderMead::Function
 {
 public:

--- a/tgs/src/main/cpp/tgs/Interpolation/KernelEstimationInterpolator.h
+++ b/tgs/src/main/cpp/tgs/Interpolation/KernelEstimationInterpolator.h
@@ -52,7 +52,7 @@ public:
    */
   KernelEstimationInterpolator(double sigma = -1);
 
-  virtual ~KernelEstimationInterpolator();
+  virtual ~KernelEstimationInterpolator() = default;
 
   virtual QString getName() const { return className(); }
 

--- a/tgs/src/main/cpp/tgs/Io/StdIoDevice.cpp
+++ b/tgs/src/main/cpp/tgs/Io/StdIoDevice.cpp
@@ -38,10 +38,6 @@ StdIoDevice::StdIoDevice(istream& in) : _in(&in)
   open(QIODevice::ReadOnly);
 }
 
-StdIoDevice::~StdIoDevice()
-{
-}
-
 bool StdIoDevice::atEnd() const
 {
   return _in->eof();

--- a/tgs/src/main/cpp/tgs/Io/StdIoDevice.h
+++ b/tgs/src/main/cpp/tgs/Io/StdIoDevice.h
@@ -47,7 +47,7 @@ public:
    */
   StdIoDevice(std::istream& in);
 
-  virtual ~StdIoDevice();
+  virtual ~StdIoDevice() = default;
 
   virtual bool atEnd() const;
 

--- a/tgs/src/main/cpp/tgs/Optimization/NelderMead.h
+++ b/tgs/src/main/cpp/tgs/Optimization/NelderMead.h
@@ -55,16 +55,8 @@ namespace Tgs
 class Vector
 {
 public:
-    Vector()
-    {
-    }
-
-    ~Vector()
-    {
-      //cout << "~Vector()" << endl << flush;
-    }
-
-    Vector(const Vector& v) : coords(v.coords) { }
+    Vector() = default;
+    ~Vector() = default;
 
     Vector(double c0)
     {
@@ -81,12 +73,6 @@ public:
         coords.push_back(c0);
         coords.push_back(c1);
         coords.push_back(c2);
-    }
-
-    Vector& operator=(const Vector& v)
-    {
-      coords = v.coords;
-      return *this;
     }
 
     // add more constructors when N gets > 3
@@ -211,7 +197,7 @@ private:
 class ValueDB
 {
 public:
-  ValueDB() { }
+  ValueDB() = default;
 
   double lookup(Vector vec)
   {
@@ -251,7 +237,7 @@ public:
   class VectorSort
   {
   public:
-    VectorSort(NelderMead* nm) : _nm(nm) {}
+    VectorSort(NelderMead* nm) : _nm(nm) { }
 
     // used in `step` to sort the vectors
     bool operator()(const Vector& a, const Vector& b)
@@ -268,7 +254,7 @@ public:
   class Function
   {
   public:
-    virtual ~Function() {}
+    virtual ~Function() = default;
 
     virtual double f(Vector v) = 0;
   };
@@ -290,10 +276,7 @@ public:
     _maxNoChange = 4;
   }
 
-  ~NelderMead()
-  {
-    //cout << "~NelderMead()" << endl << flush;
-  }
+  ~NelderMead() = default;
 
   // termination criteria: each pair of vectors in the simplex has to
   // have a distance of at most `termination_distance`

--- a/tgs/src/main/cpp/tgs/Optimization/State.cpp
+++ b/tgs/src/main/cpp/tgs/Optimization/State.cpp
@@ -32,10 +32,6 @@
 namespace Tgs
 {
 
-State::State()
-{
-}
-
 QString State::toString() const
 {
   QStringList result;

--- a/tgs/src/main/cpp/tgs/Optimization/State.h
+++ b/tgs/src/main/cpp/tgs/Optimization/State.h
@@ -39,7 +39,7 @@ namespace Tgs
 class State
 {
 public:
-  State();
+  State() : _score(0.0) { }
 
   double get(QString name) const { return _values[name]; }
 

--- a/tgs/src/main/cpp/tgs/Optimization/StateDescription.cpp
+++ b/tgs/src/main/cpp/tgs/Optimization/StateDescription.cpp
@@ -29,8 +29,4 @@
 namespace Tgs
 {
 
-StateDescription::StateDescription()
-{
-}
-
 }

--- a/tgs/src/main/cpp/tgs/Optimization/StateDescription.h
+++ b/tgs/src/main/cpp/tgs/Optimization/StateDescription.h
@@ -38,7 +38,7 @@ namespace Tgs
 class StateDescription
 {
 public:
-  StateDescription();
+  StateDescription() = default;
 
   void addVariable(ConstVariableDescriptionPtr v) { _variables.append(v); }
   void addVariable(VariableDescription* v) { _variables.append(VariableDescriptionPtr(v)); }

--- a/tgs/src/main/cpp/tgs/ProbablePath/ProbablePathCalculator.cpp
+++ b/tgs/src/main/cpp/tgs/ProbablePath/ProbablePathCalculator.cpp
@@ -92,10 +92,6 @@ namespace Tgs
   {
   }
 
-  ProbablePathCalculator::~ProbablePathCalculator()
-  {
-  }
-
   bool ProbablePathCalculator::_addReturnPaths(const PpPoint& source,
     const Destination& destination)
   {

--- a/tgs/src/main/cpp/tgs/ProbablePath/ProbablePathCalculator.h
+++ b/tgs/src/main/cpp/tgs/ProbablePath/ProbablePathCalculator.h
@@ -56,9 +56,11 @@ namespace Tgs
 
     PpPoint();
 
-    PpPoint(int row, int col) : row(row), col(col) { }
+    PpPoint(int row, int col)
+      : row(row), col(col), cost(0.0f) { }
 
-    PpPoint(int row, int col, std::string name) : row(row), col(col), name(name) { }
+    PpPoint(int row, int col, std::string name)
+      : row(row), col(col), name(name), cost(0.0f) { }
 
     bool operator!=(const PpPoint& p)
     {
@@ -103,7 +105,7 @@ namespace Tgs
     ProbablePathCalculator();
     ProbablePathCalculator(const RandomPtr& random);
 
-    virtual ~ProbablePathCalculator();
+    virtual ~ProbablePathCalculator() = default;
 
     /**
      * Calculates the most probable paths with the specified number of iterations.

--- a/tgs/src/main/cpp/tgs/RStarTree/Box.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/Box.h
@@ -51,7 +51,7 @@ public:
 
   Box(int dimensions);
 
-  ~Box() {}
+  ~Box() = default;
 
   double calculateOverlap(const Box& b) const;
 

--- a/tgs/src/main/cpp/tgs/RStarTree/DistanceIterator.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/DistanceIterator.h
@@ -49,7 +49,7 @@ class TGS_EXPORT DistanceIterator : public Iterator
 public:
   DistanceIterator(RStarTree* tree, const std::vector<double>& point, double distance);
 
-  virtual ~DistanceIterator() {}
+  virtual ~DistanceIterator() = default;
 
   virtual const Box& getBox() const;
 

--- a/tgs/src/main/cpp/tgs/RStarTree/HilbertRTree.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/HilbertRTree.cpp
@@ -332,11 +332,7 @@ public:
   HilbertRTree::BoxPair boxPair;
   int hilbertValue;
 
-  BoxHolder(const BoxHolder& bh) :
-    boxPair(bh.boxPair)
-  {
-    hilbertValue = bh.hilbertValue;
-  }
+  BoxHolder(const BoxHolder&)  = default;
 
   BoxHolder(const HilbertRTree::BoxPair& bp, int hv) :
     boxPair(bp)

--- a/tgs/src/main/cpp/tgs/RStarTree/InternalRStarTreeWrapper.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/InternalRStarTreeWrapper.cpp
@@ -43,11 +43,6 @@ namespace Tgs
     _tree = std::shared_ptr<HilbertRTree>(new HilbertRTree(mps, dimensions));
   }
 
-  InternalRStarTreeWrapper::~InternalRStarTreeWrapper()
-  {
-
-  }
-
   void InternalRStarTreeWrapper::bulkInsert(const std::vector<int>& uniqueId,
     const std::vector<double>& minBounds,
     const std::vector<double>& maxBounds)

--- a/tgs/src/main/cpp/tgs/RStarTree/InternalRStarTreeWrapper.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/InternalRStarTreeWrapper.h
@@ -30,8 +30,8 @@
 //TGS Includes
 #include <tgs/TgsExport.h>
 #include <tgs/RStarTree/DistanceIterator.h>
-#include <tgs/RStarTree/IntersectionIterator.h>
 #include <tgs/RStarTree/HilbertRTree.h>
+#include <tgs/RStarTree/IntersectionIterator.h>
 
 //Std Includes
 #include <vector>
@@ -49,7 +49,7 @@ namespace Tgs
     /**
     *  Destructor
     */
-    ~InternalRStarTreeWrapper();
+    ~InternalRStarTreeWrapper() = default;
 
     /**
     *  Updates an iterator over all the current R*Tree of all objects intersecting

--- a/tgs/src/main/cpp/tgs/RStarTree/IntersectionIterator.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/IntersectionIterator.h
@@ -50,7 +50,7 @@ public:
   IntersectionIterator(const RStarTree* tree, const std::vector<double>& minBounds,
                        const std::vector<double>& maxBounds);
 
-  virtual ~IntersectionIterator() {}
+  virtual ~IntersectionIterator() = default;
 
   virtual const Box& getBox() const;
 

--- a/tgs/src/main/cpp/tgs/RStarTree/Iterator.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/Iterator.h
@@ -36,7 +36,7 @@ namespace Tgs
   class TGS_EXPORT Iterator
   {
   public:
-    virtual ~Iterator() {}
+    virtual ~Iterator() = default;
 
     virtual bool hasNext() = 0;
 

--- a/tgs/src/main/cpp/tgs/RStarTree/KnnIteratorNd.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/KnnIteratorNd.h
@@ -58,11 +58,7 @@ namespace Tgs
     public:
       LeafDistance() : distance(0.0), fid(0) { }
 
-      LeafDistance(double dist, int fid)
-      {
-        this->distance = dist;
-        this->fid = fid;
-      }
+      LeafDistance(double dist, int fid) : distance(dist), fid(fid) { }
 
       double distance;
       int fid;
@@ -90,7 +86,7 @@ namespace Tgs
     class NodeDistance
     {
     public:
-      NodeDistance() {}
+      NodeDistance() : minPossibleDistance(0.0), id(0) { }
 
       NodeDistance(double dist, int nodeId)
       {

--- a/tgs/src/main/cpp/tgs/RStarTree/MemoryPageStore.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/MemoryPageStore.cpp
@@ -35,11 +35,7 @@
 namespace Tgs
 {
   MemoryPageStore::MemoryPageStore(int pageSize)
-  {
-    _pageSize = pageSize;
-  }
-
-  MemoryPageStore::~MemoryPageStore()
+    : _pageSize(pageSize)
   {
   }
 

--- a/tgs/src/main/cpp/tgs/RStarTree/MemoryPageStore.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/MemoryPageStore.h
@@ -46,7 +46,7 @@ namespace Tgs
   public:
     MemoryPageStore(int pageSize);
 
-    virtual ~MemoryPageStore();
+    virtual ~MemoryPageStore() = default;
 
     virtual std::shared_ptr<Page> createPage();
 

--- a/tgs/src/main/cpp/tgs/RStarTree/PageStore.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/PageStore.h
@@ -49,7 +49,7 @@ public:
   /**
    * All page shared pointers should be freed before the PageStore is destroyed.
    */
-  virtual ~PageStore() {}
+  virtual ~PageStore() = default;
 
   /**
    * Creates a new page w/ a new id and returns the page. All page shared pointers should be

--- a/tgs/src/main/cpp/tgs/RStarTree/RStarTree.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/RStarTree.cpp
@@ -79,10 +79,6 @@ RStarTree::RStarTree(const std::shared_ptr<PageStore>& ps, int dimensions)
   _dimensions = dimensions;
 }
 
-RStarTree::~RStarTree()
-{
-}
-
 void RStarTree::_addChild(RTreeNode* parent, const Box& b, int id)
 {
   if (id < 0)
@@ -372,7 +368,7 @@ public:
   Box b;
   int id;
 
-  Child() {}
+  Child() : id(0) { }
 
   Child(int id, const BoxInternalData& b) : b(b.toBox()), id(id) { }
 };

--- a/tgs/src/main/cpp/tgs/RStarTree/RStarTree.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/RStarTree.h
@@ -69,7 +69,7 @@ public:
 
   RStarTree(const std::shared_ptr<PageStore>& ps, int dimensions);
 
-  virtual ~RStarTree();
+  virtual ~RStarTree() = default;
 
   /**
    * Returns the node with the specified node ID. This can then be used for any number of

--- a/tgs/src/main/cpp/tgs/RStarTree/RTreeNode.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/RTreeNode.cpp
@@ -179,10 +179,6 @@ RTreeNode::RTreeNode(int dimensions, const std::shared_ptr<Page>& page)
   _getHeader()->childCount = *childCount;
 }
 
-RTreeNode::~RTreeNode()
-{
-}
-
 void RTreeNode::addChild(const Box& envelope, int id)
 {
   assert(getChildCount() < _maxChildCount);

--- a/tgs/src/main/cpp/tgs/RStarTree/RTreeNode.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/RTreeNode.h
@@ -122,7 +122,7 @@ class TGS_EXPORT RTreeNode
 {
 public:
 
-  virtual ~RTreeNode();
+  virtual ~RTreeNode() = default;
 
   /**
    * This is only intended for RStarTree class

--- a/tgs/src/main/cpp/tgs/RandomForest/BaseRandomForestManager.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/BaseRandomForestManager.cpp
@@ -52,8 +52,6 @@ namespace Tgs
     }
   }
 
-  BaseRandomForestManager::~BaseRandomForestManager(){}
-
   void BaseRandomForestManager::addTrainingVector(std::string classLabel,
     const std::vector<double>& trainVec)
   {

--- a/tgs/src/main/cpp/tgs/RandomForest/BaseRandomForestManager.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/BaseRandomForestManager.h
@@ -46,7 +46,7 @@ namespace Tgs
     /**
      * @brief ~BaseRandomForestManager destructor
      */
-    virtual ~BaseRandomForestManager();
+    virtual ~BaseRandomForestManager() = default;
 
     /**
     *  Adds a training vector to the random forest training set

--- a/tgs/src/main/cpp/tgs/RandomForest/DataFrame.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/DataFrame.cpp
@@ -77,11 +77,6 @@ namespace Tgs
     }
   }
 
-  DataFrame::~DataFrame()
-  {
-
-  }
-
   void DataFrame::addDataVector(std::string label, const std::vector<double>& dataItem,
     double eventWeight /*= 1.*/)
   {

--- a/tgs/src/main/cpp/tgs/RandomForest/DataFrame.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/DataFrame.h
@@ -79,7 +79,7 @@ namespace Tgs
     /**
     * Destructor
     */
-    virtual ~DataFrame();
+    virtual ~DataFrame() = default;
 
     /**
     * Appends a data vector to the end of the dataframe

--- a/tgs/src/main/cpp/tgs/RandomForest/InfoGainCalculator.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/InfoGainCalculator.cpp
@@ -38,10 +38,6 @@
 
 namespace Tgs
 {
-  InfoGainCalculator::InfoGainCalculator(){}
-
-  InfoGainCalculator::~InfoGainCalculator(){}
-
   double InfoGainCalculator::_calcLogFunc(double n)
   {
     if (n < std::numeric_limits<double>::epsilon())

--- a/tgs/src/main/cpp/tgs/RandomForest/InfoGainCalculator.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/InfoGainCalculator.h
@@ -43,12 +43,12 @@ namespace Tgs
     /**
     *  Constructor
     */
-    InfoGainCalculator();
+    InfoGainCalculator() = default;
 
     /**
     *  Destructor
     */
-    ~InfoGainCalculator();
+    ~InfoGainCalculator() = default;
 
     /**
     *  Computes the entropy of a dataset based only on the class label

--- a/tgs/src/main/cpp/tgs/RandomForest/MultithreadedRandomForest.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/MultithreadedRandomForest.h
@@ -50,7 +50,7 @@ namespace Tgs
     /**
      * @brief ~MultithreadedRandomForest destructor
      */
-    virtual ~MultithreadedRandomForest(){}
+    virtual ~MultithreadedRandomForest() = default;
 
     /**
     * Build the forest from a data set

--- a/tgs/src/main/cpp/tgs/RandomForest/MultithreadedRandomForestManager.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/MultithreadedRandomForestManager.cpp
@@ -35,15 +35,6 @@
 namespace Tgs
 {
 
-
-  MultithreadedRandomForestManager::MultithreadedRandomForestManager()
-  {
-
-  }
-
-  MultithreadedRandomForestManager::~MultithreadedRandomForestManager(){}
-
-
   void MultithreadedRandomForestManager::_initForests(int numForests)
   {
     try

--- a/tgs/src/main/cpp/tgs/RandomForest/MultithreadedRandomForestManager.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/MultithreadedRandomForestManager.h
@@ -42,12 +42,12 @@ namespace Tgs
     /**
      * @brief MultithreadedRandomForestManager Constructor
      */
-    MultithreadedRandomForestManager();
+    MultithreadedRandomForestManager() = default;
 
     /**
     *  @brief ~MultithreadedRandomForestManager Destructor
     */
-    virtual ~MultithreadedRandomForestManager();
+    virtual ~MultithreadedRandomForestManager() = default;
 
   protected:
     /**

--- a/tgs/src/main/cpp/tgs/RandomForest/RandomForestManager.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/RandomForestManager.cpp
@@ -48,11 +48,6 @@ namespace Tgs
 
   }
 
-  RandomForestManager::~RandomForestManager()
-  {
-
-  }
-
   void RandomForestManager::_initForests(int numForests)
   {
     try

--- a/tgs/src/main/cpp/tgs/RandomForest/RandomForestManager.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/RandomForestManager.h
@@ -55,7 +55,7 @@ namespace Tgs
     /**
     *  Destructor
     */
-    virtual ~RandomForestManager();
+    virtual ~RandomForestManager() = default;
 
   protected:
     /**

--- a/tgs/src/main/cpp/tgs/RandomForest/RandomForestThread.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/RandomForestThread.cpp
@@ -41,8 +41,6 @@ namespace Tgs
     _makeBalanced = makeBalanced;
   }
 
-  RandomForestThread::~RandomForestThread(){}
-
   void RandomForestThread::run()
   {
     try

--- a/tgs/src/main/cpp/tgs/RandomForest/RandomForestThread.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/RandomForestThread.h
@@ -52,7 +52,7 @@ namespace Tgs
     /**
      * @brief ~RandomForestThread Destructor
      */
-    ~RandomForestThread();
+    ~RandomForestThread() = default;
 
 
   signals:

--- a/tgs/src/main/cpp/tgs/RasterOps/Image.hpp
+++ b/tgs/src/main/cpp/tgs/RasterOps/Image.hpp
@@ -25,7 +25,7 @@ namespace Tgs
 
     Image(int width, int height) { resize(width, height); }
 
-    ~Image() { }
+    ~Image() = default;
 
     _T* getData() { return &(_values[0]); }
 

--- a/tgs/src/main/cpp/tgs/TgsException.h
+++ b/tgs/src/main/cpp/tgs/TgsException.h
@@ -106,10 +106,7 @@ namespace Tgs
     /**
      * A destructor
      */
-    ~Exception() throw ()
-    {
-
-    }
+    ~Exception() throw () = default;
 
     /** 
     * @returns the error string provided in the constructor


### PR DESCRIPTION
Fixed constructor/destructors with `=default` when standard behavior is intended.

Refs #4570 