### PR TITLE
SONAR: Override or final should be used instead of virtual

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/criterion/MultiLineStringCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/MultiLineStringCriterion.h
@@ -43,21 +43,20 @@ public:
   static QString className() { return "hoot::MultiLineStringCriterion"; }
 
   MultiLineStringCriterion() = default;
-  virtual ~MultiLineStringCriterion() = default;
+  ~MultiLineStringCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new MultiLineStringCriterion()); }
 
-  virtual QString getDescription() const { return "Identifies multi-line string features"; }
+  virtual QString getDescription() const override { return "Identifies multi-line string features"; }
 
-  virtual GeometryType getGeometryType() const
-  { return GeometryType::Line; }
+  GeometryType getGeometryType() const override { return GeometryType::Line; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/MultiUseBuildingCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/MultiUseBuildingCriterion.h
@@ -43,21 +43,20 @@ public:
   static QString className() { return "hoot::MultiUseBuildingCriterion"; }
 
   MultiUseBuildingCriterion() = default;
-  virtual ~MultiUseBuildingCriterion() = default;
+  ~MultiUseBuildingCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new MultiUseBuildingCriterion()); }
 
-  virtual QString getDescription() const { return "Identifies buildings with multiple purposes"; }
+  QString getDescription() const override { return "Identifies buildings with multiple purposes"; }
 
-  virtual GeometryType getGeometryType() const
-  { return GeometryType::Polygon; }
+  GeometryType getGeometryType() const override { return GeometryType::Polygon; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/MultiUseCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/MultiUseCriterion.h
@@ -1,3 +1,4 @@
+
 /*
  * This file is part of Hootenanny.
  *
@@ -43,17 +44,17 @@ public:
   static QString className() { return "hoot::MultiUseCriterion"; }
 
   MultiUseCriterion() = default;
-  virtual ~MultiUseCriterion() = default;
+  ~MultiUseCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new MultiUseCriterion()); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new MultiUseCriterion()); }
 
-  virtual QString getDescription() const { return "Identifies features with multiple purposes"; }
+  QString getDescription() const override { return "Identifies features with multiple purposes"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/MultiUseCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/MultiUseCriterion.h
@@ -1,4 +1,3 @@
-
 /*
  * This file is part of Hootenanny.
  *

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NameCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NameCriterion.h
@@ -52,17 +52,17 @@ public:
   NameCriterion();
   NameCriterion(const QStringList& names, const bool caseSensitive = false,
                 const bool partialMatch = false);
-  virtual ~NameCriterion() = default;
+  ~NameCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new NameCriterion(_names, _caseSensitive)); }
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies elements that contain a specified name"; }
 
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
   QStringList getNames() const { return _names; }
   bool getCaseSensitive() const { return _caseSensitive; }
@@ -71,9 +71,9 @@ public:
   void setCaseSensitive(bool caseSens) { _caseSensitive = caseSens; }
   void setPartialMatch(bool partialMatch) { _partialMatch = partialMatch; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NeedsReviewCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NeedsReviewCriterion.h
@@ -46,20 +46,20 @@ public:
 
   NeedsReviewCriterion() = default;
   NeedsReviewCriterion(ConstOsmMapPtr& map) : _map(map) { }
-  virtual ~NeedsReviewCriterion() = default;
+  ~NeedsReviewCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new NeedsReviewCriterion(_map)); }
 
-  virtual void setOsmMap(const OsmMap* map) { _map = map->shared_from_this(); }
+  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
 
-  virtual QString getDescription() const { return "Identifies features that need to be reviewed"; }
+  QString getDescription() const override { return "Identifies features that need to be reviewed"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NoInformationCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NoInformationCriterion.h
@@ -48,21 +48,21 @@ public:
   NoInformationCriterion() { setConfiguration(conf()); }
   NoInformationCriterion(bool treatReviewTagsAsMetadata) :
     _treatReviewTagsAsMetadata(treatReviewTagsAsMetadata) { }
-  virtual ~NoInformationCriterion() = default;
+  ~NoInformationCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new NoInformationCriterion(_treatReviewTagsAsMetadata)); }
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies features with no useful information"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NonBuildingAreaCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NonBuildingAreaCriterion.h
@@ -49,23 +49,23 @@ public:
 
   NonBuildingAreaCriterion() = default;
   NonBuildingAreaCriterion(ConstOsmMapPtr map) : _map(map) { }
-  virtual ~NonBuildingAreaCriterion() = default;
+  ~NonBuildingAreaCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new NonBuildingAreaCriterion()); }
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies features that are areas but not buildings"; }
 
-  virtual GeometryType getGeometryType() const { return GeometryType::Polygon; }
+  GeometryType getGeometryType() const override { return GeometryType::Polygon; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual void setOsmMap(const OsmMap* map) { _map = map->shared_from_this(); }
+  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.h
@@ -47,31 +47,30 @@ namespace hoot
 class NonConflatableCriterion : public ElementCriterion, public ConstOsmMapConsumer,
   public Configurable
 {
-
 public:
 
   static QString className() { return "hoot::NonConflatableCriterion"; }
 
   NonConflatableCriterion();
   NonConflatableCriterion(ConstOsmMapPtr map);
-  virtual ~NonConflatableCriterion() = default;
+  ~NonConflatableCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   {
     return ElementCriterionPtr(new NonConflatableCriterion(_map));
   }
 
-  virtual QString getDescription() const { return "Identifies features that are not conflatable"; }
+  QString getDescription() const override { return "Identifies features that are not conflatable"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual void setOsmMap(const OsmMap* map) { _map = map->shared_from_this(); }
+  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
 
   void setGeometryTypeFilter(const GeometryTypeCriterion::GeometryType& filter)
   { _geometryTypeFilter = filter; }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NotCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NotCriterion.h
@@ -45,29 +45,29 @@ public:
   NotCriterion() = default;
   NotCriterion(ElementCriterion* c) : _child(c) { }
   NotCriterion(ElementCriterionPtr c) : _child(c) { }
-  virtual ~NotCriterion() = default;
+  ~NotCriterion() = default;
 
-  virtual void addCriterion(const ElementCriterionPtr& e);
+  void addCriterion(const ElementCriterionPtr& e) override;
 
   /**
    * Returns true if the element satisfies the criterion.
    */
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new NotCriterion(_child->clone())); }
 
-  virtual QString getDescription() const { return "Negates a criterion"; }
+  QString getDescription() const override { return "Negates a criterion"; }
 
-  virtual QString toString() const override;
+  QString toString() const override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
-  virtual void setOsmMap(const OsmMap* map);
+  void setOsmMap(const OsmMap* map) override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/OneWayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/OneWayCriterion.h
@@ -46,18 +46,17 @@ public:
   OneWayCriterion() = default;
   virtual ~OneWayCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new OneWayCriterion()); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new OneWayCriterion()); }
 
-  virtual QString getDescription() const { return "Identifies one way streets"; }
+  QString getDescription() const override { return "Identifies one way streets"; }
 
