### PR TITLE
Extend OsmApiReader to get bounds from input file

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -420,6 +420,20 @@ Example Usage:
 hoot convert -D bounds="106.851,-6.160,107.052,-5.913" input.osm output.osm
 ----
 
+=== bounds.input.file
+
+* Data Type: string
+* Default Value: ``
+
+A complete file path that contains the bounds of to be used.  The bounds will be the min/max lat/lon
+for the entire file.
+
+Example Usage:
+
+---
+hoot convert -D bounds.input.file="$HOOT_HOME/test-files/ToyTestA.osm" input.osm output.osm
+---
+
 === bounds.hoot.api.database
 
 * Data Type: string

--- a/docs/commands/convert.asciidoc
+++ b/docs/commands/convert.asciidoc
@@ -179,6 +179,12 @@ Retrieve OSM data around Paris, France from an OSM API and save it to an OSM fil
 hoot convert -D bounds=2.277303,48.851684,2.311635,48.864701 https://osm-api-url/api/0.6/map download.osm
 --------------------------------------
 
+Same command but using a file containing the bounds around Paris, France:
+
+--------------------------------------
+hoot convert -D bounds.input.filename=bounds.osm https://osm-api-url/api/0.6/map download.osm
+--------------------------------------
+
 === Notes
 
 * The format for OSM database URLs is: protocol://<user name>:<password>@<host name>:<port>/<database name>

--- a/hoot-core/src/main/cpp/hoot/core/geometry/GeometryUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/GeometryUtils.cpp
@@ -627,6 +627,31 @@ QMap<int, geos::geom::Envelope> GeometryUtils::readBoundsFileWithIds(const QStri
   return boundsById;
 }
 
+std::shared_ptr<geos::geom::Geometry> GeometryUtils::readBoundsFromFile(const QString& input)
+{
+  OsmMapPtr map(new OsmMap());
+  LOG_INFO("Loading map bounds from ..." << input.right(50) << "...");
+  OsmMapReaderFactory::read(map, input);
+  const NodeMap nodes = map->getNodes();
+  double min_x =  180.0,
+         max_x = -180.0,
+         min_y =  90.0,
+         max_y = -90.0;
+  //  No nodes should return an empty pointer
+  if (nodes.empty())
+    return nullptr;
+  //  Iterate all nodes and find the min/max x/y
+  for (NodeMap::const_iterator nodeItr = nodes.begin(); nodeItr != nodes.end(); ++nodeItr)
+  {
+    ConstNodePtr node = nodeItr->second;
+    min_x = std::min(min_x, node->getX());
+    max_x = std::max(max_x, node->getX());
+    min_y = std::min(min_y, node->getY());
+    max_y = std::max(max_y, node->getY());
+  }
+  return GeometryUtils::envelopeToPolygon(geos::geom::Envelope(min_x, max_x, min_y, max_y));
+}
+
 QString GeometryUtils::geometryTypeIdToString(const geos::geom::GeometryTypeId& geometryTypeId)
 {
   switch (geometryTypeId)

--- a/hoot-core/src/main/cpp/hoot/core/geometry/GeometryUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/GeometryUtils.h
@@ -279,6 +279,14 @@ public:
    */
   static QMap<int, geos::geom::Envelope> readBoundsFileWithIds(const QString& input);
 
+  /**
+   * Reads a file and returns the bounds of the nodes within the file
+   *
+   * @param input path to the file
+   * @return an envelope representing the bounds of the file
+   */
+  static std::shared_ptr<geos::geom::Geometry> readBoundsFromFile(const QString& input);
+
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
@@ -29,14 +29,15 @@
 
 // Hoot
 #include <hoot/core/elements/OsmMap.h>
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/geometry/GeometryUtils.h>
+#include <hoot/core/io/OsmMapReaderFactory.h>
+#include <hoot/core/util/ConfigUtils.h>
+#include <hoot/core/util/Factory.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/OsmApiUtils.h>
 #include <hoot/core/util/StringUtils.h>
 #include <hoot/core/visitors/ReportMissingElementsVisitor.h>
-#include <hoot/core/util/ConfigUtils.h>
 
 // Qt
 #include <QBuffer>
@@ -74,7 +75,8 @@ void OsmApiReader::setConfiguration(const Settings& conf)
   setMaxThreads(configOptions.getReaderHttpBboxThreadCount());
   setCoordGridSize(configOptions.getReaderHttpBboxMaxSize());
   setMaxGridSize(configOptions.getReaderHttpBboxMaxDownloadSize());
-  setBounds(GeometryUtils::boundsFromString(configOptions.getBounds()));
+  _boundsString = configOptions.getBounds();
+  _boundsFilename = configOptions.getBoundsInputFile();
 }
 
 void OsmApiReader::setUseDataSourceIds(bool /*useDataSourceIds*/)
