### PR TITLE
SONAR: Remove const qualifier on return type of a function

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ServiceChangesetReplacementGridTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ServiceChangesetReplacementGridTest.cpp
@@ -27,27 +27,27 @@
 
 // Hoot
 #include <hoot/core/TestUtils.h>
-#include <hoot/core/util/Log.h>
-#include <hoot/core/io/OsmMapReaderFactory.h>
-#include <hoot/core/io/OsmMapWriterFactory.h>
-#include <hoot/core/io/HootApiDb.h>
-#include <hoot/core/geometry/GeometryUtils.h>
-#include <hoot/core/io/ServicesDbTestUtils.h>
-#include <hoot/core/util/ConfigOptions.h>
-#include <hoot/core/util/ConfigUtils.h>
-#include <hoot/core/util/StringUtils.h>
-#include <hoot/core/ops/MapCropper.h>
-#include <hoot/core/algorithms/changeset/ChangesetTaskGridReplacer.h>
 #include <hoot/core/algorithms/changeset/BoundsFileTaskGridGenerator.h>
+#include <hoot/core/algorithms/changeset/BoundsStringTaskGridGenerator.h>
+#include <hoot/core/algorithms/changeset/ChangesetTaskGridReplacer.h>
 #include <hoot/core/algorithms/changeset/NodeDensityTaskGridGenerator.h>
 #include <hoot/core/algorithms/changeset/UniformTaskGridGenerator.h>
-#include <hoot/core/algorithms/changeset/BoundsStringTaskGridGenerator.h>
 #include <hoot/core/conflate/ConflateUtils.h>
-#include <hoot/core/visitors/SetTagValueVisitor.h>
-#include <hoot/core/criterion/WayNodeCriterion.h>
 #include <hoot/core/criterion/NotCriterion.h>
-#include <hoot/core/visitors/FilteredVisitor.h>
+#include <hoot/core/criterion/WayNodeCriterion.h>
+#include <hoot/core/geometry/GeometryUtils.h>
+#include <hoot/core/io/HootApiDb.h>
 #include <hoot/core/io/OsmApiDbSqlChangesetApplier.h>