-  virtual GeometryType getGeometryType() const
-  { return GeometryType::Line; }
+  GeometryType getGeometryType() const override { return GeometryType::Line; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/OrCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/OrCriterion.h
@@ -44,19 +44,19 @@ public:
   OrCriterion() = default;
   OrCriterion(ElementCriterion* child1, ElementCriterion* child2);
   OrCriterion(ElementCriterionPtr child1, ElementCriterionPtr child2);
-  virtual ~OrCriterion() = default;
+  ~OrCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone();
+  ElementCriterionPtr clone() override;
 
-  virtual QString getDescription() const { return "Allows for combining criteria (logical OR)"; }
+  QString getDescription() const override { return "Allows for combining criteria (logical OR)"; }
 
-  virtual QString toString() const override;
+  QString toString() const override;
 
- virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 using OrCriterionPtr = std::shared_ptr<OrCriterion>;

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ParallelWayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ParallelWayCriterion.h
@@ -49,25 +49,25 @@ public:
 
   ParallelWayCriterion() = default;
   ParallelWayCriterion(const ConstOsmMapPtr& map, ConstWayPtr baseWay, bool isParallel = true);
-  virtual ~ParallelWayCriterion();
+  ~ParallelWayCriterion();
 
   Radians calculateDifference(const ConstWayPtr& w) const;
 
   void setThreshold(Degrees threshold) { _threshold = threshold; }
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new ParallelWayCriterion(_map, _baseWay, _isParallel)); }
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies ways that are parallel to each other"; }
 
-  virtual GeometryType getGeometryType() const { return GeometryType::Line; }
+  GeometryType getGeometryType() const override { return GeometryType::Line; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
   static bool isParallel(const ConstOsmMapPtr& map, const ConstElementPtr& e1, const ConstElementPtr& e2);
   static bool notParallel(const ConstOsmMapPtr& map, const ConstElementPtr& e1, const ConstElementPtr& e2);

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PoiCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PoiCriterion.h
@@ -43,22 +43,21 @@ public:
   static QString className() { return "hoot::PoiCriterion"; }
 
   PoiCriterion() = default;
-  virtual ~PoiCriterion() = default;
+  ~PoiCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual GeometryType getGeometryType() const
-  { return GeometryType::Point; }
+  GeometryType getGeometryType() const override { return GeometryType::Point; }
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new PoiCriterion()); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new PoiCriterion()); }
 
-  virtual QString getDescription() const { return "Identifies POIs"; }
+  QString getDescription() const override { return "Identifies POIs"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual bool supportsSpecificConflation() const { return true; }
+  bool supportsSpecificConflation() const override { return true; }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PointCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PointCriterion.h
@@ -48,24 +48,24 @@ public:
 
   PointCriterion() = default;
   PointCriterion(ConstOsmMapPtr map);
-  virtual ~PointCriterion() = default;
+  ~PointCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new PointCriterion(_map)); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new PointCriterion(_map)); }
 
-  virtual QString getDescription() const { return "Identifies point features"; }
+  QString getDescription() const override { return "Identifies point features"; }
 
-  virtual GeometryType getGeometryType() const
+  GeometryType getGeometryType() const override
   { return GeometryType::Point; }
 
-  virtual void setOsmMap(const OsmMap* map);
+  void setOsmMap(const OsmMap* map) override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual bool supportsSpecificConflation() const { return false; }
+  bool supportsSpecificConflation() const override { return false; }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PolygonCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PolygonCriterion.h
@@ -47,28 +47,27 @@ public:
 
   PolygonCriterion() = default;
   PolygonCriterion(ConstOsmMapPtr map);
-  virtual ~PolygonCriterion() = default;
+  ~PolygonCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new PolygonCriterion(_map)); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new PolygonCriterion(_map)); }
 
-  virtual QString getDescription() const { return "Identifies polygon features"; }
+  QString getDescription() const override { return "Identifies polygon features"; }
 
-  virtual GeometryType getGeometryType() const
-  { return GeometryType::Polygon; }
+  GeometryType getGeometryType() const override { return GeometryType::Polygon; }
 
-  virtual void setOsmMap(const OsmMap* map);
+  void setOsmMap(const OsmMap* map) override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual bool supportsSpecificConflation() const { return false; }
+  bool supportsSpecificConflation() const override { return false; }
 
   void setAllowMixedChildren(bool allow) { _relationCrit.setAllowMixedChildren(allow); }
 
-  virtual QStringList getChildCriteria() const;
+  QStringList getChildCriteria() const override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PolygonWayNodeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PolygonWayNodeCriterion.h
@@ -41,18 +41,18 @@ public:
 
   PolygonWayNodeCriterion();
   PolygonWayNodeCriterion(ConstOsmMapPtr map);
-  virtual ~PolygonWayNodeCriterion() = default;
+  ~PolygonWayNodeCriterion() = default;
 
-  virtual void setOsmMap(const OsmMap* map) override;
+  void setOsmMap(const OsmMap* map) override;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new PolygonWayNodeCriterion(_map)); }
 
-  virtual QString getDescription() const { return "Identifies nodes belonging to polygons"; }
+  QString getDescription() const override { return "Identifies nodes belonging to polygons"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PowerLineCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PowerLineCriterion.h
@@ -42,24 +42,23 @@ public:
   static QString className() { return "hoot::PowerLineCriterion"; }
 
   PowerLineCriterion() = default;
-  virtual ~PowerLineCriterion() = default;
+  ~PowerLineCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual GeometryType getGeometryType() const
-  { return GeometryType::Line; }
+  GeometryType getGeometryType() const override { return GeometryType::Line; }
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new PowerLineCriterion()); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new PowerLineCriterion()); }
 
-  virtual QString getDescription() const { return "Identifies power line utilities"; }
+  QString getDescription() const override { return "Identifies power line utilities"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual bool supportsSpecificConflation() const { return true; }
+  bool supportsSpecificConflation() const override { return true; }
 
-  virtual QStringList getChildCriteria() const;
+  QStringList getChildCriteria() const override;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PowerLineWayNodeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PowerLineWayNodeCriterion.h
@@ -41,16 +41,16 @@ public:
 
   PowerLineWayNodeCriterion();
   PowerLineWayNodeCriterion(ConstOsmMapPtr map);
-  virtual ~PowerLineWayNodeCriterion() = default;
+  ~PowerLineWayNodeCriterion() = default;
 
-  virtual ElementCriterionPtr clone() override
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new PowerLineWayNodeCriterion(_map)); }
 
-  virtual QString getDescription() const override { return "Identifies power line nodes"; }
+  QString getDescription() const override { return "Identifies power line nodes"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RailwayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RailwayCriterion.h
@@ -46,24 +46,24 @@ public:
   static QString className() { return "hoot::RailwayCriterion"; }
 
   RailwayCriterion() = default;
-  virtual ~RailwayCriterion() = default;
+  ~RailwayCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual GeometryType getGeometryType() const { return GeometryType::Line; }
+  GeometryType getGeometryType() const override { return GeometryType::Line; }
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new RailwayCriterion()); }
 
-  virtual QString getDescription() const { return "Identifies linear railways"; }
+  QString getDescription() const override { return "Identifies linear railways"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual bool supportsSpecificConflation() const { return true; }
+  bool supportsSpecificConflation() const override { return true; }
 
-  virtual QStringList getChildCriteria() const;
+  QStringList getChildCriteria() const override;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RailwayWayNodeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RailwayWayNodeCriterion.h
@@ -41,16 +41,16 @@ public:
 
   RailwayWayNodeCriterion();
   RailwayWayNodeCriterion(ConstOsmMapPtr map);
-  virtual ~RailwayWayNodeCriterion() = default;
+  ~RailwayWayNodeCriterion() = default;
 
-  virtual ElementCriterionPtr clone() override
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new RailwayWayNodeCriterion(_map)); }
 
-  virtual QString getDescription() const override { return "Identifies railway nodes"; }
+  QString getDescription() const override { return "Identifies railway nodes"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationMemberCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationMemberCriterion.h
@@ -47,23 +47,23 @@ public:
 
   RelationMemberCriterion() = default;
   RelationMemberCriterion(ConstOsmMapPtr map);
-  virtual ~RelationMemberCriterion() = default;
+  ~RelationMemberCriterion() = default;
 
   /**
    * @see ElementVisitor
    */
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new RelationMemberCriterion(_map)); }
 
