### PR TITLE
SONAR: using should be preferred to typedef for type aliasing

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTestServer.cpp
@@ -35,7 +35,7 @@
 namespace hoot
 {
 
-bool SimpleReaderTestServer::respond(HttpConnection::HttpConnectionPtr& connection)
+bool SimpleReaderTestServer::respond(HttpConnectionPtr& connection)
 {
   //  Read the HTTP request
   parse_request(connection);
@@ -50,7 +50,7 @@ bool SimpleReaderTestServer::respond(HttpConnection::HttpConnectionPtr& connecti
   return false;
 }
 
-bool GeographicSplitReaderTestServer::respond(HttpConnection::HttpConnectionPtr& connection)
+bool GeographicSplitReaderTestServer::respond(HttpConnectionPtr& connection)
 {
   //  Stop processing by setting this to false
   bool continue_processing = true;
@@ -98,7 +98,7 @@ HttpResponsePtr GeographicSplitReaderTestServer::get_sequence_response(const std
   return response;
 }
 
-bool ElementSplitReaderTestServer::respond(HttpConnection::HttpConnectionPtr& connection)
+bool ElementSplitReaderTestServer::respond(HttpConnectionPtr& connection)
 {
   //  Stop processing by setting this to false
   bool continue_processing = true;

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTestServer.h
@@ -41,7 +41,7 @@ public:
 
 protected:
   /** respond() function that responds once to the OSM API Capabilities request */
-  virtual bool respond(HttpConnection::HttpConnectionPtr& connection) override;
+  virtual bool respond(HttpConnectionPtr& connection) override;
 };
 
 class GeographicSplitReaderTestServer : public HttpSequencedServer
@@ -54,7 +54,7 @@ public:
 
 protected:
   /** respond() function that responds once to the OSM API Capabilities request */
-  virtual bool respond(HttpConnection::HttpConnectionPtr& connection) override;
+  virtual bool respond(HttpConnectionPtr& connection) override;
   /** get_sequence_response() function that gets the response message based on the URL requested */
   virtual HttpResponsePtr get_sequence_response(const std::string& request) override;
 };
@@ -70,7 +70,7 @@ public:
 
 protected:
   /** respond() function that responds once to the OSM API Capabilities request */
-  virtual bool respond(HttpConnection::HttpConnectionPtr& connection) override;
+  virtual bool respond(HttpConnectionPtr& connection) override;
   /** get_sequence_response() function that gets the response message based on the URL requested */
   virtual HttpResponsePtr get_sequence_response(const std::string& url) override;
   /** Force split based on "element count" */

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
@@ -35,7 +35,7 @@
 namespace hoot
 {
 
-bool CapabilitiesTestServer::respond(HttpConnection::HttpConnectionPtr &connection)
+bool CapabilitiesTestServer::respond(HttpConnectionPtr &connection)
 {
   //  Read the HTTP request
   parse_request(connection);
@@ -51,7 +51,7 @@ bool CapabilitiesTestServer::respond(HttpConnection::HttpConnectionPtr &connecti
   return false;
 }
 
-bool PermissionsTestServer::respond(HttpConnection::HttpConnectionPtr &connection)
+bool PermissionsTestServer::respond(HttpConnectionPtr &connection)
 {
   //  Read the HTTP request
   parse_request(connection);
@@ -67,7 +67,7 @@ bool PermissionsTestServer::respond(HttpConnection::HttpConnectionPtr &connectio
   return false;
 }
 
-bool RetryConflictsTestServer::respond(HttpConnection::HttpConnectionPtr& connection)
+bool RetryConflictsTestServer::respond(HttpConnectionPtr& connection)
 {
   //  Stop processing by setting this to false
   bool continue_processing = true;
@@ -103,7 +103,7 @@ bool RetryConflictsTestServer::respond(HttpConnection::HttpConnectionPtr& connec
   return continue_processing && !get_interupt();
 }
 
-bool RetryVersionTestServer::respond(HttpConnection::HttpConnectionPtr &connection)
+bool RetryVersionTestServer::respond(HttpConnectionPtr &connection)
 {
   /*
   *  - Capabilities
@@ -162,7 +162,7 @@ bool RetryVersionTestServer::respond(HttpConnection::HttpConnectionPtr &connecti
   return continue_processing && !get_interupt();
 }
 
-bool ChangesetOutputTestServer::respond(HttpConnection::HttpConnectionPtr& connection)
+bool ChangesetOutputTestServer::respond(HttpConnectionPtr& connection)
 {
   //  Stop processing by setting this to false
   bool continue_processing = true;
@@ -200,7 +200,7 @@ bool ChangesetOutputTestServer::respond(HttpConnection::HttpConnectionPtr& conne
   return continue_processing && !get_interupt();
 }
 
-bool ChangesetOutputThrottleTestServer::respond(HttpConnection::HttpConnectionPtr& connection)
+bool ChangesetOutputThrottleTestServer::respond(HttpConnectionPtr& connection)
 {
   //  Stop processing by setting this to false
   bool continue_processing = true;
@@ -240,7 +240,7 @@ bool ChangesetOutputThrottleTestServer::respond(HttpConnection::HttpConnectionPt
   return continue_processing && !get_interupt();
 }
 
-bool ChangesetCreateFailureTestServer::respond(HttpConnection::HttpConnectionPtr& connection)
+bool ChangesetCreateFailureTestServer::respond(HttpConnectionPtr& connection)
 {
   //  Stop processing by setting this to false
   bool continue_processing = true;
@@ -271,7 +271,7 @@ bool ChangesetCreateFailureTestServer::respond(HttpConnection::HttpConnectionPtr
   return continue_processing && !get_interupt();
 }
 
-bool CreateWaysFailNodesTestServer::respond(HttpConnection::HttpConnectionPtr& connection)
+bool CreateWaysFailNodesTestServer::respond(HttpConnectionPtr& connection)
 {
   //  Stop processing by setting this to false
   bool continue_processing = true;
@@ -309,7 +309,7 @@ bool CreateWaysFailNodesTestServer::respond(HttpConnection::HttpConnectionPtr& c
   return continue_processing && !get_interupt();
 }
 
-bool VersionFailureTestServer::respond(HttpConnection::HttpConnectionPtr& connection)
+bool VersionFailureTestServer::respond(HttpConnectionPtr& connection)
 {
   static int version = 1;
   //  Stop processing by setting this to false
@@ -354,7 +354,7 @@ bool VersionFailureTestServer::respond(HttpConnection::HttpConnectionPtr& connec
   return continue_processing && !get_interupt();
 }
 
-bool ElementGoneTestServer::respond(HttpConnection::HttpConnectionPtr& connection)
+bool ElementGoneTestServer::respond(HttpConnectionPtr& connection)
 {
   //  Stop processing by setting this to false
   bool continue_processing = true;
@@ -395,7 +395,7 @@ bool ElementGoneTestServer::respond(HttpConnection::HttpConnectionPtr& connectio
 }
 
 
-bool ChangesetSplitDeleteTestServer::respond(HttpConnection::HttpConnectionPtr& connection)
+bool ChangesetSplitDeleteTestServer::respond(HttpConnectionPtr& connection)
 {
   //  Stop processing by setting this to false
   bool continue_processing = true;
@@ -439,7 +439,7 @@ bool ChangesetSplitDeleteTestServer::respond(HttpConnection::HttpConnectionPtr& 
   return continue_processing && !get_interupt();
 }
 
-bool TimeoutTestServer::respond(HttpConnection::HttpConnectionPtr &connection)
+bool TimeoutTestServer::respond(HttpConnectionPtr &connection)
 {
   //  Read the HTTP request
   parse_request(connection);

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.h
@@ -41,7 +41,7 @@ public:
 
 protected:
   /** respond() function that responds once to the OSM API Capabilities request */
-  bool respond(HttpConnection::HttpConnectionPtr& connection) override;
+  bool respond(HttpConnectionPtr& connection) override;
 };
 
 class PermissionsTestServer : public HttpTestServer
@@ -52,7 +52,7 @@ public:
 
 protected:
   /** respond() function that responds once to the OSM API Permissions request */
-  bool respond(HttpConnection::HttpConnectionPtr &connection) override;
+  bool respond(HttpConnectionPtr &connection) override;
 };
 
 class RetryConflictsTestServer : public HttpTestServer
@@ -71,7 +71,7 @@ protected:
    *   - Changeset Upload - responding with an HTTP 405 error for the test
    *   - Changeset Close
    */
-  bool respond(HttpConnection::HttpConnectionPtr& connection) override;
+  bool respond(HttpConnectionPtr& connection) override;
 };
 
 class RetryVersionTestServer : public HttpTestServer
@@ -92,7 +92,7 @@ protected:
    *  - Changeset 1 Upload - respond with updated version
    *  - Changeset Close
    */
-  bool respond(HttpConnection::HttpConnectionPtr &connection) override;
+  bool respond(HttpConnectionPtr &connection) override;
 
 private:
   /** Flag set to false until the first changeset has failed once */
@@ -116,7 +116,7 @@ protected:
    *   - Changeset Upload - responds with HTTP 200
    *   - Changeset Close
    */
-  bool respond(HttpConnection::HttpConnectionPtr& connection) override;
+  bool respond(HttpConnectionPtr& connection) override;
 };
 
 class ChangesetOutputThrottleTestServer : public HttpTestServer
@@ -137,7 +137,7 @@ protected:
    *   - Changeset Upload - responds with HTTP 200
    *   - Changeset Close
    */
-  bool respond(HttpConnection::HttpConnectionPtr& connection) override;
+  bool respond(HttpConnectionPtr& connection) override;
 };
 
 class ChangesetCreateFailureTestServer : public HttpTestServer
@@ -154,7 +154,7 @@ protected:
    *   - Permissions
    *   - Changeset Create Failure x6
    */
-  bool respond(HttpConnection::HttpConnectionPtr &connection) override;
+  bool respond(HttpConnectionPtr &connection) override;
 };
 
 class CreateWaysFailNodesTestServer : public HttpTestServer
@@ -174,7 +174,7 @@ protected:
    *   - Changeset Upload - responds with HTTP 200
    *   - Changeset Close
    */
-  bool respond(HttpConnection::HttpConnectionPtr &connection) override;
+  bool respond(HttpConnectionPtr &connection) override;
 };
 
 class VersionFailureTestServer : public HttpTestServer
@@ -194,7 +194,7 @@ protected:
    *   - Element Get - responds with HTTP 200
    *   - Changeset Close
    */
-  bool respond(HttpConnection::HttpConnectionPtr &connection) override;
+  bool respond(HttpConnectionPtr &connection) override;
 };
 
 class ElementGoneTestServer : public HttpTestServer
@@ -214,7 +214,7 @@ protected:
    *   - Changeset Upload - responds with HTTP 200
    *   - Changeset Close
    */
-  bool respond(HttpConnection::HttpConnectionPtr &connection) override;
+  bool respond(HttpConnectionPtr &connection) override;
 };
 
 class ChangesetSplitDeleteTestServer : public HttpTestServer
@@ -236,7 +236,7 @@ protected:
    *   - Changeset Upload - responds with HTTP 200
    *   - Changeset Close
    */
-  bool respond(HttpConnection::HttpConnectionPtr &connection) override;
+  bool respond(HttpConnectionPtr &connection) override;
 };
 
 class TimeoutTestServer : public HttpTestServer
@@ -248,7 +248,7 @@ public:
 protected:
   /** respond() function that waits 5 seconds before responding to simulate a timeout
    */
-  bool respond(HttpConnection::HttpConnectionPtr &connection) override;
+  bool respond(HttpConnectionPtr &connection) override;
 };
 
 class OsmApiSampleRequestResponse

--- a/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.cpp
@@ -157,13 +157,13 @@ void HttpTestServer::start_accept()
   if (_interupt)
     return;
   //  Creat the connection
-  HttpConnection::HttpConnectionPtr new_connection(new HttpConnection(_acceptor->get_io_service()));
+  HttpConnectionPtr new_connection(new HttpConnection(_acceptor->get_io_service()));
   //  Accept connections async
   _acceptor->async_accept(new_connection->socket(),
     boost::bind(&HttpTestServer::handle_accept, this, new_connection, boost::asio::placeholders::error));
 }
 
-void HttpTestServer::handle_accept(HttpConnection::HttpConnectionPtr new_connection, const boost::system::error_code& error)
+void HttpTestServer::handle_accept(HttpConnectionPtr new_connection, const boost::system::error_code& error)
 {
   //  Call the overridden respond() function
   bool continue_processing = !error;
@@ -176,7 +176,7 @@ void HttpTestServer::handle_accept(HttpConnection::HttpConnectionPtr new_connect
     stop();
 }
 
-bool HttpTestServer::respond(HttpConnection::HttpConnectionPtr& connection)
+bool HttpTestServer::respond(HttpConnectionPtr& connection)
 {
   //  Read the HTTP request
   parse_request(connection);
@@ -188,7 +188,7 @@ bool HttpTestServer::respond(HttpConnection::HttpConnectionPtr& connection)
   return !_interupt;
 }
 
-void HttpTestServer::parse_request(HttpConnection::HttpConnectionPtr &connection)
+void HttpTestServer::parse_request(HttpConnectionPtr &connection)
 {
   //  Reset headers and body
   _headers.clear();
@@ -233,7 +233,7 @@ void HttpTestServer::parse_request(HttpConnection::HttpConnectionPtr &connection
   }
 }
 
-void HttpTestServer::write_response(HttpConnection::HttpConnectionPtr& connection, const std::string& response)
+void HttpTestServer::write_response(HttpConnectionPtr& connection, const std::string& response)
 {
   LOG_TRACE("Response:\n" << response);
   //  Write the response to the socket synchronously

--- a/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.h
@@ -79,7 +79,8 @@ private:
   std::map<std::string, std::string> _header_values;
 };
 
-typedef std::shared_ptr<HttpResponse> HttpResponsePtr;
+/** Type def for shared pointer */
+using HttpResponsePtr = std::shared_ptr<HttpResponse>;
 
 /**
  * @brief The HttpConnection class encapsulates an HTTP connection on a socket
@@ -87,8 +88,6 @@ typedef std::shared_ptr<HttpResponse> HttpResponsePtr;
 class HttpConnection : public std::enable_shared_from_this<HttpConnection>
 {
 public:
-  /** Type def for shared pointer */
-  typedef std::shared_ptr<HttpConnection> HttpConnectionPtr;
   /** Constructor */
   HttpConnection(boost::asio::io_service& io_service) : _socket(io_service) { }
   /** Socket accessor */
@@ -100,6 +99,9 @@ private:
   /** Socket for this HTTP connection */
   boost::asio::ip::tcp::socket _socket;
 };
+
+/** Type def for shared pointer */
+using HttpConnectionPtr = std::shared_ptr<HttpConnection>;
 
 /**
  * @brief The HttpTestServer class is a base class that provides simple HTTP server capabilites.
@@ -131,11 +133,11 @@ protected:
    * @param connection Current connection
    * @return True if the server should continue to listen for connections, false to stop
    */
-  virtual bool respond(HttpConnection::HttpConnectionPtr& connection);
+  virtual bool respond(HttpConnectionPtr& connection);
   /** Parset the headers and body of the HTTP request */
