### PR TITLE
SONAR: Replace use of push_back with emplace_back

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/FrechetDistance.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/FrechetDistance.cpp
@@ -350,7 +350,7 @@ vector<frechet_subline> FrechetDistance::matchingSublines(Meters maxDistance)
       m = sub[sub.size() - 1];
     }
     if (sub.size() > 1)
-      results.push_back(frechet_subline(sub.size(), sub));
+      results.emplace_back(sub.size(), sub);
   }
 
   sort(results.begin(), results.end(), sort_sublines);

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayMatchStringMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayMatchStringMerger.cpp
@@ -27,8 +27,8 @@
 #include "WayMatchStringMerger.h"
 
 // hoot
-#include <hoot/core/algorithms/splitter/WaySplitter.h>
 #include <hoot/core/algorithms/linearreference/WayString.h>
+#include <hoot/core/algorithms/splitter/WaySplitter.h>
 #include <hoot/core/ops/RecursiveElementRemover.h>
 #include <hoot/core/util/Log.h>
 
@@ -83,7 +83,7 @@ WaySublineMatchStringPtr WayMatchStringMerger::createMatchString() const
     ws1.ensureForwards();
     ws2.ensureForwards();
 
-    matches.push_back(WaySublineMatch(ws1, ws2, reversed));
+    matches.emplace_back(ws1, ws2, reversed);
   }
 
   LOG_VAR(matches);
@@ -327,7 +327,7 @@ void WayMatchStringMerger::_moveNode(ElementId scrapNodeId, WayLocation wl1)
 
     n1->setTags(t);
 
-    _replaced.push_back(pair<ElementId, ElementId>(scrapNodeId, n1->getElementId()));
+    _replaced.emplace_back(scrapNodeId, n1->getElementId());
   }
   else
   {
@@ -395,8 +395,7 @@ void WayMatchStringMerger::replaceScraps()
 
     for (int i = 0; i < it.value().size(); ++i)
     {
-      _replaced.push_back(
-        pair<ElementId, ElementId>(it.key()->getElementId(), it.value()[i]->getElementId()));
+      _replaced.emplace_back(it.key()->getElementId(), it.value()[i]->getElementId());
     }
   }
 }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayMatchStringSplitter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayMatchStringSplitter.cpp
@@ -131,7 +131,7 @@ void WayMatchStringSplitter::_splitWay(WayNumber wn, OsmMapPtr map,
     if (w && ElementGeometryUtils::calculateLength(w, map) > 0.0)
     {
       newWays.append(w);
-      replaced.push_back(pair<ElementId, ElementId>(way->getElementId(), w->getElementId()));
+      replaced.emplace_back(way->getElementId(), w->getElementId());
     }
 
     for (int i = 0; i < sm.size(); ++i)
@@ -141,7 +141,7 @@ void WayMatchStringSplitter::_splitWay(WayNumber wn, OsmMapPtr map,
         throw NeedsReviewException(_overlyAggressiveMergeReviewText);
 
       sm.at(i)->setNewWay(wn, w);
-      replaced.push_back(pair<ElementId, ElementId>(way->getElementId(), w->getElementId()));
+      replaced.emplace_back(way->getElementId(), w->getElementId());
       newWays.append(w);
 
       w = splits[c++];
@@ -153,7 +153,7 @@ void WayMatchStringSplitter::_splitWay(WayNumber wn, OsmMapPtr map,
           throw InternalErrorException("Only the last split should be empty.");
 
         newWays.append(w);
-        replaced.push_back(pair<ElementId, ElementId>(way->getElementId(), w->getElementId()));
+        replaced.emplace_back(way->getElementId(), w->getElementId());
       }
     }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayMatchStringMappingConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayMatchStringMappingConverter.cpp
@@ -72,7 +72,7 @@ WaySublineMatchStringPtr WayMatchStringMappingConverter::toWaySublineMatchString
     WaySubline tmp2 = sub2;
     tmp1.ensureForwards();
     tmp2.ensureForwards();
-    coll.push_back(WaySublineMatch(tmp1, tmp2, reversed));
+    coll.emplace_back(tmp1, tmp2, reversed);
 
     wl1 = sub1.getEnd();
     wl2 = sub2.getEnd();

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/FrechetSublineMatcher.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/FrechetSublineMatcher.cpp
@@ -29,11 +29,11 @@
 // geos
 #include <geos/geom/LineString.h>
 // hoot
+#include <hoot/core/algorithms/FrechetDistance.h>
+#include <hoot/core/geometry/ElementToGeometryConverter.h>
+#include <hoot/core/ops/CopyMapSubsetOp.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Units.h>
-#include <hoot/core/algorithms/FrechetDistance.h>
-#include <hoot/core/ops/CopyMapSubsetOp.h>
-#include <hoot/core/geometry/ElementToGeometryConverter.h>
 
 using namespace geos::geom;
 using namespace std;
@@ -94,7 +94,7 @@ WaySublineMatchString FrechetSublineMatcher::findMatch(
         insert = false;
     }
     if (insert)
-      v.push_back(WaySublineMatch(match, map));
+      v.emplace_back(match, map);
   }
   return WaySublineMatchString(v);
 }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/MaximalNearestSublineMatcher.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/MaximalNearestSublineMatcher.cpp