-  virtual QString getDescription() const { return "Identifies relation members"; }
+  QString getDescription() const override { return "Identifies relation members"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual void setOsmMap(const OsmMap* map) { _map = map->shared_from_this(); }
+  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithAreaMembersCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithAreaMembersCriterion.h
@@ -46,21 +46,21 @@ public:
 
   RelationWithAreaMembersCriterion();
   RelationWithAreaMembersCriterion(ConstOsmMapPtr map);
-  virtual ~RelationWithAreaMembersCriterion() = default;
+  ~RelationWithAreaMembersCriterion() = default;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new RelationWithAreaMembersCriterion(_map)); }
 
-  virtual QString getCriterion() const override;
+  QString getCriterion() const override;
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies relations with area members"; }
 
-  virtual GeometryType getGeometryType() const;
+  GeometryType getGeometryType() const override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithBuildingMembersCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithBuildingMembersCriterion.h
@@ -46,21 +46,21 @@ public:
 
   RelationWithBuildingMembersCriterion();
   RelationWithBuildingMembersCriterion(ConstOsmMapPtr map);
-  virtual ~RelationWithBuildingMembersCriterion() = default;
+  ~RelationWithBuildingMembersCriterion() = default;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new RelationWithBuildingMembersCriterion(_map)); }
 
-  virtual QString getCriterion() const override;
+  QString getCriterion() const override;
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies relations with building members"; }
 
-  virtual GeometryType getGeometryType() const;
+  GeometryType getGeometryType() const override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithHighwayMembersCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithHighwayMembersCriterion.h
@@ -46,21 +46,21 @@ public:
 
   RelationWithHighwayMembersCriterion();
   RelationWithHighwayMembersCriterion(ConstOsmMapPtr map);
-  virtual ~RelationWithHighwayMembersCriterion() = default;
+  ~RelationWithHighwayMembersCriterion() = default;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new RelationWithHighwayMembersCriterion(_map)); }
 
-  virtual QString getCriterion() const override;
+  QString getCriterion() const override;
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies relations with road members"; }
 
-  virtual GeometryType getGeometryType() const;
+  GeometryType getGeometryType() const override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithLinearMembersCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithLinearMembersCriterion.h
@@ -46,21 +46,21 @@ public:
 
   RelationWithLinearMembersCriterion();
   RelationWithLinearMembersCriterion(ConstOsmMapPtr map);
-  virtual ~RelationWithLinearMembersCriterion() = default;
+  ~RelationWithLinearMembersCriterion() = default;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new RelationWithLinearMembersCriterion(_map)); }
 
-  virtual QString getCriterion() const override;
+  QString getCriterion() const override;
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies relations with children having linear geometries"; }
 
-  virtual GeometryType getGeometryType() const;
+  GeometryType getGeometryType() const override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithMembersOfTypeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithMembersOfTypeCriterion.h
@@ -51,13 +51,13 @@ public:
   RelationWithMembersOfTypeCriterion(ConstOsmMapPtr map);
   virtual ~RelationWithMembersOfTypeCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
   virtual QString getCriterion() const = 0;
 
-  virtual void setOsmMap(const OsmMap* map);
+  void setOsmMap(const OsmMap* map) override;
 
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
   void setAllowMixedChildren(bool allow) { _allowMixedChildren = allow; }
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithPoiMembersCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithPoiMembersCriterion.h
@@ -44,21 +44,21 @@ public:
   static QString className() { return "hoot::RelationWithPoiMembersCriterion"; }
 
   RelationWithPoiMembersCriterion();
-  virtual ~RelationWithPoiMembersCriterion() = default;
+  ~RelationWithPoiMembersCriterion() = default;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new RelationWithPoiMembersCriterion()); }
 
-  virtual QString getCriterion() const override;
+  QString getCriterion() const override;
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies relations with POI members"; }
 
-  virtual GeometryType getGeometryType() const;
+  GeometryType getGeometryType() const override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithPointMembersCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithPointMembersCriterion.h
@@ -45,21 +45,21 @@ public:
 
   RelationWithPointMembersCriterion();
   RelationWithPointMembersCriterion(ConstOsmMapPtr map);
-  virtual ~RelationWithPointMembersCriterion() = default;
+  ~RelationWithPointMembersCriterion() = default;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new RelationWithPointMembersCriterion(_map)); }
 
-  virtual QString getCriterion() const override;
+  QString getCriterion() const override;
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies relations with children having point geometries"; }
 
-  virtual GeometryType getGeometryType() const;
+  GeometryType getGeometryType() const override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithPolygonMembersCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithPolygonMembersCriterion.h
@@ -45,21 +45,21 @@ public:
 
   RelationWithPolygonMembersCriterion();
   RelationWithPolygonMembersCriterion(ConstOsmMapPtr map);
-  virtual ~RelationWithPolygonMembersCriterion() = default;
+  ~RelationWithPolygonMembersCriterion() = default;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new RelationWithPolygonMembersCriterion(_map)); }
 
-  virtual QString getCriterion() const override;
+  QString getCriterion() const override;
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies relations with children having polygon geometries"; }
 
-  virtual GeometryType getGeometryType() const;
+  GeometryType getGeometryType() const override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithPowerLineMembersCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithPowerLineMembersCriterion.h
@@ -44,21 +44,21 @@ public:
   static QString className() { return "hoot::RelationWithPowerLineMembersCriterion"; }
 
   RelationWithPowerLineMembersCriterion();
-  virtual ~RelationWithPowerLineMembersCriterion() = default;
+  ~RelationWithPowerLineMembersCriterion() = default;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new RelationWithPowerLineMembersCriterion()); }
 
-  virtual QString getCriterion() const override;
+  QString getCriterion() const override;
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies relations with power line members"; }
 
-  virtual GeometryType getGeometryType() const;
+  GeometryType getGeometryType() const override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithRailwayMembersCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithRailwayMembersCriterion.h
@@ -44,21 +44,21 @@ public:
   static QString className() { return "hoot::RelationWithRailwayMembersCriterion"; }
 
   RelationWithRailwayMembersCriterion();
-  virtual ~RelationWithRailwayMembersCriterion() = default;
+  ~RelationWithRailwayMembersCriterion() = default;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new RelationWithRailwayMembersCriterion()); }
 
-  virtual QString getCriterion() const override;
+  QString getCriterion() const override;
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies relations with railway members"; }
 
-  virtual GeometryType getGeometryType() const;
+  GeometryType getGeometryType() const override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithRiverMembersCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithRiverMembersCriterion.h
@@ -45,21 +45,21 @@ public:
   static QString className() { return "hoot::RelationWithRiverMembersCriterion"; }
 
   RelationWithRiverMembersCriterion();
-  virtual ~RelationWithRiverMembersCriterion() = default;
+  ~RelationWithRiverMembersCriterion() = default;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new RelationWithRiverMembersCriterion()); }
 
-  virtual QString getCriterion() const override;
+  QString getCriterion() const override;
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies relations with river members"; }
 
-  virtual GeometryType getGeometryType() const;
+  GeometryType getGeometryType() const override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ReversedRoadCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ReversedRoadCriterion.h
@@ -48,22 +48,21 @@ public:
 
   ReversedRoadCriterion() = default;
   ReversedRoadCriterion(ConstOsmMapPtr map) : _map(map) { }