-  void parse_request(HttpConnection::HttpConnectionPtr& connection);
+  void parse_request(HttpConnectionPtr& connection);
   /** Write the response back to the requestor, called by the overridden respond() function */
-  void write_response(HttpConnection::HttpConnectionPtr& connection, const std::string& response);
+  void write_response(HttpConnectionPtr& connection, const std::string& response);
   /** Get the value of the interupt flag */
   bool get_interupt() { return _interupt; }
   /** Shutdown the thread but don't wait on it */
@@ -151,7 +153,7 @@ private:
   /** Begin the process of accepting an HTTP connection */
   void start_accept();
   /** Handle the HTTP connection and calls the overridden respond() function */
-  void handle_accept(HttpConnection::HttpConnectionPtr new_connection, const boost::system::error_code& error);
+  void handle_accept(HttpConnectionPtr new_connection, const boost::system::error_code& error);
   /** Parse out the value of the "Content-Length" HTTP header */
   long parse_content_length(const std::string& headers);
   /** IO Service object */

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/FrechetDistance.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/FrechetDistance.h
@@ -42,13 +42,13 @@
 namespace hoot
 {
 
-typedef boost::multi_array<Meters, 2> frechet_matrix;
-typedef frechet_matrix::index frechet_index;
-typedef std::pair<int, int> vertex_match;
-typedef std::vector<vertex_match> subline_entry;
-typedef std::pair<Meters, subline_entry> frechet_subline;
+using frechet_matrix = boost::multi_array<Meters, 2>;
+using frechet_index = frechet_matrix::index;
+using vertex_match = std::pair<int, int>;
+using subline_entry = std::vector<vertex_match>;
+using frechet_subline = std::pair<Meters, subline_entry>;
 
-typedef std::shared_ptr<geos::geom::LineString> LineStringPtr;
+using LineStringPtr = std::shared_ptr<geos::geom::LineString>;
 
 /** Class for calculating Frechet Distance between two ways and calculating maximal subline matches.
  *  Algorithm developed from "A new merging process for data integration base on the descrete Frechet distance"

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/Sparse2dMatrix.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/Sparse2dMatrix.h
@@ -78,8 +78,8 @@ class Sparse2dMatrix
 {
 public:
 
-  typedef Sparse2dCellId CellId;
-  typedef HashMap<CellId, double>::const_iterator const_iterator;
+  using CellId = Sparse2dCellId;
+  using const_iterator = HashMap<CellId, double>::const_iterator;
 
   Sparse2dMatrix() = default;
   virtual ~Sparse2dMatrix() = default;

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoinerAdvanced.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoinerAdvanced.h
@@ -46,12 +46,12 @@ public:
 
   static QString className() { return "hoot::WayJoinerAdvanced"; }
 
-  typedef enum
+  enum JoinAtNodeMergeType
   {
     ParentFirst,
     ParentLast,
     ShareFirstNode
-  } JoinAtNodeMergeType;
+  };
 
   WayJoinerAdvanced();
   virtual ~WayJoinerAdvanced() = default;

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayMatchStringMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayMatchStringMerger.h
@@ -95,7 +95,7 @@ public:
     WayPtr _newWay1;
     WayPtr _newWay2;
   };
-  typedef std::shared_ptr<SublineMapping> SublineMappingPtr;
+  using SublineMappingPtr = std::shared_ptr<SublineMapping>;
 
   class SublineMappingLessThan
   {
@@ -205,8 +205,8 @@ private:
   void _splitPrimary();
 };
 
-typedef std::shared_ptr<WayMatchStringMerger> WayMatchStringMergerPtr;
-typedef std::shared_ptr<const WayMatchStringMerger> ConstWayMatchStringMergerPtr;
+using WayMatchStringMergerPtr = std::shared_ptr<WayMatchStringMerger>;
+using ConstWayMatchStringMergerPtr = std::shared_ptr<const WayMatchStringMerger>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/aggregator/ValueAggregator.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/aggregator/ValueAggregator.h
@@ -59,7 +59,7 @@ public:
   virtual QString toString() const { return ""; }
 };
 
-typedef std::shared_ptr<ValueAggregator> ValueAggregatorPtr;
+using ValueAggregatorPtr = std::shared_ptr<ValueAggregator>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShape.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/alpha-shape/AlphaShape.h
@@ -62,7 +62,7 @@ class FaceGroup;
 class OsmMap;
 class Way;
 
-typedef std::shared_ptr<geos::geom::Geometry> GeometryPtr;
+using GeometryPtr = std::shared_ptr<geos::geom::Geometry>;
 
 /**
  * Representation of an Alpha Shape. Technically an Alpha complex, not an Alpha Shape, but the

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetDeriver.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetDeriver.h
@@ -106,7 +106,7 @@ private:
   QStringList _metadataAllowKeys;
 };
 
-typedef std::shared_ptr<ChangesetDeriver> ChangesetDeriverPtr;
+using ChangesetDeriverPtr = std::shared_ptr<ChangesetDeriver>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetProvider.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetProvider.h
@@ -122,7 +122,7 @@ public:
   virtual int getNumChanges() const { return 0; }
 };
 
-typedef std::shared_ptr<ChangesetProvider> ChangesetProviderPtr;
+using ChangesetProviderPtr = std::shared_ptr<ChangesetProvider>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/MemChangesetProvider.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/MemChangesetProvider.h
@@ -81,7 +81,7 @@ private:
   std::list<Change> _changes;
 };
 
-typedef std::shared_ptr<MemChangesetProvider> MemChangesetProviderPtr;
+using MemChangesetProviderPtr = std::shared_ptr<MemChangesetProvider>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/MultipleChangesetProvider.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/MultipleChangesetProvider.h
@@ -73,7 +73,7 @@ private:
   std::list<ChangesetProviderPtr> _changesets;
 };
 
-typedef std::shared_ptr<MultipleChangesetProvider> MultipleChangesetProviderPtr;
+using MultipleChangesetProviderPtr = std::shared_ptr<MultipleChangesetProvider>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/FeatureExtractor.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/FeatureExtractor.h
@@ -81,7 +81,7 @@ public:
   static bool isNull(double v) { return v == nullValue() || ::qIsNaN(v); }
 };
 
-typedef std::shared_ptr<FeatureExtractor> FeatureExtractorPtr;
+using FeatureExtractorPtr = std::shared_ptr<FeatureExtractor>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayLocation.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayLocation.h
@@ -196,8 +196,8 @@ inline uint qHash(const WayLocation& wl)
   return qHash(wl.toString());
 }
 
-typedef std::shared_ptr<WayLocation> WayLocationPtr;
-typedef std::shared_ptr<const WayLocation> ConstWayLocationPtr;
+using WayLocationPtr = std::shared_ptr<WayLocation>;
+using ConstWayLocationPtr = std::shared_ptr<const WayLocation>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayMatchStringMapping.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayMatchStringMapping.h
@@ -93,8 +93,8 @@ public:
   { return "1: " + getWayString1()->toString() + "; 2: " + getWayString2()->toString(); }
 };
 
-typedef std::shared_ptr<WayMatchStringMapping> WayMatchStringMappingPtr;
-typedef std::shared_ptr<const WayMatchStringMapping> ConstWayMatchStringMappingPtr;
+using WayMatchStringMappingPtr = std::shared_ptr<WayMatchStringMapping>;
+using ConstWayMatchStringMappingPtr = std::shared_ptr<const WayMatchStringMapping>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayString.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayString.h
@@ -105,8 +105,8 @@ private:
   WayLocation _changeToPreferred(int index, const WayLocation& wl, ElementId preferredEid) const;
 };
 
-typedef std::shared_ptr<WayString> WayStringPtr;
-typedef std::shared_ptr<const WayString> ConstWayStringPtr;
+using WayStringPtr = std::shared_ptr<WayString>;
+using ConstWayStringPtr = std::shared_ptr<const WayString>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySublineCollection.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySublineCollection.h
@@ -52,7 +52,7 @@ public:
 
   static int logWarnCount;
 
-  typedef std::vector<WaySubline> SublineCollection;
+  using SublineCollection = std::vector<WaySubline>;
 
   WaySublineCollection() = default;
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySublineMatchString.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySublineMatchString.h
@@ -53,7 +53,7 @@ public:
 
   static QString className() { return "hoot::WaySublineMatchString"; }
 
-  typedef std::vector<WaySublineMatch> MatchCollection;
+  using MatchCollection = std::vector<WaySublineMatch>;
 
   WaySublineMatchString() = default;
   /**
@@ -127,8 +127,8 @@ private:
 
 HOOT_DEFINE_EXCEPTION(OverlappingMatchesException)
 
-typedef std::shared_ptr<WaySublineMatchString> WaySublineMatchStringPtr;
-typedef std::shared_ptr<const WaySublineMatchString> ConstWaySublineMatchStringPtr;
+using WaySublineMatchStringPtr = std::shared_ptr<WaySublineMatchString>;
+using ConstWaySublineMatchStringPtr = std::shared_ptr<const WaySublineMatchString>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/SingleAssignmentProblemSolver.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/optimizer/SingleAssignmentProblemSolver.h
@@ -65,7 +65,7 @@ public:
     virtual double cost(const Actor* a, const Task* t) const = 0;
   };
 
-  typedef struct ResultPair
+  struct ResultPair
   {
     const Actor* actor;
     const Task* task;
@@ -75,7 +75,7 @@ public:
       return (actor ? actor->toString() : QString("null")) + " " +
              (task ? task->toString() : QString("null"));
     }
-  } ResultPair;
+  };
 
   SingleAssignmentProblemSolver(CostFunction& costFunction) : _costFunction(costFunction) { }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheet.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheet.h
@@ -177,7 +177,7 @@ private:
 
   static int logWarnCount;
 
-  typedef std::map<long, std::list<Match>> MatchList;
+  using MatchList = std::map<long, std::list<Match>>;
 
   class Tie
   {

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/splitter/DualHighwaySplitter.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/splitter/DualHighwaySplitter.h
@@ -55,11 +55,11 @@ public:
 
   static QString className() { return "hoot::DualHighwaySplitter"; }
 
-  typedef enum DrivingSide
+  enum DrivingSide
   {
     Left,
     Right
-  } DrivingSide;
+  };
 
   DualHighwaySplitter();
   DualHighwaySplitter(const std::shared_ptr<const OsmMap>& map, DrivingSide drivingSide,

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/splitter/OsmMapSplitter.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/splitter/OsmMapSplitter.h
@@ -75,7 +75,7 @@ private:
    */
   void _placeElementInMap(const ElementPtr& element);
 
-  typedef QMap<geos::geom::Envelope, OsmMapPtr> TileMap;
+  using TileMap = QMap<geos::geom::Envelope, OsmMapPtr>;
   /** Original map to split up */
   OsmMapPtr _map;
   /** Map of polygon ways that indicate tile divisions */

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/string/MostEnglishName.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/string/MostEnglishName.h
@@ -43,7 +43,7 @@ namespace hoot
 class MostEnglishName;
 class Tags;
 
-typedef std::shared_ptr<MostEnglishName> MostEnglishNamePtr;
+using MostEnglishNamePtr = std::shared_ptr<MostEnglishName>;
 
 /**
  * Return a best guess at the "most english" name in the list (Singleton). There are no guarantees.

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/string/SqliteWordWeightDictionary.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/string/SqliteWordWeightDictionary.h
@@ -67,7 +67,7 @@ private:
   // ** Using this one, fast, low memory and I don't have to worry about int overflow **
   // HashMap<QString, long>   1.069GB   19.4sec
   // HashMap<QString, int>    1.069GB   19.2sec
-  typedef HashMap<QString, long> WeightHash;
+  using WeightHash = HashMap<QString, long>;
   mutable WeightHash _weights;
   long _count;
   QRegExp _nonWord;

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/string/StringDistance.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/string/StringDistance.h
@@ -60,7 +60,7 @@ public:
   virtual QString toString() const = 0;
 };
 
-typedef std::shared_ptr<StringDistance> StringDistancePtr;
+using StringDistancePtr = std::shared_ptr<StringDistance>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/string/TextFileWordWeightDictionary.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/string/TextFileWordWeightDictionary.h
@@ -85,7 +85,7 @@ private:
   // ** Using this one, fast, low memory and I don't have to worry about int overflow **
   // HashMap<QString, long>   1.069GB   19.4sec
   // HashMap<QString, int>    1.069GB   19.2sec
-  typedef HashMap<QString, long> WeightHash;
+  using WeightHash = HashMap<QString, long>;
   WeightHash _weights;
   long _count;
   QRegExp _nonWord;

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/string/WordWeightDictionary.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/string/WordWeightDictionary.h
@@ -60,7 +60,7 @@ public:
   virtual double getWeight(const QString& word) const = 0;
 };
 
-typedef std::shared_ptr<WordWeightDictionary> WordWeightDictionaryPtr;
+using WordWeightDictionaryPtr = std::shared_ptr<WordWeightDictionary>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/SublineMatcher.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/SublineMatcher.h
@@ -62,7 +62,7 @@ public:
   virtual QString toString() const override { return ""; }
 };
 
-typedef std::shared_ptr<SublineMatcher> SublineMatcherPtr;
+using SublineMatcherPtr = std::shared_ptr<SublineMatcher>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/SublineStringMatcher.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/SublineStringMatcher.h
@@ -74,7 +74,7 @@ public:
   virtual QString toString() const override { return ""; }
 };
 
-typedef std::shared_ptr<SublineStringMatcher> SublineStringMatcherPtr;
+using SublineStringMatcherPtr = std::shared_ptr<SublineStringMatcher>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/BaseCommand.h
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/BaseCommand.h
@@ -71,7 +71,7 @@ protected:
   virtual QString _getHelpPath() const;
 };
 
-typedef std::shared_ptr<BaseCommand> BaseCommandPtr;
+using BaseCommandPtr = std::shared_ptr<BaseCommand>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/Command.h
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/Command.h
@@ -87,8 +87,8 @@ public:
   virtual QString getType() const { return "core"; }
 };
 
-typedef std::shared_ptr<Command> CommandPtr;
-typedef std::shared_ptr<const Command> ConstCommandPtr;
+using CommandPtr = std::shared_ptr<Command>;
+using ConstCommandPtr = std::shared_ptr<const Command>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/IdSwap.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/IdSwap.h
@@ -42,9 +42,9 @@ class IdSwap
 public:
 
   /** Helpful typedefs for container and iterators */
-  typedef std::map<ElementId, ElementId> container;
-  typedef typename container::iterator iterator;
-  typedef typename container::const_iterator const_iterator;
+  using container = std::map<ElementId, ElementId>;
+  using iterator = container::iterator;
+  using const_iterator = container::const_iterator;
 
   IdSwap() = default;
   IdSwap(ElementId id_1, ElementId id_2) { add(id_1, id_2); }
@@ -79,7 +79,7 @@ private:
   container _idMapReversed;
 };
 
-typedef std::shared_ptr<IdSwap> IdSwapPtr;
+using IdSwapPtr = std::shared_ptr<IdSwap>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/SearchBoundsCalculator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/SearchBoundsCalculator.h
@@ -56,7 +56,7 @@ private:
   std::shared_ptr<SearchRadiusProvider> _radiusProvider;
 };
 
