### PR TITLE
SONAR: Static members should be accessed statically

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/LocationOfPoint.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/LocationOfPoint.cpp
@@ -110,7 +110,7 @@ WayLocation LocationOfPoint::locate(const ConstOsmMapPtr& map, ConstWayPtr way,
 
 WayLocation LocationOfPoint::locate(const Coordinate& inputPt) const
 {
-  double minDistance = std::numeric_limits<double>().max();
+  double minDistance = std::numeric_limits<double>::max();
   int minIndex = 0;
   double minFrac = -1.0;
 
@@ -161,7 +161,7 @@ WayLocation LocationOfPoint::locateAfter(const Coordinate& inputPt, const WayLoc
 
   assert(minLocation.getWay() == _way);
 
-  double minDistance = std::numeric_limits<double>().max();
+  double minDistance = std::numeric_limits<double>::max();
   WayLocation nextClosestLocation = minLocation;
 
   LineSegment seg;

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayString.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayString.cpp
@@ -220,8 +220,7 @@ WayPtr WayString::copySimplifiedWayIntoMap(const ElementProvider& map, OsmMapPtr
     ConstWayPtr oldWay = subline.getWay();
     newWay->setPid(Way::getPid(newWay, oldWay));
 
-    newTags =
-      TagMergerFactory::getInstance().mergeTags(newTags, oldWay->getTags(), ElementType::Way);
+    newTags = TagMergerFactory::mergeTags(newTags, oldWay->getTags(), ElementType::Way);
 
     // Figure out which node is the first node. If we're between nodes, then create a new node to
     // add.

--- a/hoot-core/src/main/cpp/hoot/core/cmd/CompareCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/CompareCmd.cpp
@@ -143,7 +143,7 @@ public:
     OsmMapPtr result(new OsmMap());
     IoUtils::loadMap(result, p, false);
 
-    SuperfluousWayRemover().removeWays(result);
+    SuperfluousWayRemover::removeWays(result);
     // drop everything that isn't a highway.
     KeepHighwaysVisitor keepHighways;
     result->visitRw(keepHighways);

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ConvertCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ConvertCmd.cpp
@@ -81,7 +81,7 @@ public:
     {
       throw IllegalArgumentException(
         "When using " + MapCropper::className() + " with the convert command, the " +
-        configOpts.getCropBoundsKey() + " option must be specified.");
+        ConfigOptions::getCropBoundsKey() + " option must be specified.");
     }
 
     QStringList inputs;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressParser.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressParser.cpp
@@ -500,7 +500,7 @@ QString AddressParser::_parseAddressFromAltTags(const Tags& tags, QString& house
     }
   }
 
-  additionalTagKeys = QSet<QString>::fromList(tags.getNameKeys());
+  additionalTagKeys = QSet<QString>::fromList(Tags::getNameKeys());
   LOG_VART(additionalTagKeys);
   for (QSet<QString>::const_iterator tagItr = additionalTagKeys.begin();
        tagItr != additionalTagKeys.end(); ++tagItr)

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMerger.cpp
@@ -796,9 +796,9 @@ void BuildingMerger::mergeBuildings(OsmMapPtr map, const ElementId& mergeTargetI
   //child nodes, we want to override the default behavior and make sure the building merger always
   //arbitrarily keeps the geometry of the first building passed in.  This is ok, b/c the UI workflow
   //lets the user select which building to keep and using complexity wouldn't make sense.
-  LOG_VART(ConfigOptions().getBuildingKeepMoreComplexGeometryWhenAutoMergingKey());
+  LOG_VART(ConfigOptions::getBuildingKeepMoreComplexGeometryWhenAutoMergingKey());
   conf().set(
-    ConfigOptions().getBuildingKeepMoreComplexGeometryWhenAutoMergingKey(), "false");
+    ConfigOptions::getBuildingKeepMoreComplexGeometryWhenAutoMergingKey(), "false");
   LOG_VART(ConfigOptions().getBuildingKeepMoreComplexGeometryWhenAutoMerging());
 
   // See related note about statuses in PoiPolygonMerger::mergePoiAndPolygon. Don't know how to

--- a/hoot-core/src/main/cpp/hoot/core/criterion/AreaCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/AreaCriterion.cpp
@@ -67,7 +67,7 @@ bool AreaCriterion::isSatisfied(const Tags& tags, const ElementType& elementType
   // this to be an area feature.
   for (Tags::const_iterator it = tags.constBegin(); it != tags.constEnd(); ++it)
   {
-    const QString kvp = OsmSchema::getInstance().toKvp(it.key(), it.value());
+    const QString kvp = OsmSchema::toKvp(it.key(), it.value());
     const SchemaVertex& tv = OsmSchema::getInstance().getTagVertex(kvp);
     uint16_t g = tv.geometries;
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NeedsReviewCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NeedsReviewCriterion.cpp
@@ -27,6 +27,7 @@
 #include "NeedsReviewCriterion.h"
 
 // Hoot
+#include <hoot/core/conflate/review/ReviewMarker.h>
 #include <hoot/core/elements/Element.h>
 #include <hoot/core/util/Factory.h>
 
@@ -37,7 +38,7 @@ HOOT_FACTORY_REGISTER(ElementCriterion, NeedsReviewCriterion)
 
 bool NeedsReviewCriterion::isSatisfied(const ConstElementPtr& e) const
 {
-  return _reviewMarker.isNeedsReview(_map, e);
+  return ReviewMarker::isNeedsReview(_map, e);
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NeedsReviewCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NeedsReviewCriterion.h
@@ -28,10 +28,9 @@
 #define NEEDSREVIEWCRITERION_H
 
 // Hoot
-#include <hoot/core/elements/OsmMap.h>
-#include <hoot/core/elements/ConstOsmMapConsumer.h>
-#include <hoot/core/conflate/review/ReviewMarker.h>
 #include <hoot/core/criterion/ElementCriterion.h>
+#include <hoot/core/elements/ConstOsmMapConsumer.h>
+#include <hoot/core/elements/OsmMap.h>
 
 namespace hoot
 {
@@ -65,7 +64,6 @@ public:
 private:
 
   ConstOsmMapPtr _map;
-  ReviewMarker _reviewMarker;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
@@ -991,7 +991,7 @@ long HootApiDb::getOrCreateUser(QString email, QString displayName, bool admin)
       {
         _setUserAsAdmin.reset(new QSqlQuery(_db));
         _setUserAsAdmin->prepare(
-          "UPDATE " + this->getUsersTableName() +
+          "UPDATE " + getUsersTableName() +
           " SET privileges = privileges || '\"admin\"=>\"true\"' :: hstore"
           " WHERE id=:id;");
       }

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
@@ -903,7 +903,7 @@ std::shared_ptr<Envelope> OgrReaderInternal::getBoundingBoxFromConfig(
     if (bbox.size() != 4)
     {
       throw HootException(
-        QString("Error parsing %1 (%2)").arg(co.getBoundsKey()).arg(bboxStr));
+        QString("Error parsing %1 (%2)").arg(ConfigOptions::getBoundsKey()).arg(bboxStr));
     }
 
     bool ok;
@@ -914,7 +914,7 @@ std::shared_ptr<Envelope> OgrReaderInternal::getBoundingBoxFromConfig(
       if (!ok)
       {
         throw HootException(
-          QString("Error parsing %1 (%2)").arg(co.getBoundsKey()).arg(bboxStr));
+          QString("Error parsing %1 (%2)").arg(ConfigOptions::getBoundsKey()).arg(bboxStr));
       }
     }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbBulkInserter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbBulkInserter.cpp
@@ -1405,7 +1405,8 @@ void OsmApiDbBulkInserter::_writeChangeset()
   if (!_outputSections[ApiDb::getChangesetsTableName()])
   {
     _createOutputFile(
-      ApiDb::getChangesetsTableName(), _sqlFormatter->getChangesetSqlHeaderString());
+      ApiDb::getChangesetsTableName(),
+      OsmApiDbSqlStatementFormatter::getChangesetSqlHeaderString());
   }
 
   _outputSections[ApiDb::getChangesetsTableName()]->write(

--- a/hoot-core/src/main/cpp/hoot/core/ops/DuplicateWayRemover.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/DuplicateWayRemover.cpp
@@ -199,7 +199,7 @@ void DuplicateWayRemover::_splitDuplicateWays(WayPtr w1, WayPtr w2, bool rev1, b
   if (length > 1)
   {
     const Tags mergedTags =
-      TagMergerFactory::getInstance().mergeTags(w1->getTags(), w2->getTags(), ElementType::Way);
+      TagMergerFactory::mergeTags(w1->getTags(), w2->getTags(), ElementType::Way);
     const vector<long>& nodes1 = w1->getNodeIds();
     const vector<long>& nodes2 = w2->getNodeIds();
     // _splitDuplicateWays is always called where num_nodes(w1) >= num_nodes(w2), so the following

--- a/hoot-core/src/main/cpp/hoot/core/ops/OffsetIntersectionMergerOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/OffsetIntersectionMergerOp.cpp
@@ -60,7 +60,7 @@ namespace hoot
 HOOT_FACTORY_REGISTER(OsmMapOperation, OffsetIntersectionMergerOp)
 
 OffsetIntersectionMergerOp::OffsetIntersectionMergerOp()
-  : _offsetMax(ConfigOptions().getOffsetIntersectionMaxDefaultValue())
+  : _offsetMax(ConfigOptions().getOffsetIntersectionMax())
 {
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/RemoveReviewsByEidOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/RemoveReviewsByEidOp.cpp
@@ -78,7 +78,7 @@ void RemoveReviewsByEidOp::apply(const OsmMapPtr &map)
 
   LOG_TRACE("Removing reviews for " << _eid << " from map...");
   ElementPtr from = map->getElement(_eid);
-  set<ReviewMarker::ReviewUid> reviews = ReviewMarker().getReviewUids(map, from);
+  set<ReviewMarker::ReviewUid> reviews = ReviewMarker::getReviewUids(map, from);
   for (set<ReviewMarker::ReviewUid>::const_iterator it = reviews.begin(); it != reviews.end();
     ++it)
   {

--- a/hoot-core/src/main/cpp/hoot/core/schema/AttributeCoOccurrence.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/AttributeCoOccurrence.cpp
@@ -136,14 +136,14 @@ public:
             for (Tags::const_iterator tag1 = e->getTags().begin(); tag1 != e->getTags().end();
                  ++tag1)
             {
-              QString kvp1 = OsmSchema::getInstance().toKvp(tag1.key(),tag1.value());
+              QString kvp1 = OsmSchema::toKvp(tag1.key(),tag1.value());
 
               // We are only looking at Enumerated tags
               if (OsmSchema::getInstance().getTagVertex(kvp1).valueType == hoot::Enumeration)
               {
                 // Get the value from the corresponding tag in REF2
                 QString kvp2 =
-                  OsmSchema::getInstance().toKvp(
+                  OsmSchema::toKvp(
                     tag1.key(), _map->getElement(*eid)->getTags()[tag1.key()]);
 
                 // LOG_INFO("Got Tags:" + kvp1 + " " + kvp2);
@@ -155,7 +155,7 @@ public:
             for (Tags::const_iterator tag2 = _map->getElement(*eid)->getTags().begin();
                  tag2 != _map->getElement(*eid)->getTags().end(); ++tag2 )
             {
-              QString kvp2 = OsmSchema::getInstance().toKvp(tag2.key(),tag2.value());
+              QString kvp2 = OsmSchema::toKvp(tag2.key(),tag2.value());
 
               // Skip the tags that are common
               if (e->getTags().contains(tag2.key())) continue;
@@ -163,7 +163,7 @@ public:
               if (OsmSchema::getInstance().getTagVertex(kvp2).valueType == hoot::Enumeration)
               {
                 // "Missing" == "" tag value
-                QString kvp1 = OsmSchema::getInstance().toKvp(tag2.key(),"");
+                QString kvp1 = OsmSchema::toKvp(tag2.key(),"");
 
                 // LOG_INFO("Got Tags:" + kvp1 + " " + kvp2);
                 _coOccurrence[kvp1][kvp2]++;

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagComparator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagComparator.cpp
@@ -209,7 +209,7 @@ void TagComparator::compareEnumeratedTags(Tags t1, Tags t2, double& score,
     {
       if (tv->value == "*")
       {
-        n1.push_back(schema.toKvp(tv->key, t1[tv->key]));
+        n1.push_back(OsmSchema::toKvp(tv->key, t1[tv->key]));
       }
       else
       {
@@ -225,7 +225,7 @@ void TagComparator::compareEnumeratedTags(Tags t1, Tags t2, double& score,
     {
       if (tv->value == "*")
       {
-        n2.push_back(schema.toKvp(tv->key, t2[tv->key]));
+        n2.push_back(OsmSchema::toKvp(tv->key, t2[tv->key]));
       }
       else
       {

--- a/hoot-core/src/main/cpp/hoot/core/scoring/GraphComparator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/GraphComparator.cpp
@@ -388,14 +388,13 @@ void GraphComparator::_exportGraphImage(OsmMapPtr map, DirectedGraph& /*graph*/,
   pt.setRenderHint(QPainter::Antialiasing, true);
   pt.fillRect(pt.viewport(), Qt::black);
 
-  GeometryPainter gp;
-  QMatrix m = gp.createMatrix(pt.viewport(), _projectedBounds);
+  QMatrix m = GeometryPainter::createMatrix(pt.viewport(), _projectedBounds);
 
   QPen pen(Qt::white);
 
   pen.setWidth(7);
   pt.setPen(pen);
-  gp.drawPoint(pt, coord.x, coord.y, m);
+  GeometryPainter::drawPoint(pt, coord.x, coord.y, m);
 
   pen.setWidth(3);
   QColor c;
@@ -423,7 +422,7 @@ void GraphComparator::_exportGraphImage(OsmMapPtr map, DirectedGraph& /*graph*/,
 
     pen.setColor(c);
     pt.setPen(pen);
-    gp.drawNode(pt, it->second.get(), m);
+    GeometryPainter::drawNode(pt, it->second.get(), m);
   }
 
   image.save(path);

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MatchComparator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MatchComparator.cpp
@@ -648,7 +648,7 @@ bool MatchComparator::_isNeedsReview(const QString& uuid1, const QString& uuid2,
         return false;
       }
 
-      if (_reviewMarker.isNeedsReview(conflated, conflated->getElement(eid1),
+      if (ReviewMarker::isNeedsReview(conflated, conflated->getElement(eid1),
                                       conflated->getElement(eid2)))
       {
         result = true;

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MatchComparator.h
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MatchComparator.h
@@ -145,8 +145,6 @@ private:
 
   QMap<ElementType::Type, long> _elementWrongCounts;
 
-  ReviewMarker _reviewMarker;
-
   int _statusUpdateInterval;
 
   void _addWrong(const Tags& t1, const Tags& t2);

--- a/hoot-core/src/main/cpp/hoot/core/scoring/RasterComparator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/RasterComparator.cpp
@@ -54,8 +54,8 @@ class PaintVisitor : public ConstElementVisitor
 {
 public:
 
-  PaintVisitor(OsmMapPtr map, GeometryPainter& gp, QPainter& pt, QMatrix& m) :
-    _map(map), _gp(gp), _pt(pt), _m(m) { }
+  PaintVisitor(OsmMapPtr map, QPainter& pt, QMatrix& m) :
+    _map(map), _pt(pt), _m(m) { }
   virtual ~PaintVisitor() = default;
 
   virtual void visit(const ConstElementPtr& e)
@@ -64,7 +64,7 @@ public:
 
     for (size_t i = 0; i < ways.size(); i++)
     {
-      _gp.drawWay(_pt, _map.get(), ways[i].get(), _m);
+      GeometryPainter::drawWay(_pt, _map.get(), ways[i].get(), _m);
     }
   }
 
@@ -75,7 +75,6 @@ public:
 private:
 
   OsmMapPtr _map;
-  GeometryPainter& _gp;
   QPainter& _pt;
   QMatrix& _m;
 };
@@ -159,10 +158,9 @@ void RasterComparator::_renderImage(const std::shared_ptr<OsmMap>& map, cv::Mat&
   pen.setColor(qRgb(1, 0, 0));
   pt.setPen(pen);
 
-  GeometryPainter gp;
-  QMatrix m = gp.createMatrix(pt.viewport(), _projectedBounds);
+  QMatrix m = GeometryPainter::createMatrix(pt.viewport(), _projectedBounds);
 
-  PaintVisitor pv(map, gp, pt, m);
+  PaintVisitor pv(map, pt, m);
   HighwayCriterion crit(map);
   FilteredVisitor v(crit, pv);
   map->visitRo(v);

--- a/hoot-core/src/main/cpp/hoot/core/visitors/CountUniqueReviewsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/CountUniqueReviewsVisitor.cpp
@@ -26,8 +26,8 @@
  */
 #include "CountUniqueReviewsVisitor.h"
 
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/util/Factory.h>
 
 using namespace std;
 
@@ -39,7 +39,7 @@ HOOT_FACTORY_REGISTER(ElementVisitor, CountUniqueReviewsVisitor)
 void CountUniqueReviewsVisitor::visit(const ConstElementPtr& e)
 {
   set<ReviewMarker::ReviewUid> reviews =
-    _reviewMarker.getReviewUids(_map->shared_from_this(), e);
+    ReviewMarker::getReviewUids(_map->shared_from_this(), e);
   _reviews.insert(reviews.begin(), reviews.end());
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/CountUniqueReviewsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/CountUniqueReviewsVisitor.h
@@ -28,9 +28,9 @@
 #define COUNTUNIQUEREVIEWSVISITOR_H
 
 // hoot
-#include <hoot/core/visitors/ElementConstOsmMapVisitor.h>
 #include <hoot/core/conflate/review/ReviewMarker.h>
 #include <hoot/core/info/SingleStatistic.h>
+#include <hoot/core/visitors/ElementConstOsmMapVisitor.h>
 
 namespace hoot
 {
@@ -65,7 +65,6 @@ public:
 private:
 
   std::set<ReviewMarker::ReviewUid> _reviews;
-  ReviewMarker _reviewMarker;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidMultilineStringMembersVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidMultilineStringMembersVisitor.cpp
@@ -151,14 +151,13 @@ void RemoveInvalidMultilineStringMembersVisitor::visit(const ElementPtr& e)
 
       // Copy tags from the multiline string tags to the children and remove from relation
       vector<RelationData::Entry> members = r->getMembers();
-      TagMergerFactory& merger = TagMergerFactory::getInstance();
       for (vector<RelationData::Entry>::iterator i = members.begin(); i != members.end(); i++)
       {
         ElementId id = i->getElementId();
         ElementPtr element = _map->getElement(id);
         if (element)
         {
-          Tags merged = merger.mergeTags(element->getTags(), tags, id.getType());
+          Tags merged = TagMergerFactory::mergeTags(element->getTags(), tags, id.getType());
           element->setTags(merged);
         }
         LOG_TRACE("Removing: " << id << "...");

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidRelationVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveInvalidRelationVisitor.cpp
@@ -77,7 +77,7 @@ void RemoveInvalidRelationVisitor::visit(const ElementPtr& e)
           //  Merge the relation tags back on to the single way before deleting the relation
           ElementPtr element = _map->getElement(members[0].getElementId());
           Tags merged =
-            TagMergerFactory::getInstance().mergeTags(
+            TagMergerFactory::mergeTags(
               element->getTags(), r->getTags(), ElementType::Relation);
           element->setTags(merged);
         }

--- a/hoot-core/src/main/cpp/hoot/core/visitors/SchemaTranslationVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/SchemaTranslationVisitor.cpp
@@ -61,7 +61,7 @@ void SchemaTranslationVisitor::setConfiguration(const Settings& conf)
 
   LOG_VARD(conf.hasKey(c.getSchemaTranslationScriptKey()));
   LOG_VARD(c.getSchemaTranslationScript());
-  if (conf.hasKey(c.getSchemaTranslationScriptKey()) && c.getSchemaTranslationScript() != "")
+  if (conf.hasKey(ConfigOptions::getSchemaTranslationScriptKey()) && c.getSchemaTranslationScript() != "")
   {
     setTranslationDirection(c.getSchemaTranslationDirection());
     setTranslationScript(c.getSchemaTranslationScript());

--- a/hoot-rnd/src/main/cpp/hoot/rnd/cmd/WriteNameCountsCmd.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/cmd/WriteNameCountsCmd.cpp
@@ -77,7 +77,7 @@ public:
     }
 
     // adding the source datetime just makes things really slow.
-    conf().set(ConfigOptions().getReaderAddSourceDatetimeKey(), false);
+    conf().set(ConfigOptions::getReaderAddSourceDatetimeKey(), false);
 
     const QStringList inputs = args[0].split(";");
     const QString output = args[1];

--- a/hoot-rnd/src/main/cpp/hoot/rnd/scoring/multiary/MultiaryMatchComparator.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/scoring/multiary/MultiaryMatchComparator.cpp
@@ -147,7 +147,7 @@ void MultiaryMatchComparator::_calculateNodeBasedStats(const ConstOsmMapPtr& con
       {
         std::vector<ScriptToOgrSchemaTranslator::TranslatedFeature> translated =
             translator->translateToOgr(tags, e->getElementType(),
-              ec.getGeometryType(e, false));
+              ElementToGeometryConverter::getGeometryType(e, false));
 
         bool foundCategory = false;
         foreach (const ScriptToOgrSchemaTranslator::TranslatedFeature& tf, translated)


### PR DESCRIPTION
Update static function calls using class name instead of class instance.