@@ -116,13 +118,19 @@ void OsmApiReader::read(const OsmMapPtr& map)
   LOG_VART(_keepStatusTag);
   LOG_VART(_preserveAllTags);
 
+  //  Set the bounds once we begin the read
+  setBounds(_getBoundsEnvelope());
+
   // If a non-rectangular bounds was passed in from the config, we'll catch it here. If it is passed
   // in from setBounds, we'll silently disregard by using the envelope of the bounds only.
-  if (!ConfigOptions().getBounds().trimmed().isEmpty() &&
-      !GeometryUtils::isEnvelopeString(ConfigOptions().getBounds()))
+  if (!_boundsString.trimmed().isEmpty() && !GeometryUtils::isEnvelopeString(_boundsString))
   {
     throw IllegalArgumentException(
-      "OsmApiReader does not support a non-rectangular bounds: " + ConfigOptions().getBounds());
+      "OsmApiReader does not support a non-rectangular bounds: " + _boundsString);
+  }
+  else if (_bounds == nullptr)
+  {
+    throw IllegalArgumentException("OsmApiReader requires rectangular bounds");
   }
 
   //  Reusing the reader for multiple reads has two options, the first is the
@@ -188,6 +196,19 @@ void OsmApiReader::close()
   finalizePartial();
 
   _map.reset();
+}
+
+std::shared_ptr<geos::geom::Geometry> OsmApiReader::_getBoundsEnvelope()
+{
+  //  Try to read the bounds from the `bounds` string
+  if (_boundsString != ConfigOptions::getBoundsDefaultValue())
+    return GeometryUtils::boundsFromString(_boundsString);
+  //  Try to read the bounds from the `bounds.input.file` file
+  else if (_boundsFilename != ConfigOptions::getBoundsInputFileDefaultValue())
+    return GeometryUtils::readBoundsFromFile(_boundsFilename);
+  //  Neither exist return a NULL pointer
+  else
+    return nullptr;
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.h
@@ -59,38 +59,52 @@ public:
   /**
    * @brief close Close the reader
    */
-  virtual void close();
+  void close();
   /**
    * @brief isSupported
    * @param url URL of the OSM API to read
    * @return True if the URL is a supported format
    */
-  virtual bool isSupported(const QString& url) override;
+  bool isSupported(const QString& url) override;
   /**
    * @brief open Open up the reader
    * @param url URL of the OSM API to read from
    */
-  virtual void open(const QString& url) override;
+  void open(const QString& url) override;
   /**
    * @brief read Read the OSM from the API into the map
    * @param map Pointer to the map to read into
    */
-  virtual void read(const OsmMapPtr& map) override;
+  void read(const OsmMapPtr& map) override;
   /**
    * @brief setUseDataSourceIds
    * @param useDataSourceIds
    */
-  virtual void setUseDataSourceIds(bool useDataSourceIds) override;
+  void setUseDataSourceIds(bool useDataSourceIds) override;
   /**
    * @brief supportedFormats
    * @return the supported formats
    */
-  virtual QString supportedFormats() override;
+  QString supportedFormats() override;
   /**
    * @brief setConfiguration
    * @param conf Updated configuration
    */
-  virtual void setConfiguration(const Settings& conf) override;
+  void setConfiguration(const Settings& conf) override;
+
+private:
+
+  /**
+   * @brief _getBoundsEnvelope - Get either the `bounds` parameter value
+   *  or the bounds of a file listed in `bounds.file` parameter
+   * @return The bounds for the read
+   */
+  std::shared_ptr<geos::geom::Geometry> _getBoundsEnvelope();
+
+  /** Value of the bounds envelope string */
+  QString _boundsString;
+  /** Value of the bounds filename string */
+  QString _boundsFilename;
 };
 
 }


### PR DESCRIPTION
Updated `OsmApiReader` to get bounds from file

Closes #4603 