### PR TITLE
SONAR: #include directives in a file should only be preceded by other preprocessor directives or comments

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/DirectionFinder.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/DirectionFinder.cpp
@@ -31,7 +31,6 @@
 #include <geos/geom/CoordinateSequenceFactory.h>
 #include <geos/geom/CoordinateSequence.h>
 #include <geos/geom/GeometryFactory.h>
-using namespace geos::geom;
 
 // Hoot
 #include <hoot/core/algorithms/Distance.h>
@@ -43,10 +42,12 @@ using namespace geos::geom;
 // Standard
 #include <iostream>
 #include <vector>
-using namespace std;
 
 // TGS
 #include <tgs/StreamUtils.h>
+
+using namespace geos::geom;
+using namespace std;
 using namespace Tgs;
 
 namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/LineStringAverager.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/LineStringAverager.cpp
@@ -34,12 +34,12 @@
 #include <geos/geom/LineString.h>
 #include <geos/geom/Point.h>
 #include <geos/operation/distance/DistanceOp.h>
-using namespace geos::operation::distance;
 
 // Qt
 #include <QDebug>
 
 using namespace geos::geom;
+using namespace geos::operation::distance;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.cpp
@@ -31,27 +31,29 @@
 #include <geos/geom/LineString.h>
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/Point.h>
-using namespace geos::geom;
 
 // Hoot
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/algorithms/DirectionFinder.h>
 #include <hoot/core/algorithms/WayDiscretizer.h>
+#include <hoot/core/criterion/OneWayCriterion.h>
 #include <hoot/core/criterion/ParallelWayCriterion.h>
+#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/elements/Way.h>
+#include <hoot/core/geometry/ElementToGeometryConverter.h>
 #include <hoot/core/schema/TagComparator.h>
 #include <hoot/core/util/ConfigOptions.h>
-#include <hoot/core/geometry/ElementToGeometryConverter.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/Settings.h>
-#include <hoot/core/criterion/OneWayCriterion.h>
+
 // Standard
 #include <vector>
-using namespace std;
 
 // Tgs
 #include <tgs/StreamUtils.h>
 #include <tgs/Statistics/Normal.h>
+
+using namespace geos::geom;
+using namespace std;
 using namespace Tgs;
 
 namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayAverager.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayAverager.cpp
@@ -33,18 +33,18 @@
 #include <geos/geom/LineString.h>
 #include <geos/geom/Point.h>
 #include <geos/operation/distance/DistanceOp.h>
-using namespace geos::operation::distance;
 
 // Hoot
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/algorithms/DirectionFinder.h>
-#include <hoot/core/schema/TagMergerFactory.h>
+#include <hoot/core/criterion/OneWayCriterion.h>
+#include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/elements/Way.h>
 #include <hoot/core/geometry/ElementToGeometryConverter.h>
 #include <hoot/core/ops/RemoveWayByEid.h>
-#include <hoot/core/elements/Way.h>
-#include <hoot/core/criterion/OneWayCriterion.h>
+#include <hoot/core/schema/TagMergerFactory.h>
 
 using namespace geos::geom;
+using namespace geos::operation::distance;
 using namespace std;
 
 namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayAverager.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayAverager.h
@@ -28,6 +28,9 @@
 #ifndef WAYAVERAGER_H
 #define WAYAVERAGER_H
 
+// Hoot
+#include <hoot/core/elements/OsmMap.h>
+
 // GEOS
 namespace geos
 {
@@ -36,9 +39,6 @@ namespace geos
     class LineString;
   }
 }
-
-// Hoot
-#include <hoot/core/elements/OsmMap.h>
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayDiscretizer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayDiscretizer.cpp
@@ -30,7 +30,6 @@
 // GEOS
 #include <geos/geom/CoordinateSequence.h>
 #include <geos/geom/LineString.h>
-using namespace geos::geom;
 
 // Hoot
 #include <hoot/core/algorithms/Distance.h>
@@ -40,6 +39,8 @@ using namespace geos::geom;
 
 // Standard
 #include <iostream>
+
+using namespace geos::geom;
 using namespace std;
 
 namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayDiscretizer.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayDiscretizer.h
@@ -27,15 +27,6 @@
 #ifndef __WAY_DISCRETIZER_H__
 #define __WAY_DISCRETIZER_H__
 
-// GEOS
-namespace geos
-{
-  namespace geom
-  {
-    class Coordinate;
-  }
-}
-
 // Hoot
 #include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/util/Units.h>
@@ -46,6 +37,15 @@ namespace geos
 
 // Tgs
 #include <tgs/HashMap.h>