-  virtual ~ReversedRoadCriterion() = default;
+  ~ReversedRoadCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new ReversedRoadCriterion()); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new ReversedRoadCriterion()); }
 
-  virtual QString getDescription() const { return "Identifies reversed roads"; }
+  QString getDescription() const override { return "Identifies reversed roads"; }
 
-  virtual GeometryType getGeometryType() const
-  { return GeometryType::Line; }
+  GeometryType getGeometryType() const override { return GeometryType::Line; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual void setOsmMap(const OsmMap* map) { _map = map->shared_from_this(); }
+  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ReviewRelationCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ReviewRelationCriterion.h
@@ -43,19 +43,19 @@ public:
   static QString className() { return "hoot::ReviewRelationCriterion"; }
 
   ReviewRelationCriterion() = default;
-  virtual ~ReviewRelationCriterion() = default;
+  ~ReviewRelationCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new ReviewRelationCriterion()); }
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies review relations created during conflation"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ReviewScoreCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ReviewScoreCriterion.h
@@ -45,24 +45,24 @@ public:
   static QString className() { return "hoot::ReviewScoreCriterion"; }
 
   ReviewScoreCriterion();
-  virtual ~ReviewScoreCriterion() = default;
+  ~ReviewScoreCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new ReviewScoreCriterion()); }
 
-  virtual QString getDescription() const { return "Allows for filtering reviews by score"; }
+  QString getDescription() const override { return "Allows for filtering reviews by score"; }
 
   void setMinScoreThreshold(const double threshold);
   void setMaxScoreThreshold(const double threshold);
   void setInvertThresholding(const bool invert) { _invertThresholding = invert; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RoundaboutCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RoundaboutCriterion.h
@@ -45,20 +45,20 @@ public:
   static QString className() { return "hoot::RoundaboutCriterion"; }
 
   RoundaboutCriterion() = default;
-  virtual ~RoundaboutCriterion() = default;
+  ~RoundaboutCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new RoundaboutCriterion()); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new RoundaboutCriterion()); }
 
-  virtual QString getDescription() const { return "Identifies road roundabout junctions"; }
+  QString getDescription() const override { return "Identifies road roundabout junctions"; }
 
-  virtual GeometryType getGeometryType() const
+  GeometryType getGeometryType() const override
   { return GeometryType::Line; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/StatsAreaCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/StatsAreaCriterion.h
@@ -43,17 +43,17 @@ public:
   static QString className() { return "hoot::StatsAreaCriterion"; }
 
   StatsAreaCriterion() = default;
-  virtual ~StatsAreaCriterion() = default;
+  ~StatsAreaCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new StatsAreaCriterion()); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new StatsAreaCriterion()); }
 
-  virtual QString getDescription() const { return "Identifies areas for use by statistics"; }
+  QString getDescription() const override { return "Identifies areas for use by statistics"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/StatusCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/StatusCriterion.h
@@ -46,19 +46,19 @@ public:
 
   StatusCriterion() { setConfiguration(conf()); }
   StatusCriterion(Status s) : _status(s) { }
-  virtual ~StatusCriterion() = default;
+  ~StatusCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new StatusCriterion(_status)); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new StatusCriterion(_status)); }
 
-  virtual QString getDescription() const { return "Identifies elements with a particular status"; }
+  QString getDescription() const override { return "Identifies elements with a particular status"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/TagAdvancedCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/TagAdvancedCriterion.h
@@ -63,20 +63,20 @@ public:
 
   TagAdvancedCriterion();
   TagAdvancedCriterion(const QString& filterJsonStrOrPath);
-  virtual ~TagAdvancedCriterion() = default;
+  ~TagAdvancedCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new TagAdvancedCriterion()); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new TagAdvancedCriterion()); }
 
-  void setConfiguration(const Settings& s);
+  void setConfiguration(const Settings& s) override;
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies elements by tag using a set of advanced schema functionality"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/TagContainsCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/TagContainsCriterion.h
@@ -50,11 +50,11 @@ public:
   TagContainsCriterion();
   TagContainsCriterion(QString key, QString valueSubstring);
   TagContainsCriterion(QStringList keys, QStringList valueSubstrings);
-  virtual ~TagContainsCriterion() = default;
+  ~TagContainsCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  void setConfiguration(const Settings& s);
+  void setConfiguration(const Settings& s) override;
 
  /**
    * Adds an additional pair to the search list. If any one of the pairs matches then it is
@@ -62,19 +62,19 @@ public:
    */
   void addPair(QString key, QString valueSubstring);
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new TagContainsCriterion()); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new TagContainsCriterion()); }
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies elements having a particular tag key and tag value substring"; }
 
   void setKvps(const QStringList kvps);
   void setCaseSensitive(bool caseSens) { _caseSensitive = caseSens; }
 
-  virtual QString toString() const override;
+  QString toString() const override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/TagCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/TagCriterion.h
@@ -48,25 +48,25 @@ public:
 
   TagCriterion();
   TagCriterion(const QString& k, const QString& v);
-  virtual ~TagCriterion() = default;
+  ~TagCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  void setConfiguration(const Settings& s);
+  void setConfiguration(const Settings& s) override;
 
   void setKvps(const QStringList kvps);
   void setCaseSensitive(bool caseSens) { _caseSensitive = caseSens; }
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new TagCriterion()); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new TagCriterion()); }
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies elements containing a specified tag key/value combination"; }
 
-  virtual QString toString() const override;
+  QString toString() const override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/TagKeyContainsCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/TagKeyContainsCriterion.h
@@ -46,23 +46,23 @@ public:
 
   TagKeyContainsCriterion() : _text(""), _caseSensitive(false) { }
   explicit TagKeyContainsCriterion(const QString& text);
-  virtual ~TagKeyContainsCriterion() = default;
+  ~TagKeyContainsCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new TagKeyContainsCriterion()); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new TagKeyContainsCriterion()); }
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies elements which have a tag key containing specified text"; }
 
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
   void setText(const QString& text) { _text = text; }
   void setCaseSensitive(bool caseSens) { _caseSensitive = caseSens; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/TagKeyCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/TagKeyCriterion.h
@@ -50,22 +50,22 @@ public:
   explicit TagKeyCriterion(QString key);
   TagKeyCriterion(QString key1, QString key2);
   TagKeyCriterion(QString key1, QString key2, QString key3);
-  virtual ~TagKeyCriterion() = default;
+  ~TagKeyCriterion() = default;
 
   void addKey(QString key);
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new TagKeyCriterion(_keys)); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new TagKeyCriterion(_keys)); }
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies elements that contain a specified tag key"; }
 
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/TagValueNumericRangeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/TagValueNumericRangeCriterion.h
@@ -48,21 +48,21 @@ public:
   TagValueNumericRangeCriterion();
   TagValueNumericRangeCriterion(const QStringList tagKeys, const long rangeMin,
                                 const long rangeMax);
-  virtual ~TagValueNumericRangeCriterion() = default;
+  ~TagValueNumericRangeCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new TagValueNumericRangeCriterion()); }
 
-  void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies elements having numeric tag values falling within a range"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/TunnelCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/TunnelCriterion.h
@@ -44,20 +44,19 @@ public:
   static QString className() { return "hoot::TunnelCriterion"; }
 
   TunnelCriterion() = default;
-  virtual ~TunnelCriterion() = default;
+  ~TunnelCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new TunnelCriterion()); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new TunnelCriterion()); }
 
-  virtual QString getDescription() const { return "Identifies tunnels"; }
+  QString getDescription() const override { return "Identifies tunnels"; }
 