+#include <hoot/core/io/OsmMapReaderFactory.h>
+#include <hoot/core/io/OsmMapWriterFactory.h>
+#include <hoot/core/io/ServicesDbTestUtils.h>
+#include <hoot/core/ops/MapCropper.h>
+#include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/ConfigUtils.h>
+#include <hoot/core/util/Log.h>
+#include <hoot/core/util/StringUtils.h>
+#include <hoot/core/visitors/FilteredVisitor.h>
+#include <hoot/core/visitors/SetTagValueVisitor.h>
 
 namespace hoot
 {
@@ -1388,7 +1388,7 @@ public:
     const QString outDir = rootDir + "/" + _testName;
     conf().set(ConfigOptions::getDebugMapsFilenameKey(), outDir + "/" + _testName + "-debug.osm");
     QDir(outDir).removeRecursively();
-    QDir().mkpath(outDir);;
+    QDir().mkpath(outDir);
     _prepInput(
       rootDir + "/NOME_14992d.osm",
       rootDir + "/OSM_14992d.osm"/*,

--- a/hoot-core-test/src/test/cpp/hoot/core/elements/ElementComparerTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/elements/ElementComparerTest.cpp
@@ -123,7 +123,7 @@ public:
     WayPtr way1(new Way(Status::Unknown1, 1, 15.0));
     way1->setTag("key1", "value1");
     way1->addNode(node1->getId());
-    way1->addNode(node2->getId());;
+    way1->addNode(node2->getId());
 
     WayPtr way2(new Way(Status::Unknown1, 2, 15.0));
     way2->setTag("key1", "value1");
@@ -210,7 +210,7 @@ public:
 
     RelationPtr relation1(new Relation(Status::Unknown1, 1, 15.0, "type1"));
     relation1->setTag("key1", "value1");
-    relation1->addElement("role1", way1);;
+    relation1->addElement("role1", way1);
 
     RelationPtr relation2(new Relation(Status::Unknown1, 1, 15.0, "type1"));
     relation2->setTag("key1", "value1");

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetDeriver.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetDeriver.cpp
@@ -26,11 +26,11 @@
  */
 #include "ChangesetDeriver.h"
 
+#include <hoot/core/elements/MapProjector.h>
 #include <hoot/core/geometry/GeometryUtils.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/FileUtils.h>
-#include <hoot/core/elements/MapProjector.h>
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreatorAbstract.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetReplacementCreatorAbstract.cpp
@@ -507,7 +507,7 @@ OsmMapPtr ChangesetReplacementCreatorAbstract::_getCookieCutMap(
 
   LOG_VART(doughMap->size());
   LOG_VART(MapProjector::toWkt(doughMap->getProjection()));
-  OsmMapWriterFactory::writeDebugMap(doughMap, _changesetId + "-dough-map");;
+  OsmMapWriterFactory::writeDebugMap(doughMap, _changesetId + "-dough-map");
   LOG_VART(MapProjector::toWkt(cutterMap->getProjection()));
 
   OsmMapPtr cookieCutMap(new OsmMap(doughMap));

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetTaskGridReplacer.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetTaskGridReplacer.h
@@ -1,3 +1,4 @@
+
 /*
  * This file is part of Hootenanny.
  *
@@ -28,8 +29,8 @@
 #define CHANGESET_TASK_GRID_REPLACER_H
 
 // Hoot
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/algorithms/changeset/TaskGrid.h>
+#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/ops/DataQualityMetricTagger.h>
 
 // Qt
@@ -67,7 +68,7 @@ public:
    */
   OsmMapPtr replace(const QString& toReplace, const QString& replacement, const TaskGrid& taskGrid);
 
-  const DataQualityMetricTagger getOutputMetrics() { return _metricTagger; }
+  DataQualityMetricTagger getOutputMetrics() { return _metricTagger; }
   QMap<QString, long> getChangesetStats() const { return _changesetStats; }
 
   void setOriginalDataSize(int size) { _originalDataSize = size; }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetTaskGridReplacer.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetTaskGridReplacer.h
@@ -1,4 +1,3 @@
-
 /*
  * This file is part of Hootenanny.
  *
@@ -25,6 +24,7 @@
  *
  * @copyright Copyright (C) 2020, 2021 Maxar (http://www.maxar.com/)
  */
+
 #ifndef CHANGESET_TASK_GRID_REPLACER_H
 #define CHANGESET_TASK_GRID_REPLACER_H
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayLocation.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayLocation.cpp
@@ -87,7 +87,7 @@ _map(map)
 
     for (size_t i = 1; i < way->getNodeCount(); i++)
     {
-      ConstNodePtr n = _map->getNode(_way->getNodeId(i));;
+      ConstNodePtr n = _map->getNode(_way->getNodeId(i));
       Coordinate next = n->toCoordinate();
       double delta = next.distance(last);
       last = next;
@@ -231,7 +231,7 @@ WayLocation WayLocation::createAtEndOfWay(const ConstOsmMapPtr& map, const Const
   return WayLocation(map, way, way->getNodeCount() - 1, 0.0);
 }
 
-const Coordinate WayLocation::getCoordinate() const
+Coordinate WayLocation::getCoordinate() const
 {
   ConstNodePtr p0 = _map->getNode(_way->getNodeId(_segmentIndex));
   if (!p0)
@@ -452,9 +452,9 @@ WayLocation WayLocation::move(Meters distance) const
   return result;
 }
 
-const Coordinate WayLocation::pointAlongSegmentByFraction(const Coordinate& p0,
-                                                          const Coordinate& p1,
-                                                          double frac)
+Coordinate WayLocation::pointAlongSegmentByFraction(const Coordinate& p0,
+                                                    const Coordinate& p1,
+                                                    double frac)
 {
   if (frac <= 0.0) return p0;
   if (frac >= 1.0) return p1;

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayLocation.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayLocation.h
@@ -32,8 +32,8 @@
 #include <geos/geom/Coordinate.h>
 
 // Hoot
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/elements/Node.h>
+#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/elements/Way.h>
 
 namespace hoot
@@ -107,7 +107,7 @@ public:
    * @param length the length to the desired point
    * @return the Coordinate of the desired point
    */
-  static const geos::geom::Coordinate pointAlongSegmentByFraction(const geos::geom::Coordinate& p0,
+  static geos::geom::Coordinate pointAlongSegmentByFraction(const geos::geom::Coordinate& p0,
                                                                   const geos::geom::Coordinate& p1,
                                                                   double frac);
 
@@ -141,7 +141,7 @@ public:
 
   bool isValid() const { return _segmentIndex != -1; }
 
-  const geos::geom::Coordinate getCoordinate() const;
+  geos::geom::Coordinate getCoordinate() const;
 
   /**
    * Move the location on the way. Negative values will move closer to the beginning of the way.

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementProvider.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementProvider.h
@@ -54,14 +54,14 @@ public:
   virtual bool containsElement(const ElementId& eid) const = 0;
   virtual ConstElementPtr getElement(const ElementId& id) const = 0;
 
-  virtual const ConstNodePtr getNode(long id) const = 0;
-  virtual const NodePtr getNode(long id) = 0;
+  virtual ConstNodePtr getNode(long id) const = 0;
+  virtual NodePtr getNode(long id) = 0;
 
-  virtual const ConstRelationPtr getRelation(long id) const = 0;
-  virtual const RelationPtr getRelation(long id) = 0;
+  virtual ConstRelationPtr getRelation(long id) const = 0;
+  virtual RelationPtr getRelation(long id) = 0;
 
-  virtual const ConstWayPtr getWay(long id) const = 0;
-  virtual const WayPtr getWay(long id) = 0;
+  virtual ConstWayPtr getWay(long id) const = 0;
+  virtual WayPtr getWay(long id) = 0;
 
   virtual bool containsNode(long id) const = 0;
   virtual bool containsRelation(long id) const = 0;

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.h
@@ -105,7 +105,7 @@ public:
   template<class T>
   void addElements(T it, T end);
 
-  virtual ConstElementPtr getElement(const ElementId& id) const;
+  ConstElementPtr getElement(const ElementId& id) const override;
   ConstElementPtr getElement(ElementType type, long id) const;
   ElementPtr getElement(const ElementId& id);
   ElementPtr getElement(ElementType type, long id);
@@ -119,7 +119,7 @@ public:
    * Returns true if an element with the specified type/id exists.
    * Throws an exception if the type is unrecognized.
    */
-  virtual bool containsElement(const ElementId& eid) const;
+  bool containsElement(const ElementId& eid) const override;
   bool containsElement(ElementType type, long id) const;
   bool containsElement(const std::shared_ptr<const Element>& e) const;
 
@@ -167,10 +167,10 @@ public:
 
   //NODE///////////////////////////////////////////////////////////////////////////////////
 
-  virtual const ConstNodePtr getNode(long id) const;
-  virtual const NodePtr getNode(long id);
+  ConstNodePtr getNode(long id) const override;
+  NodePtr getNode(long id) override;
   ConstNodePtr getNode(const ElementId& eid) const { return getNode(eid.getId()); }
-  const NodePtr getNode(const ElementId& eid) { return getNode(eid.getId()); }
+  NodePtr getNode(const ElementId& eid) { return getNode(eid.getId()); }
   const NodeMap& getNodes() const { return _nodes; }
   QSet<long> getNodeIds() const;
   QSet<ElementId> getNodeElementIds() const;
@@ -180,7 +180,7 @@ public:
   /**
    * Returns true if the node is in this map.
    */
-  virtual bool containsNode(long id) const { return _nodes.find(id) != _nodes.end(); }
+  bool containsNode(long id) const override { return _nodes.find(id) != _nodes.end(); }
 
   void addNode(const NodePtr& n);
   /**
@@ -210,8 +210,8 @@ public:
   /**
    * Return the way with the specified id or null if it doesn't exist.
    */
-  virtual const WayPtr getWay(long id);
-  const WayPtr getWay(ElementId eid);
+  WayPtr getWay(long id) override;
+  WayPtr getWay(ElementId eid);
   /**
    * Similar to above but const'd.
    *
@@ -219,8 +219,8 @@ public:
    * a copy. The copy would be a temporary variable if we returned a reference which creates some
    * weirdness and a warning.
    */
-  const ConstWayPtr getWay(long id) const;
-  const ConstWayPtr getWay(ElementId eid) const;
+  ConstWayPtr getWay(long id) const;
+  ConstWayPtr getWay(ElementId eid) const;
   const WayMap& getWays() const { return _ways; }
   QSet<long> getWayIds() const;
   QSet<ElementId> getWayElementIds() const;
@@ -228,7 +228,7 @@ public:
 
   void addWay(const WayPtr& w);
 
-  virtual bool containsWay(long id) const { return _ways.find(id) != _ways.end(); }
+  bool containsWay(long id) const override { return _ways.find(id) != _ways.end(); }
 
   long createNextWayId() const { return _idGen->createWayId(); }
 
@@ -241,9 +241,9 @@ public:
 
   //RELATION///////////////////////////////////////////////////////////////////////////////////
 
-  virtual const ConstRelationPtr getRelation(long id) const;
-  virtual const RelationPtr getRelation(long id);
-  const ConstRelationPtr getRelation(ElementId eid) const;
+  ConstRelationPtr getRelation(long id) const override;
+  RelationPtr getRelation(long id) override;
+  ConstRelationPtr getRelation(ElementId eid) const;
   const RelationMap& getRelations() const { return _relations; }
   QSet<long> getRelationIds() const;
   QSet<ElementId> getRelationElementIds() const;
@@ -251,7 +251,7 @@ public:
 
   void addRelation(const RelationPtr& r);
 
-  virtual bool containsRelation(long id) const { return _relations.find(id) != _relations.end(); }
+  bool containsRelation(long id) const override { return _relations.find(id) != _relations.end(); }
 
   long createNextRelationId() const { return _idGen->createRelationId(); }
 
@@ -295,7 +295,7 @@ public:
   /**
    * Returns the SRS for this map. The SRS should never be changed and defaults to WGS84.
    */
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const { return _srs; }
+  std::shared_ptr<OGRSpatialReference> getProjection() const override { return _srs; }
 
   void clear();
 
@@ -408,8 +408,8 @@ protected:
 
   void _initCounters();
 
-  virtual void _next();
-  virtual void resetIterator();
+  void _next() override;
+  void resetIterator() override;
 };
 
 typedef std::shared_ptr<OsmMap> OsmMapPtr;
@@ -425,7 +425,7 @@ void addElements(T it, T end)
   }
 }
 
-inline const NodePtr OsmMap::getNode(long id)
+inline NodePtr OsmMap::getNode(long id)
 {
   _tmpNodeMapIt = _nodes.find(id);
   if (_tmpNodeMapIt != _nodes.end())
@@ -438,7 +438,7 @@ inline const NodePtr OsmMap::getNode(long id)
   }
 }
 
-inline const ConstNodePtr OsmMap::getNode(long id) const
+inline ConstNodePtr OsmMap::getNode(long id) const
 {
   _tmpNodeMapIt = _nodes.find(id);
   if (_tmpNodeMapIt != _nodes.end())
@@ -451,7 +451,7 @@ inline const ConstNodePtr OsmMap::getNode(long id) const
   }
 }
 
-inline const ConstRelationPtr OsmMap::getRelation(long id) const
+inline ConstRelationPtr OsmMap::getRelation(long id) const
 {
   RelationMap::iterator it = _relations.find(id);
   if (it != _relations.end())
@@ -464,12 +464,12 @@ inline const ConstRelationPtr OsmMap::getRelation(long id) const
   }
 }
 
