### PR TITLE
SONAR: emplace should be preferred over insert

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatch.cpp
@@ -165,7 +165,7 @@ map<QString, double> HighwayMatch::getFeatures(const ConstOsmMapPtr& m) const
 set<pair<ElementId, ElementId>> HighwayMatch::getMatchPairs() const
 {
   set<pair<ElementId, ElementId>> result;
-  result.insert(pair<ElementId, ElementId>(_eid1, _eid2));
+  result.emplace(pair<ElementId, ElementId>(_eid1, _eid2));
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatch.cpp
@@ -108,7 +108,7 @@ void NetworkMatch::_discoverWayPairs(ConstOsmMapPtr map, ConstEdgeMatchPtr edgeM
     ElementId element2Id =
       _toElement(string2->getEdgeAtOffset(map, d1 / length1 * length2))->getElementId();
     LOG_VART(element2Id);
-    _pairs.insert(pair<ElementId, ElementId>(element1Id, element2Id));
+    _pairs.emplace(pair<ElementId, ElementId>(element1Id, element2Id));
 
     d1 += string1->getEdge(i)->calculateLength(map);
 
@@ -117,7 +117,7 @@ void NetworkMatch::_discoverWayPairs(ConstOsmMapPtr map, ConstEdgeMatchPtr edgeM
     element2Id =
       _toElement(string2->getEdgeAtOffset(map, d1 / length1 * length2))->getElementId();
     LOG_VART(element2Id);
-    _pairs.insert(pair<ElementId, ElementId>(element1Id, element2Id));
+    _pairs.emplace(pair<ElementId, ElementId>(element1Id, element2Id));
   }
 
   Meters d2 = 0.0;
@@ -128,7 +128,7 @@ void NetworkMatch::_discoverWayPairs(ConstOsmMapPtr map, ConstEdgeMatchPtr edgeM
     LOG_VART(element1Id);
     ElementId element2Id = _toElement(string2->getEdge(i))->getElementId();
     LOG_VART(element2Id);
-    _pairs.insert(pair<ElementId, ElementId>(element1Id, element2Id));
+    _pairs.emplace(pair<ElementId, ElementId>(element1Id, element2Id));
 
     d2 += string2->getEdge(i)->calculateLength(map);
 
@@ -137,7 +137,7 @@ void NetworkMatch::_discoverWayPairs(ConstOsmMapPtr map, ConstEdgeMatchPtr edgeM
     LOG_VART(element1Id);
     element2Id = _toElement(string2->getEdge(i))->getElementId();
     LOG_VART(element2Id);
-    _pairs.insert(pair<ElementId, ElementId>(element1Id, element2Id));
+    _pairs.emplace(pair<ElementId, ElementId>(element1Id, element2Id));
   }
 
   LOG_VART(_pairs);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatch.cpp
@@ -793,11 +793,11 @@ set<pair<ElementId, ElementId>> PoiPolygonMatch::getMatchPairs() const
   // arbitrarily adding poi id first for consistency
   if (_e1IsPoi)
   {
-    result.insert(pair<ElementId, ElementId>(_eid1, _eid2));
+    result.emplace(pair<ElementId, ElementId>(_eid1, _eid2));
   }
   else
   {
-    result.insert(pair<ElementId, ElementId>(_eid2, _eid1));
+    result.emplace(pair<ElementId, ElementId>(_eid2, _eid1));
   }
   return result;
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMerger.cpp
@@ -400,7 +400,7 @@ ElementId PoiPolygonMerger::_mergeBuildings(const OsmMapPtr& map,
     size_t i2 = min(i, buildings2.size() - 1);
 
     pair<ElementId, ElementId> p(buildings1[i1], buildings2[i2]);
-    pairs.insert(p);
+    pairs.emplace(p);
   }
 
   BuildingMerger(pairs).apply(map, replaced);
@@ -408,7 +408,7 @@ ElementId PoiPolygonMerger::_mergeBuildings(const OsmMapPtr& map,
   set<ElementId> newElement;
   for (size_t i = 0; i < replaced.size(); i++)
   {
-    newElement.insert(replaced[i].second);
+    newElement.emplace(replaced[i].second);
   }
 
   return *newElement.begin();
@@ -510,7 +510,7 @@ ElementId PoiPolygonMerger::mergeOnePoiAndOnePolygon(OsmMapPtr map)
   // do the merging
   std::set<std::pair<ElementId, ElementId>> pairs;
   // Ordering doesn't matter here, since the poi is always merged into the poly.
-  pairs.insert(std::pair<ElementId, ElementId>(polyId, poiId));
+  pairs.emplace(std::pair<ElementId, ElementId>(polyId, poiId));
   PoiPolygonMerger merger(pairs);
   std::vector<std::pair<ElementId, ElementId>> replacedElements;
   merger.apply(map, replacedElements);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatch.cpp
@@ -272,7 +272,7 @@ map<QString, double> BuildingMatch::getFeatures(const ConstOsmMapPtr& m) const
 set<pair<ElementId, ElementId>> BuildingMatch::getMatchPairs() const
 {
   set<pair<ElementId, ElementId>> result;
-  result.insert(pair<ElementId, ElementId>(_eid1, _eid2));
+  result.emplace(pair<ElementId, ElementId>(_eid1, _eid2));
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
@@ -135,10 +135,10 @@ void BuildingMerger::apply(const OsmMapPtr& map, vector<pair<ElementId, ElementI
   for (set<pair<ElementId, ElementId>>::const_iterator sit = _pairs.begin(); sit != _pairs.end();
        ++sit)
   {
-    firstPairs.insert(sit->first);
-    secondPairs.insert(sit->second);
-    combined.insert(sit->first);
-    combined.insert(sit->second);
+    firstPairs.emplace(sit->first);
+    secondPairs.emplace(sit->second);
+    combined.emplace(sit->first);
+    combined.emplace(sit->second);
   }
   _manyToManyMatch = firstPairs.size() > 1 && secondPairs.size() > 1;
 
@@ -289,11 +289,11 @@ void BuildingMerger::apply(const OsmMapPtr& map, vector<pair<ElementId, ElementI
     // if we replaced the second group of buildings
     if (it->second != keeper->getElementId())
     {
-      replacedSet.insert(pair<ElementId, ElementId>(it->second, keeper->getElementId()));
+      replacedSet.emplace(pair<ElementId, ElementId>(it->second, keeper->getElementId()));
     }
     if (it->first != keeper->getElementId())
     {
-      replacedSet.insert(pair<ElementId, ElementId>(it->first, keeper->getElementId()));
+      replacedSet.emplace(pair<ElementId, ElementId>(it->first, keeper->getElementId()));
     }
   }
   replaced.insert(replaced.end(), replacedSet.begin(), replacedSet.end());
@@ -827,7 +827,7 @@ void BuildingMerger::mergeBuildings(OsmMapPtr map, const ElementId& mergeTargetI
       }
 
       std::set<std::pair<ElementId, ElementId>> pairs;
-      pairs.insert(std::pair<ElementId, ElementId>(mergeTargetId, way->getElementId()));
+      pairs.emplace(std::pair<ElementId, ElementId>(mergeTargetId, way->getElementId()));
       BuildingMerger merger(pairs);
       LOG_VART(pairs.size());
       std::vector<std::pair<ElementId, ElementId>> replacedElements;
@@ -849,7 +849,7 @@ void BuildingMerger::mergeBuildings(OsmMapPtr map, const ElementId& mergeTargetI
       }
 
       std::set<std::pair<ElementId, ElementId>> pairs;
-      pairs.insert(std::pair<ElementId, ElementId>(mergeTargetId, relation->getElementId()));
+      pairs.emplace(std::pair<ElementId, ElementId>(mergeTargetId, relation->getElementId()));
       BuildingMerger merger(pairs);
       LOG_VART(pairs.size());
       std::vector<std::pair<ElementId, ElementId>> replacedElements;

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.cpp
@@ -144,7 +144,7 @@ void ScriptMatch::_calculateClassification(
 set<pair<ElementId, ElementId>> ScriptMatch::getMatchPairs() const
 {
   set<pair<ElementId, ElementId>> result;
-  result.insert(pair<ElementId, ElementId>(_eid1, _eid2));
+  result.emplace(pair<ElementId, ElementId>(_eid1, _eid2));
   return result;
 }
 
@@ -262,9 +262,9 @@ bool ScriptMatch::_isOrderedConflicting(
   Context::Scope context_scope(_script->getContext(current));
 
   set<ElementId> eids;
-  eids.insert(sharedEid);
-  eids.insert(other1);
-  eids.insert(other2);
+  eids.emplace(sharedEid);
+  eids.emplace(other1);
+  eids.emplace(other2);
 
   OsmMapPtr copiedMap(new OsmMap(map->getProjection()));
   CopyMapSubsetOp(map, eids).apply(copiedMap);
@@ -301,7 +301,7 @@ bool ScriptMatch::_isOrderedConflicting(
 
   std::shared_ptr<const ScriptMatch> m1 = _getMatch(copiedMap, copiedMapJs, eid11, eid12, matches);
   MatchSet ms;
-  ms.insert(m1);
+  ms.emplace(m1);
   vector<MergerPtr> mergers;
   ScriptMergerCreator creator;
   creator.createMergers(ms, mergers);

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/AreaMergerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/AreaMergerJs.cpp
@@ -84,7 +84,7 @@ void AreaMergerJs::mergeAreas(OsmMapPtr map, const ElementId& mergeTargetId, Iso
       LOG_TRACE("Merging way area: " << way << " into " << mergeTargetId);
 
       std::set<std::pair<ElementId, ElementId>> matches;
-      matches.insert(std::pair<ElementId,ElementId>(mergeTargetId, ElementId::way(way->getId())));
+      matches.emplace(std::pair<ElementId,ElementId>(mergeTargetId, ElementId::way(way->getId())));
       // apply script merging
       ScriptMerger merger(script, plugin, matches);
       std::vector<std::pair<ElementId, ElementId>> replacedWays;
@@ -106,7 +106,7 @@ void AreaMergerJs::mergeAreas(OsmMapPtr map, const ElementId& mergeTargetId, Iso
       LOG_TRACE("Merging relation area: " << relation << " into " << mergeTargetId);
 
       std::set<std::pair<ElementId, ElementId>> matches;
-      matches.insert(
+      matches.emplace(
         std::pair<ElementId,ElementId>(mergeTargetId, ElementId::relation(relation->getId())));
       // apply script merging
       ScriptMerger merger(script, plugin, matches);

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/PoiMergerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/PoiMergerJs.cpp
@@ -85,7 +85,7 @@ void PoiMergerJs::mergePois(OsmMapPtr map, const ElementId& mergeTargetId, Isola
       LOG_VART(node);
 
       std::set<std::pair<ElementId, ElementId>> matches;
-      matches.insert(std::pair<ElementId,ElementId>(mergeTargetId, node->getElementId()));
+      matches.emplace(std::pair<ElementId,ElementId>(mergeTargetId, node->getElementId()));
       // apply script merging
       ScriptMerger merger(script, plugin, matches);
       std::vector<std::pair<ElementId, ElementId>> replacedNodes;


### PR DESCRIPTION
Use the `emplace()` function instead of `insert()` for standard data structures

Refs #4568