-  virtual GeometryType getGeometryType() const
-  { return GeometryType::Line; }
+  GeometryType getGeometryType() const override { return GeometryType::Line; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/TunnelWayNodeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/TunnelWayNodeCriterion.h
@@ -41,16 +41,16 @@ public:
 
   TunnelWayNodeCriterion();
   TunnelWayNodeCriterion(ConstOsmMapPtr map);
-  virtual ~TunnelWayNodeCriterion() = default;
+  ~TunnelWayNodeCriterion() = default;
 
-  virtual ElementCriterionPtr clone() override
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new TunnelWayNodeCriterion()); }
 
-  virtual QString getDescription() const override { return "Identifies tunnel nodes"; }
+  QString getDescription() const override { return "Identifies tunnel nodes"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/UselessElementCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/UselessElementCriterion.h
@@ -50,19 +50,19 @@ public:
 
   UselessElementCriterion() = default;
   UselessElementCriterion(ConstOsmMapPtr map) : _map(map) { }
-  virtual ~UselessElementCriterion() = default;
+  ~UselessElementCriterion() = default;
 
-  virtual void setOsmMap(const OsmMap* map) { _map = map->shared_from_this(); }
+  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new UselessElementCriterion()); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new UselessElementCriterion()); }
 
-  virtual QString getDescription() const { return "Identifies elements that have no use"; }
+  QString getDescription() const override { return "Identifies elements that have no use"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayBufferCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayBufferCriterion.h
@@ -48,7 +48,7 @@ public:
   static QString className() { return "hoot::WayBufferCriterion"; }
 
   WayBufferCriterion() = default;
-  virtual ~WayBufferCriterion() = default;
+  ~WayBufferCriterion() = default;
 
   /**
    * Buffer is the buffer in meters to put around the way. The circular
@@ -72,16 +72,16 @@ public:
                      Meters circularError,
                      double matchPercent);
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new WayBufferCriterion(_map, _baseLs, _buffer, 0, _matchPercent)); }
 
-  virtual QString getDescription() const { return "Allows for operations on ways with buffers"; }
+  QString getDescription() const override { return "Allows for operations on ways with buffers"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayDirectionCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayDirectionCriterion.h
@@ -46,18 +46,18 @@ public:
   WayDirectionCriterion(const ConstOsmMapPtr& map,
                         ConstWayPtr baseWay,
                         bool similarDirection = true);
-  virtual ~WayDirectionCriterion() = default;
+  ~WayDirectionCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new WayDirectionCriterion(_map, _baseWay, _similarDirection)); }
 
-  virtual QString getDescription() const { return "Identifies which direction a way is pointing"; }
+  QString getDescription() const override { return "Identifies which direction a way is pointing"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayEndNodeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayEndNodeCriterion.h
@@ -49,13 +49,13 @@ public:
 
   WayEndNodeCriterion(const bool allowShared = true);
   WayEndNodeCriterion(ConstOsmMapPtr map, const bool allowShared = true);
-  virtual ~WayEndNodeCriterion() = default;
+  ~WayEndNodeCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new WayEndNodeCriterion(_map)); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new WayEndNodeCriterion(_map)); }
 
-  virtual QString getDescription() const { return "Identifies way end nodes"; }
+  QString getDescription() const override { return "Identifies way end nodes"; }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayLengthCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayLengthCriterion.h
@@ -46,24 +46,24 @@ public:
   WayLengthCriterion(ConstOsmMapPtr map);
   WayLengthCriterion(const double comparisonLength,
                      const NumericComparisonType& numericComparisonType, ConstOsmMapPtr map);
-  virtual ~WayLengthCriterion() = default;
+  ~WayLengthCriterion() = default;
 
   /**
    * @see ElementCriterion
    */
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone() override
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new WayLengthCriterion(_map)); }
 
-  virtual QString getDescription() const override
+  QString getDescription() const override
   { return "Identifies ways that meet a length threshold"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual void setOsmMap(const OsmMap* map) { _map = map->shared_from_this(); }
+  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayNodeCountCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayNodeCountCriterion.h
@@ -43,22 +43,22 @@ public:
   WayNodeCountCriterion();
   WayNodeCountCriterion(
     const int comparisonCount, const NumericComparisonType& numericComparisonType);
-  virtual ~WayNodeCountCriterion() = default;
+  ~WayNodeCountCriterion() = default;
 
   /**
    * @see ElementCriterion
    */
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual ElementCriterionPtr clone() override
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new WayNodeCountCriterion()); }
 
-  virtual QString getDescription() const override
+  QString getDescription() const override
   { return "Identifies ways that meet a node count threshold"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/poi-polygon/PoiPolygonPoiCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/poi-polygon/PoiPolygonPoiCriterion.h
@@ -47,23 +47,23 @@ public:
   static QString className() { return "hoot::PoiPolygonPoiCriterion"; }
 
   PoiPolygonPoiCriterion();
-  virtual ~PoiPolygonPoiCriterion() = default;
+  ~PoiPolygonPoiCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual GeometryType getGeometryType() const
+  GeometryType getGeometryType() const override
   { return GeometryType::Point; }
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new PoiPolygonPoiCriterion()); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new PoiPolygonPoiCriterion()); }
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies POIs as defined by POI/Polygon Conflation"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual bool supportsSpecificConflation() const { return true; }
+  bool supportsSpecificConflation() const override { return true; }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/poi-polygon/PoiPolygonPolyCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/poi-polygon/PoiPolygonPolyCriterion.h
@@ -48,24 +48,24 @@ public:
   static QString className() { return "hoot::PoiPolygonPolyCriterion"; }
 
   PoiPolygonPolyCriterion();
-  virtual ~PoiPolygonPolyCriterion() = default;
+  ~PoiPolygonPolyCriterion() = default;
 
-  virtual bool isSatisfied(const ConstElementPtr& e) const override;
+  bool isSatisfied(const ConstElementPtr& e) const override;
 
-  virtual GeometryType getGeometryType() const { return GeometryType::Polygon; }
+  GeometryType getGeometryType() const override { return GeometryType::Polygon; }
 
-  virtual ElementCriterionPtr clone() { return ElementCriterionPtr(new PoiPolygonPolyCriterion()); }
+  ElementCriterionPtr clone() override { return ElementCriterionPtr(new PoiPolygonPolyCriterion()); }
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies polygons as defined by POI/Polygon Conflation"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual bool supportsSpecificConflation() const { return true; }
+  bool supportsSpecificConflation() const override { return true; }
 
-  virtual QStringList getChildCriteria() const;
+  QStringList getChildCriteria() const override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/poi-polygon/PoiPolygonPolyWayNodeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/poi-polygon/PoiPolygonPolyWayNodeCriterion.h
@@ -41,17 +41,17 @@ public:
 
   PoiPolygonPolyWayNodeCriterion();
   PoiPolygonPolyWayNodeCriterion(ConstOsmMapPtr map);
-  virtual ~PoiPolygonPolyWayNodeCriterion() = default;
+  ~PoiPolygonPolyWayNodeCriterion() = default;
 
-  virtual ElementCriterionPtr clone()
+  ElementCriterionPtr clone() override
   { return ElementCriterionPtr(new PoiPolygonPolyWayNodeCriterion(_map)); }
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Identifies nodes belonging to polygons as identified by POI/Polygon Conflation"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/elements/ConnectedRelationMemberFinder.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ConnectedRelationMemberFinder.h
@@ -44,7 +44,7 @@ class ConnectedRelationMemberFinder : public ConstOsmMapConsumer
 public:
 
   ConnectedRelationMemberFinder() = default;
