### PR TITLE
Fix HighwayCornerSplitter to use the config file and not just the default values

### DIFF
--- a/conf/core/AttributeConflation.conf
+++ b/conf/core/AttributeConflation.conf
@@ -9,7 +9,6 @@
   "conflate.use.data.source.ids.2": "true",
   "duplicate.name.preserve.original.name": "true",
   "geometry.linear.merger.default": "hoot::LinearTagOnlyMerger",
-  "highway.corner.splitter.rounded.split": "true",
   "hootapi.db.writer.preserve.version.on.insert": "true",
   "poi.polygon.allow.cross.conflation.merging": "true",
   "poi.polygon.auto.merge.many.poi.to.one.poly.matches": "true",

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/splitter/HighwayCornerSplitter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/splitter/HighwayCornerSplitter.cpp
@@ -56,19 +56,19 @@ namespace hoot
 HOOT_FACTORY_REGISTER(OsmMapOperation, HighwayCornerSplitter)
 
 HighwayCornerSplitter::HighwayCornerSplitter()
-  : _cornerThreshold(ConfigOptions().getHighwayCornerSplitterThresholdDefaultValue()),
-    _splitRounded(ConfigOptions().getHighwayCornerSplitterRoundedSplitDefaultValue()),
-    _roundedThreshold(ConfigOptions().getHighwayCornerSplitterRoundedThresholdDefaultValue()),
-    _roundedMaxNodeCount(ConfigOptions().getHighwayCornerSplitterRoundedMaxNodeCountDefaultValue())
+  : _cornerThreshold(ConfigOptions().getHighwayCornerSplitterThreshold()),
+    _splitRounded(ConfigOptions().getHighwayCornerSplitterRoundedSplit()),
+    _roundedThreshold(ConfigOptions().getHighwayCornerSplitterRoundedThreshold()),
+    _roundedMaxNodeCount(ConfigOptions().getHighwayCornerSplitterRoundedMaxNodeCount())
 {
 }
 
 HighwayCornerSplitter::HighwayCornerSplitter(const std::shared_ptr<OsmMap>& map)
   : _map(map),
-    _cornerThreshold(ConfigOptions().getHighwayCornerSplitterThresholdDefaultValue()),
-    _splitRounded(ConfigOptions().getHighwayCornerSplitterRoundedSplitDefaultValue()),
-    _roundedThreshold(ConfigOptions().getHighwayCornerSplitterRoundedThresholdDefaultValue()),
-    _roundedMaxNodeCount(ConfigOptions().getHighwayCornerSplitterRoundedMaxNodeCountDefaultValue())
+    _cornerThreshold(ConfigOptions().getHighwayCornerSplitterThreshold()),
+    _splitRounded(ConfigOptions().getHighwayCornerSplitterRoundedSplit()),
+    _roundedThreshold(ConfigOptions().getHighwayCornerSplitterRoundedThreshold()),
+    _roundedMaxNodeCount(ConfigOptions().getHighwayCornerSplitterRoundedMaxNodeCount())
 {
 }
 


### PR DESCRIPTION
Fixed the corner splitter configuration to use the config and always the default.

Refs #4619 