-typedef std::shared_ptr<SearchBoundsCalculator> SearchBoundsCalculatorPtr;
+using SearchBoundsCalculatorPtr = std::shared_ptr<SearchBoundsCalculator>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/SearchRadiusProvider.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/SearchRadiusProvider.h
@@ -54,7 +54,7 @@ public:
   virtual Meters calculateSearchRadius(const ConstOsmMapPtr& map, const ConstElementPtr& e) = 0;
 };
 
-typedef std::shared_ptr<SearchRadiusProvider> SearchRadiusProviderPtr;
+using SearchRadiusProviderPtr = std::shared_ptr<SearchRadiusProvider>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressTagKeys.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/AddressTagKeys.h
@@ -39,7 +39,7 @@ namespace hoot
 
 class AddressTagKeys;
 
-typedef std::shared_ptr<AddressTagKeys> AddressTagKeysPtr;
+using AddressTagKeysPtr = std::shared_ptr<AddressTagKeys>;
 
 /**
  * Allows for mapping an address part type to a range of valid OSM tag keys

--- a/hoot-core/src/main/cpp/hoot/core/conflate/address/LibPostalInit.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/address/LibPostalInit.h
@@ -35,7 +35,7 @@ namespace hoot
 
 class LibPostalInit;
 
-typedef std::shared_ptr<LibPostalInit> LibPostalInitPtr;
+using LibPostalInitPtr = std::shared_ptr<LibPostalInit>;
 
 /**
  * Singleton access for initializing/destroying libpostal (Singleton)

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/Roundabout.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/Roundabout.cpp
@@ -50,7 +50,7 @@ using geos::geom::CoordinateSequence;
 namespace hoot
 {
 
-typedef std::shared_ptr<geos::geom::Geometry> GeomPtr;
+using GeomPtr = std::shared_ptr<geos::geom::Geometry>;
 
 Roundabout::Roundabout() :
 _status(Status::Invalid),

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/Roundabout.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/Roundabout.h
@@ -174,8 +174,8 @@ private:
 };
 
 // For convenience
-typedef std::shared_ptr<Roundabout> RoundaboutPtr;
-typedef std::shared_ptr<const Roundabout> ConstRoundaboutPtr;
+using RoundaboutPtr = std::shared_ptr<Roundabout>;
+using ConstRoundaboutPtr = std::shared_ptr<const Roundabout>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/Match.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/Match.h
@@ -44,8 +44,8 @@ class MatchType;
 class MatchClassification;
 class Match;
 
-typedef std::shared_ptr<Match> MatchPtr;
-typedef std::shared_ptr<const Match> ConstMatchPtr;
+using MatchPtr = std::shared_ptr<Match>;
+using ConstMatchPtr = std::shared_ptr<const Match>;
 
 /**
  * Describes a specific match between two sets of elements. For example the match between two

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchConflicts.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchConflicts.h
@@ -46,8 +46,8 @@ class MatchConflicts
 {
 public:
 
-  typedef QMultiHash<size_t, size_t> ConflictMap;
-  typedef std::multimap<ElementId, size_t> EidIndexMap;
+  using ConflictMap = QMultiHash<size_t, size_t>;
+  using EidIndexMap = std::multimap<ElementId, size_t>;
 
   MatchConflicts(const ConstOsmMapPtr& map);
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.h
@@ -131,8 +131,8 @@ private:
   bool _boundsAddedToFilter;
 };
 
-typedef std::shared_ptr<MatchCreator> MatchCreatorPtr;
-typedef std::shared_ptr<const MatchCreator> ConstMatchCreatorPtr;
+using MatchCreatorPtr = std::shared_ptr<MatchCreator>;
+using ConstMatchCreatorPtr = std::shared_ptr<const MatchCreator>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.cpp
@@ -67,12 +67,12 @@ class MatchEdge
 {
 public:
 
-  typedef enum
+  enum MatchType
   {
     AssociatedWith,
     MatchWith,
     InvalidMatch
-  } MatchType;
+  };
 
   MatchEdge() : match(nullptr), type(InvalidMatch) { }
   MatchEdge(ConstMatchPtr m, MatchType t) : match(m), type(t) { }
@@ -91,7 +91,7 @@ public:
   ElementId eid;
 };
 
-typedef boost::adjacency_list<
+using MatchBoostGraph = boost::adjacency_list<
   // Use listS for storing VertexList -- faster, but not as space efficient (no biggie)
   boost::listS,
   // use vecS for storing OutEdgeList -- faster for traversal, but slower to build (no biggie)
@@ -99,11 +99,10 @@ typedef boost::adjacency_list<
   // Our graph is undirected
   boost::undirectedS,
   MatchVertex,
-  MatchEdge
-> MatchBoostGraph;
+  MatchEdge>;
 
-typedef boost::graph_traits<MatchBoostGraph>::vertex_descriptor MatchVertexId;
-typedef boost::graph_traits<MatchBoostGraph>::edge_descriptor MatchEdgeId;
+using MatchVertexId = boost::graph_traits<MatchBoostGraph>::vertex_descriptor;
+using MatchEdgeId = boost::graph_traits<MatchBoostGraph>::edge_descriptor;
 
 class MatchGraphInternal
 {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.h
@@ -41,7 +41,7 @@ namespace hoot
 
 class MatchGraphInternal;
 
-typedef std::vector<MatchSet> MatchSetVector;
+using MatchSetVector = std::vector<MatchSet>;
 
 /**
  * Represents a graph of matches. At some point I'd like to extend this to include additional

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchSet.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchSet.h
@@ -36,7 +36,7 @@
 namespace hoot
 {
 
-typedef std::set<ConstMatchPtr, MatchPtrComparator> MatchSet;
+using MatchSet = std::set<ConstMatchPtr, MatchPtrComparator>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchThreshold.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchThreshold.h
@@ -79,8 +79,8 @@ private:
 
 };
 
-typedef std::shared_ptr<MatchThreshold> MatchThresholdPtr;
-typedef std::shared_ptr<const MatchThreshold> ConstMatchThresholdPtr;
+using MatchThresholdPtr = std::shared_ptr<MatchThreshold>;
+using ConstMatchThresholdPtr = std::shared_ptr<const MatchThreshold>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/NodeMatcher.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/NodeMatcher.h
@@ -113,8 +113,8 @@ private:
                               size_t depth, bool debug = false);
 };
 
-typedef std::shared_ptr<NodeMatcher> NodeMatcherPtr;
-typedef std::shared_ptr<const NodeMatcher> ConstNodeMatcherPtr;
+using NodeMatcherPtr = std::shared_ptr<NodeMatcher>;
+using ConstNodeMatcherPtr = std::shared_ptr<const NodeMatcher>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearSnapMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearSnapMerger.h
@@ -109,7 +109,7 @@ private:
   void _updateScrapParent(const OsmMapPtr& map, long id, const ElementPtr& scrap);
 };
 
-typedef std::shared_ptr<LinearSnapMerger> LinearSnapMergerPtr;
+using LinearSnapMergerPtr = std::shared_ptr<LinearSnapMerger>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearTagOnlyMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearTagOnlyMerger.h
@@ -89,7 +89,7 @@ private:
                   std::vector<std::pair<ElementId, ElementId>>& replaced);
 };
 
-typedef std::shared_ptr<LinearTagOnlyMerger> LinearTagOnlyMergerPtr;
+using LinearTagOnlyMergerPtr = std::shared_ptr<LinearTagOnlyMerger>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/Merger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/Merger.h
@@ -80,8 +80,8 @@ public:
   virtual QString toString() const = 0;
 };
 
-typedef std::shared_ptr<Merger> MergerPtr;
-typedef std::shared_ptr<const Merger> ConstMergerPtr;
+using MergerPtr = std::shared_ptr<Merger>;
+using ConstMergerPtr = std::shared_ptr<const Merger>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerBase.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerBase.h
@@ -38,7 +38,7 @@ public:
 
   static QString className() { return "hoot::MergerBase"; }
 
-  typedef std::set<std::pair<ElementId, ElementId>> PairsSet;
+  using PairsSet = std::set<std::pair<ElementId, ElementId>>;
 
   MergerBase() = default;
   virtual ~MergerBase() = default;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerCreator.h
@@ -90,8 +90,8 @@ public:
   virtual void setArguments(QStringList /*args*/) { throw IllegalArgumentException(); }
 };
 
-typedef std::shared_ptr<MergerCreator> MergerCreatorPtr;
-typedef std::shared_ptr<const MergerCreator> ConstMergerCreatorPtr;
+using MergerCreatorPtr = std::shared_ptr<MergerCreator>;
+using ConstMergerCreatorPtr = std::shared_ptr<const MergerCreator>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MultipleSublineMatcherSnapMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MultipleSublineMatcherSnapMerger.h
@@ -76,7 +76,7 @@ private:
   std::shared_ptr<SublineStringMatcher> _sublineMatcher2;
 };
 
-typedef std::shared_ptr<MultipleSublineMatcherSnapMerger> MultipleSublineMatcherSnapMergerPtr;
+using MultipleSublineMatcherSnapMergerPtr = std::shared_ptr<MultipleSublineMatcherSnapMerger>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/ConflictsNetworkMatcher.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/ConflictsNetworkMatcher.h
@@ -83,9 +83,9 @@ private:
   // for white box testing.
   friend class ConflictsNetworkMatcherTest;
 
-  typedef SingleAssignmentProblemSolver<EdgeString, EdgeString> Saps;
+  using Saps = SingleAssignmentProblemSolver<EdgeString, EdgeString>;
 
-  typedef QHash<ConstEdgeMatchPtr, double> EdgeScoreMap;
+  using EdgeScoreMap = QHash<ConstEdgeMatchPtr, double>;
 
   class MatchRelationship
   {
@@ -111,10 +111,10 @@ private:
     bool _conflict;
     QSet<ConstEdgeMatchPtr> _throughStub;
   };
-  typedef std::shared_ptr<const MatchRelationship> ConstMatchRelationshipPtr;
-  typedef std::shared_ptr<MatchRelationship> MatchRelationshipPtr;
+  using MatchRelationshipPtr = std::shared_ptr<MatchRelationship>;
+  using ConstMatchRelationshipPtr = std::shared_ptr<const MatchRelationship>;
 
-  typedef QHash<ConstEdgeMatchPtr, QList<ConstMatchRelationshipPtr>> MatchRelationshipMap;
+  using MatchRelationshipMap = QHash<ConstEdgeMatchPtr, QList<ConstMatchRelationshipPtr>>;
 
   IndexedEdgeMatchSetPtr _edgeMatches;
   EdgeScoreMap _scores, _weights;
@@ -170,8 +170,8 @@ private:
   void _printEdgeMatches();
 };
 
-typedef std::shared_ptr<ConflictsNetworkMatcher> ConflictsNetworkMatcherPtr;
-typedef std::shared_ptr<const ConflictsNetworkMatcher> ConstConflictsNetworkMatcherPtr;
+using ConflictsNetworkMatcherPtr = std::shared_ptr<ConflictsNetworkMatcher>;
+using ConstConflictsNetworkMatcherPtr = std::shared_ptr<const ConflictsNetworkMatcher>;
 
 // not implemented
 bool operator<(ConstConflictsNetworkMatcherPtr, ConstConflictsNetworkMatcherPtr);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeLocation.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeLocation.h
@@ -89,8 +89,8 @@ private:
 
 };
 
-typedef std::shared_ptr<EdgeLocation> EdgeLocationPtr;
-typedef std::shared_ptr<const EdgeLocation> ConstEdgeLocationPtr;
+using EdgeLocationPtr = std::shared_ptr<EdgeLocation>;
+using ConstEdgeLocationPtr = std::shared_ptr<const EdgeLocation>;
 
 inline bool operator==(const ConstEdgeLocationPtr& a, const ConstEdgeLocationPtr& b)
 {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeMatch.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeMatch.h
@@ -128,8 +128,8 @@ private:
   void _resetHash() const { _hash = 0; }
 };
 
-typedef std::shared_ptr<EdgeMatch> EdgeMatchPtr;
-typedef std::shared_ptr<const EdgeMatch> ConstEdgeMatchPtr;
+using EdgeMatchPtr = std::shared_ptr<EdgeMatch>;
+using ConstEdgeMatchPtr = std::shared_ptr<const EdgeMatch>;
 
 // not implemented
 bool operator<(ConstEdgeMatchPtr, ConstEdgeMatchPtr);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeMatchSet.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeMatchSet.h
@@ -45,8 +45,8 @@ public:
 
 };
 
-typedef std::shared_ptr<EdgeMatchSet> EdgeMatchSetPtr;
-typedef std::shared_ptr<const EdgeMatchSet> ConstEdgeMatchSetPtr;
+using EdgeMatchSetPtr = std::shared_ptr<EdgeMatchSet>;
+using ConstEdgeMatchSetPtr = std::shared_ptr<const EdgeMatchSet>;
 
 // not implemented
 bool operator<(ConstEdgeMatchSetPtr, ConstEdgeMatchSetPtr);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeMatchSetFinder.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeMatchSetFinder.h
@@ -40,7 +40,7 @@ struct EdgeMatchScore
 };
 
 // Stores a set of edge matches, keyed by a similarity string; see EdgeMatch::isVerySimilarTo
-typedef QHash<QString, EdgeMatchScore> EdgeMatchSimilarity;
+using EdgeMatchSimilarity = QHash<QString, EdgeMatchScore>;
 
 class EdgeMatchSetFinder
 {
@@ -129,8 +129,8 @@ private:
   void _resetEdgeMatchSimilarities();
 };
 
-typedef std::shared_ptr<EdgeMatchSetFinder> EdgeMatchSetFinderPtr;
-typedef std::shared_ptr<const EdgeMatchSetFinder> ConstEdgeMatchSetFinderPtr;
+using EdgeMatchSetFinderPtr = std::shared_ptr<EdgeMatchSetFinder>;
+using ConstEdgeMatchSetFinderPtr = std::shared_ptr<const EdgeMatchSetFinder>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeString.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeString.h
@@ -239,8 +239,8 @@ private:
   QList<EdgeEntry> _edges;
 };
 
-typedef std::shared_ptr<EdgeString> EdgeStringPtr;
-typedef std::shared_ptr<const EdgeString> ConstEdgeStringPtr;
+using EdgeStringPtr = std::shared_ptr<EdgeString>;
+using ConstEdgeStringPtr = std::shared_ptr<const EdgeString>;
 
 // not implemented
 bool operator<(ConstEdgeStringPtr, ConstEdgeStringPtr);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeSubline.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeSubline.h
@@ -117,8 +117,8 @@ private:
   ConstEdgeLocationPtr _start, _end;
 };
 
-typedef std::shared_ptr<EdgeSubline> EdgeSublinePtr;
-typedef std::shared_ptr<const EdgeSubline> ConstEdgeSublinePtr;
+using EdgeSublinePtr = std::shared_ptr<EdgeSubline>;
+using ConstEdgeSublinePtr = std::shared_ptr<const EdgeSubline>;
 
 bool operator==(const ConstEdgeSublinePtr&, const ConstEdgeSublinePtr&);
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeSublineMatch.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeSublineMatch.h
@@ -57,8 +57,8 @@ private:
 
 };
 