-  virtual ~ConnectedRelationMemberFinder() = default;
+  ~ConnectedRelationMemberFinder() = default;
 
   /**
    * Determines if any way from one relation is connected to a way in another relation
@@ -59,7 +59,7 @@ public:
   /**
    * @see ConstOsmMapConsumer
    */
-  virtual void setOsmMap(const OsmMap* map) { _map = map->shared_from_this(); }
+  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/ConstElementConsumer.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ConstElementConsumer.h
@@ -40,7 +40,7 @@ public:
   virtual ~ConstElementConsumer() = default;
 
   virtual void addElement(const ConstElementPtr& e) = 0;
-  virtual void addElement(const ElementPtr& e)
+  void addElement(const ElementPtr& e) override
   {
     addElement(std::dynamic_pointer_cast<const Element>(e));
   }

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementComparer.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementComparer.h
@@ -52,7 +52,7 @@ public:
   static const long DEBUG_ID = 0;
 
   ElementComparer();
-  virtual ~ElementComparer() = default;
+  ~ElementComparer() = default;
 
   /**
    * Determines if two elements are the same
@@ -72,7 +72,7 @@ public:
    * This only needs to be set if _ignoreElementId = true. The reason a const map isn't used here
    * is for the same reason isSame doesn't take in const elements.
    */
-  virtual void setOsmMap(OsmMap* map) { _map = map->shared_from_this(); }
+  void setOsmMap(OsmMap* map) override { _map = map->shared_from_this(); }
 
   /**
    * Wrapper around ElementHashVisitor::toHashString

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementComparison.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementComparison.h
@@ -51,7 +51,7 @@ public:
 
   ElementPtr getElement() const { return _element; }
 
-  virtual bool operator==(const ElementComparison& elementComp) const;
+  bool operator==(const ElementComparison& elementComp) const;
 
   virtual QString toString() const;
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/ExternalMergeElementSorter.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ExternalMergeElementSorter.h
@@ -83,7 +83,7 @@ class ExternalMergeElementSorter : public ElementInputStream
 public:
 
   ExternalMergeElementSorter();
-  virtual ~ExternalMergeElementSorter();
+  ~ExternalMergeElementSorter();
 
   /**
    * Sorts elements first by type, then increasing by ID
@@ -95,22 +95,22 @@ public:
   /**
    * @see ElementInputStream
    */
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const override;
+  std::shared_ptr<OGRSpatialReference> getProjection() const override;
 
   /**
    * @see ElementInputStream
    */
-  virtual void close();
+  void close() override;
 
   /**
    * @see ElementInputStream
    */
-  virtual bool hasMoreElements();
+  bool hasMoreElements() override;
 
   /**
    * @see ElementInputStream
    */
-  virtual ElementPtr readNextElement() override;
+  ElementPtr readNextElement() override;
 
   void setMaxElementsPerFile(long max) { _maxElementsPerFile = max; }
   void setRetainTempFiles(bool retain) { _retainTempFiles = retain; }

--- a/hoot-core/src/main/cpp/hoot/core/elements/InMemoryElementSorter.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/InMemoryElementSorter.h
@@ -48,27 +48,27 @@ class InMemoryElementSorter : public ElementInputStream
 public:
 
   InMemoryElementSorter(ConstOsmMapPtr map);
-  virtual ~InMemoryElementSorter() = default;
+  ~InMemoryElementSorter() = default;
 
   /**
    * @see ElementInputStream
    */
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const;
+  std::shared_ptr<OGRSpatialReference> getProjection() const override;
 
   /**
    * @see ElementInputStream
    */
-  virtual void close() {}
+  void close() override { }
 
   /**
    * @see ElementInputStream
    */
-  virtual bool hasMoreElements();
+  bool hasMoreElements() override;
 
   /**
    * @see ElementInputStream
    */
-  virtual ElementPtr readNextElement();
+  ElementPtr readNextElement() override;
 
   /**
    * Sort a collection of elements to the OSM standard

--- a/hoot-core/src/main/cpp/hoot/core/elements/MapProjector.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/MapProjector.h
@@ -212,7 +212,7 @@ public:
 
   ReprojectCoordinateFilter(OGRCoordinateTransformation* t);
 
-  virtual void filter_rw(geos::geom::Coordinate* c) const;
+  void filter_rw(geos::geom::Coordinate* c) const override;
 
   void project(geos::geom::Coordinate* c) const;
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/Node.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Node.h
@@ -58,7 +58,7 @@ public:
        QString user = ElementData::USER_EMPTY, long uid = ElementData::UID_EMPTY,
        bool visible = ElementData::VISIBLE_EMPTY);
 
-  virtual ~Node() = default;
+  ~Node() = default;
 
   /**
    * Allocate a node as a shared pointer. At this time the allocated node will be allocated as
@@ -88,9 +88,9 @@ public:
    * Clears all tags. However, unlike the other elements the x/y data and circular error aren't
    * modified b/c there isn't a clear definition of "unset" for this value.
    */
-  virtual void clear();
+  void clear() override;
 
-  virtual Element* clone() const { return new Node(*this); }
+  Element* clone() const override { return new Node(*this); }
 
   /**
    * Clone this node as a shared pointer. At this time the allocated node will be allocated as
@@ -103,10 +103,10 @@ public:
    */
   std::shared_ptr<Node> cloneSp() const;
 