+
+// GEOS
+namespace geos
+{
+  namespace geom
+  {
+    class Coordinate;
+  }
+}
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShape.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShape.cpp
@@ -43,7 +43,6 @@
 #include <geos/geom/MultiPolygon.h>
 #include <geos/geom/Point.h>
 #include <geos/util/IllegalArgumentException.h>
-using namespace geos::geom;
 
 // Qt
 #include <QString>
@@ -52,13 +51,15 @@ using namespace geos::geom;
 #include <stdlib.h>
 #include <limits>
 #include <queue>
-using namespace std;
 
 // TGS
 #include <tgs/DelaunayTriangulation/DelaunayTriangulation.h>
 #include <tgs/DisjointSet/DisjointSet.h>
 #include <tgs/RStarTree/HilbertCurve.h>
 #include <tgs/Statistics/Random.h>
+
+using namespace geos::geom;
+using namespace std;
 using namespace Tgs;
 
 namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShape.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShape.h
@@ -35,7 +35,6 @@
 
 // GDAL
 #include <ogr_core.h>
-class OGRSpatialReference;
 
 // Qt
 #include <QString>
@@ -45,6 +44,8 @@ class OGRSpatialReference;
 #include <memory>
 #include <set>
 #include <vector>
+
+class OGRSpatialReference;
 
 namespace Tgs
 {

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/SampledAngleHistogramExtractor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/SampledAngleHistogramExtractor.cpp
@@ -29,20 +29,20 @@
 
 // GEOS
 #include <geos/geom/LineString.h>
-using namespace geos::geom;
 
 // hoot
-#include <hoot/core/util/Factory.h>
-#include <hoot/core/algorithms/extractors/Histogram.h>
-#include <hoot/core/visitors/ElementConstOsmMapVisitor.h>
 #include <hoot/core/algorithms/WayDiscretizer.h>
-#include <hoot/core/geometry/ElementToGeometryConverter.h>
 #include <hoot/core/algorithms/WayHeading.h>
+#include <hoot/core/algorithms/extractors/Histogram.h>
 #include <hoot/core/algorithms/linearreference/WayLocation.h>
+#include <hoot/core/geometry/ElementToGeometryConverter.h>
+#include <hoot/core/util/Factory.h>
+#include <hoot/core/visitors/ElementConstOsmMapVisitor.h>
 
 // Qt
 #include <qnumeric.h>
 
+using namespace geos::geom;
 using namespace std;
 
 namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/splitter/DualHighwaySplitter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/splitter/DualHighwaySplitter.cpp
@@ -35,8 +35,6 @@
 #include <geos/geom/Point.h>
 #include <geos/operation/buffer/BufferParameters.h>
 #include <geos/operation/buffer/BufferBuilder.h>
-using namespace geos::geom;
-using namespace geos::operation::buffer;
 
 // Hoot
 #include <hoot/core/algorithms/Distance.h>
@@ -70,6 +68,7 @@ using namespace geos::operation::buffer;
 #include <tgs/StreamUtils.h>
 
 using namespace geos::geom;
+using namespace geos::operation::buffer;
 using namespace std;
 using namespace Tgs;
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/splitter/HighwayCornerSplitter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/splitter/HighwayCornerSplitter.cpp
@@ -42,12 +42,12 @@
 #include <geos/geom/CoordinateArraySequence.h>
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/LineString.h>
-using namespace geos::geom;
 
 // Qt
 #include <QDebug>
 #include <QTextStream>
 
+using namespace geos::geom;
 using namespace std;
 
 namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/cmd/DiffCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/DiffCmd.cpp
@@ -27,23 +27,23 @@
 
 // Hoot
 #include <hoot/core/cmd/BaseCommand.h>
+#include <hoot/core/elements/MapProjector.h>
 #include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/io/IoUtils.h>
 #include <hoot/core/io/OsmApiChangeset.h>
+#include <hoot/core/ops/DuplicateNodeRemover.h>
 #include <hoot/core/scoring/MapComparator.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/elements/MapProjector.h>
 #include <hoot/core/util/Settings.h>
-#include <hoot/core/ops/DuplicateNodeRemover.h>
 #include <hoot/core/util/StringUtils.h>
-
-using namespace std;
 
 // Qt
 #include <QDir>
 #include <QFileInfo>
 #include <QElapsedTimer>
+
+using namespace std;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/phone/PhoneNumberLocator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/phone/PhoneNumberLocator.cpp
@@ -33,9 +33,10 @@
 
 // libphonenumber
 #include <phonenumbers/phonenumberutil.h>
-using namespace i18n::phonenumbers;
 
 #include <unicode/locid.h>
+
+using namespace i18n::phonenumbers;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
@@ -50,7 +50,6 @@
 // Standard
 #include <fstream>
 #include <functional>
-using namespace std;
 
 // tgs
 #include <tgs/RandomForest/RandomForest.h>
@@ -62,6 +61,7 @@ using namespace std;
 #include <QElapsedTimer>
 
 using namespace geos::geom;
+using namespace std;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ParallelWayCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ParallelWayCriterion.cpp
@@ -32,21 +32,21 @@
 #include <geos/geom/LineString.h>
 #include <geos/geom/Point.h>
 #include <geos/operation/distance/DistanceOp.h>
-using namespace geos::operation::distance;
 
 // Hoot
 #include <hoot/core/algorithms/WayDiscretizer.h>
 #include <hoot/core/algorithms/WayHeading.h>
 #include <hoot/core/algorithms/linearreference/LocationOfPoint.h>
-#include <hoot/core/elements/ElementGeometryUtils.h>
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/elements/Element.h>
+#include <hoot/core/elements/ElementGeometryUtils.h>
 #include <hoot/core/geometry/ElementToGeometryConverter.h>
+#include <hoot/core/util/Factory.h>
 
 // Qt
 #include <QDebug>
 
 using namespace geos::geom;
+using namespace geos::operation::distance;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementProvider.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementProvider.h
@@ -30,14 +30,14 @@
 // std
 #include <memory>
 
+#include <hoot/core/elements/Element.h>
+#include <hoot/core/elements/ElementId.h>
+#include <hoot/core/elements/Node.h>
+#include <hoot/core/elements/Relation.h>
+#include <hoot/core/elements/Way.h>
+
 // GDAL
 class OGRSpatialReference;
-
-#include <hoot/core/elements/ElementId.h>
-#include <hoot/core/elements/Element.h>
-#include <hoot/core/elements/Node.h>
-#include <hoot/core/elements/Way.h>
-#include <hoot/core/elements/Relation.h>
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/elements/MapProjector.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/MapProjector.h
@@ -29,8 +29,6 @@
 
 // GDAL
 #include <ogr_core.h>
-class OGRCoordinateTransformation;
-class OGRSpatialReference;
 
 // GEOS
 #include <geos/geom/Coordinate.h>
@@ -38,8 +36,8 @@ class OGRSpatialReference;
 #include <geos/geom/Geometry.h>
 
 // Hoot
-#include <hoot/core/util/Units.h>
 #include <hoot/core/elements/ElementProvider.h>
+#include <hoot/core/util/Units.h>
 
 // Qt
 #include <QString>
@@ -47,6 +45,9 @@ class OGRSpatialReference;
 // Standard
 #include <memory>
 #include <vector>
+
+class OGRCoordinateTransformation;
+class OGRSpatialReference;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/elements/Node.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Node.cpp
@@ -31,13 +31,13 @@
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/Point.h>
-using namespace geos::geom;
 
 // Hoot
-#include <hoot/core/visitors/ConstElementVisitor.h>
 #include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/visitors/ConstElementVisitor.h>
 
+using namespace geos::geom;
 using namespace std;
 
 namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.cpp
@@ -50,12 +50,12 @@
 #include <hoot/core/util/StringUtils.h>
 #include <hoot/core/util/Validate.h>
 #include <hoot/core/visitors/ConstElementVisitor.h>
-using namespace hoot::elements;
 
 // Qt
 #include <QDebug>
 #include <QFileInfo>
 
+using namespace hoot::elements;
 using namespace std;
 
 namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.h
@@ -34,8 +34,8 @@
 #include <geos/geom/Envelope.h>
 
 // Hoot
+#include <hoot/core/elements/ElementIterator.h>
 #include <hoot/core/elements/ElementProvider.h>
-#include <hoot/core/visitors/ElementVisitor.h>
 #include <hoot/core/elements/Node.h>
 #include <hoot/core/elements/NodeMap.h>
 #include <hoot/core/elements/Relation.h>
@@ -44,9 +44,11 @@
 #include <hoot/core/elements/WayMap.h>
 #include <hoot/core/util/DefaultIdGenerator.h>
 #include <hoot/core/util/Units.h>
-#include <hoot/core/elements/ElementIterator.h>
+#include <hoot/core/visitors/ElementVisitor.h>
 
+// Standard
 #include <memory>
+#include <vector>
 
 namespace hoot
 {
@@ -55,9 +57,6 @@ namespace hoot
     class Tags;
   }
 }