-typedef std::shared_ptr<EdgeSublineMatch> EdgeSublineMatchPtr;
-typedef std::shared_ptr<const EdgeSublineMatch> ConstEdgeSublineMatchPtr;
+using EdgeSublineMatchPtr = std::shared_ptr<EdgeSublineMatch>;
+using ConstEdgeSublineMatchPtr = std::shared_ptr<const EdgeSublineMatch>;
 
 // not implemented
 bool operator<(ConstEdgeSublineMatchPtr, ConstEdgeSublineMatchPtr);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/IndexedEdgeLinks.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/IndexedEdgeLinks.h
@@ -45,8 +45,8 @@ public:
   virtual ~IndexedEdgeLinks() = default;
 };
 
-typedef std::shared_ptr<IndexedEdgeLinks> IndexedEdgeLinksPtr;
-typedef std::shared_ptr<const IndexedEdgeLinks> ConstIndexedEdgeLinksPtr;
+using IndexedEdgeLinksPtr = std::shared_ptr<IndexedEdgeLinks>;
+using ConstIndexedEdgeLinksPtr = std::shared_ptr<const IndexedEdgeLinks>;
 
 // not implemented
 bool operator<(ConstIndexedEdgeLinksPtr, ConstIndexedEdgeLinksPtr);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/IndexedEdgeMatchSet.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/IndexedEdgeMatchSet.h
@@ -44,7 +44,7 @@ public:
 
   static QString className() { return "hoot::IndexedEdgeMatchSet"; }
 
-  typedef QHash<ConstEdgeMatchPtr, double> MatchHash;
+  using MatchHash = QHash<ConstEdgeMatchPtr, double>;
 
   IndexedEdgeMatchSet() = default;
   virtual ~IndexedEdgeMatchSet()  = default;
@@ -133,8 +133,8 @@ private:
 
   static int logWarnCount;
 
-  typedef QHash<ConstNetworkEdgePtr, QSet<ConstEdgeMatchPtr>> EdgeToMatchMap;
-  typedef QHash<ConstNetworkVertexPtr, QSet<ConstEdgeMatchPtr>> VertexToMatchMap;
+  using EdgeToMatchMap = QHash<ConstNetworkEdgePtr, QSet<ConstEdgeMatchPtr>>;
+  using VertexToMatchMap = QHash<ConstNetworkVertexPtr, QSet<ConstEdgeMatchPtr>>;
 
   EdgeToMatchMap _edgeToMatch;
   /**
@@ -149,8 +149,8 @@ private:
   void _removeVertexToMatchMapping(ConstEdgeStringPtr str, const ConstEdgeMatchPtr& em);
 };
 
-typedef std::shared_ptr<IndexedEdgeMatchSet> IndexedEdgeMatchSetPtr;
-typedef std::shared_ptr<const IndexedEdgeMatchSet> ConstIndexedEdgeMatchSetPtr;
+using IndexedEdgeMatchSetPtr = std::shared_ptr<IndexedEdgeMatchSet>;
+using ConstIndexedEdgeMatchSetPtr = std::shared_ptr<const IndexedEdgeMatchSet>;
 
 // not implemented
 bool operator<(ConstIndexedEdgeMatchSetPtr, ConstIndexedEdgeMatchSetPtr);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/LegacyVertexMatcher.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/LegacyVertexMatcher.h
@@ -77,7 +77,7 @@ public:
     }
   };
 
-  typedef std::shared_ptr<TiePointScore> TiePointScorePtr;
+  using TiePointScorePtr = std::shared_ptr<TiePointScore>;
 
   LegacyVertexMatcher(ConstOsmMapPtr map);
 
@@ -171,8 +171,8 @@ inline uint qHash(const LegacyVertexMatcher::TiePointScorePtr& t)
   return qHash(std::pair<ElementId, ElementId>(t->v1->getElementId(), t->v2->getElementId()));
 }
 
-typedef std::shared_ptr<LegacyVertexMatcher> LegacyVertexMatcherPtr;
-typedef std::shared_ptr<const LegacyVertexMatcher> ConstLegacyVertexMatcherPtr;
+using LegacyVertexMatcherPtr = std::shared_ptr<LegacyVertexMatcher>;
+using ConstLegacyVertexMatcherPtr = std::shared_ptr<const LegacyVertexMatcher>;
 
 // not implemented
 bool operator<(ConstLegacyVertexMatcherPtr, ConstLegacyVertexMatcherPtr);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkDetails.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkDetails.h
@@ -225,8 +225,8 @@ private:
     const WaySublineCollection& ws) const;
 };
 
-typedef std::shared_ptr<NetworkDetails> NetworkDetailsPtr;
-typedef std::shared_ptr<const NetworkDetails> ConstNetworkDetailsPtr;
+using NetworkDetailsPtr = std::shared_ptr<NetworkDetails>;
+using ConstNetworkDetailsPtr = std::shared_ptr<const NetworkDetails>;
 
 // not implemented
 bool operator<(ConstNetworkDetailsPtr, ConstNetworkDetailsPtr);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkEdge.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkEdge.h
@@ -84,8 +84,8 @@ private:
   QList<ConstElementPtr> _members;
 };
 
-typedef std::shared_ptr<NetworkEdge> NetworkEdgePtr;
-typedef std::shared_ptr<const NetworkEdge> ConstNetworkEdgePtr;
+using NetworkEdgePtr = std::shared_ptr<NetworkEdge>;
+using ConstNetworkEdgePtr = std::shared_ptr<const NetworkEdge>;
 
 // not implemented
 bool operator<(ConstNetworkEdgePtr, ConstNetworkEdgePtr);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkEdgeScore.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkEdgeScore.h
@@ -67,7 +67,7 @@ private:
 
 };
 
-typedef std::shared_ptr<NetworkEdgeScore> NetworkEdgeScorePtr;
+using NetworkEdgeScorePtr = std::shared_ptr<NetworkEdgeScore>;
 
 // not implemented
 bool operator<(NetworkEdgeScorePtr, NetworkEdgeScorePtr);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatcher.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMatcher.h
@@ -89,8 +89,8 @@ protected:
   Tgs::IntersectionIterator _createIterator(const geos::geom::Envelope& env, Tgs::HilbertRTreePtr tree);
 };
 
-typedef std::shared_ptr<NetworkMatcher> NetworkMatcherPtr;
-typedef std::shared_ptr<const NetworkMatcher> ConstNetworkMatcherPtr;
+using NetworkMatcherPtr = std::shared_ptr<NetworkMatcher>;
+using ConstNetworkMatcherPtr = std::shared_ptr<const NetworkMatcher>;
 
 // not implemented
 bool operator<(ConstNetworkMatcherPtr, ConstNetworkMatcherPtr);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkVertex.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkVertex.h
@@ -69,8 +69,8 @@ private:
   static int uidCount;
 };
 
-typedef std::shared_ptr<NetworkVertex> NetworkVertexPtr;
-typedef std::shared_ptr<const NetworkVertex> ConstNetworkVertexPtr;
+using NetworkVertexPtr = std::shared_ptr<NetworkVertex>;
+using ConstNetworkVertexPtr = std::shared_ptr<const NetworkVertex>;
 
 inline bool operator<(const NetworkVertexPtr& v1, const NetworkVertexPtr& v2)
 {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkVertexScore.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkVertexScore.h
@@ -66,7 +66,7 @@ private:
 
 };
 
-typedef std::shared_ptr<NetworkVertexScore> NetworkVertexScorePtr;
+using NetworkVertexScorePtr = std::shared_ptr<NetworkVertexScore>;
 
 // not implemented
 bool operator<(NetworkVertexScorePtr, NetworkVertexScorePtr);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/OsmNetwork.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/OsmNetwork.h
@@ -57,9 +57,9 @@ class OsmNetwork
 {
 public:
 
-  typedef QMultiHash<ElementId, ConstNetworkVertexPtr> VertexMap;
-  typedef QMultiHash<ElementId, ConstNetworkEdgePtr> EdgeMap;
-  typedef QMultiHash<ConstNetworkVertexPtr, ConstNetworkEdgePtr> VertexToEdgeMap;
+  using VertexMap = QMultiHash<ElementId, ConstNetworkVertexPtr>;
+  using EdgeMap = QMultiHash<ElementId, ConstNetworkEdgePtr>;
+  using VertexToEdgeMap = QMultiHash<ConstNetworkVertexPtr, ConstNetworkEdgePtr>;
 
   OsmNetwork() = default;
 
@@ -96,8 +96,8 @@ private:
   VertexToEdgeMap _vertexToEdge;
 };
 
-typedef std::shared_ptr<OsmNetwork> OsmNetworkPtr;
-typedef std::shared_ptr<const OsmNetwork> ConstOsmNetworkPtr;
+using OsmNetworkPtr = std::shared_ptr<OsmNetwork>;
+using ConstOsmNetworkPtr = std::shared_ptr<const OsmNetwork>;
 
 // not implemented
 bool operator<(ConstOsmNetworkPtr, ConstOsmNetworkPtr);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonInfoCache.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonInfoCache.h
@@ -36,7 +36,7 @@ namespace hoot
 
 class PoiPolygonInfoCache;
 
-typedef std::shared_ptr<PoiPolygonInfoCache> PoiPolygonInfoCachePtr;
+using PoiPolygonInfoCachePtr = std::shared_ptr<PoiPolygonInfoCache>;
 
 /**
  * Cached storing POI/Polygon feature comparison info

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonRfClassifier.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonRfClassifier.h
@@ -56,7 +56,7 @@ private:
   void _createExtractors();
 };
 
-typedef std::shared_ptr<PoiPolygonRfClassifier> PoiPolygonRfClassifierPtr;
+using PoiPolygonRfClassifierPtr = std::shared_ptr<PoiPolygonRfClassifier>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonSchemaType.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonSchemaType.h
@@ -44,7 +44,7 @@ class PoiPolygonSchemaType
 
 public:
 
-  typedef enum Type
+  enum Type
   {
     Natural = 0,
     Park,
@@ -57,7 +57,7 @@ public:
     School,
     SpecificSchool,
     Sport
-  } Type;
+  };
 
   PoiPolygonSchemaType(Type type) : _type(type) {}
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/point/PoiRfClassifier.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/point/PoiRfClassifier.h
@@ -74,7 +74,7 @@ private:
 
 };
 
-typedef std::shared_ptr<PoiRfClassifier> PoiRfClassifierPtr;
+using PoiRfClassifierPtr = std::shared_ptr<PoiRfClassifier>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/review/ReviewMarker.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/review/ReviewMarker.h
@@ -48,7 +48,7 @@ class ReviewMarker
 public:
 
   /// This definition may change over time.
-  typedef ElementId ReviewUid;
+  using ReviewUid = ElementId;
 
   ReviewMarker();
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ChainCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ChainCriterion.h
@@ -84,7 +84,7 @@ private:
   friend class RemoveRef2VisitorMultipleCriterion;
 };
 
-typedef std::shared_ptr<ChainCriterion> ChainCriterionPtr;
+using ChainCriterionPtr = std::shared_ptr<ChainCriterion>;
 
 }
 #endif // CHAINCRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ElementCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ElementCriterion.h
@@ -72,7 +72,7 @@ public:
   virtual QString toString() const override { return ""; }
 };
 
-typedef std::shared_ptr<ElementCriterion> ElementCriterionPtr;
+using ElementCriterionPtr = std::shared_ptr<ElementCriterion>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/GeometryTypeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/GeometryTypeCriterion.h
@@ -102,7 +102,7 @@ public:
                                                       const ConstOsmMapPtr& map);
 };
 
-typedef std::shared_ptr<GeometryTypeCriterion> GeometryTypeCriterionPtr;
+using GeometryTypeCriterionPtr = std::shared_ptr<GeometryTypeCriterion>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NotCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NotCriterion.h
@@ -74,7 +74,7 @@ private:
   ElementCriterionPtr _child;
 };
 
-typedef std::shared_ptr<NotCriterion> NotCriterionPtr;
+using NotCriterionPtr = std::shared_ptr<NotCriterion>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/OrCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/OrCriterion.h
@@ -59,7 +59,7 @@ public:
   virtual QString getClassName() const override { return className(); }
 };
 
-typedef std::shared_ptr<OrCriterion> OrCriterionPtr;
+using OrCriterionPtr = std::shared_ptr<OrCriterion>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/Element.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Element.h
@@ -243,8 +243,8 @@ protected:
   mutable geos::geom::Envelope _cachedEnvelope;
 };
 
-typedef std::shared_ptr<Element> ElementPtr;
-typedef std::shared_ptr<const Element> ConstElementPtr;
+using ElementPtr = std::shared_ptr<Element>;
+using ConstElementPtr = std::shared_ptr<const Element>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementAttributeType.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementAttributeType.h
@@ -48,7 +48,7 @@ class ElementAttributeType
 
 public:
 
-  typedef enum Type
+  enum Type
   {
     Changeset = 0,
     Timestamp = 1,
@@ -56,7 +56,7 @@ public:
     Uid = 3,
     Version = 4,
     Id = 5
-  } Type;
+  };
 
   ElementAttributeType() : _type(Changeset) {}
   ElementAttributeType(Type type) : _type(type) {}

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementProvider.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementProvider.h
@@ -68,8 +68,8 @@ public:
   virtual bool containsWay(long id) const = 0;
 };
 
-typedef std::shared_ptr<const ElementProvider> ConstElementProviderPtr;
-typedef std::shared_ptr<ElementProvider> ElementProviderPtr;
+using ElementProviderPtr = std::shared_ptr<ElementProvider>;
+using ConstElementProviderPtr = std::shared_ptr<const ElementProvider>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementType.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementType.h
@@ -40,14 +40,14 @@ class ElementType
 {
 public:
 
-  typedef enum Type
+  enum Type
   {
     Node = 0,
     Way = 1,
     Relation = 2,
     Unknown = 3,
     Max = 3
-  } Type;
+  };
 
   ElementType() : _type(Unknown) { }
   ElementType(Type type) : _type(type) { }

--- a/hoot-core/src/main/cpp/hoot/core/elements/ExternalMergeElementSorter.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ExternalMergeElementSorter.h
@@ -68,8 +68,8 @@ struct ElementComparePq
   }
 };
 
-typedef std::priority_queue<PqElement,
-                            std::vector<PqElement>, ElementComparePq> ElementPriorityQueue;
+using ElementPriorityQueue =
+  std::priority_queue<PqElement, std::vector<PqElement>, ElementComparePq>;
 
 /**
   This performs element sorting outside of main memory on disk and serves the sorted results up

--- a/hoot-core/src/main/cpp/hoot/core/elements/InMemoryElementSorter.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/InMemoryElementSorter.h
@@ -88,7 +88,7 @@ private:
 
 };
 
-typedef std::shared_ptr<InMemoryElementSorter> InMemoryElementSorterPtr;
+using InMemoryElementSorterPtr = std::shared_ptr<InMemoryElementSorter>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/Node.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Node.h
@@ -163,8 +163,8 @@ protected:
   virtual const ElementData& _getElementData() const { return _nodeData; }
 };
 
-typedef std::shared_ptr<Node> NodePtr;
-typedef std::shared_ptr<const Node> ConstNodePtr;
+using NodePtr = std::shared_ptr<Node>;
+using ConstNodePtr = std::shared_ptr<const Node>;
 
 inline NodePtr Node::newSp(Status s, long id, double x, double y, Meters circularError)
 {

--- a/hoot-core/src/main/cpp/hoot/core/elements/NodeMap.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/NodeMap.h
@@ -32,7 +32,7 @@
 #include <tgs/HashMap.h>
 namespace hoot
 {
-  typedef HashMap<long, NodePtr> NodeMap;
+  using NodeMap = HashMap<long, NodePtr>;
 }
 
 #endif // NODEMAP_H

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.h
@@ -412,8 +412,8 @@ protected:
   virtual void resetIterator();
 };
 
-typedef std::shared_ptr<OsmMap> OsmMapPtr;
-typedef std::shared_ptr<const OsmMap> ConstOsmMapPtr;
+using OsmMapPtr = std::shared_ptr<OsmMap>;
+using ConstOsmMapPtr = std::shared_ptr<const OsmMap>;
 
 template<class T>
 void addElements(T it, T end)

--- a/hoot-core/src/main/cpp/hoot/core/elements/Relation.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Relation.h
@@ -231,8 +231,8 @@ void Relation::replaceElements(RelationData::Entry old, IT start, IT end)
   _postGeometryChange();
 }
 
-typedef std::shared_ptr<Relation> RelationPtr;
-typedef std::shared_ptr<const Relation> ConstRelationPtr;
+using RelationPtr = std::shared_ptr<Relation>;
+using ConstRelationPtr = std::shared_ptr<const Relation>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/RelationMap.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/RelationMap.h
@@ -32,7 +32,7 @@
 
 namespace hoot
 {
-  typedef HashMap<long, RelationPtr> RelationMap;
+  using RelationMap = HashMap<long, RelationPtr>;
 }
 
 #endif // RELATIONMAP_H

--- a/hoot-core/src/main/cpp/hoot/core/elements/Status.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Status.h
@@ -37,7 +37,7 @@ class Status
 {
 public:
 
-  typedef enum TypeEnum
+  enum TypeEnum
   {
     Invalid = 0,
     Unknown1,
@@ -45,9 +45,9 @@ public:
     Conflated,
     TagChange, // Tags have been changed, but not geometry
     EnumEnd // Used for calculating multiary inputs
-  } TypeEnum;
+  };
 
-  typedef int Type;
+  using Type = int;
 
   Status() { _type = Invalid; }
   Status(Type type) { _type = type; }

--- a/hoot-core/src/main/cpp/hoot/core/elements/Way.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Way.h
@@ -269,8 +269,8 @@ private:
   bool _nodeIdsAreDuplicated(const std::vector<long>& ids) const;
 };
 
-typedef std::shared_ptr<Way> WayPtr;
-typedef std::shared_ptr<const Way> ConstWayPtr;
+using WayPtr = std::shared_ptr<Way>;
+using ConstWayPtr = std::shared_ptr<const Way>;
 
 inline bool operator<(const WayPtr& w1, const WayPtr& w2)
 {

--- a/hoot-core/src/main/cpp/hoot/core/elements/WayMap.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/WayMap.h
@@ -33,7 +33,7 @@
 
 namespace hoot
 {
-  typedef HashMap<long, WayPtr> WayMap;
+  using WayMap = HashMap<long, WayPtr>;
 }
 
 #endif // WAYMAP_H

--- a/hoot-core/src/main/cpp/hoot/core/geometry/GeometricRelationship.h
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/GeometricRelationship.h
@@ -48,7 +48,7 @@ class GeometricRelationship
 
 public:
 
-  typedef enum Type
+  enum Type
   {
     Contains = 0,
     Covers,
@@ -60,10 +60,10 @@ public:
     Overlaps,
     Touches,
     Invalid
-  } Type;
+  };
 
-  GeometricRelationship() : _type(Contains) {}
-  GeometricRelationship(Type type) : _type(type) {}
+  GeometricRelationship() : _type(Contains) { }
+  GeometricRelationship(Type type) : _type(type) { }
 
   bool operator==(GeometricRelationship t) const { return t._type == _type; }
   bool operator!=(GeometricRelationship t) const { return t._type != _type; }

--- a/hoot-core/src/main/cpp/hoot/core/geometry/GeometryMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/GeometryMerger.h
@@ -42,8 +42,8 @@
 namespace hoot
 {
 
-typedef std::shared_ptr<geos::geom::Geometry> GeometryPtr;
-typedef std::pair<GeometryPtr, GeometryPtr> GeometryPair;
+using GeometryPtr = std::shared_ptr<geos::geom::Geometry>;
+using GeometryPair = std::pair<GeometryPtr, GeometryPtr>;
 
 class GeometryMerger
 {

--- a/hoot-core/src/main/cpp/hoot/core/io/ArffWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ArffWriter.h
@@ -51,7 +51,7 @@ class ArffWriter
 {
 public:
 
-  typedef std::map<QString, double> Sample;
+  using Sample = std::map<QString, double>;
 
   /**
    * @brief ArffWriter

--- a/hoot-core/src/main/cpp/hoot/core/io/ChangesetStatsFormat.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ChangesetStatsFormat.h
@@ -43,12 +43,12 @@ class ChangesetStatsFormat
 {
 public:
 
-  typedef enum Format
+  enum Format
   {
     Text = 0,
     Json,
     Unknown
-  } Format;
+  };
 
   ChangesetStatsFormat() : _format(Unknown) { }
   ChangesetStatsFormat(Format format) : _format(format) { }

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementCache.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementCache.h
@@ -182,7 +182,7 @@ public:
 
 };
 
-typedef std::shared_ptr<ElementCache> ElementCachePtr;
+using ElementCachePtr = std::shared_ptr<ElementCache>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementCacheLRU.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementCacheLRU.h
@@ -183,7 +183,7 @@ private:
   void _updateRelationAccess(long id);
 };
 
-typedef std::shared_ptr<ElementCacheLRU> ElementCacheLRUPtr;
+using ElementCacheLRUPtr = std::shared_ptr<ElementCacheLRU>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementInputStream.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementInputStream.h
@@ -66,7 +66,7 @@ public:
   virtual ElementPtr readNextElement() = 0;
 };
 
-typedef std::shared_ptr<ElementInputStream> ElementInputStreamPtr;
+using ElementInputStreamPtr = std::shared_ptr<ElementInputStream>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.h
@@ -93,7 +93,7 @@ public:
 
 protected:
 
-  typedef Tgs::BigMap<long, long> IdRemap;
+  using IdRemap = Tgs::BigMap<long, long>;
   IdRemap _nodeRemap;
   IdRemap _relationRemap;
   IdRemap _wayRemap;

--- a/hoot-core/src/main/cpp/hoot/core/io/HootNetworkRequest.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootNetworkRequest.h
@@ -185,7 +185,7 @@ private:
   bool _timedOut;
 };
 
-typedef std::shared_ptr<HootNetworkRequest> HootNetworkRequestPtr;
+using HootNetworkRequestPtr = std::shared_ptr<HootNetworkRequest>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangeset.h
@@ -54,14 +54,14 @@ namespace hoot
 //  Forward declaration
 class ChangesetInfo;
 /** Helpful typedefs for pointers and vectors of maps */