-inline const ConstRelationPtr OsmMap::getRelation(ElementId eid) const
+inline ConstRelationPtr OsmMap::getRelation(ElementId eid) const
 {
   return getRelation(eid.getId());
 }
 
-inline const RelationPtr OsmMap::getRelation(long id)
+inline RelationPtr OsmMap::getRelation(long id)
 {
   _tmpRelationIt = _relations.find(id);
   if (_tmpRelationIt != _relations.end())
@@ -482,7 +482,7 @@ inline const RelationPtr OsmMap::getRelation(long id)
   }
 }
 
-inline const ConstWayPtr OsmMap::getWay(long id) const
+inline ConstWayPtr OsmMap::getWay(long id) const
 {
   _tmpWayIt = _ways.find(id);
   if (_tmpWayIt != _ways.end())
@@ -495,12 +495,12 @@ inline const ConstWayPtr OsmMap::getWay(long id) const
   }
 }
 
-inline const ConstWayPtr OsmMap::getWay(ElementId eid) const
+inline ConstWayPtr OsmMap::getWay(ElementId eid) const
 {
   return getWay(eid.getId());
 }
 
-inline const WayPtr OsmMap::getWay(long id)
+inline WayPtr OsmMap::getWay(long id)
 {
   _tmpWayIt = _ways.find(id);
   if (_tmpWayIt != _ways.end())
@@ -513,7 +513,7 @@ inline const WayPtr OsmMap::getWay(long id)
   }
 }
 
-inline const WayPtr OsmMap::getWay(ElementId eid)
+inline WayPtr OsmMap::getWay(ElementId eid)
 {
   return getWay(eid.getId());
 }

--- a/hoot-core/src/main/cpp/hoot/core/elements/Relation.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Relation.cpp
@@ -36,11 +36,11 @@
 
 // hoot
 #include <hoot/core/elements/OsmMap.h>
-#include <hoot/core/visitors/ConstElementVisitor.h>
 #include <hoot/core/elements/Way.h>
-#include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/geometry/GeometryUtils.h>
+#include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/util/Log.h>
+#include <hoot/core/visitors/ConstElementVisitor.h>
 
 
 using namespace geos::geom;
@@ -163,7 +163,7 @@ int Relation::numElementsByRole(const QString& role)
   return getElementsByRole(role).size();
 }
 