-  virtual geos::geom::Envelope* getEnvelope(
+  geos::geom::Envelope* getEnvelope(
     const std::shared_ptr<const ElementProvider>& ep) const override;
 
-  virtual const geos::geom::Envelope& getEnvelopeInternal(
+  const geos::geom::Envelope& getEnvelopeInternal(
     const std::shared_ptr<const ElementProvider>& ep) const override;
 
   double getX() const { return _nodeData.getX(); }
@@ -115,7 +115,7 @@ public:
   void setX(double y);
   void setY(double x);
 
-  virtual ElementType getElementType() const { return ElementType(ElementType::Node); }
+  ElementType getElementType() const override { return ElementType(ElementType::Node); }
 
   geos::geom::Coordinate toCoordinate() const
   { return geos::geom::Coordinate(_nodeData.getX(), _nodeData.getY()); }
@@ -127,14 +127,14 @@ public:
   /**
    * @see Element
    */
-  virtual void visitRo(const ElementProvider& map, ConstElementVisitor& visitor,
-                       const bool recursive = false) const;
+  void visitRo(const ElementProvider& map, ConstElementVisitor& visitor,
+                       const bool recursive = false) const override;
 
   /**
    * @see Element
    */
-  virtual void visitRw(ElementProvider& map, ConstElementVisitor& visitor,
-                       const bool recursive = false);
+  void visitRw(ElementProvider& map, ConstElementVisitor& visitor,
+                       const bool recursive = false) override;
 
   /**
    * Determines if the coordinates from this node match with that of another given a configurable
@@ -158,9 +158,9 @@ protected:
 
   NodeData _nodeData;
 
-  virtual ElementData& _getElementData() { return _nodeData; }
+  ElementData& _getElementData() override { return _nodeData; }
 
-  virtual const ElementData& _getElementData() const { return _nodeData; }
+  const ElementData& _getElementData() const override { return _nodeData; }
 };
 
 using NodePtr = std::shared_ptr<Node>;

--- a/hoot-core/src/main/cpp/hoot/core/elements/NodeData.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/NodeData.h
@@ -40,7 +40,7 @@ public:
   NodeData(const NodeData& nd);
   NodeData(long id, double x, double y);
 
-  virtual ~NodeData() = default;
+  ~NodeData() = default;
 
   void init(long id, double x, double y, long changeset = ElementData::CHANGESET_EMPTY,
             long version = ElementData::VERSION_EMPTY,

--- a/hoot-core/src/main/cpp/hoot/core/elements/Relation.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Relation.h
@@ -61,7 +61,7 @@ public:
            QString user = ElementData::USER_EMPTY, long uid = ElementData::UID_EMPTY,
            bool visible = ElementData::VISIBLE_EMPTY);
 
-  virtual ~Relation() = default;
+  ~Relation() = default;
 
   void addElement(const QString& role, const std::shared_ptr<const Element>& e);
   void addElement(const QString& role, ElementType t, long id);
@@ -72,7 +72,7 @@ public:
    */
   void clear() override;
 
-  Element* clone() const { return new Relation(*this); }
+  Element* clone() const override { return new Relation(*this); }
 
   /**
    * Returns true if this relation contains the specified ElementId. This does not recursively
@@ -191,7 +191,7 @@ public:
    */
   void setType(const QString& type);
 
-  QString toString() const;
+  QString toString() const override;
 
   /**
    * @see Element

--- a/hoot-core/src/main/cpp/hoot/core/elements/RelationData.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/RelationData.h
@@ -80,11 +80,11 @@ public:
 
   RelationData(const RelationData& rd);
 
-  virtual ~RelationData() = default;
+  ~RelationData() = default;
 
   void addElement(const QString& role, ElementId eid);
 
-  virtual void clear();
+  void clear() override;
 
   const std::vector<Entry>& getElements() const { return _members; }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/RelationMemberComparison.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/RelationMemberComparison.h
@@ -50,11 +50,11 @@ public:
   RelationMemberComparison() = default;
   RelationMemberComparison(ElementPtr element, const OsmMap& sourceMap, const QString& role,
                            const bool ignoreElementId = false);
-  virtual ~RelationMemberComparison() = default;
+  ~RelationMemberComparison() = default;
 
-  virtual bool operator==(const RelationMemberComparison& memberComp) const;
+  bool operator==(const RelationMemberComparison& memberComp) const;
 
-  virtual QString toString() const;
+  QString toString() const override;
 
   QString getRole() const { return _role; }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/RelationMemberNodeCounter.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/RelationMemberNodeCounter.h
@@ -43,7 +43,7 @@ class RelationMemberNodeCounter : public ConstOsmMapConsumer
 public:
 
   RelationMemberNodeCounter() = default;
-  virtual ~RelationMemberNodeCounter() = default;
+  ~RelationMemberNodeCounter() = default;
 
   /**
    * Returns the total recursive count of all nodes contained in a relation
@@ -56,7 +56,7 @@ public:
   /**
    * @see ConstOsmMapConsumer
    */
-  virtual void setOsmMap(const OsmMap* map) { _map = map->shared_from_this(); }
+  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/Way.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Way.h
@@ -57,7 +57,7 @@ public:
 
   Way(const Way& way);
 
-  virtual ~Way() = default;
+  ~Way() = default;
 
   void addNode(long id);
   void insertNode(long index, long id);
@@ -74,9 +74,9 @@ public:
   /**
    * Removes tags, nodes and circularError.
    */
-  virtual void clear();
+  void clear() override;
 
-  Element* clone() const { return new Way(*this); }
+  Element* clone() const override { return new Way(*this); }
 
   bool containsNodeId(long nid) const;
 
@@ -99,12 +99,12 @@ public:
   const geos::geom::Envelope& getApproximateEnvelope(
     const std::shared_ptr<const ElementProvider>& ep) const;
 
-  virtual ElementType getElementType() const { return ElementType(ElementType::Way); }
+  ElementType getElementType() const override { return ElementType(ElementType::Way); }
 
   /**
    * Returns the same result as getEnvelopeInternal, but copied so the caller gets ownership.
    */
-  virtual geos::geom::Envelope* getEnvelope(
+  geos::geom::Envelope* getEnvelope(
     const std::shared_ptr<const ElementProvider>& ep) const override
   { return new geos::geom::Envelope(getEnvelopeInternal(ep)); }
 
@@ -112,7 +112,7 @@ public:
    * Returns the envelope for this way. This is guaranteed to be exact. If any of the nodes for
    * this way are not loaded into RAM then the behavior is undefined (probably an assert).
    */
-  virtual const geos::geom::Envelope& getEnvelopeInternal(
+  const geos::geom::Envelope& getEnvelopeInternal(
     const std::shared_ptr<const ElementProvider>& ep) const override;
 
   /**
@@ -227,19 +227,19 @@ public:
    */
   void setCachedEnvelope(const geos::geom::Envelope& e) { _cachedEnvelope = e; }
 
-  QString toString() const;
+  QString toString() const override;
 
   /**
    * @see Element
    */
-  virtual void visitRo(const ElementProvider& map, ConstElementVisitor& filter,
-                       const bool recursive = true) const;
+  void visitRo(const ElementProvider& map, ConstElementVisitor& filter,
+                       const bool recursive = true) const override;
 
   /**
    * @see Element
    */
-  virtual void visitRw(ElementProvider& map, ConstElementVisitor& filter,
-                       const bool recursive = true);
+  void visitRw(ElementProvider& map, ConstElementVisitor& filter,
+                       const bool recursive = true) override;
 
   /**
    * Functions for getting/setting/resetting the parent ID, i.e. the ID of the way
@@ -254,9 +254,9 @@ public:
 
 protected:
 
-  virtual ElementData& _getElementData() { _makeWritable(); return *_wayData; }
+  ElementData& _getElementData() override { _makeWritable(); return *_wayData; }
 
-  virtual const ElementData& _getElementData() const { return *_wayData; }
+  const ElementData& _getElementData() const override { return *_wayData; }
 
   void _makeWritable();
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/WayData.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/WayData.h
@@ -50,12 +50,12 @@ public:
 
   WayData(const WayData& from);
 
-  virtual ~WayData() = default;
+  ~WayData() = default;
 
   void addNode(long id) { _nodes.push_back(id); }
   void insertNode(long index, long id ) { _nodes.insert(_nodes.begin() + index, id); }
 
-  void clear();
+  void clear() override;
 
   const std::vector<long>& getNodeIds() const { return _nodes; }
 

--- a/hoot-core/src/main/cpp/hoot/core/index/ElementToRelationMap.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/index/ElementToRelationMap.cpp
@@ -49,9 +49,9 @@ void ElementToRelationMap::addRelation(const OsmMap& map,
       _rid = rid;
       LOG_VART(_rid);
     }
-    virtual ~AddMemberVisitor() = default;
+    ~AddMemberVisitor() = default;
 
-    virtual void visit(const ConstElementPtr& e)
+    void visit(const ConstElementPtr& e) override
     {
       ElementId eid = e->getElementId();
       LOG_VART(eid);
@@ -62,9 +62,9 @@ void ElementToRelationMap::addRelation(const OsmMap& map,
       }
     }
 
-    virtual QString getDescription() const { return ""; }
-    virtual QString getName() const { return ""; }
-    virtual QString getClassName() const override { return ""; }
+    QString getDescription() const override { return ""; }
+    QString getName() const override { return ""; }
+    QString getClassName() const override { return ""; }
 
   protected:
     HashMap<ElementId, set<long>>& _mapping;
@@ -111,13 +111,13 @@ void ElementToRelationMap::removeRelation(const OsmMap& map,
     {
       _rid = rid;
     }
-    virtual ~RemoveMemberVisitor() = default;
+    ~RemoveMemberVisitor() = default;
 
-    virtual QString getDescription() const { return ""; }
-    virtual QString getName() const { return ""; }
-    virtual QString getClassName() const override { return ""; }
+    QString getDescription() const override { return ""; }
+    QString getName() const override { return ""; }
+    QString getClassName() const override { return ""; }
 
-    virtual void visit(const ConstElementPtr& e)
+    void visit(const ConstElementPtr& e) override
     {
       ElementId ep(e->getElementType(), e->getId());
       set<long>& relations = _mapping[ep];
@@ -150,13 +150,13 @@ bool ElementToRelationMap::validate(const OsmMap& map) const
     {
       _found = false;
     }
-    virtual ~ContainsElementVisitor() = default;
+    ~ContainsElementVisitor() = default;
 
-    virtual QString getDescription() const { return ""; }
-    virtual QString getName() const { return ""; }
-    virtual QString getClassName() const override { return ""; }
+    QString getDescription() const override { return ""; }
+    QString getName() const override { return ""; }
+    QString getClassName() const override { return ""; }
 
-    virtual void visit(const ConstElementPtr& e)
+    void visit(const ConstElementPtr& e) override
     {
       if (e->getElementId() == _eid)
       {
@@ -184,11 +184,11 @@ bool ElementToRelationMap::validate(const OsmMap& map) const
     {
       _good = true;
     }
-    virtual ~CheckVisitor() = default;
+    ~CheckVisitor() = default;
 
-    virtual QString getDescription() const { return ""; }
-    virtual QString getName() const { return ""; }
-    virtual QString getClassName() const override { return ""; }
+    QString getDescription() const override { return ""; }
+    QString getName() const override { return ""; }
+    QString getClassName() const override { return ""; }
 
     bool containsRecursive(const ConstRelationPtr& r, ElementId eid)
     {
@@ -197,7 +197,7 @@ bool ElementToRelationMap::validate(const OsmMap& map) const
       return v.isFound();
     }
 
-    virtual void visit(const ConstElementPtr& e)
+    void visit(const ConstElementPtr& e) override
     {
       ElementType type = e->getElementType();
       long id = e->getId();

--- a/hoot-core/src/main/cpp/hoot/core/index/KnnWayIterator.h
+++ b/hoot-core/src/main/cpp/hoot/core/index/KnnWayIterator.h
@@ -50,21 +50,21 @@ public:
 
   KnnWayIterator(const OsmMap& map, ConstWayPtr way, const Tgs::RStarTree* tree,
                  const std::vector<long>& treeIdToWid, bool addError = false);
-  virtual ~KnnWayIterator() = default;
+  ~KnnWayIterator() = default;
 
   long getWayId() const { return _treeIdToWid[getId()]; }
 
   ConstWayPtr getWay() const { return _map.getWay(getWayId()); }
 
-  virtual bool hasNext();
+  bool hasNext() override;
 
   int getDistanceCount() { return _distanceCount; }
 
 protected:
 
-  virtual double _calculateDistance(const Tgs::BoxInternalData& box, int id) const;
+  double _calculateDistance(const Tgs::BoxInternalData& box, int id) const override;
 
-  virtual double _calculateDistance(const Tgs::BoxInternalData& box) const;
+  double _calculateDistance(const Tgs::BoxInternalData& box) const override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/index/OsmMapIndex.h
+++ b/hoot-core/src/main/cpp/hoot/core/index/OsmMapIndex.h
@@ -50,7 +50,7 @@ class OsmMapIndex : public ElementListener
 public:
 
   OsmMapIndex(const OsmMap& map);
-  virtual ~OsmMapIndex() = default;
+  ~OsmMapIndex() = default;
 
   void addNode(const ConstNodePtr& n);
   void addRelation(const ConstRelationPtr& r);
@@ -119,8 +119,8 @@ public:
    * This gets called before an element changes. Between this call and the call to
    * postGeometryChange the index is in an inconsistent state.
    */
-  virtual void preGeometryChange(Element* element);
-  virtual void postGeometryChange(Element* element);
+  void preGeometryChange(Element* element) override;
+  void postGeometryChange(Element* element) override;
 
   void removeNode(ConstNodePtr n);
   void removeRelation(const ConstRelationPtr& r);

--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.h
@@ -58,7 +58,7 @@ public:
   ApiDbReader();
   virtual ~ApiDbReader() = default;
 
-  virtual bool isSupported(const QString& urlStr) override;
+  bool isSupported(const QString& urlStr) override;
 
   void setBoundingBox(const QString& bbox);
   void setOverrideBoundingBox(const QString& bbox);
@@ -69,12 +69,12 @@ public:
    * Determines the reader's default element status. By default this is Invalid which specifies that
    * the file's status will be used.
    */
-  virtual void setDefaultStatus(Status status) override { _status = status; }
+  void setDefaultStatus(Status status) override { _status = status; }
 
   /**
    * Determines whether the reader should use the element id's from the file being read
    */
-  virtual void setUseDataSourceIds(bool useDataSourceIds) override
+  void setUseDataSourceIds(bool useDataSourceIds) override
   { _useDataSourceIds = useDataSourceIds; }
 
   void setUserEmail(const QString& email) { _email = email; }
@@ -82,34 +82,34 @@ public:
   /**
    * @see PartialOsmMapReader
    */
-  virtual void initializePartial() override;
+  void initializePartial() override;
 
   /**
    * The read command called after open.
    */
-  virtual void read(const OsmMapPtr& map) override;
+  void read(const OsmMapPtr& map) override;
 
   /**
    * @see PartialOsmMapReader
    */
-  virtual void finalizePartial() override;
+  void finalizePartial() override;
 
-  void close();
-
-  /**
-   * @see PartialOsmMapReader
-   */
-  virtual bool hasMoreElements() override;
+  void close() override;
 
   /**
    * @see PartialOsmMapReader
    */
-  virtual std::shared_ptr<Element> readNextElement() override;
+  bool hasMoreElements() override;
 
   /**
    * @see PartialOsmMapReader
    */
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const override;
+  std::shared_ptr<Element> readNextElement() override;
+
+  /**
+   * @see PartialOsmMapReader
+   */
+  std::shared_ptr<OGRSpatialReference> getProjection() const override;
 
   void setKeepImmediatelyConnectedWaysOutsideBounds(bool keep)
   { _keepImmediatelyConnectedWaysOutsideBounds = keep; }

--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
@@ -47,7 +47,7 @@ namespace hoot
 class elementTranslatorThread : public QThread
 {
   Q_OBJECT
-  void run();
+  void run() override;
 
 public:
 
@@ -64,7 +64,7 @@ public:
 class ogrWriterThread : public QThread
 {
   Q_OBJECT
-  void run();
+  void run() override;
 
 public:
 
@@ -92,9 +92,9 @@ public:
   static const QString JOB_SOURCE;
 
   DataConverter();
-  virtual ~DataConverter() = default;
+  ~DataConverter() = default;
 
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
   /**
    * Converts multiple datasets from format to a single output format

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementCache.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementCache.h
@@ -125,6 +125,10 @@ public:
 
   // Functions for ElementInputStream
   virtual void close() = 0;             // Also works for elementoutputstream
+
+  /**
+   * TODO: Fix this, overrides ElementInputStream::hasMoreElements with pure virtual function
+   */
   virtual bool hasMoreElements() = 0;
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementCacheLRU.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementCacheLRU.h
@@ -64,7 +64,7 @@ public:
   /**
    * @brief ~ElementCache
    */
-  virtual ~ElementCacheLRU() = default;
+  ~ElementCacheLRU() = default;
 
   bool isEmpty() const override;
 


### PR DESCRIPTION
Override should be used instead of virtual for derived functions
Refs #4561 