### PR TITLE
Handle untyped and site relations better when calculating stats

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressNormalizer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressNormalizer.cpp
@@ -101,6 +101,11 @@ QSet<QString> AddressNormalizer::normalizeAddress(const QString& address) const
 
 QSet<QString> AddressNormalizer::_normalizeAddressWithLibPostal(const QString& address) const
 {
+  if (address.trimmed().isEmpty())
+  {
+    return QSet<QString>();
+  }
+
   LOG_TRACE("Normalizing " << address << " with libpostal...");
 
   QSet<QString> normalizedAddresses;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressParser.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressParser.cpp
@@ -137,21 +137,21 @@ QList<Address> AddressParser::parseAddresses(const Element& element,
   // class's init when its a mem var on another class, since this init is expensive.
   LibPostalInit::getInstance();
 
-  LOG_VARD(element.getElementId());
+  LOG_VART(element.getElementId());
   QList<Address> addresses;
 
   QString houseNum;
   QString street;
   const QSet<QString> parsedAddresses = _parseAddresses(element, houseNum, street);
-  LOG_DEBUG("Parsed " << parsedAddresses.size() << " addresses for " << element.getElementId());
-  LOG_VARD(parsedAddresses);
+  LOG_TRACE("Parsed " << parsedAddresses.size() << " addresses for " << element.getElementId());
+  LOG_VART(parsedAddresses);
 
   // add the parsed addresses to a collection in which they will later be compared to each other
   for (QSet<QString>::const_iterator parsedAddressItr = parsedAddresses.begin();
        parsedAddressItr != parsedAddresses.end(); ++parsedAddressItr)
   {
     QString parsedAddress = *parsedAddressItr;
-    LOG_VARD(parsedAddress);
+    LOG_VART(parsedAddress);
 
     // optional additional lang pre-normalization translation
     if (_preTranslateTagValuesToEnglish)
@@ -168,26 +168,26 @@ QList<Address> AddressParser::parseAddresses(const Element& element,
         parsedAddress = houseNum + " " + street;
       }
     }
-    LOG_VARD(parsedAddress);
+    LOG_VART(parsedAddress);
 
     if (normalizeAddresses)
     {
       // normalize and translate the address strings, so we end up comparing apples to apples
       const QSet<QString> normalizedAddresses = _addressNormalizer.normalizeAddress(parsedAddress);
-      LOG_VARD(normalizedAddresses);
+      LOG_VART(normalizedAddresses);
 
       for (QSet<QString>::const_iterator normalizedAddressItr = normalizedAddresses.begin();
            normalizedAddressItr != normalizedAddresses.end(); ++normalizedAddressItr)
       {
         const QString normalizedAddress = *normalizedAddressItr;
-        LOG_VARD(normalizedAddress);
+        LOG_VART(normalizedAddress);
         Address address(normalizedAddress, _allowLenientHouseNumberMatching);
         address.setParsedFromAddressTag(_parsedFromAddressTag);
         address.setIsRange(_isHouseNumRange);
         address.setIsSubLetter(_isSubLetter);
         if (!addresses.contains(address))
         {
-          LOG_DEBUG("Adding address: " << address << " for element: " << element.getElementId());
+          LOG_TRACE("Adding address: " << address << " for element: " << element.getElementId());
           addresses.append(address);
         }
       }
@@ -200,7 +200,7 @@ QList<Address> AddressParser::parseAddresses(const Element& element,
       address.setIsSubLetter(_isSubLetter);
       if (!addresses.contains(address))
       {
-        LOG_DEBUG("Adding address: " << address << " for element: " << element.getElementId());
+        LOG_TRACE("Adding address: " << address << " for element: " << element.getElementId());
         addresses.append(address);
       }
     }
@@ -213,7 +213,7 @@ QList<Address> AddressParser::parseAddressesFromWayNodes(const Way& way, const O
                                                          const ElementId& skipElementId) const
 {
   QList<Address> addresses;
-  LOG_DEBUG("Collecting addresses from way nodes...");
+  LOG_TRACE("Collecting addresses from way nodes...");
   const std::vector<long> wayNodeIds = way.getNodeIds();
   for (size_t i = 0; i < wayNodeIds.size(); i++)
   {
@@ -232,7 +232,7 @@ QList<Address> AddressParser::parseAddressesFromRelationMembers(const Relation& 
                                                                 const ElementId& skipElementId) const
 {
   QList<Address> addresses;
-  LOG_DEBUG("Collecting addresses from relation members...");
+  LOG_TRACE("Collecting addresses from relation members...");
   const std::vector<RelationData::Entry> relationMembers = relation.getMembers();
   for (size_t i = 0; i < relationMembers.size(); i++)
   {
@@ -275,18 +275,18 @@ QSet<QString> AddressParser::_parseAddressAsRange(const QString& houseNum,
   {
     bool startHouseNumParsedOk = false;
     const int startHouseNum = houseNumParts[0].toInt(&startHouseNumParsedOk);
-    LOG_VARD(startHouseNum);
+    LOG_VART(startHouseNum);
     if (startHouseNumParsedOk)
     {
       bool endHouseNumParsedOk = false;
       const int endHouseNum = houseNumParts[1].toInt(&endHouseNumParsedOk);
-      LOG_VARD(endHouseNum);
+      LOG_VART(endHouseNum);
       if (endHouseNumParsedOk && startHouseNum < endHouseNum)
       {
         for (int i = startHouseNum; i < endHouseNum + 1; i++)
         {
           const QString parsedAddress = QString::number(i) + " " + street;
-          LOG_DEBUG("Parsed address as range: " << parsedAddress);
+          LOG_TRACE("Parsed address as range: " << parsedAddress);
           parsedAddresses.insert(parsedAddress);
         }
       }
@@ -300,17 +300,17 @@ bool AddressParser::_isParseableAddressFromComponents(const Tags& tags, QString&
 {
   // we only require a valid street address...no other higher order parts, like city, state, etc.
   houseNum = _addressNormalizer.getAddressTagKeys()->getAddressTagValue(tags, "house_number");
-  LOG_VARD(houseNum);
+  LOG_VART(houseNum);
   street = _addressNormalizer.getAddressTagKeys()->getAddressTagValue(tags, "street").toLower();
-  LOG_VARD(street);
+  LOG_VART(street);
   if (!houseNum.isEmpty() && !street.isEmpty())
   {
-    LOG_DEBUG("Found address from components: " << houseNum << ", " << street << ".");
+    LOG_TRACE("Found address from components: " << houseNum << ", " << street << ".");
     return true;
   }
   else
   {
-    LOG_DEBUG("No parseable address present.");
+    LOG_TRACE("No parseable address present.");
     return false;
   }
 }
@@ -332,7 +332,7 @@ bool AddressParser::_isValidAddressStr(QString& address, QString& houseNum, QStr
   {
     return false;
   }
-  LOG_VARD(address);
+  LOG_VART(address);
 
   // use libpostal to break down the address string
   libpostal_address_parser_response_t* parsed =
@@ -351,9 +351,9 @@ bool AddressParser::_isValidAddressStr(QString& address, QString& houseNum, QStr
   for (size_t i = 0; i < parsed->num_components; i++)
   {
     const QString label = parsed->labels[i];
-    LOG_VARD(label);
+    LOG_VART(label);
     const QString component = QString::fromUtf8((const char*)parsed->components[i]);
-    LOG_VARD(component);
+    LOG_VART(component);
     // we only care about the street address
     if (label == "house_number")
     {
@@ -366,18 +366,18 @@ bool AddressParser::_isValidAddressStr(QString& address, QString& houseNum, QStr
   }
   libpostal_address_parser_response_destroy(parsed);
 
-  LOG_VARD(street);
-  LOG_VARD(houseNum);
-  LOG_VARD(requireStreetTypeInIntersection);
-  LOG_VARD(Address::isStreetIntersectionAddress(street, requireStreetTypeInIntersection));
-  LOG_VARD(Address::isStreetIntersectionAddress(address, requireStreetTypeInIntersection));
+  LOG_VART(street);
+  LOG_VART(houseNum);
+  LOG_VART(requireStreetTypeInIntersection);
+  LOG_VART(Address::isStreetIntersectionAddress(street, requireStreetTypeInIntersection));
+  LOG_VART(Address::isStreetIntersectionAddress(address, requireStreetTypeInIntersection));
 
   // street address with house number
   if (!houseNum.isEmpty() && !street.isEmpty())
   {
     address = houseNum + " " + street;
     address = address.trimmed();
-    LOG_DEBUG("Found address: " << address);
+    LOG_TRACE("Found address: " << address);
     return true;
   }
   // intersections won't have numbers
@@ -386,7 +386,7 @@ bool AddressParser::_isValidAddressStr(QString& address, QString& houseNum, QStr
   {
     address = street;
     address = address.trimmed();
-    LOG_DEBUG("Found intersection address: " << address);
+    LOG_TRACE("Found intersection address: " << address);
     return true;
   }
   // if libpostal didn't pull out a street, then let's see if the string passed in is an
@@ -394,7 +394,7 @@ bool AddressParser::_isValidAddressStr(QString& address, QString& houseNum, QStr
   else if (Address::isStreetIntersectionAddress(address, requireStreetTypeInIntersection))
   {
     address = address.trimmed();
-    LOG_DEBUG("Found intersection address: " << address);
+    LOG_TRACE("Found intersection address: " << address);
     return true;
   }
   else
@@ -421,7 +421,7 @@ QString AddressParser::_parseFullAddress(const QString& fullAddress, QString& ho
     msg += " invalid";
   }
   msg += " address: " + parsedAddress + " from full address: " + fullAddress;
-  LOG_DEBUG(msg);
+  LOG_TRACE(msg);
 
   if (validAddress)
   {
@@ -433,7 +433,7 @@ QString AddressParser::_parseFullAddress(const QString& fullAddress, QString& ho
 QSet<QString> AddressParser::_parseAddressFromComponents(const Tags& tags, QString& houseNum,
                                                          QString& street) const
 {
-  LOG_DEBUG("Parsing address from component tags...");
+  LOG_TRACE("Parsing address from component tags...");
   QSet<QString> parsedAddresses;
 
   if (_isParseableAddressFromComponents(tags, houseNum, street))
@@ -443,14 +443,14 @@ QSet<QString> AddressParser::_parseAddressFromComponents(const Tags& tags, QStri
       // use custom logic for a address containing a range of addresses
       parsedAddresses = _parseAddressAsRange(houseNum, street);
       _isHouseNumRange = true;
-      LOG_DEBUG("Address is range address.");
+      LOG_TRACE("Address is range address.");
     }
     else
     {
       if (_isSubLetterAddress(houseNum))
       {
         _isSubLetter = true;
-        LOG_DEBUG("Address is subletter address.");
+        LOG_TRACE("Address is subletter address.");
       }
 
       QString parsedAddress = houseNum + " ";
@@ -468,7 +468,7 @@ QSet<QString> AddressParser::_parseAddressFromComponents(const Tags& tags, QStri
         parsedAddress += " " + streetPrefix;
       }
       parsedAddresses.insert(parsedAddress);
-      LOG_DEBUG(
+      LOG_TRACE(
         "Found address by parsing address parts from component tags: " << parsedAddress << ".");
     }
   }
@@ -479,13 +479,13 @@ QSet<QString> AddressParser::_parseAddressFromComponents(const Tags& tags, QStri
 QString AddressParser::_parseAddressFromAltTags(const Tags& tags, QString& houseNum,
                                                 QString& street) const
 {
-  LOG_DEBUG("Parsing address from alt tags...");
+  LOG_TRACE("Parsing address from alt tags...");
   QString parsedAddress;
 
   // let's always look in the name field; arguably, we could look in all of them instead of just
   // one...
   QSet<QString> additionalTagKeys = _addressNormalizer.getAddressTagKeys()->getAdditionalTagKeys();
-  LOG_VARD(additionalTagKeys);
+  LOG_VART(additionalTagKeys);
 
   for (QSet<QString>::const_iterator tagItr = additionalTagKeys.begin();
        tagItr != additionalTagKeys.end(); ++tagItr)
@@ -495,13 +495,13 @@ QString AddressParser::_parseAddressFromAltTags(const Tags& tags, QString& house
     if (!tagVal.isEmpty() && _isValidAddressStr(tagVal, houseNum, street))
     {
       parsedAddress = tagVal;
-      LOG_DEBUG("Found address: " << parsedAddress << " from additional tag key: " << tagKey << ".");
+      LOG_TRACE("Found address: " << parsedAddress << " from additional tag key: " << tagKey << ".");
       break;
     }
   }
 
   additionalTagKeys = QSet<QString>::fromList(tags.getNameKeys());
-  LOG_VARD(additionalTagKeys);
+  LOG_VART(additionalTagKeys);
   for (QSet<QString>::const_iterator tagItr = additionalTagKeys.begin();
        tagItr != additionalTagKeys.end(); ++tagItr)
   {
@@ -510,7 +510,7 @@ QString AddressParser::_parseAddressFromAltTags(const Tags& tags, QString& house
     if (!tagVal.isEmpty() && _isValidAddressStr(tagVal, houseNum, street, true))
     {
       parsedAddress = tagVal;
-      LOG_DEBUG("Found address: " << parsedAddress << " from additional tag key: " << tagKey << ".");
+      LOG_TRACE("Found address: " << parsedAddress << " from additional tag key: " << tagKey << ".");
       break;
     }
   }
@@ -527,7 +527,7 @@ QSet<QString> AddressParser::_parseAddresses(const Element& element, QString& ho
   // look for a full address tag first
   QString fullAddress =
     _addressNormalizer.getAddressTagKeys()->getAddressTagValue(element.getTags(), "full_address");
-  LOG_VARD(fullAddress);
+  LOG_VART(fullAddress);
   if (fullAddress.isEmpty())
   {
     // If we don't have the full address, let's try to get an address from parts.
@@ -561,8 +561,8 @@ QSet<QString> AddressParser::_parseAddresses(const Element& element, QString& ho
 bool AddressParser::addressesMatchDespiteSubletterDiffs(const QString& address1,
                                                         const QString& address2)
 {
-  LOG_VARD(address1);
-  LOG_VARD(address2);
+  LOG_VART(address1);
+  LOG_VART(address2);
 
   /* going to allow sub letter differences be matches; ex "34 elm street" matches
    * "34a elm street".  This is b/c the subletters are sometimes left out of the addresses by
@@ -592,7 +592,7 @@ QString AddressParser::_getSubLetterCleanedAddress(const QString& address)
 
   QString addressTemp = addressParts[0];
   const QString addressHouseNumStr = addressTemp.replace(QRegExp("[a-z]+"), "");
-  LOG_VARD(addressHouseNumStr);
+  LOG_VART(addressHouseNumStr);
   bool addressHouseNumOk = false;
   /*const int address1HouseNum = */addressHouseNumStr.toInt(&addressHouseNumOk);
 
@@ -606,7 +606,7 @@ QString AddressParser::_getSubLetterCleanedAddress(const QString& address)
   {
     subletterCleanedAddress += " " + addressParts[k];
   }
-  LOG_VARD(subletterCleanedAddress);
+  LOG_VART(subletterCleanedAddress);
   return subletterCleanedAddress;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/CalculateStatsOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CalculateStatsOp.cpp
@@ -42,7 +42,8 @@
 #include <hoot/core/schema/ScriptSchemaTranslatorFactory.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/elements/MapProjector.h>
-#include <hoot/core/visitors/CalculateAreaVisitor.h>
+//#include <hoot/core/visitors/CalculateAreaVisitor.h>
+#include <hoot/core/visitors/CalculateAreaForStatsVisitor.h>
 #include <hoot/core/visitors/CountUniqueReviewsVisitor.h>
 #include <hoot/core/visitors/ElementCountVisitor.h>
 #include <hoot/core/visitors/FeatureCountVisitor.h>
@@ -227,6 +228,9 @@ void CalculateStatsOp::_initStatCalc()
   // way. Admittedly, the way the stat total count is being calculated here is a very brittle way to
   // do it but haven't come up with a better way yet. This also could eventually be tied in with
   // progress reporting.
+
+  // TODO: This isn't quite right. Have recently seen 198 calculated as the total when 202 stats
+  // were actually run.
 
   const int numQuickStatCalcs = _quickStatData.size();
   LOG_VARD(numQuickStatCalcs);
@@ -1017,21 +1021,21 @@ void CalculateStatsOp::_generateFeatureStats(const CreatorDescription::BaseFeatu
         FilteredVisitor(
           ChainCriterion(
             ElementCriterionPtr(new StatusCriterion(Status::Conflated)), criterion->clone()),
-          ConstElementVisitorPtr(new CalculateAreaVisitor())),
+          ConstElementVisitorPtr(new /*CalculateAreaVisitor*/CalculateAreaForStatsVisitor())),
         "Area Conflated: " + description));
     _addStat(QString("Square Meters of Unmatched %1s From Map 1").arg(description),
       _applyVisitor(
         FilteredVisitor(
           ChainCriterion(
             ElementCriterionPtr(new StatusCriterion(Status::Unknown1)), criterion->clone()),
-          ConstElementVisitorPtr(new CalculateAreaVisitor())),
+          ConstElementVisitorPtr(new /*CalculateAreaVisitor*/CalculateAreaForStatsVisitor())),
         "Area Unmatched Map 1: " + description));
     _addStat(QString("Square Meters of Unmatched %1s From Map 2").arg(description),
       _applyVisitor(
         FilteredVisitor(
           ChainCriterion(
             ElementCriterionPtr(new StatusCriterion(Status::Unknown2)), criterion->clone()),
-          ConstElementVisitorPtr(new CalculateAreaVisitor())),
+          ConstElementVisitorPtr(new /*CalculateAreaVisitor*/CalculateAreaForStatsVisitor())),
         "Area Unmatched Map 2: " + description));
     _numGenerateFeatureStatCalls++;
   }

--- a/hoot-core/src/main/cpp/hoot/core/ops/CalculateStatsOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CalculateStatsOp.cpp
@@ -42,7 +42,6 @@
 #include <hoot/core/schema/ScriptSchemaTranslatorFactory.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/elements/MapProjector.h>
-//#include <hoot/core/visitors/CalculateAreaVisitor.h>
 #include <hoot/core/visitors/CalculateAreaForStatsVisitor.h>
 #include <hoot/core/visitors/CountUniqueReviewsVisitor.h>
 #include <hoot/core/visitors/ElementCountVisitor.h>
@@ -1021,21 +1020,21 @@ void CalculateStatsOp::_generateFeatureStats(const CreatorDescription::BaseFeatu
         FilteredVisitor(
           ChainCriterion(
             ElementCriterionPtr(new StatusCriterion(Status::Conflated)), criterion->clone()),
-          ConstElementVisitorPtr(new /*CalculateAreaVisitor*/CalculateAreaForStatsVisitor())),
+          ConstElementVisitorPtr(new CalculateAreaForStatsVisitor())),
         "Area Conflated: " + description));
     _addStat(QString("Square Meters of Unmatched %1s From Map 1").arg(description),
       _applyVisitor(
         FilteredVisitor(
           ChainCriterion(
             ElementCriterionPtr(new StatusCriterion(Status::Unknown1)), criterion->clone()),
-          ConstElementVisitorPtr(new /*CalculateAreaVisitor*/CalculateAreaForStatsVisitor())),
+          ConstElementVisitorPtr(new CalculateAreaForStatsVisitor())),
         "Area Unmatched Map 1: " + description));
     _addStat(QString("Square Meters of Unmatched %1s From Map 2").arg(description),
       _applyVisitor(
         FilteredVisitor(
           ChainCriterion(
             ElementCriterionPtr(new StatusCriterion(Status::Unknown2)), criterion->clone()),
-          ConstElementVisitorPtr(new /*CalculateAreaVisitor*/CalculateAreaForStatsVisitor())),
+          ConstElementVisitorPtr(new CalculateAreaForStatsVisitor())),
         "Area Unmatched Map 2: " + description));
     _numGenerateFeatureStatCalls++;
   }

--- a/hoot-core/src/main/cpp/hoot/core/visitors/CalculateAreaForStatsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/CalculateAreaForStatsVisitor.cpp
@@ -52,8 +52,11 @@ Meters CalculateAreaForStatsVisitor::getArea(const OsmMapPtr& map, ElementPtr e)
 void CalculateAreaForStatsVisitor::visit(const ConstElementPtr& e)
 {
   std::shared_ptr<Geometry> g =
-    ElementToGeometryConverter(_map->shared_from_this()).convertToGeometry(e, true, true);
-  _total += g->getArea();
+    ElementToGeometryConverter(_map->shared_from_this()).convertToGeometry(e, false, true);
+  if (!g->isEmpty())
+  {
+    _total += g->getArea();
+  }
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/visitors/CalculateAreaForStatsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/CalculateAreaForStatsVisitor.h
@@ -35,8 +35,8 @@ namespace hoot
 {
 
 /**
- * Sums the length of all the ways. The map projection is used so to get meters the map must be
- * first reprojected into meters.
+ * Sums the area of all the ways. The map projection is used so to get meters the map must be
+ * first reprojected into meters. This is meant for use in calculating map statistics only.
  */
 class CalculateAreaForStatsVisitor : public ElementConstOsmMapVisitor, public SingleStatistic
 {

--- a/hoot-core/src/main/cpp/hoot/core/visitors/CalculateAreaVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/CalculateAreaVisitor.cpp
@@ -50,8 +50,12 @@ Meters CalculateAreaVisitor::getArea(const OsmMapPtr& map, ElementPtr e)
 
 void CalculateAreaVisitor::visit(const ConstElementPtr& e)
 {
-  std::shared_ptr<Geometry> g = ElementToGeometryConverter(_map->shared_from_this()).convertToGeometry(e);
-  _total += g->getArea();
+  std::shared_ptr<Geometry> g =
+    ElementToGeometryConverter(_map->shared_from_this()).convertToGeometry(e, false, true);
+  if (!g->isEmpty())
+  {
+    _total += g->getArea();
+  }
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/visitors/CalculateAreaVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/CalculateAreaVisitor.h
@@ -35,7 +35,7 @@ namespace hoot
 {
 
 /**
- * Sums the length of all the ways. The map projection is used so to get meters the map must be
+ * Sums the area of all the ways. The map projection is used so to get meters the map must be
  * first reprojected into meters.
  */
 class CalculateAreaVisitor : public ElementConstOsmMapVisitor, public SingleStatistic


### PR DESCRIPTION
The calculation of area stats was crashing when encountering either a relation with no type or a relation of `type=site`. Now, a warning is logged instead in both cases and the offending feature excluded from the stat calculation. The `type-site` fix applies to all stats encountering this data, as well as any code attempting to convert such a feature to a geometry. The untyped relation fix currently applies only to calculating area statistics. Other callers converting such a feature to a geometry will need to be modified to not throw an error and skip the feature in question (see `CalculateAreaVisitor`).