-
-// Standard
-#include <vector>
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/elements/Way.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Way.cpp
@@ -40,10 +40,10 @@
 #include <geos/geom/LinearRing.h>
 #include <geos/geom/LineString.h>
 #include <geos/geom/Polygon.h>
-using namespace geos::geom;
 
 #include <tgs/StreamUtils.h>
 
+using namespace geos::geom;
 using namespace std;
 
 namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/geometry/CoordinateExt.h
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/CoordinateExt.h
@@ -29,21 +29,19 @@
 
 #include <geos/geom/Coordinate.h>
 
-using namespace geos::geom;
-
 namespace hoot
 {
 
 /*
  * Helper for 2D vector math with Coordinates
  */
-class CoordinateExt : public Coordinate
+class CoordinateExt : public geos::geom::Coordinate
 {
 public:
 
-  CoordinateExt(Coordinate c) : Coordinate(c) {}
+  CoordinateExt(geos::geom::Coordinate c) : geos::geom::Coordinate(c) { }
   CoordinateExt(double xNew = 0.0, double yNew = 0.0, double zNew = DoubleNotANumber)
-    : Coordinate( xNew, yNew, zNew ) {}
+    : Coordinate( xNew, yNew, zNew ) { }
 
   double length() const
   {

--- a/hoot-core/src/main/cpp/hoot/core/geometry/ElementToGeometryConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/ElementToGeometryConverter.h
@@ -28,27 +28,9 @@
 #ifndef ELEMENT_TO_GEOMETRY_CONVERTER_H
 #define ELEMENT_TO_GEOMETRY_CONVERTER_H
 
-// GDAL
-class OGRSpatialReference;
-
 // GEOS
 #include <geos/geom/Envelope.h>
 #include <geos/geom/Geometry.h>
-
-namespace geos
-{
-  namespace geom
-  {
-    class Geometry;
-    class GeometryCollection;
-    class LinearRing;
-    class LineString;
-    class MultiLineString;
-    class MultiPolygon;
-    class Point;
-    class Polygon;
-  }
-}
 
 // GDAL
 #include <ogr_geometry.h>
@@ -62,6 +44,15 @@ namespace geos
 
 // Standard
 #include <memory>
+
+namespace geos
+{
+  namespace geom
+  {
+    class LineString;
+    class Polygon;
+  }
+}
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/geometry/GeometryPainter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/GeometryPainter.cpp
@@ -31,7 +31,6 @@
 #include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/util/Exception.h>
-using namespace hoot::elements;
 
 // GDAL Includes
 #include <ogrsf_frmts.h>
@@ -39,6 +38,8 @@ using namespace hoot::elements;
 // Qt Includes
 #include <QPainter>
 #include <QPainterPath>
+
+using namespace hoot::elements;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/geometry/GeometryPainter.h
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/GeometryPainter.h
@@ -28,7 +28,13 @@
 #ifndef __GEOMETRY_PAINTER_H__
 #define __GEOMETRY_PAINTER_H__
 
-//OGR Includes
+// Qt Includes
+#include <QMatrix>
+class QPainter;
+class QPolygonF;
+class QRect;
+
+// OGR
 class OGREnvelope;
 class OGRGeometry;
 class OGRGeometryCollection;
@@ -37,12 +43,6 @@ class OGRLineString;
 class OGRPoint;
 class OGRPolygon;
 class OGRMultiPoint;
-
-// Qt Includes
-#include <QMatrix>
-class QPainter;
-class QPolygonF;
-class QRect;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/geometry/GeometryToElementConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/GeometryToElementConverter.h
@@ -28,6 +28,15 @@
 #ifndef GEOMETRY_TO_ELEMENT_CONVERTER_H
 #define GEOMETRY_TO_ELEMENT_CONVERTER_H
 
+// GDAL
+#include <ogr_geometry.h>
+
+// Hoot
+#include <hoot/core/elements/OsmMap.h>
+
+// Qt
+#include <QString>
+
 // GEOS
 #include <geos/geom/Envelope.h>
 
@@ -45,15 +54,6 @@ namespace geos
     class Point;
   }
 }
-
-// GDAL
-#include <ogr_geometry.h>
-
-// Hoot
-#include <hoot/core/elements/OsmMap.h>
-
-// Qt
-#include <QString>
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/geometry/GeometryUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/GeometryUtils.h
@@ -28,23 +28,6 @@
 #ifndef GEOMETRYUTILS_H
 #define GEOMETRYUTILS_H
 
-// GEOS
-#include <geos/geom/Envelope.h>
-#include <geos/geom/Polygon.h>
-
-namespace geos
-{
-  namespace geom
-  {
-    class Geometry;
-    class GeometryCollection;
-    class LinearRing;
-    class LineString;
-    class MultiLineString;
-    class MultiPolygon;
-  }
-}
-
 // GDAL
 #include <ogr_geometry.h>
 
@@ -53,6 +36,18 @@ namespace geos
 
 // Qt
 #include <QString>
+
+// GEOS
+#include <geos/geom/Envelope.h>
+#include <geos/geom/Polygon.h>
+
+namespace geos
+{
+  namespace geom
+  {
+    class GeometryCollection;
+  }
+}
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/info/ApiEntityInfo.h
+++ b/hoot-core/src/main/cpp/hoot/core/info/ApiEntityInfo.h
@@ -27,10 +27,10 @@
 #ifndef API_ENTITY_INFO_H
 #define API_ENTITY_INFO_H
 
+#include <QString>
+
 namespace hoot
 {
-
-#include <QString>
 
 /**
  * Interface to describe the functionality of various Hoot API entities.

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
@@ -33,7 +33,6 @@
 
 // GEOS
 #include <geos/geom/LineString.h>
-using namespace geos::geom;
 
 // Hoot
 #include <hoot/core/criterion/AreaCriterion.h>
@@ -58,6 +57,7 @@ using namespace geos::geom;
 #include <QFileInfo>
 #include <QDateTime>
 
+using namespace geos::geom;
 using namespace std;
 
 namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.h
@@ -29,14 +29,15 @@
 
 // GDAL
 #include <gdal.h>
-// Forward declaration
-class GDALDataset;
 
 // Qt
 #include <QString>
 #include <QSet>
 
 #include <vector>
+
+// Forward declaration
+class GDALDataset;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
@@ -28,20 +28,19 @@
 #include "OsmJsonReader.h"
 
 // hoot
+#include <hoot/core/geometry/GeometryUtils.h>
 #include <hoot/core/io/HootNetworkRequest.h>
+#include <hoot/core/io/IoUtils.h>
 #include <hoot/core/schema/MetadataTags.h>
 #include <hoot/core/util/Factory.h>
-#include <hoot/core/geometry/GeometryUtils.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/StringUtils.h>
-#include <hoot/core/io/IoUtils.h>
 #include <hoot/core/visitors/RemoveMissingElementsVisitor.h>
 
 // Boost
 #include <boost/foreach.hpp>
 #include <boost/property_tree/json_parser.hpp>
-namespace pt = boost::property_tree;
 
 // Qt
 #include <QTextCodec>
@@ -54,6 +53,8 @@ namespace pt = boost::property_tree;
 #include <sstream>
 #include <thread>
 #include <unistd.h>
+
+namespace pt = boost::property_tree;
 using namespace std;
 
 namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonWriter.h
@@ -38,11 +38,11 @@
 #include <QHash>
 #include <QString>
 #include <QXmlDefaultHandler>
-class QXmlStreamWriter;
 
 // Standard
 #include <deque>
 
+class QXmlStreamWriter;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.cpp
@@ -36,14 +36,12 @@
 #include <hoot/core/io/PbfConstants.h>
 #include <hoot/core/proto/FileFormat.pb.h>
 #include <hoot/core/proto/OsmFormat.pb.h>
+#include <hoot/core/schema/MetadataTags.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/schema/MetadataTags.h>
 #include <hoot/core/visitors/ReportMissingElementsVisitor.h>
-
-using namespace hoot::pb;
 
 // Standard Includes
 #include <fstream>
@@ -62,6 +60,7 @@ using namespace hoot::pb;
 #include <zlib.h>
 
 using namespace geos::geom;
+using namespace hoot::pb;
 using namespace std;
 
 namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.h
@@ -28,9 +28,6 @@
 #ifndef OSMPBFREADER_H
 #define OSMPBFREADER_H
 
-// GDAL
-class OGRSpatialReference;
-
 // Qt
 #include <QHash>
 #include <QString>
@@ -46,6 +43,9 @@ class OGRSpatialReference;
 
 // tgs
 #include <tgs/BigContainers/BigMap.h>
+
+// GDAL
+class OGRSpatialReference;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfWriter.cpp
@@ -32,17 +32,15 @@
 #include <hoot/core/io/PbfConstants.h>
 #include <hoot/core/proto/FileFormat.pb.h>
 #include <hoot/core/proto/OsmFormat.pb.h>
+#include <hoot/core/schema/MetadataTags.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/schema/MetadataTags.h>
 #include <hoot/core/visitors/CalculateMapBoundsVisitor.h>
 
 //  Version must be included last
 #include <hoot/core/info/Version.h>
 #include <hoot/core/info/VersionDefines.h>
-
-using namespace hoot::pb;
 
 // Qt
 #include <qendian.h>
@@ -57,6 +55,7 @@ using namespace hoot::pb;
 #include <arpa/inet.h>
 
 using namespace geos::geom;
+using namespace hoot::pb;
 using namespace std;
 
 namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.h
@@ -36,13 +36,14 @@
 #include <QHash>
 #include <QString>
 #include <QXmlDefaultHandler>
-class QXmlStreamWriter;
 
 // Standard
 #include <deque>
 
 // geos
 #include <geos/geom/Envelope.h>
+
+class QXmlStreamWriter;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/io/ShapefileWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ShapefileWriter.cpp
@@ -33,7 +33,6 @@
 // GEOS
 #include <geos/geom/LineString.h>
 #include <geos/geom/Polygon.h>
-using namespace geos::geom;
 
 // Hoot
 #include <hoot/core/criterion/AreaCriterion.h>
@@ -53,6 +52,8 @@ using namespace geos::geom;
 #include <QFileInfo>
 #include <QHash>
 #include <QMap>
+
+using namespace geos::geom;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
@@ -66,7 +66,6 @@
 // Standard
 #include <iostream>
 #include <fstream>
-using namespace std;
 
 // TGS
 #include <tgs/HashMap.h>
@@ -74,6 +73,8 @@ using namespace std;
 #ifdef BOOST_GRAPH_NO_BUNDLED_PROPERTIES
 #error Bundle support is required.
 #endif
+
+using namespace std;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/scoring/BaseComparator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/BaseComparator.cpp
@@ -32,14 +32,13 @@
 #include <geos/geom/Point.h>
 #include <geos/geom/GeometryFactory.h>
 #include <geos/operation/distance/DistanceOp.h>
-using namespace geos::operation::distance;
 
 // Hoot
-#include <hoot/core/geometry/GeometryPainter.h>
 #include <hoot/core/elements/MapProjector.h>
 #include <hoot/core/elements/OsmMap.h>
-#include <hoot/core/index/OsmMapIndex.h>
 #include <hoot/core/geometry/ElementToGeometryConverter.h>
+#include <hoot/core/geometry/GeometryPainter.h>
+#include <hoot/core/index/OsmMapIndex.h>
 #include <hoot/core/util/OpenCv.h>
 #include <hoot/core/visitors/CalculateMapBoundsVisitor.h>
 
@@ -49,6 +48,7 @@ using namespace geos::operation::distance;
 #include <QPainter>
 
 using namespace geos::geom;
+using namespace geos::operation::distance;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/scoring/GraphComparator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/GraphComparator.cpp
@@ -33,7 +33,6 @@
 #include <geos/geom/LineString.h>
 #include <geos/geom/Point.h>
 #include <geos/operation/distance/DistanceOp.h>
-using namespace geos::operation::distance;
 
 // Hoot
 #include <hoot/core/algorithms/linearreference/LocationOfPoint.h>
@@ -60,6 +59,7 @@ using namespace geos::operation::distance;
 #include <tgs/ProbablePath/ProbablePathCalculator.h>
 
 using namespace geos::geom;
+using namespace geos::operation::distance;
 using namespace std;
 using namespace Tgs;
 

--- a/hoot-core/src/main/cpp/hoot/core/util/Progress.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/Progress.cpp
@@ -29,7 +29,6 @@
 
 // std
 #include <iostream>
-using namespace std;
 
 // Qt
 #include <QtCore/QStringBuilder>
@@ -38,6 +37,8 @@ using namespace std;
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
+
+using namespace std;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/util/Settings.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/Settings.cpp
@@ -43,7 +43,6 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/foreach.hpp>
-namespace pt = boost::property_tree;
 
 // Qt
 #include <QStringList>
@@ -53,7 +52,10 @@ namespace pt = boost::property_tree;
 #include <iostream>
 #include <sstream>
 #include <unistd.h>
+
 using namespace std;
+
+namespace pt = boost::property_tree;
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/visitors/geometrymodifiers/PolyClusterGeoModifierAction.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/geometrymodifiers/PolyClusterGeoModifierAction.cpp
@@ -29,13 +29,13 @@
 
 // Hoot
 #include <hoot/core/algorithms/alpha-shape/AlphaShape.h>
+#include <hoot/core/geometry/CoordinateExt.h>
 #include <hoot/core/geometry/ElementToGeometryConverter.h>
+#include <hoot/core/geometry/GeometryToElementConverter.h>
 #include <hoot/core/index/OsmMapIndex.h>
 #include <hoot/core/ops/RemoveNodeByEid.h>
 #include <hoot/core/ops/RemoveWayByEid.h>
 #include <hoot/core/util/Factory.h>
-#include <hoot/core/geometry/CoordinateExt.h>
-#include <hoot/core/geometry/GeometryToElementConverter.h>
 #include <hoot/core/visitors/WorstCircularErrorVisitor.h>
 
 // Geos

--- a/hoot-core/src/main/cpp/hoot/core/visitors/geometrymodifiers/PolyClusterGeoModifierAction.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/geometrymodifiers/PolyClusterGeoModifierAction.h
@@ -108,7 +108,7 @@ private:
   QList<QList<long>> _clusters;
   QList<long> _processedPolys;
   QHash<long, CoordinateExt> _coordinateByNodeIx;
-  QHash<long, std::shared_ptr<Polygon>> _polyByWayId;
+  QHash<long, std::shared_ptr<geos::geom::Polygon>> _polyByWayId;
   std::shared_ptr<ClosePointHash> _pClosePointHash;
   QHash<QString,QString> _clusterTags;
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/geometrymodifiers/WayToPolyGeoModifierAction.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/geometrymodifiers/WayToPolyGeoModifierAction.cpp
@@ -33,6 +33,7 @@
 
 #include <math.h>
 
+using namespace geos::geom;
 using namespace std;
 
 namespace hoot

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryReviewCommand.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryReviewCommand.cpp
@@ -39,10 +39,10 @@
 // Boost
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/foreach.hpp>
-namespace pt = boost::property_tree;
-
 
 #include <QCryptographicHash>
+
+namespace pt = boost::property_tree;
 
 namespace hoot
 {

--- a/hoot-rnd/src/main/cpp/hoot/rnd/io/MultiaryIngestChangesetWriter.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/io/MultiaryIngestChangesetWriter.cpp
@@ -29,19 +29,19 @@
 // geos
 #include <geos/geom/Envelope.h>
 
-using namespace geos::geom;
-
 // hoot
 #include <hoot/core/conflate/matching/MatchFactory.h>
+#include <hoot/core/io/OsmXmlWriter.h>
+#include <hoot/core/schema/MetadataTags.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Exception.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/schema/MetadataTags.h>
-#include <hoot/core/io/OsmXmlWriter.h>
 
 // Qt
 #include <QStringBuilder>
+
+using namespace geos::geom;
 
 namespace hoot
 {

--- a/hoot-rnd/src/main/cpp/hoot/rnd/io/SparkChangesetWriter.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/io/SparkChangesetWriter.cpp
@@ -29,20 +29,20 @@
 // geos
 #include <geos/geom/Envelope.h>
 
-using namespace geos::geom;
-
 // hoot
 #include <hoot/core/conflate/matching/MatchFactory.h>
+#include <hoot/core/schema/MetadataTags.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Exception.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Log.h>
-#include <hoot/core/schema/MetadataTags.h>
 #include <hoot/rnd/conflate/multiary/MultiaryUtilities.h>
 
 // Qt
 #include <QStringBuilder>
 #include <QFileInfo>
+
+using namespace geos::geom;
 
 namespace hoot
 {

--- a/hoot-rnd/src/main/cpp/hoot/rnd/io/SparkJsonWriter.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/io/SparkJsonWriter.cpp
@@ -29,8 +29,6 @@
 // geos
 #include <geos/geom/Envelope.h>
 
-using namespace geos::geom;
-
 // hoot
 #include <hoot/core/conflate/matching/MatchFactory.h>
 #include <hoot/core/io/OsmJsonWriter.h>
@@ -42,6 +40,8 @@ using namespace geos::geom;
 
 // Qt
 #include <QStringBuilder>
+
+using namespace geos::geom;
 
 namespace hoot
 {

--- a/tbs/src/main/cpp/tbs/stats/TDistribution.cpp
+++ b/tbs/src/main/cpp/tbs/stats/TDistribution.cpp
@@ -34,12 +34,12 @@
 // Standard
 #include <iostream>
 #include <math.h>
-using namespace std;
 
 // tbs
 #include <tbs/optimization/GoldenSectionSearch.h>
 
 using namespace cv;
+using namespace std;
 
 namespace tbs
 {

--- a/tgs/src/main/cpp/tgs/DelaunayTriangulation/DelaunayTriangulation.cpp
+++ b/tgs/src/main/cpp/tgs/DelaunayTriangulation/DelaunayTriangulation.cpp
@@ -30,11 +30,12 @@
 // Standard
 #include <algorithm>
 #include <sstream>
-using namespace std;
 
 // Tgs
 #include <tgs/HashMap.h>
 #include <tgs/TgsException.h>
+
+using namespace std;
 
 namespace Tgs
 {

--- a/tgs/src/main/cpp/tgs/Interpolation/Interpolator.h
+++ b/tgs/src/main/cpp/tgs/Interpolation/Interpolator.h
@@ -27,14 +27,14 @@
 #ifndef INTERPOLATOR_H
 #define INTERPOLATOR_H
 
-// Qt
-class QIODevice;
-
 // Standard
 #include <vector>
 
 // Tgs
 #include <tgs/RandomForest/DataFrame.h>
+
+// Qt
+class QIODevice;
 
 namespace Tgs
 {

--- a/tgs/src/main/cpp/tgs/RStarTree/HilbertRTree.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/HilbertRTree.cpp
@@ -33,7 +33,6 @@
 #include <cmath>
 #include <exception>
 #include <iostream>
-using namespace std;
 
 // Tgs
 #include <tgs/RStarTree/HilbertCurve.h>
@@ -41,6 +40,7 @@ using namespace std;
 #include <tgs/RStarTree/RTreeNode.h>
 #include <tgs/Statistics/Random.h>
 
+using namespace std;
 using namespace Tgs;
 
 HilbertRTree::HilbertRTree(const std::shared_ptr<PageStore>& ps, int dimensions) :

--- a/tgs/src/main/cpp/tgs/RStarTree/RStarTree.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/RStarTree.cpp
@@ -33,13 +33,13 @@
 #include <cmath>
 #include <exception>
 #include <iostream>
-using namespace std;
 
 #include <tgs/StreamUtils.h>
 #include <tgs/TgsException.h>
 #include <tgs/RStarTree/PageStore.h>
 #include <tgs/RStarTree/RTreeNode.h>
 
+using namespace std;
 using namespace Tgs;
 
 RStarTree::RStarTree(const std::shared_ptr<PageStore>& ps, int dimensions)

--- a/tgs/src/main/cpp/tgs/RStarTree/RTreeNode.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/RTreeNode.cpp
@@ -31,11 +31,11 @@
 #include <algorithm>
 #include <assert.h>
 #include <math.h>
-using namespace std;
 
 #include <tgs/TgsException.h>
 #include <tgs/RStarTree/RTreeNodeStore.h>
 
+using namespace std;
 using namespace Tgs;
 
 BoxInternalData::BoxInternalData(int dimensions, const char* data)

--- a/tgs/src/main/cpp/tgs/RandomForest/DataFrame.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/DataFrame.cpp
@@ -42,11 +42,12 @@
 #include <limits>
 #include <sstream>
 #include <stdexcept>
-using namespace std;
 
 // Tgs
 #include <tgs/TgsException.h>
 #include <tgs/Statistics/Random.h>
+
+using namespace std;
 
 namespace Tgs
 {

--- a/tgs/src/main/cpp/tgs/RasterOps/MaxChannelCombiner.cpp
+++ b/tgs/src/main/cpp/tgs/RasterOps/MaxChannelCombiner.cpp
@@ -27,10 +27,9 @@
 
 #include "MaxChannelCombiner.h"
 
-// Standard Includes
-using namespace std;
-
 #include <tgs/TgsException.h>
+
+using namespace std;
 
 namespace Tgs
 {

--- a/tgs/src/main/cpp/tgs/StreamUtils.h
+++ b/tgs/src/main/cpp/tgs/StreamUtils.h
@@ -37,14 +37,6 @@
 #include <typeinfo>
 #include <vector>
 
-#if HAVE_LIBNEWMAT
-// newmat
-namespace NEWMAT
-{
-  class Matrix;
-}
-#endif
-
 #include <tgs/HashMap.h>
 #include <tgs/TgsException.h>
 #include <tgs/TgsExport.h>
@@ -58,6 +50,14 @@ namespace NEWMAT
 # include <QVector>
 #endif
 
+#if HAVE_LIBNEWMAT
+// newmat
+namespace NEWMAT
+{
+  class Matrix;
+}
+#endif
+
 namespace Tgs
 {
 #if HAVE_LIBNEWMAT
@@ -67,6 +67,5 @@ namespace Tgs
 #include <tgs/StreamUtils.hh>
 
 }
-
 
 #endif


### PR DESCRIPTION
Move all precompliler directives before any code