### PR TITLE
SONAR: emplace should be preferred over insert

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatch.cpp
@@ -165,7 +165,7 @@ map<QString, double> HighwayMatch::getFeatures(const ConstOsmMapPtr& m) const
 set<pair<ElementId, ElementId>> HighwayMatch::getMatchPairs() const
 {
   set<pair<ElementId, ElementId>> result;
-  result.emplace(pair<ElementId, ElementId>(_eid1, _eid2));
+  result.emplace(_eid1, _eid2);
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatch.cpp
@@ -108,7 +108,7 @@ void NetworkMatch::_discoverWayPairs(ConstOsmMapPtr map, ConstEdgeMatchPtr edgeM
     ElementId element2Id =
       _toElement(string2->getEdgeAtOffset(map, d1 / length1 * length2))->getElementId();
     LOG_VART(element2Id);
-    _pairs.emplace(pair<ElementId, ElementId>(element1Id, element2Id));
+    _pairs.emplace(element1Id, element2Id);
 
     d1 += string1->getEdge(i)->calculateLength(map);
 
@@ -117,7 +117,7 @@ void NetworkMatch::_discoverWayPairs(ConstOsmMapPtr map, ConstEdgeMatchPtr edgeM
     element2Id =
       _toElement(string2->getEdgeAtOffset(map, d1 / length1 * length2))->getElementId();
     LOG_VART(element2Id);
-    _pairs.emplace(pair<ElementId, ElementId>(element1Id, element2Id));
+    _pairs.emplace(element1Id, element2Id);
   }
 
   Meters d2 = 0.0;
@@ -128,7 +128,7 @@ void NetworkMatch::_discoverWayPairs(ConstOsmMapPtr map, ConstEdgeMatchPtr edgeM
     LOG_VART(element1Id);
     ElementId element2Id = _toElement(string2->getEdge(i))->getElementId();
     LOG_VART(element2Id);
-    _pairs.emplace(pair<ElementId, ElementId>(element1Id, element2Id));
+    _pairs.emplace(element1Id, element2Id);
 
     d2 += string2->getEdge(i)->calculateLength(map);
 
@@ -137,7 +137,7 @@ void NetworkMatch::_discoverWayPairs(ConstOsmMapPtr map, ConstEdgeMatchPtr edgeM
     LOG_VART(element1Id);
     element2Id = _toElement(string2->getEdge(i))->getElementId();
     LOG_VART(element2Id);
-    _pairs.emplace(pair<ElementId, ElementId>(element1Id, element2Id));
+    _pairs.emplace(element1Id, element2Id);
   }
 
   LOG_VART(_pairs);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatch.cpp
@@ -792,13 +792,9 @@ set<pair<ElementId, ElementId>> PoiPolygonMatch::getMatchPairs() const
   set<pair<ElementId, ElementId>> result;
   // arbitrarily adding poi id first for consistency
   if (_e1IsPoi)
-  {
-    result.emplace(pair<ElementId, ElementId>(_eid1, _eid2));
-  }
+    result.emplace(_eid1, _eid2);
   else
-  {
-    result.emplace(pair<ElementId, ElementId>(_eid2, _eid1));
-  }
+    result.emplace(_eid2, _eid1);
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMerger.cpp
@@ -398,8 +398,7 @@ ElementId PoiPolygonMerger::_mergeBuildings(const OsmMapPtr& map,
     size_t i1 = min(i, buildings1.size() - 1);
     size_t i2 = min(i, buildings2.size() - 1);
 
-    pair<ElementId, ElementId> p(buildings1[i1], buildings2[i2]);
-    pairs.emplace(p);
+    pairs.emplace(buildings1[i1], buildings2[i2]);
   }
 
   BuildingMerger(pairs).apply(map, replaced);
@@ -509,7 +508,7 @@ ElementId PoiPolygonMerger::mergeOnePoiAndOnePolygon(OsmMapPtr map)
   // do the merging
   std::set<std::pair<ElementId, ElementId>> pairs;
   // Ordering doesn't matter here, since the poi is always merged into the poly.
-  pairs.emplace(std::pair<ElementId, ElementId>(polyId, poiId));
+  pairs.emplace(polyId, poiId);
   PoiPolygonMerger merger(pairs);
   std::vector<std::pair<ElementId, ElementId>> replacedElements;
   merger.apply(map, replacedElements);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatch.cpp
@@ -272,7 +272,7 @@ map<QString, double> BuildingMatch::getFeatures(const ConstOsmMapPtr& m) const
 set<pair<ElementId, ElementId>> BuildingMatch::getMatchPairs() const
 {
   set<pair<ElementId, ElementId>> result;
-  result.emplace(pair<ElementId, ElementId>(_eid1, _eid2));
+  result.emplace(_eid1, _eid2);
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
@@ -289,13 +289,10 @@ void BuildingMerger::apply(const OsmMapPtr& map, vector<pair<ElementId, ElementI
   {
     // if we replaced the second group of buildings
     if (it->second != keeper->getElementId())
-    {
-      replacedSet.emplace(pair<ElementId, ElementId>(it->second, keeper->getElementId()));
-    }
+      replacedSet.emplace(it->second, keeper->getElementId());
+
     if (it->first != keeper->getElementId())
-    {
-      replacedSet.emplace(pair<ElementId, ElementId>(it->first, keeper->getElementId()));
-    }
+      replacedSet.emplace(it->first, keeper->getElementId());
   }
   replaced.insert(replaced.end(), replacedSet.begin(), replacedSet.end());
 }
@@ -830,7 +827,7 @@ void BuildingMerger::mergeBuildings(OsmMapPtr map, const ElementId& mergeTargetI
       }
 
       std::set<std::pair<ElementId, ElementId>> pairs;
-      pairs.emplace(std::pair<ElementId, ElementId>(mergeTargetId, way->getElementId()));
+      pairs.emplace(mergeTargetId, way->getElementId());
       BuildingMerger merger(pairs);
       LOG_VART(pairs.size());
       std::vector<std::pair<ElementId, ElementId>> replacedElements;
@@ -852,7 +849,7 @@ void BuildingMerger::mergeBuildings(OsmMapPtr map, const ElementId& mergeTargetI
       }
 
       std::set<std::pair<ElementId, ElementId>> pairs;
-      pairs.emplace(std::pair<ElementId, ElementId>(mergeTargetId, relation->getElementId()));
+      pairs.emplace(mergeTargetId, relation->getElementId());
       BuildingMerger merger(pairs);
       LOG_VART(pairs.size());
       std::vector<std::pair<ElementId, ElementId>> replacedElements;

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.cpp
@@ -144,7 +144,7 @@ void ScriptMatch::_calculateClassification(
 set<pair<ElementId, ElementId>> ScriptMatch::getMatchPairs() const
 {
   set<pair<ElementId, ElementId>> result;
-  result.emplace(pair<ElementId, ElementId>(_eid1, _eid2));
+  result.emplace(_eid1, _eid2);
   return result;
 }
 

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/AreaMergerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/AreaMergerJs.cpp
@@ -84,7 +84,7 @@ void AreaMergerJs::mergeAreas(OsmMapPtr map, const ElementId& mergeTargetId, Iso
       LOG_TRACE("Merging way area: " << way << " into " << mergeTargetId);
 
       std::set<std::pair<ElementId, ElementId>> matches;
-      matches.emplace(std::pair<ElementId,ElementId>(mergeTargetId, ElementId::way(way->getId())));
+      matches.emplace(mergeTargetId, ElementId::way(way->getId()));
       // apply script merging
       ScriptMerger merger(script, plugin, matches);
       std::vector<std::pair<ElementId, ElementId>> replacedWays;
@@ -106,8 +106,7 @@ void AreaMergerJs::mergeAreas(OsmMapPtr map, const ElementId& mergeTargetId, Iso
       LOG_TRACE("Merging relation area: " << relation << " into " << mergeTargetId);
 
       std::set<std::pair<ElementId, ElementId>> matches;
-      matches.emplace(
-        std::pair<ElementId,ElementId>(mergeTargetId, ElementId::relation(relation->getId())));
+      matches.emplace(mergeTargetId, ElementId::relation(relation->getId()));
       // apply script merging
       ScriptMerger merger(script, plugin, matches);
       std::vector<std::pair<ElementId, ElementId>> replacedRelations;

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/PoiMergerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/PoiMergerJs.cpp
@@ -85,7 +85,7 @@ void PoiMergerJs::mergePois(OsmMapPtr map, const ElementId& mergeTargetId, Isola
       LOG_VART(node);
 
       std::set<std::pair<ElementId, ElementId>> matches;
-      matches.emplace(std::pair<ElementId,ElementId>(mergeTargetId, node->getElementId()));
+      matches.emplace(mergeTargetId, node->getElementId());
       // apply script merging
       ScriptMerger merger(script, plugin, matches);
       std::vector<std::pair<ElementId, ElementId>> replacedNodes;


### PR DESCRIPTION
`emplace()` takes on the parameters of the constructor instead of using temporary objects