-typedef std::shared_ptr<ChangesetInfo> ChangesetInfoPtr;
-typedef std::map<long, ChangesetElementPtr, osm_id_sort> ChangesetElementMap;
-typedef std::vector<ChangesetElementMap> ChangesetTypeMap;
-typedef std::map<long, std::set<long>> NodeIdToWayIdMap;
-typedef std::map<long, std::set<long>> NodeIdToRelationIdMap;
-typedef std::map<long, std::set<long>> WayIdToRelationIdMap;
-typedef std::map<long, std::set<long>> RelationIdToRelationIdMap;
-typedef std::vector<std::set<long>> ElementCountSet;
+using ChangesetInfoPtr = std::shared_ptr<ChangesetInfo>;
+using ChangesetElementMap = std::map<long, ChangesetElementPtr, osm_id_sort>;
+using ChangesetTypeMap = std::vector<ChangesetElementMap>;
+using NodeIdToWayIdMap = std::map<long, std::set<long>>;
+using NodeIdToRelationIdMap = std::map<long, std::set<long>>;
+using WayIdToRelationIdMap = std::map<long, std::set<long>>;
+using RelationIdToRelationIdMap = std::map<long, std::set<long>>;
+using ElementCountSet = std::vector<std::set<long>>;
 
 /** Last element pushed in a ChangesetInfo object */
 struct LastElementInfo
@@ -569,9 +569,9 @@ class ChangesetInfo
 {
 public:
   /** Helpful typedefs for container and iterators */
-  typedef std::unordered_set<long> container;
-  typedef typename container::iterator iterator;
-  typedef typename container::const_iterator const_iterator;
+  using container = std::unordered_set<long>;
+  using iterator = container::iterator;
+  using const_iterator = container::const_iterator;
   /** Constructor */
   ChangesetInfo();
   /**

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
@@ -50,10 +50,10 @@ namespace hoot
 class ElementIdToIdMap;
 
 /** Object that matches an XML tag to its XML attributes */
-typedef QPair<QString, QXmlStreamAttributes> XmlObject;
-typedef std::vector<std::pair<QString, QString>> ElementAttributes;
-typedef std::pair<QString, QString> ElementTag;
-typedef std::vector<ElementTag> ElementTags;
+using XmlObject = QPair<QString, QXmlStreamAttributes>;
+using ElementAttributes = std::vector<std::pair<QString, QString>>;
+using ElementTag = std::pair<QString, QString>;
+using ElementTags = std::vector<ElementTag>;
 
 /** Elements in a changeset can be in three sections, create, modify, and delete.  Max is used for iterating */
 enum ChangesetType : int
@@ -199,8 +199,8 @@ protected:
   /** Element status */
   ElementStatus _status;
 };
-/** Handy typedef for element shared pointer */
-typedef std::shared_ptr<ChangesetElement> ChangesetElementPtr;
+/** Handy alias for element shared pointer */
+using ChangesetElementPtr = std::shared_ptr<ChangesetElement>;
 
 /** Simplified changeset node abstraction */
 class ChangesetNode : public ChangesetElement
@@ -229,8 +229,8 @@ public:
    */
   bool diff(const ChangesetNode& node, QString& diffOutput) const;
 };
-/** Handy typedef for node shared pointer */
-typedef std::shared_ptr<ChangesetNode> ChangesetNodePtr;
+/** Handy alias for node shared pointer */
+using ChangesetNodePtr = std::shared_ptr<ChangesetNode>;
 
 /** Simplified changeset way abstraction */
 class ChangesetWay : public ChangesetElement
@@ -285,8 +285,8 @@ private:
   /** Vector of node ID in the way */
   QVector<long> _nodes;
 };
-/** Handy typedef for way shared pointer */
-typedef std::shared_ptr<ChangesetWay> ChangesetWayPtr;
+/** Handy alias for way shared pointer */
+using ChangesetWayPtr = std::shared_ptr<ChangesetWay>;
 
 /** Simplified changeset relation member abstraction */
 class ChangesetRelationMember
@@ -404,8 +404,8 @@ private:
   /** List of relation members */
   QList<ChangesetRelationMember> _members;
 };
-/** Handy typedef for relation shared pointer */
-typedef std::shared_ptr<ChangesetRelation> ChangesetRelationPtr;
+/** Handy alias for relation shared pointer */
+using ChangesetRelationPtr = std::shared_ptr<ChangesetRelation>;
 
 /** Custom sorting function to sort IDs from -1 to -n followed by 1 to m */
 bool id_sort_order(long lhs, long rhs);
@@ -417,8 +417,8 @@ public:
     return id_sort_order(lhs, rhs);
   }
 };
-/** Handy typedef for a vector of sorted ID maps */
-typedef std::vector<std::map<long, long, osm_id_sort>> ChangesetElementIdMap;
+/** Handy alias for a vector of sorted ID maps */
+using ChangesetElementIdMap = std::vector<std::map<long, long, osm_id_sort>>;
 
 /**
  *  Class for storing ID to ID associations, this is required because elements that are created in
@@ -431,12 +431,12 @@ class ElementIdToIdMap
 {
 public:
   /** Helpful typedefs for iterators */
-  typedef typename std::map<long, long, osm_id_sort>::iterator iterator;
-  typedef typename std::map<long, long, osm_id_sort>::const_iterator const_iterator;
+  using iterator = std::map<long, long, osm_id_sort>::iterator;
+  using const_iterator = std::map<long, long, osm_id_sort>::const_iterator;
   /** Constructor */
   ElementIdToIdMap()
     : _idToId(ElementType::Unknown)
-  {}
+  { }
   /**
    * @brief addId Add ID to the map
    * @param type Element type (node/way/relation)

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -164,7 +164,7 @@ private:
     /** HTTP response body */
     QString response;
   };