@@ -31,9 +31,9 @@
 
 // hoot
 #include <hoot/core/algorithms/subline-matching/MaximalNearestSubline.h>
+#include <hoot/core/geometry/ElementToGeometryConverter.h>
 #include <hoot/core/ops/CopyMapSubsetOp.h>
 #include <hoot/core/util/Factory.h>
-#include <hoot/core/geometry/ElementToGeometryConverter.h>
 
 using namespace geos::geom;
 using namespace std;
@@ -110,7 +110,7 @@ WaySublineMatchString MaximalNearestSublineMatcher::findMatch(const ConstOsmMapP
 
   vector<WaySublineMatch> v;
   // switch the subline match to reference a different map.
-  v.push_back(WaySublineMatch(match, map));
+  v.emplace_back(match, map);
 
   return WaySublineMatchString(v);
 }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/MaximalSubline.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/MaximalSubline.cpp
@@ -300,7 +300,7 @@ vector<WaySublineMatch> MaximalSubline::_extractAllMatches(const ConstOsmMapPtr&
     if (ws1.isValid() && ws1.isZeroLength() == false &&
         ws2.isValid() && ws2.isZeroLength() == false)
     {
-      result.push_back(WaySublineMatch(ws1, ws2));
+      result.emplace_back(ws1, ws2);
     }
   }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/zindex/ZCurveRanger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/zindex/ZCurveRanger.cpp
@@ -36,9 +36,6 @@
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
 
-//Boost Includes
-#include <boost/make_shared.hpp>
-
 //Qt includes
 #include <QStringList>
 