-const std::vector<RelationData::Entry> Relation::getElementsByRole(const QString& role)
+std::vector<RelationData::Entry> Relation::getElementsByRole(const QString& role)
 {
   const vector<RelationData::Entry>& members = getMembers();
   std::vector<RelationData::Entry> membersByRole;

--- a/hoot-core/src/main/cpp/hoot/core/elements/Relation.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Relation.h
@@ -70,7 +70,7 @@ public:
   /**
    * Removes members, tags, type and circularError.
    */
-  virtual void clear();
+  void clear() override;
 
   Element* clone() const { return new Relation(*this); }
 
@@ -111,7 +111,7 @@ public:
    * @param role role to search for
    * @return a collection of members
    */
-  const std::vector<RelationData::Entry> getElementsByRole(const QString& role);
+  std::vector<RelationData::Entry> getElementsByRole(const QString& role);
 
   const std::vector<RelationData::Entry>& getMembers() const
   { return _relationData->getElements(); }
@@ -126,12 +126,12 @@ public:
    */
   std::set<ElementId> getMemberIds(const ElementType& elementType = ElementType::Unknown) const;
 
-  virtual geos::geom::Envelope* getEnvelope(
+  geos::geom::Envelope* getEnvelope(
     const std::shared_ptr<const ElementProvider>& ep) const override;
-  virtual const geos::geom::Envelope& getEnvelopeInternal(
+  const geos::geom::Envelope& getEnvelopeInternal(
     const std::shared_ptr<const ElementProvider>& ep) const override;
 
-  virtual ElementType getElementType() const { return ElementType(ElementType::Relation); }
+  ElementType getElementType() const override { return ElementType(ElementType::Relation); }
 
   QString getType() const { return _relationData->getType(); }
 
@@ -196,14 +196,14 @@ public:
   /**
    * @see Element
    */
-  virtual void visitRo(const ElementProvider& map, ConstElementVisitor& filter,
-                       const bool recursive = true) const;
+  void visitRo(const ElementProvider& map, ConstElementVisitor& filter,
+               const bool recursive = true) const override;
 
   /**
    * @see Element
    */
-  virtual void visitRw(ElementProvider& map, ConstElementVisitor& filter,
-                       const bool recursive = true);
+  void visitRw(ElementProvider& map, ConstElementVisitor& filter,
+               const bool recursive = true) override;
 
 private:
 
@@ -211,8 +211,8 @@ private:
 
   std::shared_ptr<RelationData> _relationData;
 
-  virtual ElementData& _getElementData() { _makeWritable(); return *_relationData; }
-  virtual const ElementData& _getElementData() const { return *_relationData; }
+  ElementData& _getElementData() override { _makeWritable(); return *_relationData; }
+  const ElementData& _getElementData() const override { return *_relationData; }
 
   void _makeWritable();
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/Tags.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Tags.h
@@ -28,8 +28,8 @@
 #define TAGS_H
 
 // Hoot
-#include <hoot/core/util/Units.h>
 #include <hoot/core/schema/SchemaVertex.h>
+#include <hoot/core/util/Units.h>
 
 // Qt
 #include <QHash>
@@ -102,7 +102,7 @@ public:
    */
   bool hasInformationTag() const;
 
-  const QString get(const QString& k) const { return operator[](k); }
+  QString get(const QString& k) const { return operator[](k); }
 
   /**
    * Gets the element's UUID(s). If the UUID doesn't exist then it creates a new UUID.

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementCache.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementCache.h
@@ -150,17 +150,17 @@ public:
 
   virtual ConstElementPtr getElement(const ElementId& id) const = 0;
 
-  virtual const ConstNodePtr getNode(long id) const = 0;
+  virtual ConstNodePtr getNode(long id) const = 0;
 
-  virtual const NodePtr getNode(long id) = 0;
+  virtual NodePtr getNode(long id) = 0;
 
-  virtual const ConstRelationPtr getRelation(long id) const = 0;
+  virtual ConstRelationPtr getRelation(long id) const = 0;
 
-  virtual const RelationPtr getRelation(long id) = 0;
+  virtual RelationPtr getRelation(long id) = 0;
 
-  virtual const ConstWayPtr getWay(long id) const = 0;
+  virtual ConstWayPtr getWay(long id) const = 0;
 
-  virtual const WayPtr getWay(long id) = 0;
+  virtual WayPtr getWay(long id) = 0;
 
   virtual bool containsNode(long id) const = 0;
 

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementCacheLRU.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementCacheLRU.cpp
@@ -345,12 +345,12 @@ ConstElementPtr ElementCacheLRU::getElement(const ElementId& eid) const
 // This const function kind of defeats the purpose of the LRU cache,
 // but it's necessary to conform to the interface. It should call
 // _updateNodeAccess(id) - but can't because of const
-const ConstNodePtr ElementCacheLRU::getNode(long id) const
+ConstNodePtr ElementCacheLRU::getNode(long id) const
 {
   return _nodes.find(id)->second.first;
 }
 
-const NodePtr ElementCacheLRU::getNode(long id)
+NodePtr ElementCacheLRU::getNode(long id)
 {
   _updateNodeAccess(id);
   return std::const_pointer_cast<Node>(_nodes.find(id)->second.first);
@@ -359,12 +359,12 @@ const NodePtr ElementCacheLRU::getNode(long id)
 // This const function kind of defeats the purpose of the LRU cache,
 // but it's necessary to conform to the interface. It should call
 // _updateWayAccess - but can't because of const
-const ConstWayPtr ElementCacheLRU::getWay(long id) const
+ConstWayPtr ElementCacheLRU::getWay(long id) const
 {
   return _ways.find(id)->second.first;
 }
 
-const WayPtr ElementCacheLRU::getWay(long id)
+WayPtr ElementCacheLRU::getWay(long id)
 {
   _updateWayAccess(id);
   return std::const_pointer_cast<Way>(_ways.find(id)->second.first);
@@ -373,12 +373,12 @@ const WayPtr ElementCacheLRU::getWay(long id)
 // This const function kind of defeats the purpose of the LRU cache,
 // but it's necessary to conform to the interface. It should call
 // _updateRelationAccess - but can't becuase of const
-const ConstRelationPtr ElementCacheLRU::getRelation(long id) const
+ConstRelationPtr ElementCacheLRU::getRelation(long id) const
 {
   return _relations.find(id)->second.first;
 }
 
-const RelationPtr ElementCacheLRU::getRelation(long id)
+RelationPtr ElementCacheLRU::getRelation(long id)
 {
   _updateRelationAccess(id);
   return std::const_pointer_cast<Relation>(_relations.find(id)->second.first);

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementCacheLRU.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementCacheLRU.h
@@ -32,8 +32,8 @@
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 
-#include <hoot/core/elements/ElementType.h>
 #include <hoot/core/elements/ElementId.h>
+#include <hoot/core/elements/ElementType.h>
 #include <hoot/core/io/ElementCache.h>
 
 #include <ogr_spatialref.h>
@@ -66,11 +66,11 @@ public:
    */
   virtual ~ElementCacheLRU() = default;
 
-  virtual bool isEmpty() const;
+  bool isEmpty() const override;
 
-  virtual unsigned long size() const;
+  unsigned long size() const override;
 
-  virtual unsigned long typeCount(const ElementType::Type typeToCount) const;
+  unsigned long typeCount(const ElementType::Type typeToCount) const override;
 
   /**
    * @brief addElement
@@ -78,61 +78,61 @@ public:
    * @note The last access time for an element added to the cache will be initialized to the
    *    current time
    */
-  virtual void addElement(ConstElementPtr& newElement);
+  void addElement(ConstElementPtr& newElement) override;
 
-  virtual void resetElementIterators();
+  void resetElementIterators() override;
 
-  virtual ConstNodePtr getNextNode();
+  ConstNodePtr getNextNode() override;
 
-  virtual ConstWayPtr getNextWay();
+  ConstWayPtr getNextWay() override;
 
-  virtual ConstRelationPtr getNextRelation();
+  ConstRelationPtr getNextRelation() override;
 
   // Functions for ElementInputStream
-  virtual void close();
-  virtual bool hasMoreElements();
+  void close() override;
+  bool hasMoreElements() override;
 
-  virtual ElementPtr readNextElement();
+  ElementPtr readNextElement() override;
 
   // Functions for ElementOutputStream
-  virtual void writeElement(ElementPtr& element);
+  void writeElement(ElementPtr& element) override;
 
   // Functions for ElementProvider
 
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const;
+  std::shared_ptr<OGRSpatialReference> getProjection() const override;
 
-  virtual bool containsElement(const ElementId& eid) const;
+  bool containsElement(const ElementId& eid) const override;
 
-  virtual ConstElementPtr getElement(const ElementId& id) const;
+  ConstElementPtr getElement(const ElementId& id) const override;
 
-  virtual const ConstNodePtr getNode(long id) const;
+  ConstNodePtr getNode(long id) const override;
 
-  virtual const NodePtr getNode(long id);
+  NodePtr getNode(long id) override;
 
-  virtual const ConstRelationPtr getRelation(long id) const;
+  ConstRelationPtr getRelation(long id) const override;
 
-  virtual const RelationPtr getRelation(long id);
+  RelationPtr getRelation(long id) override;
 
-  virtual const ConstWayPtr getWay(long id) const;
+  ConstWayPtr getWay(long id) const override;
 
-  virtual const WayPtr getWay(long id);
+  WayPtr getWay(long id) override;
 
-  virtual bool containsNode(long id) const;
+  bool containsNode(long id) const override;
 
-  virtual bool containsRelation(long id) const;
+  bool containsRelation(long id) const override;
 
-  virtual bool containsWay(long id) const;
+  bool containsWay(long id) const override;
 
   // Cache-specific items
-  virtual void removeElement(const ElementId& eid);
+  void removeElement(const ElementId& eid) override;
 
-  virtual void removeElements(const ElementType::Type type);
+  void removeElements(const ElementType::Type type) override;
 
-  virtual unsigned long getNodeCacheSize() { return _maxNodeCount; }
+  unsigned long getNodeCacheSize() override { return _maxNodeCount; }
 
-  virtual unsigned long getWayCacheSize() { return _maxWayCount; }
+  unsigned long getWayCacheSize() override { return _maxWayCount; }
 
-  virtual unsigned long getRelationCacheSize() { return _maxRelationCount; }
+  unsigned long getRelationCacheSize() override { return _maxRelationCount; }
 
   // For testing - gets a comma-seperated list of IDs of the Least Recently Used
   // cache items, from most recent to least recent.

--- a/hoot-core/src/main/cpp/hoot/core/ops/ElementIdRemapper.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/ElementIdRemapper.cpp
@@ -27,8 +27,8 @@
 #include "ElementIdRemapper.h"
 
 // hoot
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/ops/RemoveElementByEid.h>
+#include <hoot/core/util/Factory.h>
 
 namespace hoot
 {
@@ -168,7 +168,7 @@ void ElementIdRemapper::restore(OsmMapPtr& map)
       LOG_TRACE(
         "Restoring " << currentElement->getElementId() << " to " <<
         originalElement->getElementId() << "...");
-      map->addElement(originalElement);;
+      map->addElement(originalElement);
       map->replace(currentElement, originalElement);
       _restoredIds++;
     }

--- a/hoot-core/src/main/cpp/hoot/core/schema/MetadataTags.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/MetadataTags.h
@@ -50,194 +50,193 @@ namespace hoot
 class MetadataTags
 {
 public:
-  inline static const QString HootTagPrefix()           { return "hoot:"; }
+  inline static QString HootTagPrefix()                 { return "hoot:"; }
 
   static const QString ACCURACY;
   inline static const QString& Accuracy()               { return ACCURACY; }
   static const QString ERROR_CIRCULAR;
   inline static const QString& ErrorCircular()          { return ERROR_CIRCULAR; }
-  inline static const QString SourceDateTime()          { return "source:datetime"; }
-  inline static const QString SourceIngestDateTime()    { return "source:ingest:datetime"; }
-  inline static const QString SourceImagery()           { return "source:imagery"; }
+  inline static QString SourceDateTime()                { return "source:datetime"; }
+  inline static QString SourceIngestDateTime()          { return "source:ingest:datetime"; }
+  inline static QString SourceImagery()                 { return "source:imagery"; }
 
-  inline static const QString HootBuildingMatch()       { return "hoot:building:match"; }
+  inline static QString HootBuildingMatch()             { return "hoot:building:match"; }
 
-  inline static const QString HootActual()              { return "hoot:actual"; }
-  inline static const QString HootExpected()            { return "hoot:expected"; }
-  inline static const QString HootMismatch()            { return "hoot:mismatch"; }
-  inline static const QString HootWrong()               { return "hoot:wrong"; }
-  inline static const QString HootCorrectReview()       { return "hoot:correct_review"; }
+  inline static QString HootActual()                    { return "hoot:actual"; }
+  inline static QString HootExpected()                  { return "hoot:expected"; }
+  inline static QString HootMismatch()                  { return "hoot:mismatch"; }
+  inline static QString HootWrong()                     { return "hoot:wrong"; }
+  inline static QString HootCorrectReview()             { return "hoot:correct_review"; }
 
-  inline static const QString HootEdge()                { return "hoot:edge"; }
-  inline static const QString HootEdgeId()              { return "hoot:edge:id"; }
-  inline static const QString HootEdgeScore()           { return "hoot:edge:score"; }
-  inline static const QString HootEdgeScore12()         { return "hoot:edge:score12"; }
-  inline static const QString HootEdgeScore21()         { return "hoot:edge:score21"; }
+  inline static QString HootEdge()                      { return "hoot:edge"; }
+  inline static QString HootEdgeId()                    { return "hoot:edge:id"; }
+  inline static QString HootEdgeScore()                 { return "hoot:edge:score"; }
+  inline static QString HootEdgeScore12()               { return "hoot:edge:score12"; }
+  inline static QString HootEdgeScore21()               { return "hoot:edge:score21"; }
 
-  inline static const QString HootVertex()              { return "hoot:vertex"; }
-  inline static const QString HootVertexScore()         { return "hoot:vertex:score"; }
-  inline static const QString HootVertexScore12()       { return "hoot:vertex:score12"; }
-  inline static const QString HootVertexScore21()       { return "hoot:vertex:score21"; }
+  inline static QString HootVertex()                    { return "hoot:vertex"; }
+  inline static QString HootVertexScore()               { return "hoot:vertex:score"; }
+  inline static QString HootVertexScore12()             { return "hoot:vertex:score12"; }
+  inline static QString HootVertexScore21()             { return "hoot:vertex:score21"; }
 
   static const QString HOOT_ID;
   inline static const QString& HootId()                 { return HOOT_ID; }
-  inline static const QString HootHash()                { return "hoot:hash"; }
-  inline static const QString HootChangeType()          { return "hoot:change:type"; }
-  inline static const QString HootChangeExcludeDelete() { return "hoot:change:exclude:delete"; }
+  inline static QString HootHash()                      { return "hoot:hash"; }
+  inline static QString HootChangeType()                { return "hoot:change:type"; }
+  inline static QString HootChangeExcludeDelete()       { return "hoot:change:exclude:delete"; }
 
-  inline static const QString HootLayername()           { return "hoot:layername"; }
+  inline static QString HootLayername()                 { return "hoot:layername"; }
 
   // These are used by rubbersheeting only...could be a little better named.
-  inline static const QString HootMatchOrder()          { return "hoot:match:order"; }
-  inline static const QString HootMatchP()              { return "hoot:match:p"; }
-  inline static const QString HootMatchScore()          { return "hoot:match:score"; }
+  inline static QString HootMatchOrder()                { return "hoot:match:order"; }
+  inline static QString HootMatchP()                    { return "hoot:match:p"; }
+  inline static QString HootMatchScore()                { return "hoot:match:score"; }
 
-  inline static const QString HootMatchedBy()           { return "hoot:matchedBy"; }
+  inline static QString HootMatchedBy()                 { return "hoot:matchedBy"; }
 
-  inline static const QString HootPertied()             { return "hoot:pertied"; }
+  inline static QString HootPertied()                   { return "hoot:pertied"; }
 
   // used by PoiPolygonMerger to keep track of the number of POIs merged into a polygon during
   // POI/Polygon Conflation
-  inline static const QString HootPoiPolygonPoisMerged(){ return "hoot:poipolygon:poismerged"; }
-  inline static const QString HootPoiPolygonPoisMerged1(){ return "hoot:poipolygon:poismerged:1"; }
-  inline static const QString HootPoiPolygonPoisMerged2(){ return "hoot:poipolygon:poismerged:2"; }
+  inline static QString HootPoiPolygonPoisMerged()      { return "hoot:poipolygon:poismerged"; }
+  inline static QString HootPoiPolygonPoisMerged1()     { return "hoot:poipolygon:poismerged:1"; }
+  inline static QString HootPoiPolygonPoisMerged2()     { return "hoot:poipolygon:poismerged:2"; }
 
-  inline static const QString HootMergeTarget()         { return "hoot:merge:target"; }
+  inline static QString HootMergeTarget()               { return "hoot:merge:target"; }
 
-  inline static const QString HootReviewTagPrefix()     { return "hoot:review:"; }
-  inline static const QString HootReviewChoices()       { return "hoot:review:choices"; }
-  inline static const QString HootReviewMembers()       { return "hoot:review:members"; }
-  inline static const QString HootReviewNeeds()         { return "hoot:review:needs"; }
-  inline static const QString HootReviewNote()          { return "hoot:review:note"; }
-  inline static const QString HootReviewScore()         { return "hoot:review:score"; }
-  inline static const QString HootReviewSortOrder()     { return "hoot:review:sort_order"; }
-  inline static const QString HootReviewType()          { return "hoot:review:type"; }
-  inline static const QString HootReviewUuid()          { return "hoot:review:uuid"; }
-  inline static const QString HootReviewRoadCrossingPolygon() { return "road_crossing_polygon"; }
+  inline static QString HootReviewTagPrefix()           { return "hoot:review:"; }
+  inline static QString HootReviewChoices()             { return "hoot:review:choices"; }
+  inline static QString HootReviewMembers()             { return "hoot:review:members"; }
+  inline static QString HootReviewNeeds()               { return "hoot:review:needs"; }
+  inline static QString HootReviewNote()                { return "hoot:review:note"; }
+  inline static QString HootReviewScore()               { return "hoot:review:score"; }
+  inline static QString HootReviewSortOrder()           { return "hoot:review:sort_order"; }
+  inline static QString HootReviewType()                { return "hoot:review:type"; }
+  inline static QString HootReviewUuid()                { return "hoot:review:uuid"; }
+  inline static QString HootReviewRoadCrossingPolygon() { return "road_crossing_polygon"; }
 
-  inline static const QString HootScoreMatch()          { return "hoot:score:match"; }
-  inline static const QString HootScoreMiss()           { return "hoot:score:miss"; }
-  inline static const QString HootScoreReview()         { return "hoot:score:review"; }
-  inline static const QString HootScoreUuid()           { return "hoot:score:uuid"; }
-  inline static const QString HootUserName()            { return "hoot:user_name"; }
-  inline static const QString HootUserId()              { return "hoot:user_id"; }
+  inline static QString HootScoreMatch()                { return "hoot:score:match"; }
+  inline static QString HootScoreMiss()                 { return "hoot:score:miss"; }
+  inline static QString HootScoreReview()               { return "hoot:score:review"; }
+  inline static QString HootScoreUuid()                 { return "hoot:score:uuid"; }
+  inline static QString HootUserName()                  { return "hoot:user_name"; }
+  inline static QString HootUserId()                    { return "hoot:user_id"; }
 
   // used with JOSM validation interop; match those used in JosmValidator.java
-  inline static const QString HootValidationError()     { return "hoot:validation:error"; }
-  inline static const QString HootValidationCleanStatus()
-  { return "hoot:validation:error:clean:status"; }
-  inline static const QString HootValidationSource()    { return "hoot:validation:error:source"; }
+  inline static QString HootValidationError()           { return "hoot:validation:error"; }
+  inline static QString HootValidationCleanStatus()     { return "hoot:validation:error:clean:status"; }
+  inline static QString HootValidationSource()          { return "hoot:validation:error:source"; }
 
   static const QString HOOT_STATUS;
   inline static const QString& HootStatus()             { return HOOT_STATUS; }
 
-  inline static const QString HootSource()              { return "hoot:source"; }
+  inline static QString HootSource()                    { return "hoot:source"; }
 
-  inline static const QString HootSpecial()             { return "hoot:special"; }
-  inline static const QString RoundaboutCenter()        { return "roundabout_center"; }
-  inline static const QString RoundaboutConnector()     { return "roundabout_connector"; }
+  inline static QString HootSpecial()                   { return "hoot:special"; }
+  inline static QString RoundaboutCenter()              { return "roundabout_center"; }
+  inline static QString RoundaboutConnector()           { return "roundabout_connector"; }
 
-  inline static const QString HootSplitParentId()       { return "hoot:split_parent_id"; }
+  inline static QString HootSplitParentId()             { return "hoot:split_parent_id"; }
 
-  inline static const QString HootStub()                { return "hoot:stub"; }
+  inline static QString HootStub()                      { return "hoot:stub"; }
 
-  inline static const QString HootFirstSeen()           { return "hoot:first_seen"; }
-  inline static const QString HootLastSeen()            { return "hoot:last_seen"; }
-  inline static const QString HootTotalObservations()   { return "hoot:total_observations"; }
-  inline static const QString HootTotalMisses()         { return "hoot:total_misses"; }
-  inline static const QString HootMaxConsecutive()      { return "hoot:max_consecutive"; }
-  inline static const QString HootMaxConsecutiveStart() { return "hoot:max_consecutive_start"; }
-  inline static const QString HootHistogram()           { return "hoot:histogram"; }
+  inline static QString HootFirstSeen()                 { return "hoot:first_seen"; }
+  inline static QString HootLastSeen()                  { return "hoot:last_seen"; }
+  inline static QString HootTotalObservations()         { return "hoot:total_observations"; }
+  inline static QString HootTotalMisses()               { return "hoot:total_misses"; }
+  inline static QString HootMaxConsecutive()            { return "hoot:max_consecutive"; }
+  inline static QString HootMaxConsecutiveStart()       { return "hoot:max_consecutive_start"; }
+  inline static QString HootHistogram()                 { return "hoot:histogram"; }
 
-  inline static const QString Ref1()                    { return "REF1"; }
-  inline static const QString Ref2()                    { return "REF2"; }
-  inline static const QString Review()                  { return "REVIEW"; }
-  inline static const QString Uuid()                    { return "uuid"; }
+  inline static QString Ref1()                          { return "REF1"; }
+  inline static QString Ref2()                          { return "REF2"; }
+  inline static QString Review()                        { return "REVIEW"; }
+  inline static QString Uuid()                          { return "uuid"; }
 
-  inline static const QString Unknown1()                { return "Unknown1"; }
-  inline static const QString Unknown2()                { return "Unknown2"; }
+  inline static QString Unknown1()                      { return "Unknown1"; }
+  inline static QString Unknown2()                      { return "Unknown2"; }
 
-  inline static const QString BuildingPart()            { return "building:part"; }
-  inline static const QString BuildingHeight()          { return "height"; }
-  inline static const QString BuildingLevels()          { return "building:levels"; }
+  inline static QString BuildingPart()                  { return "building:part"; }
+  inline static QString BuildingHeight()                { return "height"; }
+  inline static QString BuildingLevels()                { return "building:levels"; }
 
-  inline static const QString RelationBoundary()        { return "boundary"; }
-  inline static const QString RelationBuilding()        { return "building"; }
-  inline static const QString RelationCollection()      { return "collection"; }
-  inline static const QString RelationInner()           { return "inner"; }
-  inline static const QString RelationMultilineString() { return "multilinestring"; }
-  inline static const QString RelationMultiPolygon()    { return "multipolygon"; }
-  inline static const QString RelationMultiPoint()      { return "multipoint"; }
-  inline static const QString RelationNetwork()         { return "network"; }
-  inline static const QString RelationOuter()           { return "outer"; }
-  inline static const QString RelationRestriction()     { return "restriction"; }
-  inline static const QString RelationReview()          { return "review"; }
-  inline static const QString RelationRoute()           { return "route"; }
-  inline static const QString RelationRouteMaster()     { return "route_master"; }
-  inline static const QString RelationSite()            { return "site"; }
-  inline static const QString RelationSuperRoute()      { return "superroute"; }
-  inline static const QString RelationWaterway()        { return "waterway"; }
-  inline static const QString RelationType()            { return "type"; }
+  inline static QString RelationBoundary()              { return "boundary"; }
+  inline static QString RelationBuilding()              { return "building"; }
+  inline static QString RelationCollection()            { return "collection"; }
+  inline static QString RelationInner()                 { return "inner"; }
+  inline static QString RelationMultilineString()       { return "multilinestring"; }
+  inline static QString RelationMultiPolygon()          { return "multipolygon"; }
+  inline static QString RelationMultiPoint()            { return "multipoint"; }
+  inline static QString RelationNetwork()               { return "network"; }
+  inline static QString RelationOuter()                 { return "outer"; }
+  inline static QString RelationRestriction()           { return "restriction"; }
+  inline static QString RelationReview()                { return "review"; }
+  inline static QString RelationRoute()                 { return "route"; }
+  inline static QString RelationRouteMaster()           { return "route_master"; }
+  inline static QString RelationSite()                  { return "site"; }
+  inline static QString RelationSuperRoute()            { return "superroute"; }
+  inline static QString RelationWaterway()              { return "waterway"; }
+  inline static QString RelationType()                  { return "type"; }
 
-  inline static const QString RoleInner()               { return RelationInner(); }
-  inline static const QString RoleOuter()               { return RelationOuter(); }
-  inline static const QString RoleOutline()             { return "outline"; }
-  inline static const QString RolePart()                { return "part"; }
-  inline static const QString RoleReviewee()            { return "reviewee"; }
+  inline static QString RoleInner()                     { return RelationInner(); }
+  inline static QString RoleOuter()                     { return RelationOuter(); }
+  inline static QString RoleOutline()                   { return "outline"; }
+  inline static QString RolePart()                      { return "part"; }
+  inline static QString RoleReviewee()                  { return "reviewee"; }
   // temp tag used by BuildingMerger
-  inline static const QString HootMultiPolyRole()       { return "hoot:multi_poly:role"; }
+  inline static QString HootMultiPolyRole()             { return "hoot:multi_poly:role"; }
 
-  inline static const QString Length()                  { return "length"; }
+  inline static QString Length()                        { return "length"; }
 
-  inline static const QString Source()                  { return "source"; }
-  inline static const QString OsmApiDbScheme()          { return "osmapidb"; }
-  inline static const QString HootApiDbScheme()         { return "hootapidb"; }
+  inline static QString Source()                        { return "source"; }
+  inline static QString OsmApiDbScheme()                { return "osmapidb"; }
+  inline static QString HootApiDbScheme()               { return "hootapidb"; }
 
   /**
    * This is used by ChangesetReplacementCreator to focus attention on input elements with missing
    * child references so that they may later be cleaned up.
    */
-  inline static const QString HootMissingChild()        { return "hoot:missing_child"; }
+  inline static QString HootMissingChild()              { return "hoot:missing_child"; }
 
   /**
    * Used by ElementIdSynchronizer to mark elements whose IDs it synched
    */
-  inline static const QString HootIdSynchronized()      { return "hoot:synced:id"; }
+  inline static QString HootIdSynchronized()            { return "hoot:synced:id"; }
 
   /**
    * Used to identify superfluous nodes without removing them for debugging purposes
    */
-  inline static const QString HootSuperfluous()         { return "hoot:superfluous"; }
+  inline static QString HootSuperfluous()               { return "hoot:superfluous"; }
 
   /**
    * Used to identify disconnected ways for debugging purposes
    */
-  inline static const QString HootDisconnected()        { return "hoot:disconnected"; }
+  inline static QString HootDisconnected()              { return "hoot:disconnected"; }
 
   /**
    * Used to identify way end nodes for debugging purposes
    */
-  inline static const QString HootWayEndNode()        { return "hoot:way_end_node"; }
+  inline static QString HootWayEndNode()                { return "hoot:way_end_node"; }
 
   /**
    * Used to identify empty ways for debugging purposes
    */
-  inline static const QString HootEmptyWay()            { return "hoot:empty:way"; }
+  inline static QString HootEmptyWay()                  { return "hoot:empty:way"; }
 
   /**
    * Used to identify superfluous nodes without removing them for debugging purposes
    */
-  inline static const QString HootDuplicate()           { return "hoot:duplicate"; }
+  inline static QString HootDuplicate()                 { return "hoot:duplicate"; }
 
   /**
    * Used to mark roads that are divided highways
    */
-  inline static const QString HootDualHighway()         { return "hoot:dual_highway"; }
+  inline static QString HootDualHighway()               { return "hoot:dual_highway"; }
 
   /**
    * Used to mark roads that cross divided highways
    */
-  inline static const QString HootDualHighwayCrossing() { return "hoot:dual_highway_crossing"; }
+  inline static QString HootDualHighwayCrossing()       { return "hoot:dual_highway_crossing"; }
 
   /**
    * Identifies features snapped with UnconnectedWaySnapper
@@ -253,50 +252,50 @@ public:
    * to_way_target      - newly added target way node or way containing the newly added target way
    *                      node that a source feature was snapped to
    */
-  inline static const QString HootSnapped()             { return "hoot:snapped"; }
+  inline static QString HootSnapped()                   { return "hoot:snapped"; }
 
   /**
    * Identifies ways outside of bounds that are immediately connected to other ways within the
    * bounds
    */
-  inline static const QString HootConnectedWayOutsideBounds() { return "hoot:connected_way"; }
+  inline static QString HootConnectedWayOutsideBounds() { return "hoot:connected_way"; }
 
   /**
    * Identifies multilinestring relations hoot adds during conflation
    */
-  inline static const QString HootMultilineString()     { return "hoot:multilinestring"; }
+  inline static QString HootMultilineString()           { return "hoot:multilinestring"; }
 
   /**
    * Identifies ElementConflatableCriteria that consider an element conflatable
    */
-  inline static const QString HootConflatableCriteria() { return "hoot:conflatable:criteria"; }
+  inline static QString HootConflatableCriteria()       { return "hoot:conflatable:criteria"; }
 
   /**
    * ID Unique to a training data set with multiary training data.
    * @sa MultiaryMatchComparator
    */
-  inline static const QString TrainingId()              { return "ID"; }
+  inline static QString TrainingId()                    { return "ID"; }
   /**
    * Refers to a match between two or more elements in a multiary training data set.
    * @sa MultiaryMatchComparator
    */
-  inline static const QString TrainingMatch()           { return "MATCH"; }
+  inline static QString TrainingMatch()                 { return "MATCH"; }
   /**
    * Refers to a review between two or more elements in a multiary training data set.
    * @sa MultiaryMatchComparator
    */
-  inline static const QString TrainingReview()          { return "REVIEW"; }
+  inline static QString TrainingReview()                { return "REVIEW"; }
 
   // used by FindIntersectionsVisitor
-  inline static const QString HootIntersectionWayCount() { return "hoot:intersection:way_count"; }
-  inline static const QString HootIntersectionMinAngle() { return "hoot:intersection:min_angle"; }
-  inline static const QString HootIntersectionMaxAngle() { return "hoot:intersection:max_angle"; }
+  inline static QString HootIntersectionWayCount()      { return "hoot:intersection:way_count"; }
+  inline static QString HootIntersectionMinAngle()      { return "hoot:intersection:min_angle"; }
+  inline static QString HootIntersectionMaxAngle()      { return "hoot:intersection:max_angle"; }
 
   // used by FindStreetIntersectionsByName
-  inline static const QString HootIntersectionStreet1() { return "hoot:intersection:street1"; }
-  inline static const QString HootIntersectionStreet2() { return "hoot:intersection:street2"; }
+  inline static QString HootIntersectionStreet1()       { return "hoot:intersection:street1"; }
+  inline static QString HootIntersectionStreet2()       { return "hoot:intersection:street2"; }
 
-  inline static const QString HootWayNodeCount() { return "hoot:way:node:count"; }
+  inline static QString HootWayNodeCount()              { return "hoot:way:node:count"; }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/ScriptSchemaTranslator.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/ScriptSchemaTranslator.h
@@ -73,7 +73,7 @@ public:
   /**
    * String containing the regexp to use for filtering the layer names.
    */
-  virtual const QString getLayerNameFilter() { return "."; }
+  virtual QString getLayerNameFilter() { return "."; }
 
   /**
    * lower order values make the script engine get evaluated earlier.

--- a/hoot-js/src/main/cpp/hoot/js/schema/JavaScriptSchemaTranslator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/JavaScriptSchemaTranslator.cpp
@@ -30,7 +30,6 @@
 // hoot
 #include <hoot/core/elements/ElementType.h>
 #include <hoot/core/elements/Tags.h>
-#include <hoot/js/io/DataConvertJs.h>
 #include <hoot/core/io/schema/DoubleFieldDefinition.h>
 #include <hoot/core/io/schema/Feature.h>
 #include <hoot/core/io/schema/FeatureDefinition.h>
@@ -44,8 +43,9 @@
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/UuidHelper.h>
-#include <hoot/js/util/HootExceptionJs.h>
 #include <hoot/js/PluginContext.h>
+#include <hoot/js/io/DataConvertJs.h>
+#include <hoot/js/util/HootExceptionJs.h>
 
 // Qt
 #include <QCoreApplication>
@@ -307,7 +307,7 @@ void JavaScriptSchemaTranslator::_init()
 }
 
 // Use the layerNameFilter function to get the filter string (regexp)
-const QString JavaScriptSchemaTranslator::getLayerNameFilter()
+QString JavaScriptSchemaTranslator::getLayerNameFilter()
 {
   // Just making sure
   if (!_initialized)

--- a/hoot-js/src/main/cpp/hoot/js/schema/JavaScriptSchemaTranslator.h
+++ b/hoot-js/src/main/cpp/hoot/js/schema/JavaScriptSchemaTranslator.h
@@ -77,7 +77,7 @@ public:
 
   const Settings& getConfiguration() const { return _conf; }
 
-  virtual bool isValidScript();
+  bool isValidScript() override;
 
   /**
    * Should not be called publicly.
@@ -89,23 +89,23 @@ public:
    */
   int getLogCount(const QString& log);
 
-  virtual std::shared_ptr<const Schema> getOgrOutputSchema();
+  std::shared_ptr<const Schema> getOgrOutputSchema() override;
 
   // Filter for file names
-  virtual const QString getLayerNameFilter() override;
+  QString getLayerNameFilter() override;
 
   /**
    * Uses the specified script text instead of loading the script from a file.
    */
   void setScriptText(const QString& text) { close(); _scriptText = text; _scriptPath = QString(); }
 
-  virtual std::vector<TranslatedFeature> translateToOgr(Tags& tags, ElementType elementType,
-    geos::geom::GeometryTypeId geometryType);
+  std::vector<TranslatedFeature> translateToOgr(Tags& tags, ElementType elementType,
+    geos::geom::GeometryTypeId geometryType) override;
 
-  virtual std::vector<Tags> translateToOgrTags(Tags& tags, ElementType elementType,
-    geos::geom::GeometryTypeId geometryType);
+  std::vector<Tags> translateToOgrTags(Tags& tags, ElementType elementType,
+    geos::geom::GeometryTypeId geometryType) override;
 
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
 protected:
 
@@ -125,7 +125,7 @@ protected:
   std::vector<TranslatedFeature> _createAllFeatures(const QVariantList& vm);
   std::shared_ptr<Feature> _createFeature(const QVariantMap& vm, QString& tableName);
 
-  virtual void _init();
+  void _init() override;
 
   /**
    * Warn the user about the feature currently being processed.
@@ -133,7 +133,7 @@ protected:
   void _featureWarn(const QString& message, const QString& fileName, const QString& functionName,
                     int lineNumber);
 
-  virtual void _finalize();
+  void _finalize() override;
 
   QVariant& _getMapValue(QVariantMap& map, const QString& key);
 
@@ -156,7 +156,7 @@ protected:
   QVariantList _translateToOgrVariants(Tags& tags,
     ElementType elementType, geos::geom::GeometryTypeId geometryType);
 
-  virtual void _translateToOsm(Tags& t, const char *layerName, const char* geomType);
+  void _translateToOsm(Tags& t, const char *layerName, const char* geomType) override;
 };
 
 }

--- a/tgs/src/main/cpp/tgs/DelaunayTriangulation/DelaunayTriangulation.cpp
+++ b/tgs/src/main/cpp/tgs/DelaunayTriangulation/DelaunayTriangulation.cpp
@@ -97,18 +97,18 @@ double Edge::getOriginY() const { return _ie->Org2d().y; }
 double Edge::getDestinationX() const { return _ie->Dest2d().x; }
 double Edge::getDestinationY() const { return _ie->Dest2d().y; }
 
-const Edge Edge::getOriginNext() const { return _ie->Onext(); }
-const Edge Edge::getOriginPrevious() const { return _ie->Oprev(); }
-const Edge Edge::getDestinationNext() const { return _ie->Dnext(); }
-const Edge Edge::getDestinationPrevious() const { return _ie->Dprev(); }
+Edge Edge::getOriginNext() const { return _ie->Onext(); }
+Edge Edge::getOriginPrevious() const { return _ie->Oprev(); }
+Edge Edge::getDestinationNext() const { return _ie->Dnext(); }
+Edge Edge::getDestinationPrevious() const { return _ie->Dprev(); }
 
-const Edge Edge::getLeftNext() const { return _ie->Lnext(); }
-const Edge Edge::getLeftPrevious() const { return _ie->Lprev(); }
+Edge Edge::getLeftNext() const { return _ie->Lnext(); }
+Edge Edge::getLeftPrevious() const { return _ie->Lprev(); }
 
-const Edge Edge::getReverse() const { return _ie->Sym(); }
+Edge Edge::getReverse() const { return _ie->Sym(); }
 
-const Edge Edge::getRightNext() const { return _ie->Rnext(); }
-const Edge Edge::getRightPrevious() const { return _ie->Rprev(); }
+Edge Edge::getRightNext() const { return _ie->Rnext(); }
+Edge Edge::getRightPrevious() const { return _ie->Rprev(); }
 
 inline double distance(double x1, double x2, double y1, double y2)
 {
@@ -917,7 +917,7 @@ FaceIterator DelaunayTriangulation::getFaceIterator() const
   return FaceIterator(getEdgeIterator(), getEdgeEnd());
 }
 
-const Edge DelaunayTriangulation::getStartingEdge() const
+Edge DelaunayTriangulation::getStartingEdge() const
 {
   if (_pointCount < 3)
   {

--- a/tgs/src/main/cpp/tgs/DelaunayTriangulation/DelaunayTriangulation.h
+++ b/tgs/src/main/cpp/tgs/DelaunayTriangulation/DelaunayTriangulation.h
@@ -95,18 +95,18 @@ public:
   double getDestinationX() const;
   double getDestinationY() const;
 
-  const Edge getOriginNext() const;
-  const Edge getOriginPrevious() const;
-  const Edge getDestinationNext() const;
-  const Edge getDestinationPrevious() const;
+  Edge getOriginNext() const;
+  Edge getOriginPrevious() const;
+  Edge getDestinationNext() const;
+  Edge getDestinationPrevious() const;
 
-  const Edge getLeftNext() const;
-  const Edge getLeftPrevious() const;
+  Edge getLeftNext() const;
+  Edge getLeftPrevious() const;
 
-  const Edge getReverse() const;
+  Edge getReverse() const;
 
-  const Edge getRightNext() const;
-  const Edge getRightPrevious() const;
+  Edge getRightNext() const;
+  Edge getRightPrevious() const;
 
   double getLength() const;
 
@@ -250,7 +250,7 @@ public:
    * built while points are inserted so this should return very quickly. Any inserts that occur
    * will invalidate all previous edge pointers.
    */
-  const Edge getStartingEdge() const;
+  Edge getStartingEdge() const;
 
   const EdgeIterator& getEdgeEnd() const { return _edgeEnd; }
 

--- a/tgs/src/main/cpp/tgs/RStarTree/RTreeNode.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/RTreeNode.cpp
@@ -241,7 +241,7 @@ int RTreeNode::getChildCount() const
   return _getHeader()->childCount;
 }
 
-const BoxInternalData RTreeNode::getChildEnvelope(int childIndex) const
+BoxInternalData RTreeNode::getChildEnvelope(int childIndex) const
 {
   assert(childIndex < getChildCount());
   BoxInternalData bid(_dimensions, _getChildPtr(childIndex)->getBox());

--- a/tgs/src/main/cpp/tgs/RStarTree/RTreeNode.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/RTreeNode.h
@@ -167,7 +167,7 @@ public:
    * Returns the envelope for a specific child index
    * @param childIndex >= 0 && < getChildCount()
    */
-  const BoxInternalData getChildEnvelope(int childIndex) const;
+  BoxInternalData getChildEnvelope(int childIndex) const;
 
   /**
    * This method should rarely be used, and probably only be internal structure, not iterators


### PR DESCRIPTION
Remove const on return types for functions that aren't constant references

Closes #4566 