-  typedef std::shared_ptr<OsmApiFailureInfo> OsmApiFailureInfoPtr;
+  using OsmApiFailureInfoPtr = std::shared_ptr<OsmApiFailureInfo>;
   /**
    * @brief _createChangeset Request a changeset ID from the API
    *  see: https://wiki.openstreetmap.org/wiki/API_v0.6#Create:_PUT_.2Fapi.2F0.6.2Fchangeset.2Fcreate

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.cpp
@@ -482,7 +482,7 @@ void OsmGeoJsonReader::_parseGeoJsonRelation(const string& id, const pt::ptree& 
     string roles_values = properties.get("roles", "");
     if (roles_values.compare("") != 0)
     {
-      typedef boost::tokenizer<boost::char_separator<char>> _tokenizer;
+      using _tokenizer = boost::tokenizer<boost::char_separator<char>>;
       _tokenizer tokens(roles_values, boost::char_separator<char>(";", nullptr, boost::keep_empty_tokens));
       for (_tokenizer::iterator it = tokens.begin(); it != tokens.end(); ++it)
         _roles.push(*it);

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.h
@@ -48,7 +48,7 @@
 namespace hoot
 {
 
-typedef std::vector<geos::geom::Coordinate> JsonCoordinates;
+using JsonCoordinates = std::vector<geos::geom::Coordinate>;
 
 /**
  * This class is intended to create an OsmMap from a given GeoJSON string.

--- a/hoot-core/src/main/cpp/hoot/core/io/ServicesJobStatus.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ServicesJobStatus.h
@@ -38,16 +38,16 @@ class ServicesJobStatus
 public:
 
   // matches the same enum in hoot-services JobStatus.java
-  typedef enum TypeEnum
+  enum TypeEnum
   {
     Running = 0,
     Complete,
     Failed,
     Cancelled,
     Unknown
-  } TypeEnum;
+  };
 
-  typedef int Type;
+  using Type = int;
 
   ServicesJobStatus() { _type = Unknown; }
   ServicesJobStatus(Type type) { _type = type; }

--- a/hoot-core/src/main/cpp/hoot/core/io/TableType.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/TableType.h
@@ -43,7 +43,7 @@ class TableType
 public:
 
   // we could add the changesets table to this
-  typedef enum Type
+  enum Type
   {
     Node = 0,
     Way = 1,
@@ -51,7 +51,7 @@ public:
     WayNode = 3,
     RelationMember = 4,
     Unknown
-  } Type;
+  };
 
   TableType() { _type = Unknown; }
   TableType(Type type) { _type = type; }

--- a/hoot-core/src/main/cpp/hoot/core/schema/AttributeCoOccurrence.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/AttributeCoOccurrence.cpp
@@ -55,7 +55,7 @@ class RefToEidVisitor : public ConstElementVisitor
 {
 public:
 
-  typedef map<QString, set<ElementId>> RefToEid;
+  using RefToEid = map<QString, set<ElementId>>;
 
   explicit RefToEidVisitor(QString ref) : _ref(ref) { }
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/AttributeCoOccurrence.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/AttributeCoOccurrence.h
@@ -41,7 +41,7 @@ class AttributeCoOccurrence
 {
 public:
 
-  typedef HashMap<QString, HashMap<QString, int>> CoOccurrenceHash;
+  using CoOccurrenceHash = HashMap<QString, HashMap<QString, int>>;
 
   AttributeCoOccurrence() = default;
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/KeyValuePair.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/KeyValuePair.h
@@ -74,8 +74,8 @@ private:
   QString _value;
 };
 
-typedef std::shared_ptr<KeyValuePair> KeyValuePairPtr;
-typedef std::shared_ptr<const KeyValuePair> ConstKeyValuePairPtr;
+using KeyValuePairPtr = std::shared_ptr<KeyValuePair>;
+using ConstKeyValuePairPtr = std::shared_ptr<const KeyValuePair>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
@@ -79,7 +79,7 @@ using namespace std;
 namespace hoot
 {
 
-typedef boost::adjacency_list<
+using TagGraph = boost::adjacency_list<
   // Use listS for storing VertexList -- faster, but not as space efficient (no biggie)
   boost::listS,
   // use vecS for storing OutEdgeList -- faster for traversal, but slower to build (no biggie)
@@ -88,10 +88,10 @@ typedef boost::adjacency_list<
   boost::directedS,
   SchemaVertex,
   TagEdge
-> TagGraph;
+>;
 
-typedef boost::graph_traits<TagGraph>::vertex_descriptor VertexId;
-typedef boost::graph_traits<TagGraph>::edge_descriptor EdgeId;
+using VertexId = boost::graph_traits<TagGraph>::vertex_descriptor;
+using EdgeId = boost::graph_traits<TagGraph>::edge_descriptor;
 
 SchemaVertex empty;
 
@@ -920,7 +920,7 @@ private:
   HashMap<VertexId, VertexId> _parents;
   QList<pair<QRegExp, VertexId>> _regexKeys;
   HashMap<pair<VertexId, VertexId>, bool> _isAncestorCache;
-  typedef HashMap<VertexId, vector<pair<VertexId, double>>> VertexToScoreCache;
+  using VertexToScoreCache = HashMap<VertexId, vector<pair<VertexId, double>>>;
   VertexToScoreCache _vertexToScoresCache;
 
   TagGraph _graph;

--- a/hoot-core/src/main/cpp/hoot/core/schema/PythonSchemaTranslator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/PythonSchemaTranslator.cpp
@@ -52,7 +52,7 @@
 
 // Python version before 2.4 don't have a Py_ssize_t typedef.
 #if PY_VERSION_HEX < 0x02050000 && !defined(PY_SSIZE_T_MIN)
-typedef int Py_ssize_t;
+using Py_ssize_t = int;
 #endif
 
 using namespace std;

--- a/hoot-core/src/main/cpp/hoot/core/schema/SchemaVertex.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/SchemaVertex.h
@@ -74,15 +74,15 @@ class SchemaVertex
 {
 public:
 
-  typedef enum VertexType
+  enum VertexType
   {
     UnknownVertexType,
     Tag,
     Compound
-  } VertexType;
+  };
 
-  typedef QList<KeyValuePairPtr> CompoundRule;
-  typedef QList<CompoundRule> CompoundRuleList;
+  using CompoundRule = QList<KeyValuePairPtr>;
+  using CompoundRuleList = QList<CompoundRule>;
 
   SchemaVertex();
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/ScriptSchemaTranslator.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/ScriptSchemaTranslator.h
@@ -129,7 +129,7 @@ protected:
   virtual void _translateToOsm(Tags& tags, const char *layerName, const char* geomType) = 0;
 };
 
-typedef std::shared_ptr<ScriptSchemaTranslator> ScriptSchemaTranslatorPtr;
+using ScriptSchemaTranslatorPtr = std::shared_ptr<ScriptSchemaTranslator>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/ScriptToOgrSchemaTranslator.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/ScriptToOgrSchemaTranslator.h
@@ -48,7 +48,7 @@ class ScriptToOgrSchemaTranslator
 {
 public:
 
-  typedef struct TranslatedFeature
+  struct TranslatedFeature
   {
   public:
 
@@ -59,7 +59,7 @@ public:
     {
       return tableName + ": " + feature->toString();
     }
-  } TranslatedFeature;
+  };
 
   ScriptToOgrSchemaTranslator() = default;
   virtual ~ScriptToOgrSchemaTranslator() = default;
@@ -73,8 +73,8 @@ public:
     geos::geom::GeometryTypeId geometryType) = 0;
 };
 
-typedef std::shared_ptr<ScriptToOgrSchemaTranslator> ScriptToOgrSchemaTranslatorPtr;
-typedef std::shared_ptr<const ScriptToOgrSchemaTranslator> ConstScriptToOgrSchemaTranslatorPtr;
+using ScriptToOgrSchemaTranslatorPtr = std::shared_ptr<ScriptToOgrSchemaTranslator>;
+using ConstScriptToOgrSchemaTranslatorPtr = std::shared_ptr<const ScriptToOgrSchemaTranslator>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagInfo.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagInfo.h
@@ -58,7 +58,7 @@ public:
 
 private:
 
-  typedef QHash<QString, QHash<QString, int>> TagInfoHash;
+  using TagInfoHash = QHash<QString, QHash<QString, int>>;
 
   // the maximum number of tag values to return per key
   int _tagValuesPerKeyLimit;

--- a/hoot-core/src/main/cpp/hoot/core/schema/TagMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TagMerger.h
@@ -72,8 +72,8 @@ protected:
   bool _caseSensitive;
 };
 
-typedef std::shared_ptr<TagMerger> TagMergerPtr;
-typedef std::shared_ptr<const TagMerger> ConstTagMergerPtr;
+using TagMergerPtr = std::shared_ptr<TagMerger>;
+using ConstTagMergerPtr = std::shared_ptr<const TagMerger>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/TranslatedTagDifferencer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TranslatedTagDifferencer.cpp
@@ -124,8 +124,8 @@ double TranslatedTagDifferencer::diff(const ConstOsmMapPtr& map, const ConstElem
 
   CostFunction cost;
   cost.ttd = this;
-  typedef SingleAssignmentProblemSolver<ScriptToOgrSchemaTranslator::TranslatedFeature,
-      ScriptToOgrSchemaTranslator::TranslatedFeature> Saps;
+  using Saps = SingleAssignmentProblemSolver<ScriptToOgrSchemaTranslator::TranslatedFeature,
+      ScriptToOgrSchemaTranslator::TranslatedFeature> ;
   Saps sap(cost);
 
   for (size_t i = 0; i < tf1.size(); i++)

--- a/hoot-core/src/main/cpp/hoot/core/scoring/DataSamples.h
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/DataSamples.h
@@ -39,7 +39,7 @@
 namespace hoot
 {
 
-typedef std::map<QString, double> Sample;
+using Sample = std::map<QString, double>;
 
 /**
  * A very simple construct for storing simple data samples.

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MatchComparator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MatchComparator.cpp
@@ -60,7 +60,7 @@ class GetRefUuidVisitor : public ConstElementVisitor
 {
 public:
 
-  typedef map<QString, set<QString>> RefToUuid;
+  using RefToUuid = map<QString, set<QString>>;
 
   GetRefUuidVisitor(QString ref) : _ref(ref) { }
 

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MatchComparator.h
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MatchComparator.h
@@ -55,7 +55,7 @@ public:
 
   static QString className() { return "hoot::MatchComparator"; }
 
-  typedef QMultiMap<QString, ElementId> UuidToEid;
+  using UuidToEid = QMultiMap<QString, ElementId>;
 
   MatchComparator();
   virtual ~MatchComparator() = default;
@@ -118,7 +118,7 @@ private:
 
   static int logWarnCount;
 
-  typedef std::pair<QString, QString> UuidPair;
+  using UuidPair = std::pair<QString, QString>;
 
   std::set<UuidPair> _actual;
   std::set<UuidPair> _expected;

--- a/hoot-core/src/main/cpp/hoot/core/scoring/TextTable.h
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/TextTable.h
@@ -38,7 +38,7 @@ class TextTable
 {
 public:
 
-  typedef QHash<QString, QHash<QString, QVariant>> Data;
+  using Data = QHash<QString, QHash<QString, QVariant>>;
 
   TextTable(const Data& d) : _data(d) {}
 

--- a/hoot-core/src/main/cpp/hoot/core/util/Float.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Float.h
@@ -35,10 +35,10 @@ namespace hoot
 #if HOOT_HAVE_FLOAT128
 // this is a GCC extension. If this becomes a problem in the future then the Boost multiprecision
 // or similar library may be an option.
-typedef __float128 Float128;
+using Float128 = __float128;
 #else
 #warning "Float128 does not work properly on this platform, falling back to double."
-typedef double Float128;
+using Float128 = double;
 #endif
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/util/HootException.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/HootException.h
@@ -95,7 +95,7 @@ class HootExceptionThrower
 {
 public:
 
-  typedef void (*ThrowMethod)(HootException* e);
+  using ThrowMethod = void(*)(HootException* e);
 
   static HootExceptionThrower& getInstance();
 

--- a/hoot-core/src/main/cpp/hoot/core/util/IdGenerator.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/IdGenerator.h
@@ -63,7 +63,7 @@ private:
   static std::shared_ptr<IdGenerator> _theInstance;
 };
 
-typedef std::shared_ptr<IdGenerator> IdGeneratorPtr;
+using IdGeneratorPtr = std::shared_ptr<IdGenerator>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/util/NumericComparisonType.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/NumericComparisonType.h
@@ -44,14 +44,14 @@ class NumericComparisonType
 
 public:
 
-  typedef enum Type
+  enum Type
   {
     EqualTo = 0,
     LessThan,
     LessThanOrEqualTo,
     GreaterThan,
     GreaterThanOrEqualTo
-  } Type;
+  };
 
   NumericComparisonType();
   NumericComparisonType(Type type);

--- a/hoot-core/src/main/cpp/hoot/core/util/Progress.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Progress.h
@@ -41,14 +41,14 @@ class Progress
 {
 public:
 
-  typedef enum
+  enum JobState
   {
     Pending = 1,
     NotRunning,
     Running,
     Successful,
     Failed
-  } JobState;
+  };
 
   Progress(QString jobId = "", QString source = "", JobState jobState = JobState::Pending,
            float percentComplete = 0.0, float taskWeight = 0.0);

--- a/hoot-core/src/main/cpp/hoot/core/util/Settings.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Settings.h
@@ -62,7 +62,7 @@ public:
   // then be a true Singleton?
   Settings();
 
-  typedef QHash<QString, QVariant> SettingsMap;
+  using SettingsMap = QHash<QString, QVariant>;
 
   void append(const QString& key, const QStringList& values);
   void prepend(const QString& key, const QStringList& values);

--- a/hoot-core/src/main/cpp/hoot/core/util/TextComparisonType.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/TextComparisonType.h
@@ -44,13 +44,13 @@ class TextComparisonType
 
 public:
 
-  typedef enum Type
+  enum Type
   {
     EqualTo = 0,
     Contains,
     StartsWith,
     EndsWith
-  } Type;
+  };
 
   TextComparisonType() : _type(EqualTo) {}
   TextComparisonType(Type type) : _type(type) {}

--- a/hoot-core/src/main/cpp/hoot/core/util/Units.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Units.h
@@ -42,22 +42,22 @@
 
 namespace hoot
 {
-  typedef double Degrees;
-  typedef double Meters;
-  typedef double Radians;
+  using Degrees = double;
+  using Meters = double;
+  using Radians = double;
 
   //Boost types
-  typedef boost::units::quantity<boost::units::si::time, double> Times;
-  typedef boost::units::quantity<boost::units::si::length, double> Length;
-  typedef boost::units::quantity<boost::units::si::velocity, double> Velocity;
+  using Times = boost::units::quantity<boost::units::si::time, double>;
+  using Length = boost::units::quantity<boost::units::si::length, double>;
+  using Velocity = boost::units::quantity<boost::units::si::velocity, double>;
 
-  typedef boost::units::us::foot_base_unit::unit_type foot_unit;
+  using foot_unit = boost::units::us::foot_base_unit::unit_type;
   BOOST_UNITS_STATIC_CONSTANT(feet, foot_unit);
-  typedef boost::units::us::mile_base_unit::unit_type mile_unit;
+  using mile_unit = boost::units::us::mile_base_unit::unit_type;
   BOOST_UNITS_STATIC_CONSTANT(mile, mile_unit);
-  typedef boost::units::metric::nautical_mile_base_unit::unit_type nmi_unit;
+  using nmi_unit = boost::units::metric::nautical_mile_base_unit::unit_type;
   BOOST_UNITS_STATIC_CONSTANT(nmi, nmi_unit);
-  typedef boost::units::metric::knot_base_unit::unit_type knot_unit;
+  using knot_unit = boost::units::metric::knot_base_unit::unit_type;
   BOOST_UNITS_STATIC_CONSTANT(knot, knot_unit);
 
   inline Radians toRadians(Degrees d) { return d / 180.0 * M_PI; }

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ConstElementVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ConstElementVisitor.h
@@ -55,7 +55,7 @@ public:
   }
 };
 
-typedef std::shared_ptr<ConstElementVisitor> ConstElementVisitorPtr;
+using ConstElementVisitorPtr = std::shared_ptr<ConstElementVisitor>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ElementOsmMapVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ElementOsmMapVisitor.h
@@ -55,7 +55,7 @@ protected:
   OsmMap* _map;
 };
 
-typedef std::shared_ptr<ElementOsmMapVisitor> ElementOsmMapVisitorPtr;
+using ElementOsmMapVisitorPtr = std::shared_ptr<ElementOsmMapVisitor>;
 }
 
 #endif // ELEMENTOSMMAPVISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ElementVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ElementVisitor.h
@@ -105,7 +105,7 @@ public:
   QString toString() const override { return ""; }
 };
 
-typedef std::shared_ptr<ElementVisitor> ElementVisitorPtr;
+using ElementVisitorPtr = std::shared_ptr<ElementVisitor>;
 
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveRef2Visitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveRef2Visitor.h
@@ -51,7 +51,7 @@ class RemoveRef2Visitor : public ElementVisitor, public ConstOsmMapConsumer,
 
 public:
 
-  typedef QMap<QString, ElementId> Ref1ToEid;
+  using Ref1ToEid = QMap<QString, ElementId>;
 
   static QString className() { return "hoot::RemoveRef2Visitor"; }
 

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.h
@@ -106,7 +106,7 @@ private:
   std::shared_ptr<PluginContext> _script;
   QString _explainText;
 
-  typedef std::pair<ElementId, ElementId> ConflictKey;
+  using ConflictKey = std::pair<ElementId, ElementId>;
   mutable QHash<ConflictKey, bool> _conflicts;
 
   friend class ScriptMatchTest;

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/ElementMergerJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/ElementMergerJs.h
@@ -64,13 +64,13 @@ class ElementMergerJs : public HootBaseJs
 
 public:
 
- typedef enum MergeType
+ enum MergeType
  {
    PoiToPoi = 0,        // supports multiple
    PoiToPolygon,        // one poi and one poly
    AreaToArea,          // supports multiple
    BuildingToBuilding   // supports multiple
-  } MergeType;
+  };
 
  static void Init(v8::Handle<v8::Object> target);
  static void mergeElements(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryCluster.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryCluster.h
@@ -65,7 +65,7 @@ public:
   QString toString() const;
 };
 
-typedef std::shared_ptr<MultiaryCluster> MultiaryClusterPtr;
+using MultiaryClusterPtr = std::shared_ptr<MultiaryCluster>;
 
 }
 

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryClusterAlgorithm.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryClusterAlgorithm.h
@@ -89,12 +89,12 @@ public:
     }
   };
 
-  typedef std::shared_ptr<ClusterLink> ClusterLinkPtr;
+  using ClusterLinkPtr = std::shared_ptr<ClusterLink>;
 
   /**
    * A list of clusters that represent a subgraph.
    */