@@ -335,7 +332,7 @@ vector<Range> ZCurveRanger::_decomposeRange(LongBox box, LongBox focusBox, int l
 vector<Range> ZCurveRanger::_decomposeRangeIterative(LongBox box, int count)
 {
   priority_queue<LongBoxContainer> pq;
-  pq.push(LongBoxContainer(box, calculateExcess(std::make_shared<LongBox>(box))));
+  pq.emplace(box, calculateExcess(std::make_shared<LongBox>(box)));
 
   vector<LongBox> completed;
   while ((!pq.empty()) && (((int)pq.size() + (int)completed.size()) < count))
@@ -357,8 +354,8 @@ vector<Range> ZCurveRanger::_decomposeRangeIterative(LongBox box, int count)
       }
       else if (boxes.size() == 2)
       {
-        pq.push(LongBoxContainer(*boxes[0].get(), calculateExcess(boxes[0])));
-        pq.push(LongBoxContainer(*boxes[1].get(), calculateExcess(boxes[1])));
+        pq.emplace(*boxes[0].get(), calculateExcess(boxes[0]));
+        pq.emplace(*boxes[1].get(), calculateExcess(boxes[1]));
       }
       else
       {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
@@ -27,28 +27,27 @@
 #include "HighwayMatchCreator.h"
 
 // hoot
-#include <hoot/core/util/Factory.h>
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/algorithms/subline-matching/MaximalNearestSublineMatcher.h>
 #include <hoot/core/algorithms/subline-matching/MaximalSublineStringMatcher.h>
+#include <hoot/core/algorithms/subline-matching/SublineStringMatcher.h>
+#include <hoot/core/conflate/highway/HighwayClassifier.h>
+#include <hoot/core/conflate/highway/HighwayExpertClassifier.h>
+#include <hoot/core/conflate/highway/HighwayMatch.h>
 #include <hoot/core/conflate/matching/MatchType.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
-#include <hoot/core/conflate/highway/HighwayMatch.h>
-#include <hoot/core/conflate/highway/HighwayExpertClassifier.h>
-#include <hoot/core/visitors/ConstElementVisitor.h>
 #include <hoot/core/criterion/ArbitraryCriterion.h>
-#include <hoot/core/util/NotImplementedException.h>
+#include <hoot/core/criterion/HighwayCriterion.h>
+#include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/schema/TagAncestorDifferencer.h>
 #include <hoot/core/util/ConfPath.h>
 #include <hoot/core/util/ConfigOptions.h>
-#include <hoot/core/util/Units.h>
-#include <hoot/core/visitors/SpatialIndexer.h>
-#include <hoot/core/conflate/highway/HighwayClassifier.h>
-#include <hoot/core/algorithms/subline-matching/SublineStringMatcher.h>
-#include <hoot/core/util/NotImplementedException.h>
-#include <hoot/core/schema/TagAncestorDifferencer.h>
-#include <hoot/core/util/StringUtils.h>
+#include <hoot/core/util/Factory.h>
 #include <hoot/core/util/MemoryUsageChecker.h>
-#include <hoot/core/criterion/HighwayCriterion.h>
+#include <hoot/core/util/NotImplementedException.h>
+#include <hoot/core/util/StringUtils.h>
+#include <hoot/core/util/Units.h>
+#include <hoot/core/visitors/ConstElementVisitor.h>
+#include <hoot/core/visitors/SpatialIndexer.h>
 
 // Standard
 #include <fstream>
@@ -398,12 +397,11 @@ void HighwayMatchCreator::createMatches(
 vector<CreatorDescription> HighwayMatchCreator::getAllCreators() const
 {
   vector<CreatorDescription> result;
-  result.push_back(
-    CreatorDescription(
-      className(),
-      "Generates matchers that match roads with the 2nd Generation (Unifying) Algorithm",
-      CreatorDescription::Highway,
-      false));
+  result.emplace_back(
+    className(),
+    "Generates matchers that match roads with the 2nd Generation (Unifying) Algorithm",
+    CreatorDescription::Highway,
+    false);
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.cpp
@@ -95,11 +95,10 @@ bool HighwayMergerCreator::createMergers(const MatchSet& matches, vector<MergerP
 vector<CreatorDescription> HighwayMergerCreator::getAllCreators() const
 {
   vector<CreatorDescription> result;
-  result.push_back(
-    CreatorDescription(
-      className(),
-      "Generates mergers that merge roads with the 2nd Generation (Unifying) Algorithm",
-      false));
+  result.emplace_back(
+    className(),
+    "Generates mergers that merge roads with the 2nd Generation (Unifying) Algorithm",
+    false);
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.cpp
@@ -177,7 +177,7 @@ public:
       // if this is a match that requires review.
       else if (type == MatchType::Review)
       {
-        result.push_back(MatchSet());
+        result.emplace_back();
         MatchSet& matches = result.back();
         matches.insert(m);
       }
@@ -191,7 +191,7 @@ public:
     for (DisjointSetMap<ElementId>::AllGroups::const_iterator it = ag.begin(); it != ag.end(); ++it)
     {
       const vector<ElementId>& v = it->second;
-      result.push_back(MatchSet());
+      result.emplace_back();
       MatchSet& matches = result.back();
 
       for (size_t i = 0; i < v.size(); i++)

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearSnapMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearSnapMerger.cpp
@@ -827,8 +827,7 @@ void LinearSnapMerger::_splitElement(const OsmMapPtr& map, const WaySublineColle
       scrap->getTags().set(MetadataTags::HootMultilineString(), "yes");
     }
 
-    replaced.push_back(
-      std::pair<ElementId, ElementId>(splitee->getElementId(), scrap->getElementId()));
+    replaced.emplace_back(splitee->getElementId(), scrap->getElementId());
     LOG_VART(replaced);
   }
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearTagOnlyMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearTagOnlyMerger.cpp
@@ -29,16 +29,16 @@
 // hoot
 #include <hoot/core/algorithms/DirectionFinder.h>
 #include <hoot/core/criterion/BridgeCriterion.h>
-#include <hoot/core/criterion/OneWayCriterion.h>
 #include <hoot/core/criterion/CriterionUtils.h>
-#include <hoot/core/elements/OsmUtils.h>
+#include <hoot/core/criterion/OneWayCriterion.h>
+#include <hoot/core/conflate/highway/HighwayMatch.h>
 #include <hoot/core/conflate/highway/HighwayUtils.h>
+#include <hoot/core/elements/OsmUtils.h>
+#include <hoot/core/elements/TagUtils.h>
 #include <hoot/core/schema/TagMergerFactory.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/conflate/highway/HighwayMatch.h>
-#include <hoot/core/elements/TagUtils.h>
 
 namespace hoot
 {
@@ -213,9 +213,7 @@ bool LinearTagOnlyMerger::_mergeWays(
   if (removeSecondaryElement)
   {
     LOG_TRACE("Marking " << elementWithTagsToRemove->getElementId() << " for replacement...");
-    replaced.push_back(
-      std::pair<ElementId, ElementId>(
-        elementWithTagsToRemove->getElementId(), elementWithTagsToKeep->getElementId()));
+    replaced.emplace_back(elementWithTagsToRemove->getElementId(), elementWithTagsToKeep->getElementId());
   }
 
   return true;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/RelationMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/RelationMerger.cpp
@@ -296,10 +296,9 @@ bool RelationMerger::_mergeMembers(RelationPtr replacingRelation, RelationPtr re
   {
     const RelationMemberComparison currentMemberFromReplaced = replacingRelationMemberComps[i];
     // Add the relation member to the relation we're keeping.
-    modifiedMembers.push_back(
-      RelationData::Entry(
+    modifiedMembers.emplace_back(
         currentMemberFromReplaced.getRole(),
-        currentMemberFromReplaced.getElement()->getElementId()));
+        currentMemberFromReplaced.getElement()->getElementId());
     // Remove the member from the relation we may or may not be keeping.
     relationBeingReplaced->removeElement(currentMemberFromReplaced.getElement()->getElementId());
     numMembersCopied++;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatchCreator.cpp
@@ -33,8 +33,9 @@
 #include <hoot/core/conflate/network/NetworkMatcher.h>
 #include <hoot/core/conflate/network/OsmNetworkExtractor.h>
 #include <hoot/core/criterion/ChainCriterion.h>
+#include <hoot/core/criterion/HighwayCriterion.h>
 #include <hoot/core/criterion/StatusCriterion.h>
-#include <hoot/core/visitors/ConstElementVisitor.h>
+#include <hoot/core/elements/MapProjector.h>
 #include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/io/OsmMapWriterFactory.h>
@@ -42,10 +43,9 @@
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/elements/MapProjector.h>
-#include <hoot/core/util/StringUtils.h>
 #include <hoot/core/util/NotImplementedException.h>
-#include <hoot/core/criterion/HighwayCriterion.h>
+#include <hoot/core/util/StringUtils.h>
+#include <hoot/core/visitors/ConstElementVisitor.h>
 
 // Standard
 #include <fstream>
@@ -193,12 +193,11 @@ void NetworkMatchCreator::createMatches(
 vector<CreatorDescription> NetworkMatchCreator::getAllCreators() const
 {
   vector<CreatorDescription> result;
-  result.push_back(
-    CreatorDescription(
-      className(),
-      "Generates matchers that match roads with the Network Algorithm",
-      CreatorDescription::BaseFeatureType::Highway,
-      false));
+  result.emplace_back(
+    className(),
+    "Generates matchers that match roads with the Network Algorithm",
+    CreatorDescription::BaseFeatureType::Highway,
+    false);
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMergerCreator.cpp
@@ -188,11 +188,10 @@ bool NetworkMergerCreator::createMergers(
 vector<CreatorDescription> NetworkMergerCreator::getAllCreators() const
 {
   vector<CreatorDescription> result;
-  result.push_back(
-    CreatorDescription(
-      className(),
-      "Generates mergers that merge roads conflated with the Network Algorithm",
-      false));
+  result.emplace_back(
+    className(),
+    "Generates mergers that merge roads conflated with the Network Algorithm",
+    false);
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMatchCreator.cpp
@@ -27,16 +27,16 @@
 #include "PoiPolygonMatchCreator.h"
 
 // hoot
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/conflate/poi-polygon/PoiPolygonMatch.h>
-#include <hoot/core/visitors/poi-polygon/PoiPolygonMatchVisitor.h>
+#include <hoot/core/criterion/poi-polygon/PoiPolygonPoiCriterion.h>
+#include <hoot/core/criterion/poi-polygon/PoiPolygonPolyCriterion.h>
+#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/util/ConfPath.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/StringUtils.h>
-#include <hoot/core/criterion/poi-polygon/PoiPolygonPoiCriterion.h>
-#include <hoot/core/criterion/poi-polygon/PoiPolygonPolyCriterion.h>
+#include <hoot/core/visitors/poi-polygon/PoiPolygonMatchVisitor.h>
 
 // Std
 #include <float.h>
@@ -539,15 +539,14 @@ int PoiPolygonMatchCreator::_retainClosestDistanceMatchesOnlyByType(
 std::vector<CreatorDescription> PoiPolygonMatchCreator::getAllCreators() const
 {
   std::vector<CreatorDescription> result;
-  result.push_back(
-    CreatorDescription(
-      className(),
-      "Generates matchers that match POIs to polygons",
-      //this match creator has two conflatable types, so arbitrarily just picking one of them as
-      //the base feature type; stats class will handle the logic to deal with both poi and polygon
-      //input types
-      CreatorDescription::Polygon,
-      false));
+  result.emplace_back(
+    className(),
+    "Generates matchers that match POIs to polygons",
+    //this match creator has two conflatable types, so arbitrarily just picking one of them as
+    //the base feature type; stats class will handle the logic to deal with both poi and polygon
+    //input types
+    CreatorDescription::Polygon,
+    false);
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMerger.cpp
@@ -212,7 +212,7 @@ void PoiPolygonMerger::apply(const OsmMapPtr& map, vector<pair<ElementId, Elemen
     const pair<ElementId, ElementId>& p = *it;
     if (p.first.getType() == ElementType::Node)
     {
-      replaced.push_back(pair<ElementId, ElementId>(p.first, finalBuildingEid));
+      replaced.emplace_back(p.first, finalBuildingEid);
       // clear the tags just in case it is part of a way
       if (map->containsElement(p.first))
       {
@@ -235,7 +235,7 @@ void PoiPolygonMerger::apply(const OsmMapPtr& map, vector<pair<ElementId, Elemen
 
     if (p.second.getType() == ElementType::Node)
     {
-      replaced.push_back(pair<ElementId, ElementId>(p.second, finalBuildingEid));
+      replaced.emplace_back(p.second, finalBuildingEid);
       // clear the tags just in case it is part of a way
       if (map->containsElement(p.second))
       {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonMergerCreator.cpp
@@ -146,11 +146,10 @@ bool PoiPolygonMergerCreator::createMergers(
 vector<CreatorDescription> PoiPolygonMergerCreator::getAllCreators() const
 {
   vector<CreatorDescription> result;
-  result.push_back(
-    CreatorDescription(
-      className(),
-      "Generates mergers that merge POIs into polygons",
-      false));
+  result.emplace_back(
+    className(),
+    "Generates mergers that merge POIs into polygons",
+    false);
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
@@ -27,25 +27,25 @@
 #include "BuildingMatchCreator.h"
 
 // hoot
-#include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/algorithms/extractors/OverlapExtractor.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
 #include <hoot/core/conflate/matching/MatchType.h>
 #include <hoot/core/conflate/polygon/BuildingMatch.h>
 #include <hoot/core/conflate/polygon/BuildingRfClassifier.h>
 #include <hoot/core/criterion/ArbitraryCriterion.h>
-#include <hoot/core/visitors/ConstElementVisitor.h>
-#include <hoot/core/util/NotImplementedException.h>
+#include <hoot/core/criterion/BuildingCriterion.h>
+#include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/schema/OsmSchema.h>
+#include <hoot/core/util/CollectionUtils.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/ConfPath.h>
 #include <hoot/core/util/Factory.h>
-#include <hoot/core/util/Settings.h>
-#include <hoot/core/visitors/SpatialIndexer.h>
-#include <hoot/core/util/StringUtils.h>
-#include <hoot/core/util/CollectionUtils.h>
-#include <hoot/core/algorithms/extractors/OverlapExtractor.h>
-#include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/util/MemoryUsageChecker.h>
-#include <hoot/core/criterion/BuildingCriterion.h>
+#include <hoot/core/util/NotImplementedException.h>
+#include <hoot/core/util/Settings.h>
+#include <hoot/core/util/StringUtils.h>
+#include <hoot/core/visitors/ConstElementVisitor.h>
+#include <hoot/core/visitors/SpatialIndexer.h>
 
 // Standard
 #include <fstream>
@@ -474,12 +474,11 @@ void BuildingMatchCreator::createMatches(const ConstOsmMapPtr& map,
 std::vector<CreatorDescription> BuildingMatchCreator::getAllCreators() const
 {
   std::vector<CreatorDescription> result;
-  result.push_back(
-    CreatorDescription(
-      className(),
-      "Generates matchers that match buildings",
-      CreatorDescription::Building,
-      false));
+  result.emplace_back(
+    className(),
+    "Generates matchers that match buildings",
+    CreatorDescription::Building,
+    false);
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMergerCreator.cpp
@@ -84,11 +84,10 @@ bool BuildingMergerCreator::createMergers(const MatchSet& matches, vector<Merger
 vector<CreatorDescription> BuildingMergerCreator::getAllCreators() const
 {
   vector<CreatorDescription> result;
-  result.push_back(
-    CreatorDescription(
-      className(),
-      "Generates mergers that merge buildings together",
-      false));
+  result.emplace_back(
+    className(),
+    "Generates mergers that merge buildings together",
+    false);
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/RelationData.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/RelationData.cpp
@@ -50,7 +50,7 @@ RelationData::RelationData(const RelationData& rd)
 
 void RelationData::addElement(const QString& role, ElementId eid)
 {
-  _members.push_back(Entry(role, eid));
+  _members.emplace_back(role, eid);
 }
 
 void RelationData::clear()
@@ -126,7 +126,7 @@ void RelationData::replaceElement(ElementId from, const QList<ElementId>& to)
     {
       for (int j = 0; j < to.size(); ++j)
       {
-        newCopy.push_back(Entry(e.role, to[j]));
+        newCopy.emplace_back(e.role, to[j]);
       }
     }
     else

--- a/hoot-core/src/main/cpp/hoot/core/geometry/GeometryMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/GeometryMerger.cpp
@@ -92,7 +92,7 @@ GeometryPtr GeometryMerger::mergeGeometries(std::vector<GeometryPtr> geometries,
     _geometryStackMutex.lock();
     _geometryStack.empty();
     for (size_t i = 0; i < geometries.size() - 1; i += 2)
-      _geometryStack.push(GeometryPair(geometries[i], geometries[i + 1]));
+      _geometryStack.emplace(geometries[i], geometries[i + 1]);
     _geometryStackMutex.unlock();
     //  Reset finished threads to zero each round of merges
     _finishedThreads = 0;

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.cpp
@@ -48,42 +48,42 @@ void OgrUtilities::loadDriverInfo()
 {
   //  Load the extension-based driver info
   //                               EXT          DESCRIPTION       EXT/PRE   R/W     VECTOR/RASTER/BOTH
-  _drivers.push_back(OgrDriverInfo(".shp",      "ESRI Shapefile", true,     true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".dbf",      "ESRI Shapefile", true,     true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".sqlite",   "SQLite",         true,     true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".db",       "SQLite",         true,     true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".mif",      "MapInfo File",   true,     true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".tab",      "MapInfo File",   true,     true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".s57",      "S57",            true,     true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".000",      "S57",            true,     true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".bna",      "BNA",            true,     true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".csv",      "CSV",            true,     true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".gml",      "GML",            true,     true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".gpx",      "GPX",            true,     true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".kml",      "LIBKML",         true,     true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".kmz",      "LIBKML",         true,     true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".dxf",      "DXF",            true,     true,   GDAL_OF_VECTOR));
+  _drivers.emplace_back(".shp",      "ESRI Shapefile", true,     true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back(".dbf",      "ESRI Shapefile", true,     true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back(".sqlite",   "SQLite",         true,     true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back(".db",       "SQLite",         true,     true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back(".mif",      "MapInfo File",   true,     true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back(".tab",      "MapInfo File",   true,     true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back(".s57",      "S57",            true,     true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back(".000",      "S57",            true,     true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back(".bna",      "BNA",            true,     true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back(".csv",      "CSV",            true,     true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back(".gml",      "GML",            true,     true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back(".gpx",      "GPX",            true,     true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back(".kml",      "LIBKML",         true,     true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back(".kmz",      "LIBKML",         true,     true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back(".dxf",      "DXF",            true,     true,   GDAL_OF_VECTOR);
   // Order is important here for the two FileGDB drivers, grab the first for read ops and the second
   // for write
-  _drivers.push_back(OgrDriverInfo(".gdb",      "OpenFileGDB",    true,     false,  GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".gdb",      "FileGDB",        true,     true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".gpkg",     "GPKG",           true,     true,   GDAL_OF_ALL));
-  _drivers.push_back(OgrDriverInfo(".pix",      "PCIDSK",         true,     true,   GDAL_OF_ALL));
-  _drivers.push_back(OgrDriverInfo(".sql",      "PGDump",         true,     true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".gtm",      "GPSTrackMaker",  true,     true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo(".gmt",      "GMT",            true,     true,   GDAL_OF_ALL));
-  _drivers.push_back(OgrDriverInfo(".vrt",      "VRT",            true,     true,   GDAL_OF_ALL));
+  _drivers.emplace_back(".gdb",      "OpenFileGDB",    true,     false,  GDAL_OF_VECTOR);
+  _drivers.emplace_back(".gdb",      "FileGDB",        true,     true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back(".gpkg",     "GPKG",           true,     true,   GDAL_OF_ALL);
+  _drivers.emplace_back(".pix",      "PCIDSK",         true,     true,   GDAL_OF_ALL);
+  _drivers.emplace_back(".sql",      "PGDump",         true,     true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back(".gtm",      "GPSTrackMaker",  true,     true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back(".gmt",      "GMT",            true,     true,   GDAL_OF_ALL);
+  _drivers.emplace_back(".vrt",      "VRT",            true,     true,   GDAL_OF_ALL);
   //  Load the prefix-based driver info
-  _drivers.push_back(OgrDriverInfo("PG:",       "PostgreSQL",     false,    true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo("MySQL:",    "MySQL",          false,    true,   GDAL_OF_ALL));
-  _drivers.push_back(OgrDriverInfo("CouchDB:",  "CouchDB",        false,    true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo("GFT:",      "GFT",            false,    true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo("gltp:",     "OGR_OGDI",       false,    true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo("MSSQL:",    "MSSQLSpatial",   false,    true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo("ODBC:",     "ODBC",           false,    true,   GDAL_OF_VECTOR));
-  _drivers.push_back(OgrDriverInfo("OCI:",      "OCI",            false,    true,   GDAL_OF_ALL));
-  _drivers.push_back(OgrDriverInfo("SDE:",      "SDE",            false,    true,   GDAL_OF_ALL));
-  _drivers.push_back(OgrDriverInfo("WFS:",      "WFS",            false,    true,   GDAL_OF_ALL));
+  _drivers.emplace_back("PG:",       "PostgreSQL",     false,    true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back("MySQL:",    "MySQL",          false,    true,   GDAL_OF_ALL);
+  _drivers.emplace_back("CouchDB:",  "CouchDB",        false,    true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back("GFT:",      "GFT",            false,    true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back("gltp:",     "OGR_OGDI",       false,    true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back("MSSQL:",    "MSSQLSpatial",   false,    true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back("ODBC:",     "ODBC",           false,    true,   GDAL_OF_VECTOR);
+  _drivers.emplace_back("OCI:",      "OCI",            false,    true,   GDAL_OF_ALL);
+  _drivers.emplace_back("SDE:",      "SDE",            false,    true,   GDAL_OF_ALL);
+  _drivers.emplace_back("WFS:",      "WFS",            false,    true,   GDAL_OF_ALL);
 }
 
 OgrUtilities::OgrUtilities()

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.cpp
@@ -698,7 +698,7 @@ JsonCoordinates OsmGeoJsonReader::_parseGeometry(const pt::ptree& geometry)
     double x = it->second.get_value<double>();
     ++it;
     double y = it->second.get_value<double>();
-    results.push_back(Coordinate(x, y));
+    results.emplace_back(x, y);
   }
   else if (type == "LineString")
   {

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
@@ -90,12 +90,11 @@ void ParallelBoundedApiReader::beginRead(const QUrl& endpoint, const geos::geom:
       double lat = envelope.getMinY() + _coordGridSize * j;
       _bboxMutex.lock();
       //  Start at the upper right corner and create boxes left to right, top to bottom
-      _bboxes.push(
-          geos::geom::Envelope(
-              lon,
-              std::min(lon + _coordGridSize, envelope.getMaxX()),
-              lat,
-              std::min(lat + _coordGridSize, envelope.getMaxY())));
+      _bboxes.emplace(
+        lon,
+        std::min(lon + _coordGridSize, envelope.getMaxX()),
+        lat,
+        std::min(lat + _coordGridSize, envelope.getMaxY()));
       _bboxMutex.unlock();
     }
   }
@@ -229,10 +228,10 @@ void ParallelBoundedApiReader::_process()
           double lat3 = envelope.getMaxY();
           _bboxMutex.lock();
           //  Split the boxes into quads and push them onto the queue
-          _bboxes.push(geos::geom::Envelope(lon1, lon2, lat1, lat2));
-          _bboxes.push(geos::geom::Envelope(lon2, lon3, lat1, lat2));
-          _bboxes.push(geos::geom::Envelope(lon1, lon2, lat2, lat3));
-          _bboxes.push(geos::geom::Envelope(lon2, lon3, lat2, lat3));
+          _bboxes.emplace(lon1, lon2, lat1, lat2);
+          _bboxes.emplace(lon2, lon3, lat1, lat2);
+          _bboxes.emplace(lon1, lon2, lat2, lat3);
+          _bboxes.emplace(lon2, lon3, lat2, lat3);
           //  Increment by three because 1 turned into 4, i.e. 3 more were added
           _totalEnvelopes += 3;
           _bboxMutex.unlock();

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMerger.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMerger.cpp
@@ -28,13 +28,13 @@
 
 // hoot
 #include <hoot/core/index/OsmMapIndex.h>
-#include <hoot/js/elements/OsmMapJs.h>
-#include <hoot/js/elements/ElementJs.h>
-#include <hoot/js/elements/ElementIdJs.h>
-#include <hoot/js/io/DataConvertJs.h>
-#include <hoot/js/util/HootExceptionJs.h>
-#include <hoot/js/io/StreamUtilsJs.h>
 #include <hoot/core/util/Factory.h>
+#include <hoot/js/elements/ElementIdJs.h>
+#include <hoot/js/elements/ElementJs.h>
+#include <hoot/js/elements/OsmMapJs.h>
+#include <hoot/js/io/DataConvertJs.h>
+#include <hoot/js/io/StreamUtilsJs.h>
+#include <hoot/js/util/HootExceptionJs.h>
 
 // node.js
 #include <hoot/js/SystemNodeJs.h>
@@ -150,12 +150,12 @@ void ScriptMerger::_applyMergePair(const OsmMapPtr& map,
   LOG_VART(map->containsElement(_eid1));
   if (map->containsElement(_eid1) == false)
   {
-    replaced.push_back(pair<ElementId, ElementId>(_eid1, newElement->getElementId()));
+    replaced.emplace_back(_eid1, newElement->getElementId());
   }
   LOG_VART(map->containsElement(_eid2));
   if (map->containsElement(_eid2) == false)
   {
-    replaced.push_back(pair<ElementId, ElementId>(_eid2, newElement->getElementId()));
+    replaced.emplace_back(_eid2, newElement->getElementId());
   }
 }
 

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMerger.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMerger.cpp
@@ -27,8 +27,8 @@
 #include "MultiaryPoiMerger.h"
 
 // hoot
-#include <hoot/core/conflate/merging/MergerCreator.h>
 #include <hoot/core/conflate/matching/MatchFactory.h>
+#include <hoot/core/conflate/merging/MergerCreator.h>
 #include <hoot/core/conflate/merging/MergerFactory.h>
 #include <hoot/core/conflate/review/ReviewMarker.h>
 #include <hoot/core/ops/RecursiveElementRemover.h>
@@ -120,10 +120,9 @@ void MultiaryPoiMerger::_mergeClusters(const OsmMapPtr& map,
       if (e->getElementId() != mc->mergedElement->getElementId())
       {
         RecursiveElementRemover(e->getElementId()).apply(map);
-        replaced.push_back(
-          std::pair<ElementId, ElementId>(
+        replaced.emplace_back(
             e->getElementId(),
-            mc->mergedElement->getElementId()));
+            mc->mergedElement->getElementId());
       }
     }
     // Copy mergedElement so we know this is the only map that contains the element.

--- a/tgs/src/main/cpp/tgs/RStarTree/DistanceIterator.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/DistanceIterator.cpp
@@ -125,7 +125,7 @@ namespace Tgs
           {
             if (node->isLeafNode())
             {
-              _pendingResults.push_back(Result(b, node->getChildUserId(i)));
+              _pendingResults.emplace_back(b, node->getChildUserId(i));
             }
             else
             {

--- a/tgs/src/main/cpp/tgs/RStarTree/HilbertRTree.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/HilbertRTree.cpp
@@ -389,7 +389,7 @@ int HilbertRTree::_splitBoxes(BoxVector& boxes)
       assert(point[j] >= 0 && point[j] < (1 << ORDER));
     }
 
-    hilbertBoxes.push_back(BoxHolder(boxes[i], _hilbertCurve->encode(point)));
+    hilbertBoxes.emplace_back(boxes[i], _hilbertCurve->encode(point));
   }
   //sort(hilbertBoxes.begin(), hilbertBoxes.end());
   bool swap = false;

--- a/tgs/src/main/cpp/tgs/RStarTree/IntersectionIterator.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/IntersectionIterator.cpp
@@ -118,7 +118,7 @@ namespace Tgs
           {
             if (node->isLeafNode())
             {
-              _pendingResults.push_back(Result(b, node->getChildUserId(i)));
+              _pendingResults.emplace_back(b, node->getChildUserId(i));
             }
             else
             {

--- a/tgs/src/main/cpp/tgs/RStarTree/RStarTree.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/RStarTree.cpp
@@ -486,11 +486,11 @@ void RStarTree::_split(RTreeNode* node, RTreeNode*& newNode)
   {
     if (leaf)
     {
-      boxes.push_back(BoxPair(node->getChildEnvelope(i), node->getChildUserId(i)));
+      boxes.emplace_back(node->getChildEnvelope(i), node->getChildUserId(i));
     }
     else
     {
-      boxes.push_back(BoxPair(node->getChildEnvelope(i), node->getChildNodeId(i)));
+      boxes.emplace_back(node->getChildEnvelope(i), node->getChildNodeId(i));
     }
   }
 
@@ -511,7 +511,7 @@ void RStarTree::_split(RTreeNode* node, RTreeNode*& newNode)
     // efficient.
     for (unsigned int i = 0; i < boxes.size(); i++)
     {
-      tmp.push_back(std::pair<Box, int>(boxes[i].box.toBox(), boxes[i].id)); 
+      tmp.emplace_back(boxes[i].box.toBox(), boxes[i].id);
     }
     node->clear();
     node->setParentId(parentId);


### PR DESCRIPTION
Replace `push_back()` with `emplace_back()` on standard containers

Closes #4567 