-  typedef QList<MultiaryClusterPtr> ClusterList;
+  using ClusterList = QList<MultiaryClusterPtr>;
 
   /**
    * Comparison operation to determine if one link has a lower score than another. This is used
@@ -165,10 +165,8 @@ protected:
   ClusterList _clusters;
 
   /// Priority queue that is used to store cluster links. High scoring links are at the top.
-  typedef std::priority_queue<
-    ClusterLinkPtr,
-    std::vector<ClusterLinkPtr>,
-    ClusterLinkPtrLess> LinkPriorityQueue;
+  using LinkPriorityQueue =
+    std::priority_queue<ClusterLinkPtr, std::vector<ClusterLinkPtr>, ClusterLinkPtrLess>;
   LinkPriorityQueue _linkQueue;
 
   MultiaryPoiMergeCachePtr _mergeCache;

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergeCache.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryPoiMergeCache.h
@@ -70,7 +70,7 @@ private:
   std::shared_ptr<MergerCreator> _mergerCreator;
 };
 
-typedef std::shared_ptr<MultiaryPoiMergeCache> MultiaryPoiMergeCachePtr;
+using MultiaryPoiMergeCachePtr = std::shared_ptr<MultiaryPoiMergeCache>;
 
 }
 

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryScoreCache.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/multiary/MultiaryScoreCache.h
@@ -75,7 +75,7 @@ private:
   std::shared_ptr<MatchCreator> _matchCreator;
 };
 
-typedef std::shared_ptr<MultiaryScoreCache> MultiaryScoreCachePtr;
+using MultiaryScoreCachePtr = std::shared_ptr<MultiaryScoreCache>;
 
 }
 

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/IterativeEdgeMatcher.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/IterativeEdgeMatcher.h
@@ -84,12 +84,12 @@ private:
     bool reversed;
   };
 
-  typedef SingleAssignmentProblemSolver<ConstNetworkEdgePtr, ConstNetworkEdgePtr> Saps;
+  using Saps = SingleAssignmentProblemSolver<ConstNetworkEdgePtr, ConstNetworkEdgePtr>;
 
   /// [row][col]
-  typedef QHash<ConstNetworkEdgePtr, QHash<ConstNetworkEdgePtr, DirectedEdgeScore>> EdgeScoreMap;
+  using EdgeScoreMap = QHash<ConstNetworkEdgePtr, QHash<ConstNetworkEdgePtr, DirectedEdgeScore>>;
   /// [row][col]
-  typedef QHash<ConstNetworkVertexPtr, QHash<ConstNetworkVertexPtr, double>> VertexScoreMap;
+  using VertexScoreMap = QHash<ConstNetworkVertexPtr, QHash<ConstNetworkVertexPtr, double>>;
 
   /**
    * A cost function used to compare network edges. It is a simple lookup.

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/IterativeNetworkMatcher.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/IterativeNetworkMatcher.h
@@ -90,11 +90,11 @@ private:
   // for white box testing.
   friend class IterativeNetworkMatcherTest;
 
-  typedef SingleAssignmentProblemSolver<EdgeString, EdgeString> Saps;
+  using Saps = SingleAssignmentProblemSolver<EdgeString, EdgeString>;
 
-  typedef QHash<ConstEdgeMatchPtr, double> EdgeScoreMap;
+  using EdgeScoreMap = QHash<ConstEdgeMatchPtr, double>;
   /// [row][col]
-  typedef QHash<ConstNetworkVertexPtr, QHash<ConstNetworkVertexPtr, double>> VertexScoreMap;
+  using VertexScoreMap = QHash<ConstNetworkVertexPtr, QHash<ConstNetworkVertexPtr, double>>;
 
   /**
    * A cost function used to compare network edges. It is a simple lookup.
@@ -185,8 +185,8 @@ private:
 
 };
 
-typedef std::shared_ptr<IterativeNetworkMatcher> IterativeNetworkMatcherPtr;
-typedef std::shared_ptr<const IterativeNetworkMatcher> ConstIterativeNetworkMatcherPtr;
+using IterativeNetworkMatcherPtr = std::shared_ptr<IterativeNetworkMatcher>;
+using ConstIterativeNetworkMatcherPtr = std::shared_ptr<const IterativeNetworkMatcher>;
 
 // not implemented
 bool operator<(ConstIterativeNetworkMatcherPtr, ConstIterativeNetworkMatcherPtr);

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/SingleSidedNetworkMatcher.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/SingleSidedNetworkMatcher.h
@@ -115,14 +115,14 @@ private:
     double score;
   };
 
-  typedef std::shared_ptr<EdgeLinkScore> EdgeLinkScorePtr;
+  using EdgeLinkScorePtr = std::shared_ptr<EdgeLinkScore>;
 
-  typedef SingleAssignmentProblemSolver<ConstNetworkEdgePtr, ConstNetworkEdgePtr> Saps;
+  using Saps = SingleAssignmentProblemSolver<ConstNetworkEdgePtr, ConstNetworkEdgePtr>;
 
   /// [v2]
-  typedef QHash<ConstNetworkEdgePtr, QList<EdgeLinkScorePtr>> EdgeMatchScoreMap;
+  using EdgeMatchScoreMap = QHash<ConstNetworkEdgePtr, QList<EdgeLinkScorePtr>>;
   /// [v2][v1]
-  typedef QHash<ConstNetworkVertexPtr, QHash<ConstNetworkVertexPtr, double>> VertexScoreMap;
+  using VertexScoreMap = QHash<ConstNetworkVertexPtr, QHash<ConstNetworkVertexPtr, double>>;
 
   IndexedEdgeMatchSetPtr _edgeMatches;
   EdgeMatchScoreMap _edge2Scores;
@@ -153,8 +153,8 @@ private:
 
 };
 
-typedef std::shared_ptr<SingleSidedNetworkMatcher> SingleSidedNetworkMatcherPtr;
-typedef std::shared_ptr<const SingleSidedNetworkMatcher> ConstSingleSidedNetworkMatcherPtr;
+using SingleSidedNetworkMatcherPtr = std::shared_ptr<SingleSidedNetworkMatcher>;
+using ConstSingleSidedNetworkMatcherPtr = std::shared_ptr<const SingleSidedNetworkMatcher>;
 
 // not implemented
 bool operator<(ConstSingleSidedNetworkMatcherPtr, ConstSingleSidedNetworkMatcherPtr);

--- a/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/VagabondNetworkMatcher.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/conflate/network/VagabondNetworkMatcher.h
@@ -115,8 +115,8 @@ private:
   QSet<EdgeMatchPtr> _getConnectedEdges(ConstNetworkVertexPtr v1, ConstNetworkVertexPtr v2);
 };
 
-typedef std::shared_ptr<VagabondNetworkMatcher> VagabondNetworkMatcherPtr;
-typedef std::shared_ptr<const VagabondNetworkMatcher> ConstVagabondNetworkMatcherPtr;
+using VagabondNetworkMatcherPtr = std::shared_ptr<VagabondNetworkMatcher>;
+using ConstVagabondNetworkMatcherPtr = std::shared_ptr<const VagabondNetworkMatcher>;
 
 // not implemented
 bool operator<(ConstVagabondNetworkMatcherPtr, ConstVagabondNetworkMatcherPtr);

--- a/hoot-rnd/src/main/cpp/hoot/rnd/language/LanguageDetectionConfidenceLevel.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/language/LanguageDetectionConfidenceLevel.h
@@ -40,13 +40,13 @@ class LanguageDetectionConfidenceLevel
 {
 public:
 
-  typedef enum Level
+  enum Level
   {
     None = 0,
     Low,
     Medium,
     High
-  } Level;
+  };
 
   LanguageDetectionConfidenceLevel();
   LanguageDetectionConfidenceLevel(Level level);

--- a/hoot-rnd/src/main/cpp/hoot/rnd/scoring/multiary/MultiaryMatchComparator.h
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/scoring/multiary/MultiaryMatchComparator.h
@@ -62,7 +62,7 @@ public:
 
   static int logWarnCount;
 
-  typedef QMap<QString, ElementId> IdToEid;
+  using IdToEid = QMap<QString, ElementId>;
 
   MultiaryMatchComparator();
 
@@ -149,8 +149,8 @@ public:
 private:
 
   /// a cluster of IDs.
-  typedef QSet<QString> IdCluster;
-  typedef std::shared_ptr<IdCluster> IdClusterPtr;
+  using IdCluster = QSet<QString>;
+  using IdClusterPtr = std::shared_ptr<IdCluster>;
 
   /// Provides indexed access to a set of elements that need to be reviewed.
   class ReviewClusterIndex : public QMap<QString, IdClusterPtr>
@@ -216,7 +216,7 @@ private:
   QHash<QString, IdClusterPtr> _expectedMatchGroups;
   ReviewClusterIndex _expectedReviews;
 
-  typedef QHash<int, QHash<int, int>> ConfusionTable;
+  using ConfusionTable = QHash<int, QHash<int, int>>;
 
   /**
    * Confusion matrix with [actual][expected]

--- a/hoot-test/src/main/cpp/hoot/test/ProcessPool.h
+++ b/hoot-test/src/main/cpp/hoot/test/ProcessPool.h
@@ -37,7 +37,7 @@
 #include <QProcess>
 #include <QThread>
 #include <QWaitCondition>
-typedef std::shared_ptr<QProcess> QProcessPtr;
+using QProcessPtr = std::shared_ptr<QProcess>;
 
 #define HOOT_TEST_FINISHED "HOOT_TEST_FINISHED"
 
@@ -154,7 +154,8 @@ private:
   /** Shared pointer containing ownership of the process pointer from createProcess() */
   QProcessPtr _proc;
 };
-typedef std::shared_ptr<ProcessThread> ProcessThreadPtr;
+
+using ProcessThreadPtr = std::shared_ptr<ProcessThread>;
 
 /**
  * @brief The ProcessPool class that encapsulates the division of work amongs processes.  Tests

--- a/hoot-test/src/main/cpp/hoot/test/main.cpp
+++ b/hoot-test/src/main/cpp/hoot/test/main.cpp
@@ -74,7 +74,7 @@ using namespace std;
 // Tgs
 #include <tgs/System/Time.h>
 
-typedef std::shared_ptr<CppUnit::Test> TestPtr;
+using TestPtr = std::shared_ptr<CppUnit::Test>;
 
 enum _TestType
 {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.exclusions=**/*.pb.cc,**/*.pb.h,**/*.sql,**/*.o,**/*.gcda,**/*.gcno,**/*.q
 sonar.github.repository=ngageoint/hootenanny
 sonar.host.url=https://sonarcloud.io
 sonar.sources=./hoot-core/src/main,./hoot-js/src/main,./hoot-rnd/src/main,./tbs/src/main,./tgs/src/main
-sonar.issue.ignore.multicriteria=cout1,cout2,cout3,cout4,cout5,cout6,cout7,cout8,protected1,undef1,empty1,explicit1,override1,ruleOf5,floatcounter,commentedCode,singleDeclaration,literalSuffix,generalCatch,macroParenthesis,misraMacro,cognitiveComplexity,initializer,classSize,structSize,hootLog,tripleNest,forEach,noAuto,namespace,subexpressions,nullptrAuto1,nullptrAuto2,ruleOfZero
+sonar.issue.ignore.multicriteria=cout1,cout2,cout3,cout4,cout5,cout6,cout7,cout8,protected1,undef1,empty1,explicit1,override1,ruleOf5,floatcounter,commentedCode,singleDeclaration,literalSuffix,generalCatch,macroParenthesis,misraMacro,cognitiveComplexity,initializer,classSize,structSize,hootLog,tripleNest,forEach,noAuto,namespace,subexpressions,nullptrAuto1,nullptrAuto2,ruleOfZero,usingTypedef1,usingTypedef2
 # Remove the "Incremental analysis cache" warning
 sonar.cfamily.cache.enabled=false
 
@@ -127,3 +127,9 @@ sonar.issue.ignore.multicriteria.nullptrAuto2.resourceKey=**/*.hh
 # Ignore the "Rule-of-Zero" rule
 sonar.issue.ignore.multicriteria.ruleOfZero.ruleKey=cpp:S4963
 sonar.issue.ignore.multicriteria.ruleOfZero.resourceKey=**/*
+
+# Ignore the "using should be preferred for type aliasing" rule
+sonar.issue.ignore.multicriteria.usingTypedef1.ruleKey=cpp:S5416
+sonar.issue.ignore.multicriteria.usingTypedef1.resourceKey=**/BasicBloomFilter.h
+sonar.issue.ignore.multicriteria.usingTypedef2.ruleKey=cpp:S5416
+sonar.issue.ignore.multicriteria.usingTypedef2.resourceKey=**/*.pb.h

--- a/tgs/src/main/cpp/tgs/BigContainers/BigMapStxxl.h
+++ b/tgs/src/main/cpp/tgs/BigContainers/BigMapStxxl.h
@@ -120,21 +120,22 @@ private:
     static long max_value() { return std::numeric_limits<A>::max(); }
   };
 
-  typedef stxxl::map<K, V, CompareLess<K>, 4096, 4096> MapType;
+  using MapType = stxxl::map<K, V, CompareLess<K>, 4096, 4096>;
 
   // scaled for ~100M entries and FPR of 0.001
   // http://hur.st/bloomfilter?n=100000000&p=0.001
-  typedef boost::bloom_filters::basic_bloom_filter<long, 1437 * 1000 * 1000, boost::mpl::vector<
-      boost::bloom_filters::boost_hash<size_t, 0x327B23C66B8B4567>,
-      boost::bloom_filters::boost_hash<size_t, 0x66334873643C9869>,
-      boost::bloom_filters::boost_hash<size_t, 0x19495CFF74B0DC51>,
-      boost::bloom_filters::boost_hash<size_t, 0x625558EC2AE8944A>,
-      boost::bloom_filters::boost_hash<size_t, 0x46E87CCD238E1F29>,
-      boost::bloom_filters::boost_hash<size_t, 0x507ED7AB3D1B58BA>,
-      boost::bloom_filters::boost_hash<size_t, 0x41B71EFB2EB141F2>,
-      boost::bloom_filters::boost_hash<size_t, 0x7545E14679E2A9E3>,
-      boost::bloom_filters::boost_hash<size_t, 0x5BD062C2515F007C>,
-      boost::bloom_filters::boost_hash<size_t, 0x4DB127F812200854>>> BloomFilter;
+  using BloomFilter =
+    boost::bloom_filters::basic_bloom_filter<long, 1437 * 1000 * 1000, boost::mpl::vector<
+    boost::bloom_filters::boost_hash<size_t, 0x327B23C66B8B4567>,
+    boost::bloom_filters::boost_hash<size_t, 0x66334873643C9869>,
+    boost::bloom_filters::boost_hash<size_t, 0x19495CFF74B0DC51>,
+    boost::bloom_filters::boost_hash<size_t, 0x625558EC2AE8944A>,
+    boost::bloom_filters::boost_hash<size_t, 0x46E87CCD238E1F29>,
+    boost::bloom_filters::boost_hash<size_t, 0x507ED7AB3D1B58BA>,
+    boost::bloom_filters::boost_hash<size_t, 0x41B71EFB2EB141F2>,
+    boost::bloom_filters::boost_hash<size_t, 0x7545E14679E2A9E3>,
+    boost::bloom_filters::boost_hash<size_t, 0x5BD062C2515F007C>,
+    boost::bloom_filters::boost_hash<size_t, 0x4DB127F812200854>>>;
 
   std::shared_ptr<MapType> _map;
   std::shared_ptr<BloomFilter> _bloom;

--- a/tgs/src/main/cpp/tgs/DelaunayTriangulation/geom2d.h
+++ b/tgs/src/main/cpp/tgs/DelaunayTriangulation/geom2d.h
@@ -47,7 +47,7 @@
 
 #define EPS 1e-6
 
-typedef double	Real;
+using Real = double;
 
 class Vector2d
 {

--- a/tgs/src/main/cpp/tgs/DisjointSet/DisjointSet.h
+++ b/tgs/src/main/cpp/tgs/DisjointSet/DisjointSet.h
@@ -38,12 +38,12 @@ namespace Tgs
 {
 // disjoint-set forests using union-by-rank and path compression (sort of).
 
-typedef struct
+struct uni_elt
 {
   int rank;
   int p;
   int size;
-} uni_elt;
+};
 
 class DisjointSet
 {

--- a/tgs/src/main/cpp/tgs/DisjointSet/DisjointSetMap.h
+++ b/tgs/src/main/cpp/tgs/DisjointSet/DisjointSetMap.h
@@ -47,8 +47,8 @@ template<class T>
 class DisjointSetMap
 {
 public:
-  typedef typename HashMap<T, int> UserMap;
-  typedef HashMap<int, std::vector<T>> AllGroups;
+  using UserMap = typename HashMap<T, int>;
+  using AllGroups = HashMap<int, std::vector<T>>;
 
   void clear()
   {

--- a/tgs/src/main/cpp/tgs/LruCache.h
+++ b/tgs/src/main/cpp/tgs/LruCache.h
@@ -48,12 +48,12 @@ class LruCache
 {
 public:
 
-  typedef std::pair<K, V> Entry;
+  using Entry = std::pair<K, V>;
   // back of the list is the most recently used.
-  typedef std::list<Entry> CacheList;
-  typedef HashMap<K, typename CacheList::iterator> CacheMap;
+  using CacheList = std::list<Entry>;
+  using CacheMap = HashMap<K, typename CacheList::iterator>;
 
-  LruCache(long maxSize = 1000) : _maxSize(maxSize) {}
+  LruCache(long maxSize = 1000) : _maxSize(maxSize) { }
 
   /**
    * Intert a new item. This becomes the most recently used item. After inserting check for

--- a/tgs/src/main/cpp/tgs/Optimization/FitnessFunction.h
+++ b/tgs/src/main/cpp/tgs/Optimization/FitnessFunction.h
@@ -43,8 +43,8 @@ public:
   virtual double f(const ConstStatePtr& s) = 0;
 };
 
-typedef std::shared_ptr<FitnessFunction> FitnessFunctionPtr;
-typedef std::shared_ptr<const FitnessFunction> ConstFitnessFunctionPtr;
+using FitnessFunctionPtr = std::shared_ptr<FitnessFunction>;
+using ConstFitnessFunctionPtr = std::shared_ptr<const FitnessFunction>;
 
 }
 

--- a/tgs/src/main/cpp/tgs/Optimization/State.h
+++ b/tgs/src/main/cpp/tgs/Optimization/State.h
@@ -62,8 +62,8 @@ private:
   QMap<QString, double> _values;
 };
 
-typedef std::shared_ptr<State> StatePtr;
-typedef std::shared_ptr<const State> ConstStatePtr;
+using StatePtr = std::shared_ptr<State>;
+using ConstStatePtr = std::shared_ptr<const State>;
 
 inline uint qHash(const ConstStatePtr& s)
 {

--- a/tgs/src/main/cpp/tgs/Optimization/StateDescription.h
+++ b/tgs/src/main/cpp/tgs/Optimization/StateDescription.h
@@ -50,8 +50,8 @@ private:
 
 };
 
-typedef std::shared_ptr<StateDescription> StateDescriptionPtr;
-typedef std::shared_ptr<const StateDescription> ConstStateDescriptionPtr;
+using StateDescriptionPtr = std::shared_ptr<StateDescription>;
+using ConstStateDescriptionPtr = std::shared_ptr<const StateDescription>;
 
 }
 

--- a/tgs/src/main/cpp/tgs/Optimization/VariableDescription.h
+++ b/tgs/src/main/cpp/tgs/Optimization/VariableDescription.h
@@ -40,11 +40,11 @@ class VariableDescription
 {
 public:
 
-  typedef enum
+  enum VariableType
   {
     Real,
     Integer
-  } VariableType;
+  };
 
   VariableDescription(QString name, VariableType type, double min, double max);
 
@@ -71,8 +71,8 @@ private:
   VariableType _type;
 };
 
-typedef std::shared_ptr<VariableDescription> VariableDescriptionPtr;
-typedef std::shared_ptr<const VariableDescription> ConstVariableDescriptionPtr;
+using VariableDescriptionPtr = std::shared_ptr<VariableDescription>;
+using ConstVariableDescriptionPtr = std::shared_ptr<const VariableDescription>;
 
 }
 

--- a/tgs/src/main/cpp/tgs/RStarTree/FilePageStore.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/FilePageStore.h
@@ -69,7 +69,7 @@ private:
 
   int _pageSize;
 
-  typedef HashMap<int, std::weak_ptr<Page>> PageMap;
+  using PageMap = HashMap<int, std::weak_ptr<Page>>;
   PageMap _pagesMap;
   bool _readOnly;
   int _pageCount;

--- a/tgs/src/main/cpp/tgs/RStarTree/HilbertCurve.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/HilbertCurve.h
@@ -55,8 +55,8 @@ namespace Tgs
   {
   public:
 
-    typedef int64_t bitmask_t;
-    typedef int64_t halfmask_t;
+    using bitmask_t = int64_t;
+    using halfmask_t = int64_t;
 
     HilbertCurve(int dimensions, int order)
     {

--- a/tgs/src/main/cpp/tgs/RStarTree/HilbertRTree.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/HilbertRTree.h
@@ -114,8 +114,8 @@ namespace Tgs
     double _swapGrandChildNodes(int parentId, const std::vector<double>& overlaps);
   };
 
-  typedef std::shared_ptr<HilbertRTree> HilbertRTreePtr;
-  typedef std::shared_ptr<const HilbertRTree> ConstHilbertRTreePtr;
+  using HilbertRTreePtr = std::shared_ptr<HilbertRTree>;
+  using ConstHilbertRTreePtr = std::shared_ptr<const HilbertRTree>;
 }
 
 

--- a/tgs/src/main/cpp/tgs/RStarTree/RStarTree.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/RStarTree.cpp
@@ -373,7 +373,7 @@ public:
   Child(int id, const BoxInternalData& b) : b(b.toBox()), id(id) { }
 };
 
-typedef std::pair<double, int> DistancePair;
+using DistancePair = std::pair<double, int>;
 
 class CompareDistancePairs
 {

--- a/tgs/src/main/cpp/tgs/RStarTree/RStarTree.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/RStarTree.h
@@ -138,7 +138,7 @@ protected:
     Reinsert
   };
 
-  typedef std::vector<BoxPair> BoxVector;
+  using BoxVector = std::vector<BoxPair>;
 
   // TODO: store dimensions and such.
   class Header

--- a/tgs/src/main/cpp/tgs/RStarTree/RTreeNodeStore.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/RTreeNodeStore.h
@@ -85,7 +85,7 @@ protected:
     RTreeNode * pNode;
   };
 
-  typedef HashMap<int, RecItem*> NodeMap;
+  using NodeMap = HashMap<int, RecItem*>;
 
   // mutable cache
   NodeMap _availableNodes;

--- a/tgs/src/main/cpp/tgs/RandomForest/DataFrame.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/DataFrame.h
@@ -57,17 +57,17 @@ namespace Tgs
   {
   public:
 
-    typedef enum FactorType
+    enum FactorType
     {
       Numerical,
       Nominal
-    } FactorType;
+    };
 
-    typedef enum NullTreatment
+    enum NullTreatment
     {
       NullAsValue,
       NullAsMissingValue
-    } NullTreatment;
+    };
 
     /**
     * Constructor

--- a/tgs/src/main/cpp/tgs/SpinImage/NormalEstimator.h
+++ b/tgs/src/main/cpp/tgs/SpinImage/NormalEstimator.h
@@ -110,11 +110,11 @@ protected:
   /// this is set to true for a point if its children have been traversed.
   std::vector<bool> _processed;
 
-  typedef std::vector<HashSet<int>> RiemannianGraph;
+  using RiemannianGraph = std::vector<HashSet<int>>;
 
   RiemannianGraph _edges;
 
-  typedef std::priority_queue<VertexOrder, std::vector<VertexOrder>, LessVertexOrder> MstQueue;
+  using MstQueue = std::priority_queue<VertexOrder, std::vector<VertexOrder>, LessVertexOrder>;
 
   MstQueue _mstQueue;
 

--- a/tgs/src/main/cpp/tgs/Statistics/Random.h
+++ b/tgs/src/main/cpp/tgs/Statistics/Random.h
@@ -84,7 +84,7 @@ namespace Tgs
     bool _is_single;
   };
 
-  typedef std::shared_ptr<Random> RandomPtr;
+  using RandomPtr = std::shared_ptr<Random>;
 }
 
 #endif

--- a/tgs/src/test/cpp/tgs/BigContainers/BasicBloomFilterTest.cpp
+++ b/tgs/src/test/cpp/tgs/BigContainers/BasicBloomFilterTest.cpp
@@ -52,17 +52,18 @@ public:
 
   void simpleTest()
   {
-    typedef boost::bloom_filters::basic_bloom_filter<long, 1000 * 1000 * 120, boost::mpl::vector<
-        boost::bloom_filters::boost_hash<size_t, 0x327B23C66B8B4567>,
-        boost::bloom_filters::boost_hash<size_t, 0x66334873643C9869>,
-        boost::bloom_filters::boost_hash<size_t, 0x19495CFF74B0DC51>,
-        boost::bloom_filters::boost_hash<size_t, 0x625558EC2AE8944A>,
-        boost::bloom_filters::boost_hash<size_t, 0x46E87CCD238E1F29>,
-        boost::bloom_filters::boost_hash<size_t, 0x507ED7AB3D1B58BA>,
-        boost::bloom_filters::boost_hash<size_t, 0x41B71EFB2EB141F2>,
-        boost::bloom_filters::boost_hash<size_t, 0x7545E14679E2A9E3>,
-        boost::bloom_filters::boost_hash<size_t, 0x5BD062C2515F007C>,
-        boost::bloom_filters::boost_hash<size_t, 0x4DB127F812200854>>> Bloom;
+    using Bloom =
+      boost::bloom_filters::basic_bloom_filter<long, 1000 * 1000 * 120, boost::mpl::vector<
+      boost::bloom_filters::boost_hash<size_t, 0x327B23C66B8B4567>,
+      boost::bloom_filters::boost_hash<size_t, 0x66334873643C9869>,
+      boost::bloom_filters::boost_hash<size_t, 0x19495CFF74B0DC51>,
+      boost::bloom_filters::boost_hash<size_t, 0x625558EC2AE8944A>,
+      boost::bloom_filters::boost_hash<size_t, 0x46E87CCD238E1F29>,
+      boost::bloom_filters::boost_hash<size_t, 0x507ED7AB3D1B58BA>,
+      boost::bloom_filters::boost_hash<size_t, 0x41B71EFB2EB141F2>,
+      boost::bloom_filters::boost_hash<size_t, 0x7545E14679E2A9E3>,
+      boost::bloom_filters::boost_hash<size_t, 0x5BD062C2515F007C>,
+      boost::bloom_filters::boost_hash<size_t, 0x4DB127F812200854>>>;
     //  NOTE: Bloom must be created on the heap and not the stack, thus the "new Bloom()"
     std::shared_ptr<Bloom> b(new Bloom());
 

--- a/tgs/src/test/cpp/tgs/BigContainers/BigMapTest.cpp
+++ b/tgs/src/test/cpp/tgs/BigContainers/BigMapTest.cpp
@@ -97,10 +97,10 @@ public:
 ////    stxxl::config* cfg = stxxl::config::get_instance();
 ////    cfg->
 //    const int m = 1;
-//    typedef stxxl::map<long, long, CompareLess, 4096 * m, 4096 * m> MapType;
+//    using MayType = stxxl::map<long, long, CompareLess, 4096 * m, 4096 * m>;
 //    MapType foo(1024 * 1024 * 512, 1024 * 1024 * 256);
 
-//    typedef stxxl::VECTOR_GENERATOR<long>::result VectorType;
+//    using VectorType = stxxl::VECTOR_GENERATOR<long>::result;
 //    VectorType bar;
 
 //    size_t iterations = 10000000;
@@ -184,10 +184,10 @@ public:
 //    size_t iterations = 10000000;
 //    bool doReadTest = false;
 //    //BigMap<long, long> foo;
-//    typedef stxxl::map<long, long, CompareLess, 4096, 4096> MapType;
+//    using MapType = stxxl::map<long, long, CompareLess, 4096, 4096>;
 //    MapType bar(1024 * 1024 * 512, 1024 * 1024 * 256);
 
-//    typedef stxxl::VECTOR_GENERATOR<long>::result VectorType;
+//    using VectorType stxxl::VECTOR_GENERATOR<long>::result;
 //    VectorType v;
 
 //    vector<pair<long, long>> pairs;


### PR DESCRIPTION
Refactoring 'typedef' aliases to 'using' aliases

Closes #4565