### PR TITLE
SONAR: Override or final should be used instead of virtual

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/ElementCache.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementCache.h
@@ -123,56 +123,6 @@ public:
    */
   virtual ConstRelationPtr getNextRelation() = 0;
 
-  // Functions for ElementInputStream
-  virtual void close() = 0;             // Also works for elementoutputstream
-
-  /**
-   * TODO: Fix this, overrides ElementInputStream::hasMoreElements with pure virtual function
-   */
-  virtual bool hasMoreElements() = 0;
-
-  /**
-   * @brief readNextElement
-   *
-   * @note There is no guarantee of the order that items will be pulled from the cache when this
-   *      method is invoked. If ordering of elements (e.g., all nodes first, then all ways, and
-   *      finally all relations) is required, the getNext(Node/Way/Relation) methods should be
-   *      invoked
-   *
-   * @return Pointer to next element out of cache
-   */
-  virtual ElementPtr readNextElement() = 0;
-
-  // Functions for ElementOutputStream
-  virtual void writeElement(ElementPtr& element) = 0;
-
-  // Functions from ElementProvider
-
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const = 0;
-
-  virtual bool containsElement(const ElementId& eid) const = 0;
-
-  virtual ConstElementPtr getElement(const ElementId& id) const = 0;
-
-  virtual ConstNodePtr getNode(long id) const = 0;
-
-  virtual NodePtr getNode(long id) = 0;
-
-  virtual ConstRelationPtr getRelation(long id) const = 0;
-
-  virtual RelationPtr getRelation(long id) = 0;
-
-  virtual ConstWayPtr getWay(long id) const = 0;
-
-  virtual WayPtr getWay(long id) = 0;
-
-  virtual bool containsNode(long id) const = 0;
-
-  virtual bool containsRelation(long id) const = 0;
-
-  virtual bool containsWay(long id) const = 0;
-
-
   // Cache-specific items
   virtual void removeElement(const ElementId& eid) = 0;
 

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementCriterionInputStream.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementCriterionInputStream.h
@@ -47,31 +47,31 @@ public:
    */
   ElementCriterionInputStream(const ElementInputStreamPtr& elementSource,
                               const ElementCriterionPtr& criterion);
-  virtual ~ElementCriterionInputStream() = default;
+  ~ElementCriterionInputStream() = default;
 
   /**
    * @brief close
    * Invokes the close function on the source element input stream
    */
-  virtual void close() { _elementSource->close(); }
+  void close() override { _elementSource->close(); }
 
   /**
    * Returns the source's projection.
    */
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const;
+  std::shared_ptr<OGRSpatialReference> getProjection() const override;
 
   /**
    * @brief hasMoreElements
    * @return return value from call to source ElementInputStream's hasMoreElements() method
    */
-  virtual bool hasMoreElements() { return _elementSource->hasMoreElements(); }
+  bool hasMoreElements() override { return _elementSource->hasMoreElements(); }
 
   /**
    * @brief readNextElement
    * @return Pointer to an elemement that is read from elementSource and is satisfied by the
    *    criterion.
    */
-  virtual ElementPtr readNextElement();
+  ElementPtr readNextElement() override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementCriterionVisitorInputStream.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementCriterionVisitorInputStream.h
@@ -69,31 +69,31 @@ public:
                                      const ElementCriterionPtr& criterion,
                                      const QList<ElementVisitorPtr>& visitors);
 
-  virtual ~ElementCriterionVisitorInputStream();
+  ~ElementCriterionVisitorInputStream();
 
   /**
    * @brief close
    * Invokes the close function on the source element input stream
    */
-  virtual void close();
+  void close() override;
 
   /**
    * Returns the source's projection.
    */
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const override;
+  std::shared_ptr<OGRSpatialReference> getProjection() const override;
 
   /**
    * @brief hasMoreElements
    * @return return value from call to source ElementInputStream's hasMoreElements() method
    */
-  virtual bool hasMoreElements();
+  bool hasMoreElements() override;
 
   /**
    * @brief readNextElement
    * @return Pointer to an elemement that is read from elementSource and is satisfied by the
    *    criterion.
    */
-  virtual ElementPtr readNextElement() override;
+  ElementPtr readNextElement() override;
 
   long getNumFeaturesTotal() const { return _numFeaturesTotal; }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementVisitorInputStream.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementVisitorInputStream.h
@@ -46,31 +46,31 @@ public:
    */
   ElementVisitorInputStream(const ElementInputStreamPtr& elementSource,
                             const ElementVisitorPtr& visitor);
-  virtual ~ElementVisitorInputStream() = default;
+  ~ElementVisitorInputStream() = default;
 
   /**
    * @brief close
    * Invokes the close function on the source element input stream
    */
-  virtual void close() { _elementSource->close(); }
+  void close() override { _elementSource->close(); }
 
   /**
    * Returns the source's projection.
    */
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const;
+  std::shared_ptr<OGRSpatialReference> getProjection() const override;
 
   /**
    * @brief hasMoreElements
    * @return return value from call to source ElementInputStream's hasMoreElements() method
    */
-  virtual bool hasMoreElements() { return _elementSource->hasMoreElements(); }
+  bool hasMoreElements() override { return _elementSource->hasMoreElements(); }
 
   /**
    * @brief readNextElement
    * @return Pointer to an elemement which will have been read from the source elementinputstream
    *    AND had the visitor's visit method applied to it before it is returned
    */
-  virtual ElementPtr readNextElement();
+  ElementPtr readNextElement() override;
 
   ElementVisitorPtr getVisitor() const { return _visitor; }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/GeoNamesReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/GeoNamesReader.h
@@ -43,31 +43,31 @@ public:
   static QString className() { return "hoot::GeoNamesReader"; }
 
   GeoNamesReader();
-  virtual ~GeoNamesReader() = default;
+  ~GeoNamesReader() = default;
 
-  virtual void close();
+  void close() override;
 
-  virtual void initializePartial() { }
+  void initializePartial() override { }
 
-  virtual void finalizePartial() { }
+  void finalizePartial() override { }
 
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const;
+  std::shared_ptr<OGRSpatialReference> getProjection() const override;
 
-  virtual bool hasMoreElements();
+  bool hasMoreElements() override;
 
-  virtual bool isSupported(const QString& url) override;
+  bool isSupported(const QString& url) override;
 
-  virtual void open(const QString& url) override;
+  void open(const QString& url) override;
 
-  virtual ElementPtr readNextElement() override;
+  ElementPtr readNextElement() override;
 
   void setDefaultAccuracy(Meters circularError) { _defaultCircularError = circularError; }
 
   void setDefaultStatus(Status s) { _status = s; }
 
-  virtual void setUseDataSourceIds(bool useDataSourceIds) { _useDataSourceIds = useDataSourceIds; }
+  void setUseDataSourceIds(bool useDataSourceIds) override { _useDataSourceIds = useDataSourceIds; }
 
-  virtual QString supportedFormats() override { return ".geonames"; }
+  QString supportedFormats() override { return ".geonames"; }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
@@ -50,35 +50,38 @@ public:
 
   HootApiDb();
 
-  virtual ~HootApiDb();
+  ~HootApiDb();
 
   /**
    * Called after open. This will read the bounds of the specified layer in a relatively efficient
    * manner. (e.g. SELECT min(x)...)
    */
+  /**
+   * TODO: Implement EnvelopeProvider
+   */
   virtual geos::geom::Envelope calculateEnvelope() const;
 
-  virtual void close();
+  void close() override;
 
   virtual bool isCorrectHootDbVersion();
 
   virtual QString getHootDbVersion();
 
-  virtual bool isSupported(const QUrl& url) override;
+  bool isSupported(const QUrl& url) override;
 
-  virtual void open(const QUrl& url) override;
+  void open(const QUrl& url) override;
 
-  virtual void commit();
+  void commit() override;
 
   /**
    * @see ApiDb::elementTypeToElementTableName
    */
-  virtual QString elementTypeToElementTableName(const ElementType& elementType) const override;
+  QString elementTypeToElementTableName(const ElementType& elementType) const override;
 
   /**
    * Returns a vector with all the OSM node ID's for a given way
    */
-  virtual std::vector<long> selectNodeIdsForWay(long wayId) override;
+  std::vector<long> selectNodeIdsForWay(long wayId) override;
 
   /**
    * Returns a query results with node_id, lat, and long with all the OSM node ID's for a given way
@@ -163,7 +166,7 @@ public:
    */
   void deleteMap(long mapId);
 
-  virtual void deleteUser(long userId);
+  void deleteUser(long userId) override;
 
   /**
    * Start a new changeset
@@ -374,9 +377,9 @@ public:
   QString execToString(QString sql, QVariant v1 = QVariant(), QVariant v2 = QVariant(),
                        QVariant v3 = QVariant());
 
-  virtual QString tableTypeToTableName(const TableType& tableType) const override;
+  QString tableTypeToTableName(const TableType& tableType) const override;
 
-  virtual long getNextId(const ElementType& elementType);
+  long getNextId(const ElementType& elementType) override;
 
   static QUrl getBaseUrl();
 
@@ -575,7 +578,7 @@ public:
 
 protected:
 
-  virtual void _resetQueries();
+  void _resetQueries() override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbBulkInserter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbBulkInserter.h
@@ -57,7 +57,7 @@ public:
   static QString className() { return "hoot::HootApiDbBulkInserter"; }
 
   HootApiDbBulkInserter();
-  virtual ~HootApiDbBulkInserter();
+  ~HootApiDbBulkInserter();
 
   bool isSupported(const QString& url) override;
   void open(const QString& url) override;

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbReader.h
@@ -51,23 +51,26 @@ public:
    * Called after open. This will read the bounds of the specified layer in a relatively efficient
    * manner. (e.g. SELECT min(x)...)
    */
+  /**
+   * TODO: Implement EnvelopeProvider
+   */
   virtual geos::geom::Envelope calculateEnvelope() const;
 
-  virtual void setConfiguration(const Settings& conf) override;
+  void setConfiguration(const Settings& conf) override;
 
-  virtual void open(const QString& urlStr) override;
+  void open(const QString& urlStr) override;
 
-  virtual void read(const OsmMapPtr& map) override;
+  void read(const OsmMapPtr& map) override;
 
 protected:
 
-  virtual NodePtr _resultToNode(const QSqlQuery& resultIterator, OsmMap& map) override;
-  virtual WayPtr _resultToWay(const QSqlQuery& resultIterator, OsmMap& map) override;
-  virtual RelationPtr _resultToRelation(const QSqlQuery& resultIterator, const OsmMap& map) override;
+  NodePtr _resultToNode(const QSqlQuery& resultIterator, OsmMap& map) override;
+  WayPtr _resultToWay(const QSqlQuery& resultIterator, OsmMap& map) override;
+  RelationPtr _resultToRelation(const QSqlQuery& resultIterator, const OsmMap& map) override;
 
-  virtual std::shared_ptr<ApiDb> _getDatabase() const override { return _database; }
+  std::shared_ptr<ApiDb> _getDatabase() const override { return _database; }
 
-  virtual QString supportedFormats() { return MetadataTags::HootApiDbScheme() + "://"; }
+  QString supportedFormats() { return MetadataTags::HootApiDbScheme() + "://"; }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbSqlStatementFormatter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbSqlStatementFormatter.h
@@ -59,7 +59,7 @@ class HootApiDbSqlStatementFormatter : public ApiDbSqlStatementFormatter
 public:
 
   HootApiDbSqlStatementFormatter(const QString& delimiter, const long mapId);
-  virtual ~HootApiDbSqlStatementFormatter() = default;
+  ~HootApiDbSqlStatementFormatter() = default;
 
   QString nodeToSqlString(const ConstNodePtr& node, const long nodeId, const long changesetId,
                           const long version, const bool validate = false);

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.h
@@ -46,7 +46,7 @@ public:
   static QString className() { return "hoot::HootApiDbWriter"; }
 
   HootApiDbWriter();
-  virtual ~HootApiDbWriter();
+  ~HootApiDbWriter();
 
   void close() override;
 

--- a/hoot-core/src/main/cpp/hoot/core/io/HootNetworkCookieJar.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootNetworkCookieJar.h
@@ -44,7 +44,7 @@ class HootNetworkCookieJar : public QNetworkCookieJar
 public:
 
   explicit HootNetworkCookieJar(QObject* parent = nullptr);
-  virtual ~HootNetworkCookieJar() = default;
+  ~HootNetworkCookieJar() = default;
 
   int size() const { return allCookies().size(); }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
@@ -79,7 +79,7 @@ public:
 
   OgrReaderInternal();
 
-  virtual ~OgrReaderInternal();
+  ~OgrReaderInternal();
 
   void close();
 
@@ -90,7 +90,7 @@ public:
   /**
    * @see ProgressReporter
    */
-  virtual unsigned int getNumSteps() const { return 1; }
+  unsigned int getNumSteps() const override { return 1; }
 
   /**
    * See the associated configuration options text for details.
@@ -222,18 +222,18 @@ public:
     _map.reset(new OsmMap());
   }
 
-  virtual ~OgrElementIterator()
+  ~OgrElementIterator()
   {
     _d->close();
     delete _d;
   }
 
   // not implemented
-  virtual void resetIterator() {}
+  void resetIterator() override { }
 
 protected:
 
-  virtual void _next()
+  void _next() override
   {
     _map->clear();
     _d->readNext(_map);

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrReader.h
@@ -93,7 +93,7 @@ public:
 
   void setDefaultCircularError(Meters circularError);
 
-  void setDefaultStatus(Status s);
+  void setDefaultStatus(Status s) override;
 
   void setLimit(long limit);
 
@@ -101,21 +101,21 @@ public:
 
   long getFeatureCount(const QString& path, const QString& layer);
 
-  virtual void initializePartial() override;
+  void initializePartial() override;
 
-  virtual bool hasMoreElements() override;
+  bool hasMoreElements() override;
 
-  virtual ElementPtr readNextElement() override;
+  ElementPtr readNextElement() override;
 
-  virtual void close() override;
+  void close() override;
 
-  virtual bool isSupported(const QString& url) override;
+  bool isSupported(const QString& url) override;
 
-  virtual void open(const QString& url) override;
+  void open(const QString& url) override;
 
-  virtual void setUseDataSourceIds(bool useDataSourceIds) override;
+  void setUseDataSourceIds(bool useDataSourceIds) override;
 
-  virtual void finalizePartial() override;
+  void finalizePartial() override;
 
   /**
    * Returns the bounding box for the specified projection and configuration settings. This is
@@ -124,10 +124,10 @@ public:
   virtual std::shared_ptr<geos::geom::Envelope> getBoundingBoxFromConfig(const Settings& s,
     OGRSpatialReference* srs);
 
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const;
+  std::shared_ptr<OGRSpatialReference> getProjection() const override;
 
   //leaving this empty for the time being
-  virtual QString supportedFormats() override { return ""; }
+  QString supportedFormats() override { return ""; }
 
   /**
    * @see ProgressReporter
@@ -136,7 +136,7 @@ public:
   /**
    * @see ProgressReporter
    */
-  virtual unsigned int getNumSteps() const { return 1; }
+  unsigned int getNumSteps() const override { return 1; }
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
@@ -63,7 +63,7 @@ public:
   static QString className() { return "hoot::OgrWriter"; }
 
   OgrWriter();
-  virtual ~OgrWriter() = default;
+  ~OgrWriter() = default;
 
   /**
    * @brief setCacheCapacity
@@ -77,7 +77,7 @@ public:
   void setCacheCapacity(const unsigned long maxNodes, const unsigned long maxWays,
                         const unsigned long maxRelations);
 
-  void close();
+  void close() override;
 
   bool isSupported(const QString& url) override;
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiChangesetElement.h
@@ -212,15 +212,15 @@ public:
    * @param idMap ID to ID Map for updated IDs
    */
   ChangesetNode(const XmlObject& node, ElementIdToIdMap* idMap);
-  /** Virtual destructor */
-  virtual ~ChangesetNode() = default;
+  /** Destructor */
+  ~ChangesetNode() = default;
   /**
    * @brief toString Get the XML string equivalent for the node
    * @param changesetId ID of the changeset to insert into the node
    * @param type Changeset section type (create, modify, delete)
    * @return XML string
    */
-  virtual QString toString(long changesetId, ChangesetType type) const;
+  QString toString(long changesetId, ChangesetType type) const override;
   /**
    * @brief diff Compare two nodes and build a 'diff' style string
    * @param node Node to compare this node against
@@ -242,8 +242,8 @@ public:
    * @param idMap ID to ID Map for updated IDs
    */
   ChangesetWay(const XmlObject& way, ElementIdToIdMap* idMap);
-  /** Virtual destructor */
-  virtual ~ChangesetWay() = default;
+  /** Destructor */
+  ~ChangesetWay() = default;
   /**
    * @brief addNode Add a node ID to the node (in order)
    * @param id Node ID
@@ -272,7 +272,7 @@ public:
    * @param type Changeset section type (create, modify, delete)
    * @return XML string
    */
-  virtual QString toString(long changesetId, ChangesetType type) const;
+  QString toString(long changesetId, ChangesetType type) const override;
   /**
    * @brief diff Compare two ways and build a 'diff' style string
    * @param way Way to compare this way against
@@ -355,8 +355,8 @@ public:
    * @param idMap ID to ID Map for updated IDs
    */
   ChangesetRelation(const XmlObject& relation, ElementIdToIdMap* idMap);
-  /** Virtual destructor */
-  virtual ~ChangesetRelation() = default;
+  /** Destructor */
+  ~ChangesetRelation() = default;
   /**
    * @brief addMember Add relation member
    * @param member XML attributes of the relation member
@@ -391,7 +391,7 @@ public:
    * @param type Changeset section type (create, modify, delete)
    * @return XML string
    */
-  virtual QString toString(long changesetId, ChangesetType type) const;
+  QString toString(long changesetId, ChangesetType type) const override;
   /**
    * @brief diff Compare two relations and build a 'diff' style string
    * @param relation Relation to compare this relation against

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDb.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDb.h
@@ -56,32 +56,32 @@ public:
 
   OsmApiDb();
 
-  virtual ~OsmApiDb();
+  ~OsmApiDb();
 
-  virtual void close();
+  void close() override;
 
-  virtual bool isSupported(const QUrl& url) override;
+  bool isSupported(const QUrl& url) override;
 
-  virtual void open(const QUrl& url) override;
+  void open(const QUrl& url) override;
 
-  virtual void commit();
+  void commit() override;
 
-  virtual void deleteUser(long userId);
+  void deleteUser(long userId) override;
 
   /**
    * Returns a vector with all the OSM node ID's for a given way
    */
-  virtual std::vector<long> selectNodeIdsForWay(long wayId) override;
+  std::vector<long> selectNodeIdsForWay(long wayId) override;
 
   /**
    * Returns a query results with node_id, lat, and long with all the OSM node ID's for a given way
    */
-  virtual std::shared_ptr<QSqlQuery> selectNodesForWay(long wayId) override;
+  std::shared_ptr<QSqlQuery> selectNodesForWay(long wayId) override;
 
   /**
    * Returns a vector with all the relation members for a given relation
    */
-  virtual std::vector<RelationData::Entry> selectMembersForRelation(long relationId) override;
+  std::vector<RelationData::Entry> selectMembersForRelation(long relationId) override;
 
   /**
     * Deletes data in the Osm Api db
@@ -114,7 +114,7 @@ public:
    * @param tableName element type associated with the sequence
    * @return the next sequence ID for the given type
    */
-  virtual long getNextId(const ElementType& elementType);
+  long getNextId(const ElementType& elementType) override;
 
   /**
    * Increment the sequence ID for the given sequence and return it
@@ -150,7 +150,7 @@ public:
   /**
    * @see ApiDb::elementTypeToElementTableName
    */
-  virtual QString elementTypeToElementTableName(const ElementType& elementType) const override;
+  QString elementTypeToElementTableName(const ElementType& elementType) const override;
 
   /**
    * Converts a table type to a OSM API database table name
@@ -158,7 +158,7 @@ public:
    * @param tableType table type enum to convert
    * @return a database table name string
    */
-  virtual QString tableTypeToTableName(const TableType& tableType) const override;
+  QString tableTypeToTableName(const TableType& tableType) const override;
 
   /**
    * Returns an OSM API database table name
@@ -193,7 +193,7 @@ public:
 
 protected:
 
-  void _resetQueries();
+  void _resetQueries() override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbReader.h
@@ -43,21 +43,21 @@ public:
   static QString className() { return "hoot::OsmApiDbReader"; }
 
   OsmApiDbReader();
-  virtual ~OsmApiDbReader();
+  ~OsmApiDbReader();
 
-  virtual void open(const QString& urlStr) override;
+  void open(const QString& urlStr) override;
 
-  virtual void setConfiguration(const Settings &conf) override;
+  void setConfiguration(const Settings &conf) override;
 
-  virtual QString supportedFormats() override { return MetadataTags::OsmApiDbScheme() + "://"; }
+  QString supportedFormats() override { return MetadataTags::OsmApiDbScheme() + "://"; }
 
 protected:
 
-  virtual NodePtr _resultToNode(const QSqlQuery& resultIterator, OsmMap& map) override;
-  virtual WayPtr _resultToWay(const QSqlQuery& resultIterator, OsmMap& map) override;
-  virtual RelationPtr _resultToRelation(const QSqlQuery& resultIterator, const OsmMap& map) override;
+  NodePtr _resultToNode(const QSqlQuery& resultIterator, OsmMap& map) override;
+  WayPtr _resultToWay(const QSqlQuery& resultIterator, OsmMap& map) override;
+  RelationPtr _resultToRelation(const QSqlQuery& resultIterator, const OsmMap& map) override;
 
-  virtual std::shared_ptr<ApiDb> _getDatabase() const override { return _database; }
+  std::shared_ptr<ApiDb> _getDatabase() const override { return _database; }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetFileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetFileWriter.h
@@ -60,37 +60,37 @@ public:
 
   OsmApiDbSqlChangesetFileWriter();
   OsmApiDbSqlChangesetFileWriter(const QUrl& url);
-  virtual ~OsmApiDbSqlChangesetFileWriter();
+  ~OsmApiDbSqlChangesetFileWriter();
 
   /**
    * @see ChangesetFileWriter
    */
-  virtual void write(const QString& path, const ChangesetProviderPtr& changesetProvider);
+  void write(const QString& path, const ChangesetProviderPtr& changesetProvider) override;
 
   /**
    * @see ChangesetFileWriter
    */
-  virtual void write(const QString& path, const QList<ChangesetProviderPtr>& changesetProviders);
+  void write(const QString& path, const QList<ChangesetProviderPtr>& changesetProviders) override;
 
   /**
    * @see ChangesetFileWriter
    */
-  virtual QString getStatsTable(
-    const ChangesetStatsFormat& /*format = StatisticsFormat::Text*/) const
+  QString getStatsTable(
+    const ChangesetStatsFormat& /*format = StatisticsFormat::Text*/) const override
   { throw NotImplementedException("Changeset statistics not implemented for SQL changesets."); }
 
-  virtual void setMap1List(const QList<ConstOsmMapPtr>& mapList) { _map1List = mapList; }
-  virtual void setMap2List(const QList<ConstOsmMapPtr>& mapList) { _map2List = mapList; }
+  void setMap1List(const QList<ConstOsmMapPtr>& mapList) override { _map1List = mapList; }
+  void setMap2List(const QList<ConstOsmMapPtr>& mapList) override { _map2List = mapList; }
 
   /**
    * @see ChangesetFileWriter
    */
-  virtual bool isSupported(const QString& output) const { return output.endsWith(".osc.sql"); }
+  bool isSupported(const QString& output) const override { return output.endsWith(".osc.sql"); }
 
   /**
    * @see Configurable
    */
-  virtual void setConfiguration(const Settings &conf);
+  void setConfiguration(const Settings &conf) override;
 
   void setOsmApiDbUrl(const QString& url) { _db.open(url); }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlStatementFormatter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlStatementFormatter.h
@@ -73,7 +73,7 @@ class OsmApiDbSqlStatementFormatter : public ApiDbSqlStatementFormatter
 public:
 
   OsmApiDbSqlStatementFormatter(const QString& delimiter);
-  virtual ~OsmApiDbSqlStatementFormatter() = default;
+  ~OsmApiDbSqlStatementFormatter() = default;
 
   QStringList nodeToSqlStrings(const ConstNodePtr& node, const long nodeId, const long changesetId,
                                const bool validate = false);

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.h
@@ -55,11 +55,11 @@ public:
   /** Constructor */
   OsmApiReader();
   /** Destructor */
-  virtual ~OsmApiReader();
+  ~OsmApiReader();
   /**
    * @brief close Close the reader
    */
-  void close();
+  void close() override;
   /**
    * @brief isSupported
    * @param url URL of the OSM API to read

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -68,12 +68,12 @@ public:
   /** Constructors with one or multiple files consisting of one large changeset */
   OsmApiWriter(const QUrl& url, const QString& changeset);
   OsmApiWriter(const QUrl& url, const QList<QString>& changesets);
-  virtual ~OsmApiWriter() = default;
+  ~OsmApiWriter() = default;
   /**
    * @brief setConfiguration Update the configuration settings with new configuration
    * @param conf - Updated configurations
    */
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
   /**
    * @brief isSupported
    * @param url - Must be a valid, full HTTP[S] URL pointing to an OSM website
@@ -133,7 +133,7 @@ public:
   /**
    * @see ProgressReporter
    */
-  virtual unsigned int getNumSteps() const { return 1; }
+  unsigned int getNumSteps() const override { return 1; }
   /**
    * @brief setErrorPathname Record the pathname of the error changeset
    * @param path Pathname

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetFileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmChangesetFileWriter.h
@@ -86,11 +86,6 @@ public:
   virtual bool isSupported(const QString& output) const = 0;
 
   /**
-   * @see Configurable
-   */
-  virtual void setConfiguration(const Settings& conf) = 0;
-
-  /**
    * Sets all maps corresponding to the former state of the datasets
    *
    * @todo These map setters feel a little kludgy...maybe use a new map list interface, similar to

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxJsonWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxJsonWriter.h
@@ -49,28 +49,28 @@ public:
   static QString className() { return "hoot::OsmGbdxJsonWriter"; }
 
   OsmGbdxJsonWriter(int precision = ConfigOptions().getWriterPrecision());
-  virtual ~OsmGbdxJsonWriter() = default;
+  ~OsmGbdxJsonWriter() = default;
 
   /**
    * @brief Create a directory to hold all of the GeoJSON files
    * @param url
    */
-  virtual void open(const QString& path) override;
+  void open(const QString& path) override;
 
   /**
    * @brief write Write the OsmMap out in GeoJSON format with one feature per file, writer must be "open"
    * @param map
    */
-  virtual void write(const ConstOsmMapPtr& map) override;
+  void write(const ConstOsmMapPtr& map) override;
 
   /**
    * @brief isSupported returns true if the URL is likely supported
    * @param url Filename ending in ".gbdx"
    * @return
    */
-  virtual bool isSupported(const QString& url) override { return url.toLower().endsWith(".gbdx"); }
+  bool isSupported(const QString& url) override { return url.toLower().endsWith(".gbdx"); }
 
-  virtual QString supportedFormats() override { return ".gdbx"; }
+  QString supportedFormats() override { return ".gdbx"; }
 
 protected:
 
@@ -87,7 +87,7 @@ protected:
    * @brief _writeNodes Iterates all nodes that aren't part of another element and writes
    *   them out individual GeoJSON files
    */
-  virtual void _writeNodes();
+  void _writeNodes() override;
 
   /**
    * @brief _writeNode Writes a single node; metadata, tags, and geometry
@@ -99,7 +99,7 @@ protected:
    * @brief _writeWays Iterates all ways that aren't part of another element and writes
    *   them out individual GeoJSON files
    */
-  virtual void _writeWays();
+  void _writeWays() override;
 
   /**
    * @brief _writeWay Writes a single way; metadata, tags, and geometry
@@ -111,7 +111,7 @@ protected:
    * @brief _writeRelations Iterates all relations that aren't part of another element and writes
    *   them out individual GeoJSON files
    */
-  virtual void _writeRelations();
+  void _writeRelations() override;
   /**
    * @brief _writeRelationInfo Writes relation specific information, relation-type and roles
    * @param relation

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxXmlWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxXmlWriter.h
@@ -57,7 +57,7 @@ public:
   static QString className() { return "hoot::OsmGbdxXmlWriter"; }
 
   OsmGbdxXmlWriter();
-  virtual ~OsmGbdxXmlWriter();
+  ~OsmGbdxXmlWriter();
 
   bool isSupported(const QString& url) override { return url.toLower().endsWith(".gxml"); }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonReader.h
@@ -64,7 +64,7 @@ public:
   static QString className() { return "hoot::OsmGeoJsonReader"; }
 
   OsmGeoJsonReader() = default;
-  virtual ~OsmGeoJsonReader() = default;
+  ~OsmGeoJsonReader() = default;
 
   /**
    * @brief isSupported returns true if the URL is likely supported. This isn't
@@ -73,7 +73,7 @@ public:
    * @param url
    * @return
    */
-  virtual bool isSupported(const QString& url) override;
+  bool isSupported(const QString& url) override;
 
   /**
    * @brief read Reads the data specified by the last call to open(...)
@@ -81,7 +81,7 @@ public:
    *        will likely be closed after this call
    * @param map
    */
-  virtual void read(const OsmMapPtr& map) override;
+  void read(const OsmMapPtr& map) override;
 
   /**
    * @brief loadFromString - Builds a map from the JSON string. Throws a
@@ -90,7 +90,7 @@ public:
    * @param jsonStr - input string, map - the map to load the JSON into
    * @return
    */
-  virtual void loadFromString(const QString& jsonStr, const OsmMapPtr& map);
+  void loadFromString(const QString& jsonStr, const OsmMapPtr& map);
 
   /**
    * @brief loadFromFile - Reads the whole file as a string, passes it
@@ -98,9 +98,9 @@ public:
    * @param path - Path to file
    * @return Smart pointer to the OSM map
    */
-  virtual OsmMapPtr loadFromFile(const QString& path);
+  OsmMapPtr loadFromFile(const QString& path);
 
-  virtual QString supportedFormats() override { return ".geojson"; }
+  QString supportedFormats() override { return ".geojson"; }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonWriter.h
@@ -48,30 +48,30 @@ public:
   static QString className() { return "hoot::OsmGeoJsonWriter"; }
 
   OsmGeoJsonWriter(int precision = ConfigOptions().getWriterPrecision());
-  virtual ~OsmGeoJsonWriter() = default;
+  ~OsmGeoJsonWriter() = default;
 
   /**
    * @brief write Write the OsmMap out to a file in GeoJSON format, writer must be "open"
    * @param map
    */
-  virtual void write(const ConstOsmMapPtr& map) override;
+  void write(const ConstOsmMapPtr& map) override;
 
   /**
    * @brief isSupported returns true if the URL is likely supported
    * @param url Filename ending in ".geojson"
    * @return
    */
-  virtual bool isSupported(const QString& url) override { return url.toLower().endsWith(".geojson"); }
+  bool isSupported(const QString& url) override { return url.toLower().endsWith(".geojson"); }
 
   /**
    * @brief setConfiguration allows configuration settings to override the defaults
    * @param conf Configuration settings object
    */
-  virtual void setConfiguration(const Settings& conf) override;
+  void setConfiguration(const Settings& conf) override;
 
-  virtual QString supportedFormats() override { return ".geojson"; }
+  QString supportedFormats() override { return ".geojson"; }
 
-  virtual QString toString(const ConstOsmMapPtr& map);
+  QString toString(const ConstOsmMapPtr& map);
 
 protected:
 
@@ -79,7 +79,7 @@ protected:
    * @brief _writeNodes Iterates all nodes that aren't part of another element and writes
    *   them out to the GeoJSON file
    */
-  virtual void _writeNodes();
+  void _writeNodes() override;
 
   /**
    * @brief _writeNode Writes a single node; metadata, tags, and geometry
@@ -91,7 +91,7 @@ protected:
    * @brief _writeWays Iterates all ways that aren't part of another element and writes
    *   them out to the GeoJSON file
    */
-  virtual void _writeWays();
+  void _writeWays() override;
 
   /**
    * @brief _writeWay Writes a single way; metadata, tags, and geometry
@@ -103,7 +103,7 @@ protected:
    * @brief _writeRelations Iterates all relations that aren't part of another element and writes
    *   them out to the GeoJSON file
    */
-  virtual void _writeRelations();
+  void _writeRelations() override;
 
   /**
    * @brief _writeRelationInfo Writes relation specific information, relation-type and roles

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.h
@@ -128,7 +128,7 @@ public:
    * @param url
    * @return
    */
-  virtual bool isSupported(const QString& url) override;
+  bool isSupported(const QString& url) override;
 
   /**
    * @brief open Specifies the URL to read from. Can be a file (file://some/path/to/a/file)
@@ -136,7 +136,7 @@ public:
    *    http://overpass-api.de/api/interpreter?data=[out:json];way(35.2097,-120.6207,35.2241,-120.5955);out;
    * @param url
    */
-  virtual void open(const QString& url) override;
+  void open(const QString& url) override;
 
   /**
    * @brief close close internal filehandle, if needed
@@ -149,21 +149,21 @@ public:
    *        will likely be closed after this call
    * @param map
    */
-  virtual void read(const OsmMapPtr& map) override;
+  void read(const OsmMapPtr& map) override;
 
   /**
    * @brief setDefaultStatus Sets the default status to use for elements
    *        in the map
    * @param status
    */
-  virtual void setDefaultStatus(Status status) override { _defaultStatus = status; }
+  void setDefaultStatus(Status status) override { _defaultStatus = status; }
 
   /**
    * @brief setUseDataSourceIds Sets whether the reader should use the element IDs
    *        from the data being read, or self-generate unique IDs
    * @param useDataSourceIds true to use source IDs
    */
-  virtual void setUseDataSourceIds(bool useDataSourceIds) override
+  void setUseDataSourceIds(bool useDataSourceIds) override
   { _useDataSourceIds = useDataSourceIds; }
 
   /**
@@ -227,12 +227,12 @@ public:
    */
   static void scrubBigInts(QString &jsonStr);
 
-  virtual QString supportedFormats() override { return ".json"; }
+  QString supportedFormats() override { return ".json"; }
 
   /**
    * Set the configuration for this object.
    */
-  virtual void setConfiguration(const Settings& conf) override;
+  void setConfiguration(const Settings& conf) override;
 
   void setKeepImmediatelyConnectedWaysOutsideBounds(bool keep)
   { _keepImmediatelyConnectedWaysOutsideBounds = keep; }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonWriter.h
@@ -67,14 +67,14 @@ public:
   OsmJsonWriter(int precision = ConfigOptions().getWriterPrecision());
   virtual ~OsmJsonWriter() = default;
 
-  virtual bool isSupported(const QString& url) override { return url.toLower().endsWith(".json"); }
+  bool isSupported(const QString& url) override { return url.toLower().endsWith(".json"); }
 
   /**
    * Mark up a string so it can be used in JSON. This will add double quotes around the string too.
    */
   static QString markupString(const QString& str);
 
-  virtual void open(const QString& url) override;
+  void open(const QString& url) override;
 
   virtual void close() { if (_fp.isOpen()) { _fp.close(); } }
 
@@ -87,7 +87,7 @@ public:
    */
   void write(const ConstOsmMapPtr& map, const QString& path);
 
-  virtual void write(const ConstOsmMapPtr& map);
+  void write(const ConstOsmMapPtr& map) override;
 
   /**
    * Very handy for testing.
@@ -104,9 +104,9 @@ public:
   void setIncludeCircularError(bool includeCircularError)
   { _addExportTagsVisitor.setIncludeCircularError( includeCircularError); }
 
-  virtual QString supportedFormats() override { return ".json"; }
+  QString supportedFormats() override { return ".json"; }
 
-  virtual void setConfiguration(const Settings& conf) override;
+  void setConfiguration(const Settings& conf) override;
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapReader.h
@@ -101,7 +101,7 @@ public:
   void setWarnOnVersionZeroElement(bool warn) { _warnOnVersionZeroElement = warn; }
 
   /** Configurable interface */
-  virtual void setConfiguration(const Settings& conf) override
+  void setConfiguration(const Settings& conf) override
   {
     _ignoreDuplicates =  ConfigOptions(conf).getMapMergeIgnoreDuplicateIds();
   }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.h
@@ -92,12 +92,9 @@ public:
    */
   OsmPbfReader(const QString& urlString);
 
-  virtual ~OsmPbfReader();
+  ~OsmPbfReader();
 
-  /**
-   * @see ElementInputStream
-   */
-  virtual OsmPbfReader* clone() const { return new OsmPbfReader(*this); }
+  OsmPbfReader* clone() const { return new OsmPbfReader(*this); }
 
   /**
    * Scan through the file and calculate the offsets of every blob. This is handy when
@@ -108,14 +105,14 @@ public:
   /**
    * Determines the reader's default element status
    */
-  virtual void setDefaultStatus(Status status) override { _status = status; }
+  void setDefaultStatus(Status status) override { _status = status; }
 
   /**
    * Determines whether the reader should use the element id's from the file being read
    */
-  virtual void setUseDataSourceIds(bool useDataSourceIds) override { _useFileId = useDataSourceIds; }
+  void setUseDataSourceIds(bool useDataSourceIds) override { _useFileId = useDataSourceIds; }
 
-  virtual void setUseFileStatus(bool useFileStatus) override { _useFileStatus = useFileStatus; }
+  void setUseFileStatus(bool useFileStatus) override { _useFileStatus = useFileStatus; }
 
   /**
    * If the input is a directory then the underlying files are read in turn, otherwise readFile
@@ -143,27 +140,27 @@ public:
    */
   void setPermissive(bool permissive) { _permissive = permissive; }
 
-  virtual bool isSupported(const QString& urlStr) override;
+  bool isSupported(const QString& urlStr) override;
 
-  virtual void open(const QString& urlStr) override;
+  void open(const QString& urlStr) override;
 
-  virtual void initializePartial();
+  void initializePartial() override;
   /**
    * The read command called after open.
    */
-  virtual void read(const OsmMapPtr& map) override;
+  void read(const OsmMapPtr& map) override;
 
-  virtual bool hasMoreElements() override;
+  bool hasMoreElements() override;
 
-  virtual std::shared_ptr<Element> readNextElement() override;
+  std::shared_ptr<Element> readNextElement() override;
 
-  virtual void finalizePartial() override;
+  void finalizePartial() override;
 
-  void close();
+  void close() override;
 
-  virtual void setConfiguration(const Settings &conf) override;
+  void setConfiguration(const Settings &conf) override;
 
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const override;
+  std::shared_ptr<OGRSpatialReference> getProjection() const override;
 
   bool getSortedTypeThenId() { return _typeThenId; }
 
@@ -177,7 +174,7 @@ public:
    */
   bool isSorted(const QString& file);
 
-  virtual QString supportedFormats() { return ".osm.pbf"; }
+  QString supportedFormats() override { return ".osm.pbf"; }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfWriter.h
@@ -74,7 +74,7 @@ public:
   static const char* const OSM_HEADER;
 
   OsmPbfWriter();
-  virtual ~OsmPbfWriter();
+  ~OsmPbfWriter();
 
   /**
    * Used to finalize a call to writePartial.

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPgCsvWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPgCsvWriter.h
@@ -47,7 +47,7 @@ public:
   static QString className() { return "hoot::OsmCsvWriter"; }
 
   OsmPgCsvWriter();
-  virtual ~OsmPgCsvWriter() = default;
+  ~OsmPgCsvWriter() = default;
 
   /**
    * @brief isSupported returns true if the URL is likely supported

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlChangesetFileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlChangesetFileWriter.h
@@ -57,33 +57,33 @@ public:
   static QString className() { return "hoot::OsmXmlChangesetFileWriter"; }
 
   OsmXmlChangesetFileWriter();
-  virtual ~OsmXmlChangesetFileWriter() = default;
+  ~OsmXmlChangesetFileWriter() = default;
 
   /**
    * @see ChangesetFileWriter
    */
-  virtual void write(const QString& path, const ChangesetProviderPtr& changesetProvider);
+  void write(const QString& path, const ChangesetProviderPtr& changesetProvider) override;
 
   /**
    * @see ChangesetFileWriter
    */
-  virtual void write(const QString& path, const QList<ChangesetProviderPtr>& changesetProviders);
+  void write(const QString& path, const QList<ChangesetProviderPtr>& changesetProviders) override;
 
   /**
    * @see ChangesetFileWriter
    */
-  virtual QString getStatsTable(
-    const ChangesetStatsFormat& format = ChangesetStatsFormat::Text) const;
+  QString getStatsTable(
+    const ChangesetStatsFormat& format = ChangesetStatsFormat::Text) const override;
 
-  virtual void setMap1List(const QList<ConstOsmMapPtr>& mapList) { _map1List = mapList; }
-  virtual void setMap2List(const QList<ConstOsmMapPtr>& mapList) { _map2List = mapList; }
+  void setMap1List(const QList<ConstOsmMapPtr>& mapList) override { _map1List = mapList; }
+  void setMap2List(const QList<ConstOsmMapPtr>& mapList) override { _map2List = mapList; }
 
   /**
    * @see ChangesetFileWriter
    */
-  virtual bool isSupported(const QString& output) const { return output.endsWith(".osc"); }
+  bool isSupported(const QString& output) const override { return output.endsWith(".osc"); }
 
-  virtual void setConfiguration(const Settings &conf);
+  void setConfiguration(const Settings &conf) override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.h
@@ -58,28 +58,28 @@ public:
   static QString className() { return "hoot::OsmXmlReader"; }
 
   OsmXmlReader();
-  virtual ~OsmXmlReader();
+  ~OsmXmlReader();
 
-  virtual void close();
+  void close() override;
 
-  virtual QString errorString() const { return _errorString; }
+  QString errorString() const override { return _errorString; }
 
-  virtual bool endElement(const QString& namespaceURI, const QString& localName,
-                          const QString& qName);
+  bool endElement(const QString& namespaceURI, const QString& localName,
+                  const QString& qName) override;
 
-  virtual bool fatalError(const QXmlParseException &exception);
+  bool fatalError(const QXmlParseException &exception) override;
 
-  virtual void initializePartial() {}
+  void initializePartial() override { }
 
-  virtual void finalizePartial();
+  void finalizePartial() override;
 
-  virtual std::shared_ptr<OGRSpatialReference> getProjection() const;
+  std::shared_ptr<OGRSpatialReference> getProjection() const override;
 
-  virtual bool hasMoreElements();
+  bool hasMoreElements() override;
 
-  virtual bool isSupported(const QString& url) override;
+  bool isSupported(const QString& url) override;
 
-  virtual void read(const OsmMapPtr& map) override;
+  void read(const OsmMapPtr& map) override;
 
   void readFromString(const QString& xml, const OsmMapPtr& map);
 
@@ -100,15 +100,15 @@ public:
 
   void read(const QString& path, const OsmMapPtr& map);
 
-  virtual ElementPtr readNextElement() override;
+  ElementPtr readNextElement() override;
 
-  virtual void setDefaultStatus(Status s) override { _status = s; }
-  virtual void setUseFileStatus(bool useFileStatus) { _useFileStatus = useFileStatus; }
+  void setDefaultStatus(Status s) override { _status = s; }
+  void setUseFileStatus(bool useFileStatus) override { _useFileStatus = useFileStatus; }
 
-  virtual bool startElement(const QString& namespaceURI, const QString& localName,
-                            const QString& qName, const QXmlAttributes& attributes);
+  bool startElement(const QString& namespaceURI, const QString& localName,
+                    const QString& qName, const QXmlAttributes& attributes) override;
 
-  virtual void setUseDataSourceIds(bool useDataSourceIds) { _useDataSourceId = useDataSourceIds; }
+  void setUseDataSourceIds(bool useDataSourceIds) override { _useDataSourceId = useDataSourceIds; }
   void setKeepStatusTag(bool keepStatusTag) { _keepStatusTag = keepStatusTag; }
   void setDefaultAccuracy(Meters circularError) { _defaultCircularError = circularError; }
   void setAddSourceDateTime(bool add) { _addSourceDateTime = add; }
@@ -125,9 +125,9 @@ public:
   { _addChildRefsWhenMissing = addChildRefsWhenMissing; }
   void setCircularErrorTagKeys(const QStringList& keys) { _circularErrorTagKeys = keys; }
 
-  virtual QString supportedFormats() override { return ".osm;.osm.bz2;.osm.gz"; }
+  QString supportedFormats() override { return ".osm;.osm.bz2;.osm.gz"; }
 
-  virtual void setConfiguration(const Settings& conf) override;
+  void setConfiguration(const Settings& conf) override;
 
   // Its possible we may want to move this method and the ones for all other classes using it up
   // to OsmMapReader.

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.h
@@ -58,7 +58,7 @@ public:
   static QString className() { return "hoot::OsmXmlWriter"; }
 
   OsmXmlWriter();
-  virtual ~OsmXmlWriter();
+  ~OsmXmlWriter();
 
   bool isSupported(const QString& url) override { return url.toLower().endsWith(".osm"); }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/PartialOsmMapReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/PartialOsmMapReader.h
@@ -54,7 +54,7 @@ public:
   /**
    * The default reads the map and then calls finalizePartial();
    */
-  virtual void read(const OsmMapPtr& map) override;
+  void read(const OsmMapPtr& map) override;
 
   /**
    * Reads all the entries in the OsmMap.
@@ -73,20 +73,6 @@ public:
      complete.
    */
   virtual void finalizePartial() = 0;
-
-  /**
-   * Returns true if the reader can read any more elements
-   *
-   * @return true if there are more elements; false otherwise
-   */
-  virtual bool hasMoreElements() = 0;
-
-  /**
-   * Reads the next available element from the data source
-   *
-   * @return an element
-   */
-  virtual ElementPtr readNextElement() = 0;
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/PartialOsmMapWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/PartialOsmMapWriter.h
@@ -70,7 +70,7 @@ public:
   virtual void writePartial(const ConstWayPtr& w) = 0;
   virtual void writePartial(const ConstRelationPtr& r) = 0;
 
-  virtual void writeElement(ElementPtr& element);
+  void writeElement(ElementPtr& element) override;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/PbfElementIterator.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/PbfElementIterator.h
@@ -48,10 +48,10 @@ public:
    */
   PbfElementIterator(QString path);
 
-  virtual ~PbfElementIterator() = default;
+  ~PbfElementIterator() = default;
 
   // not implemented
-  virtual void resetIterator() { }
+  void resetIterator() override { }
 
 private:
 
@@ -63,7 +63,7 @@ private:
 
   void _init(const std::shared_ptr<std::istream>& in);
 
-  virtual void _next();
+  void _next() override;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/ShapefileWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ShapefileWriter.cpp
@@ -65,9 +65,9 @@ class ColumnVisitor : public ElementConstOsmMapVisitor
 public:
 
   ColumnVisitor(ElementType type) : _type(type) { }
-  virtual ~ColumnVisitor() = default;
+  ~ColumnVisitor() = default;
 
-  virtual void visit(const std::shared_ptr<const Element>& e)
+  void visit(const std::shared_ptr<const Element>& e) override
   {
     if (e->getElementType() == _type || _type == ElementType::Unknown)
     {
@@ -91,9 +91,9 @@ public:
     return result;
   }
 
-  virtual QString getDescription() const { return ""; }
-  virtual QString getName() const { return ""; }
-  virtual QString getClassName() const override { return ""; }
+  QString getDescription() const override { return ""; }
+  QString getName() const override { return ""; }
+  QString getClassName() const override { return ""; }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/ShapefileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ShapefileWriter.h
@@ -57,11 +57,11 @@ public:
   static QString className() { return "hoot::ShapefileWriter"; }
 
   ShapefileWriter();
-  virtual ~ShapefileWriter() = default;
+  ~ShapefileWriter() = default;
 
-  virtual bool isSupported(const QString& url) override { return url.toLower().endsWith(".shp"); }
+  bool isSupported(const QString& url) override { return url.toLower().endsWith(".shp"); }
 
-  virtual void open(const QString& url) override;
+  void open(const QString& url) override;
 
   QStringList getColumns(ConstOsmMapPtr map, ElementType type) const;
 
@@ -73,7 +73,7 @@ public:
    * path + "Lines.shp"
    * path + "Polygons.shp"
    */
-  virtual void write(const ConstOsmMapPtr& map) override;
+  void write(const ConstOsmMapPtr& map) override;
 
   /**
    * @deprecated Use open and write instead.
@@ -86,12 +86,12 @@ public:
 
   void writePolygons(const ConstOsmMapPtr& map, const QString& path);
 
-  virtual QString supportedFormats() override { return ".shp"; }
+  QString supportedFormats() override { return ".shp"; }
 
   /**
    * Set the configuration for this object.
    */
-  virtual void setConfiguration(const Settings& conf) override;
+  void setConfiguration(const Settings& conf) override;
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/SqlBulkDelete.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/SqlBulkDelete.h
@@ -47,15 +47,15 @@ public:
 
   SqlBulkDelete(const QSqlDatabase& db, const QString& tableName);
 
-  virtual ~SqlBulkDelete();
+  ~SqlBulkDelete();
 
-  virtual void flush();
+  void flush() override;
 
-  virtual int getPendingCount() const { return _pending.size(); }
+  int getPendingCount() const override { return _pending.size(); }
 
-  virtual QString getTableName() const { return _tableName; }
+  QString getTableName() const override { return _tableName; }
 
-  virtual void deleteElement(const long id);
+  void deleteElement(const long id) override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/SqlBulkInsert.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/SqlBulkInsert.h
@@ -46,15 +46,15 @@ class SqlBulkInsert : public BulkInsert
 public:
   SqlBulkInsert(QSqlDatabase& db, const QString& tableName, const QStringList& columns, bool ignoreConflict = false);
 
-  virtual ~SqlBulkInsert();
+  ~SqlBulkInsert();
 
-  virtual void flush();
+  void flush() override;
 
-  virtual int getPendingCount() const { return _pending.size(); }
+  int getPendingCount() const override { return _pending.size(); }
 
-  virtual QString getTableName() const { return _tableName; }
+  QString getTableName() const override { return _tableName; }
 
-  virtual void insert(const QList<QVariant> l);
+  void insert(const QList<QVariant> l) override;
 
 private:
   QList<QList<QVariant>> _pending;

--- a/hoot-core/src/main/cpp/hoot/core/io/schema/DoubleFieldDefinition.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/schema/DoubleFieldDefinition.h
@@ -40,19 +40,19 @@ class DoubleFieldDefinition : public FieldDefinition
 public:
 
   DoubleFieldDefinition();
-  virtual ~DoubleFieldDefinition() = default;
+  ~DoubleFieldDefinition() = default;
 
   void addEnumeratedValue(double v) { _enumeratedValues.insert(v); }
 
-  virtual QVariant::Type getType() const { return QVariant::Double; }
+  QVariant::Type getType() const override { return QVariant::Double; }
 
-  virtual QVariant getDefaultValue() const;
+  QVariant getDefaultValue() const override;
 
   double getMaxValue() const { return _max; }
 
   double getMinValue() const { return _min; }
 
-  virtual bool hasDefaultValue() const;
+  bool hasDefaultValue() const override;
 
   bool hasEnumeratedValue(double v) { return _enumeratedValues.find(v) != _enumeratedValues.end(); }
 
@@ -62,9 +62,9 @@ public:
 
   void setMinValue(double min) { _min = min; }
 
-  virtual QString toString() const;
+  QString toString() const override;
 
-  virtual void validate(const QVariant& v, StrictChecking strict) const;
+  void validate(const QVariant& v, StrictChecking strict) const;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/schema/FieldDefinition.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/schema/FieldDefinition.h
@@ -51,7 +51,7 @@ public:
     {
     }
 
-    virtual ~InvalidValueException() throw() = default;
+    ~InvalidValueException() throw() = default;
 
   private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/schema/IntegerFieldDefinition.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/schema/IntegerFieldDefinition.h
@@ -40,15 +40,15 @@ class IntegerFieldDefinition : public FieldDefinition
 public:
 
   IntegerFieldDefinition();
-  virtual ~IntegerFieldDefinition() = default;
+  ~IntegerFieldDefinition() = default;
 
   void addEnumeratedValue(int v) { _enumeratedValues.insert(v); }
 
-  virtual QVariant getDefaultValue() const;
+  QVariant getDefaultValue() const override;
 
-  virtual QVariant::Type getType() const { return QVariant::Int; }
+  QVariant::Type getType() const override { return QVariant::Int; }
 
-  virtual bool hasDefaultValue() const;
+  bool hasDefaultValue() const override;
 
   bool hasEnumeratedValue(int v) { return _enumeratedValues.find(v) != _enumeratedValues.end(); }
 
@@ -58,9 +58,9 @@ public:
 
   void setMinValue(double min) { _min = min; }
 
-  virtual QString toString() const;
+  QString toString() const override;
 
-  virtual void validate(const QVariant& v, StrictChecking strict) const;
+  void validate(const QVariant& v, StrictChecking strict) const override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/schema/LongIntegerFieldDefinition.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/schema/LongIntegerFieldDefinition.h
@@ -40,15 +40,15 @@ class LongIntegerFieldDefinition : public FieldDefinition
 public:
 
   LongIntegerFieldDefinition();
-  virtual ~LongIntegerFieldDefinition() = default;
+  ~LongIntegerFieldDefinition() = default;
 
   void addEnumeratedValue(long long v) { _enumeratedValues.insert(v); }
 
-  virtual QVariant getDefaultValue() const;
+  QVariant getDefaultValue() const override;
 
-  virtual QVariant::Type getType() const { return QVariant::LongLong; }
+  QVariant::Type getType() const override { return QVariant::LongLong; }
 
-  virtual bool hasDefaultValue() const;
+  bool hasDefaultValue() const override;
 
   bool hasEnumeratedValue(long long v) { return _enumeratedValues.find(v) != _enumeratedValues.end(); }
 
@@ -58,9 +58,9 @@ public:
 
   void setMinValue(long long min) { _min = min; }
 
-  virtual QString toString() const;
+  QString toString() const override;
 
-  virtual void validate(const QVariant& v, StrictChecking strict) const;
+  void validate(const QVariant& v, StrictChecking strict) const override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/schema/StringFieldDefinition.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/schema/StringFieldDefinition.h
@@ -37,19 +37,19 @@ class StringFieldDefinition : public FieldDefinition
 public:
 
   StringFieldDefinition() = default;
-  virtual ~StringFieldDefinition() = default;
+  ~StringFieldDefinition() = default;
 
-  virtual QVariant::Type getType() const override { return QVariant::String; }
+  QVariant::Type getType() const override { return QVariant::String; }
 
-  virtual void validate(const QVariant& v, StrictChecking strict) const override;
+  void validate(const QVariant& v, StrictChecking strict) const override;
 
-  virtual QVariant getDefaultValue() const override;
+  QVariant getDefaultValue() const override;
 
-  virtual bool hasDefaultValue() const;
+  bool hasDefaultValue() const override;
 
   void setDefaultValue(const QString& v) { _defaultValue = v; }
 
-  virtual QString toString() const;
+  QString toString() const override;
 
 private:
   QString _defaultValue;

--- a/hoot-core/src/main/cpp/hoot/core/language/ToEnglishAddressTranslator.h
+++ b/hoot-core/src/main/cpp/hoot/core/language/ToEnglishAddressTranslator.h
@@ -44,9 +44,9 @@ public:
   static QString className() { return "hoot::ToEnglishAddressTranslator"; }
 
   ToEnglishAddressTranslator() = default;
-  virtual ~ToEnglishAddressTranslator() = default;
+  ~ToEnglishAddressTranslator() = default;
 
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
   /**
    * Translates an address to English

--- a/hoot-core/src/main/cpp/hoot/core/language/ToEnglishDictionaryTranslator.h
+++ b/hoot-core/src/main/cpp/hoot/core/language/ToEnglishDictionaryTranslator.h
@@ -58,7 +58,7 @@ public:
   static QString className() { return "hoot::ToEnglishDictionaryTranslator"; }
 
   ToEnglishDictionaryTranslator();
-  virtual ~ToEnglishDictionaryTranslator() = default;
+  ~ToEnglishDictionaryTranslator() = default;
 
   /**
    * Translates the given input string into a translation & transliteration of the input.
@@ -68,7 +68,7 @@ public:
   /**
    * @see ToEnglishTranslator; wraps call to toEnglish
    */
-  virtual QString translate(const QString& textToTranslate) override;
+  QString translate(const QString& textToTranslate) override;
 
   /**
    * Converts the given input string into all possible known translations. E.g.
@@ -91,15 +91,15 @@ public:
 
   QString translateStreet(const QString& input);
 
-  virtual QStringList getSourceLanguages() const override { return QStringList(); }
-  virtual void setSourceLanguages(const QStringList& /*langCodes*/) override {}
-  virtual QString getDetectedLanguage() const override { return ""; }
+  QStringList getSourceLanguages() const override { return QStringList(); }
+  void setSourceLanguages(const QStringList& /*langCodes*/) override { }
+  QString getDetectedLanguage() const override { return ""; }
 
-  virtual void setConfiguration(const Settings& /*conf*/) {}
+  void setConfiguration(const Settings& /*conf*/) override { }
 
   void setTokenizeInput(bool tokenize) { _tokenizeInput = tokenize; }
 
-  virtual void setId(const QString& /*id*/) override {}
+  void setId(const QString& /*id*/) override { }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/language/ToEnglishTranslateStringDistance.h
+++ b/hoot-core/src/main/cpp/hoot/core/language/ToEnglishTranslateStringDistance.h
@@ -52,29 +52,29 @@ public:
   ToEnglishTranslateStringDistance(const StringDistancePtr& d,
                                    const std::shared_ptr<ToEnglishTranslator>& translator);
 
-  virtual ~ToEnglishTranslateStringDistance() = default;
+  ~ToEnglishTranslateStringDistance() = default;
 
-  virtual void setStringDistance(const StringDistancePtr& sd) override { _d = sd; }
+  void setStringDistance(const StringDistancePtr& sd) override { _d = sd; }
 
   /**
    * Returns a value from 1 (very similar) to 0 (very dissimilar) describing the distance between
    * two strings.
    */
-  virtual double compare(const QString& s1, const QString& s2) const override;
+  double compare(const QString& s1, const QString& s2) const override;
 
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
-  virtual QString toString() const override { return "Translate " + _d->toString(); }
+  QString toString() const override { return "Translate " + _d->toString(); }
 
   void setTokenize(bool tokenize) { _tokenize = tokenize; }
   void setTranslateAll(bool translateAll) { _translateAll = translateAll; }
 
-  virtual QString getDescription() const override
+  QString getDescription() const override
   { return "Returns a string comparison score based on the associated string comparator after first translating to English"; }
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/AddHilbertReviewSortOrderOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/AddHilbertReviewSortOrderOp.h
@@ -44,21 +44,21 @@ public:
   static int logWarnCount;
 
   AddHilbertReviewSortOrderOp() = default;
-  virtual ~AddHilbertReviewSortOrderOp() = default;
+  ~AddHilbertReviewSortOrderOp() = default;
 
-  virtual void apply(OsmMapPtr& map);
+  void apply(OsmMapPtr& map) override;
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual QString getInitStatusMessage() const
+  QString getInitStatusMessage() const override
   { return "Adding geospatial sorting tags to review relations..."; }
 
-  virtual QString getCompletedStatusMessage() const
+  QString getCompletedStatusMessage() const override
   { return "Added " + StringUtils::formatLargeNumber(_numAffected) + " sorting tags"; }
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Adds tags that enable sorting reviewable features geospatially"; }
 
 private:

--- a/hoot-core/src/main/cpp/hoot/core/ops/BuildingOutlineRemoveOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/BuildingOutlineRemoveOp.h
@@ -48,25 +48,25 @@ public:
   static QString className() { return "hoot::BuildingOutlineRemoveOp"; }
 
   BuildingOutlineRemoveOp() = default;
-  virtual ~BuildingOutlineRemoveOp() = default;
+  ~BuildingOutlineRemoveOp() = default;
 
-  virtual void apply(std::shared_ptr<OsmMap>& map) override;
+  void apply(std::shared_ptr<OsmMap>& map) override;
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual QString getInitStatusMessage() const { return "Removing outlines around buildings..."; }
+  QString getInitStatusMessage() const override { return "Removing outlines around buildings..."; }
 
-  virtual QString getCompletedStatusMessage() const
+  QString getCompletedStatusMessage() const override
   { return "Removed " + QString::number(_numAffected) + " building outlines"; }
 
-  virtual QString getDescription() const override { return "Removes the outline around buildings"; }
+  QString getDescription() const override { return "Removes the outline around buildings"; }
 
   /**
    * @see FilteredByGeometryTypeCriteria
    */
-  virtual QStringList getCriteria() const;
+  QStringList getCriteria() const override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/BuildingOutlineUpdateOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/BuildingOutlineUpdateOp.cpp
@@ -64,9 +64,9 @@ class NodeIdVisitor : public ConstElementVisitor
 public:
 
   NodeIdVisitor(set<long>& nodes) : allNodes(nodes) { }
-  virtual ~NodeIdVisitor() = default;
+  ~NodeIdVisitor() = default;
 
-  virtual void visit(const ConstElementPtr& e)
+  void visit(const ConstElementPtr& e) override
   {
     if (e->getElementType() == ElementType::Node)
     {
@@ -74,9 +74,9 @@ public:
     }
   }
 
-  virtual QString getDescription() const { return ""; }
-  virtual QString getName() const { return ""; }
-virtual QString getClassName() const override { return ""; }
+  QString getDescription() const override { return ""; }
+  QString getName() const override { return ""; }
+  QString getClassName() const override { return ""; }
 
 private:
 
@@ -90,9 +90,9 @@ public:
   NodeReplaceVisitor(OsmMap& map, const std::map<long, long>& fromTo)
     : _fromTo(fromTo), _map(map)
   { }
-  virtual ~NodeReplaceVisitor() = default;
+  ~NodeReplaceVisitor() = default;
 
-  virtual void visit(const ConstElementPtr& e)
+  void visit(const ConstElementPtr& e) override
   {
     if (e->getElementType() == ElementType::Way)
     {
@@ -123,9 +123,9 @@ public:
     }
   }
 
-  virtual QString getDescription() const { return ""; }
-  virtual QString getName() const { return ""; }
-  virtual QString getClassName() const override { return ""; }
+  QString getDescription() const override { return ""; }
+  QString getName() const override { return ""; }
+  QString getClassName() const override { return ""; }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/BuildingOutlineUpdateOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/BuildingOutlineUpdateOp.h
@@ -50,27 +50,27 @@ public:
   static QString className() { return "hoot::BuildingOutlineUpdateOp"; }
 
   BuildingOutlineUpdateOp() = default;
-  virtual ~BuildingOutlineUpdateOp() = default;
+  ~BuildingOutlineUpdateOp() = default;
 
-  virtual void apply(std::shared_ptr<OsmMap>& map) override;
+  void apply(std::shared_ptr<OsmMap>& map) override;
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual QString getInitStatusMessage() const
+  QString getInitStatusMessage() const override
   { return "Updating building outlines..."; }
 
-  virtual QString getCompletedStatusMessage() const
+  QString getCompletedStatusMessage() const override
   { return "Updated " + QString::number(_numAffected) + " building outlines"; }
 
-  virtual QString getDescription() const override
+  QString getDescription() const override
   { return "Updates multi-part building outlines"; }
 
   /**
    * @see FilteredByGeometryTypeCriteria
    */
-  virtual QStringList getCriteria() const;
+  QStringList getCriteria() const override;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/BuildingPartMergeOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/BuildingPartMergeOp.h
@@ -100,22 +100,22 @@ public:
 
 
   BuildingPartMergeOp(bool preserveTypes = false);
-  virtual ~BuildingPartMergeOp() = default;
+  ~BuildingPartMergeOp() = default;
 
-  virtual void apply(OsmMapPtr& map) override;
+  void apply(OsmMapPtr& map) override;
 
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual QString getDescription() const override
+  QString getDescription() const override
   { return "Merges individual building parts into a single building"; }
 
-  virtual QString getInitStatusMessage() const { return "Merging building parts..."; }
+  QString getInitStatusMessage() const override { return "Merging building parts..."; }
 
-  virtual QString getCompletedStatusMessage() const
+  QString getCompletedStatusMessage() const override
   {
     return
       "Merged " + StringUtils::formatLargeNumber(_numAffected) +

--- a/hoot-core/src/main/cpp/hoot/core/ops/CalculateStatsOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CalculateStatsOp.h
@@ -61,9 +61,9 @@ public:
   CalculateStatsOp(QString mapName = "", bool inputIsConflatedMapOutput = false);
   CalculateStatsOp(ElementCriterionPtr criterion, QString mapName = "",
                    bool inputIsConflatedMapOutput = false);
-  virtual ~CalculateStatsOp() = default;
+  ~CalculateStatsOp() = default;
 
-  virtual void apply(const OsmMapPtr& map);
+  void apply(const OsmMapPtr& map) override;
 
   QList<SingleStat> getStats() const { return _stats; }
 
@@ -84,13 +84,13 @@ public:
 
   void setQuickSubset(bool quick) { _quick = quick; }
 
-  virtual QString getDescription() const { return "Calculates map statistics"; }
+  QString getDescription() const override { return "Calculates map statistics"; }
 
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/ConstOsmMapOperation.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/ConstOsmMapOperation.h
@@ -46,7 +46,7 @@ public:
   ConstOsmMapOperation() = default;
   virtual ~ConstOsmMapOperation() = default;
 
-  virtual void apply(std::shared_ptr<OsmMap>& map)
+  void apply(std::shared_ptr<OsmMap>& map) override
   { apply((const std::shared_ptr<OsmMap>&)map); }
 
   /**
@@ -55,7 +55,7 @@ public:
    */
   virtual void apply(const std::shared_ptr<OsmMap>& map) = 0;
 
-  virtual QString getDescription() const { return ""; }
+  QString getDescription() const override { return ""; }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/ops/CookieCutterOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CookieCutterOp.h
@@ -47,22 +47,22 @@ public:
   static QString className() { return "hoot::CookieCutterOp"; }
 
   CookieCutterOp();
-  virtual ~CookieCutterOp() = default;
+  ~CookieCutterOp() = default;
 
-  virtual void apply(std::shared_ptr<OsmMap>& map) override;
+  void apply(std::shared_ptr<OsmMap>& map) override;
 
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
   void setAlpha(double alpha) { _alpha = alpha; }
   void setAlphaShapeBuffer(double buffer) { _alphaShapeBuffer = buffer; }
   void setCrop(bool crop) { _crop = crop; }
 
-  virtual QString getDescription() const override
+  QString getDescription() const override
   { return "Cookie cuts one dataset out of another"; }
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.cpp
@@ -52,9 +52,9 @@ public:
   {
     LOG_VART(_copyChildren);
   }
-  virtual ~AddAllVisitor() = default;
+  ~AddAllVisitor() = default;
 
-  virtual void visit(const ConstElementPtr& e)
+  void visit(const ConstElementPtr& e) override
   {
     ElementId eid = e->getElementId();
     LOG_VART(eid);
@@ -94,9 +94,9 @@ public:
     }
   }
 
-  virtual QString getDescription() const { return ""; }
-  virtual QString getName() const { return ""; }
-  virtual QString getClassName() const override { return ""; }
+  QString getDescription() const override { return ""; }
+  QString getName() const override { return ""; }
+  QString getClassName() const override { return ""; }
 
   std::set<ElementId>& getElementsAdded() { return _elementsAdded; }
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.h
@@ -55,29 +55,29 @@ public:
   CopyMapSubsetOp(const ConstOsmMapPtr& from, ElementId eid);
   CopyMapSubsetOp(const ConstOsmMapPtr& from, ElementId eid1, ElementId eid2);
   CopyMapSubsetOp(const ConstOsmMapPtr& from, const ElementCriterionPtr& crit);
-  virtual ~CopyMapSubsetOp() = default;
+  ~CopyMapSubsetOp() = default;
 
   /**
    * A new map is created and the eids specified in the constructor and their dependencies will be
    * copied into the new map. The map will be set to point to the new map.
    */
-  virtual void apply(OsmMapPtr& map);
+  void apply(OsmMapPtr& map) override;
 
   /**
    * @see ConstOsmMapConsumer
    */
-  virtual void setOsmMap(const OsmMap* map) { _from = map->shared_from_this(); }
+  void setOsmMap(const OsmMap* map) override { _from = map->shared_from_this(); }
 
   /**
    * @see ElementCriterionConsumer
    */
-  virtual void addCriterion(const ElementCriterionPtr& crit);
+  void addCriterion(const ElementCriterionPtr& crit) override;
 
-  virtual QString getDescription() const { return "Copies a subset of the map into a new map"; }
+  QString getDescription() const override { return "Copies a subset of the map into a new map"; }
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
   std::set<ElementId>& getEidsCopied() { return _eidsCopied; }
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/DataQualityMetricTagger.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/DataQualityMetricTagger.h
@@ -50,26 +50,26 @@ public:
   static QString className() { return "hoot::DataQualityMetricTagger"; }
 
   DataQualityMetricTagger();
-  virtual ~DataQualityMetricTagger() = default;
+  ~DataQualityMetricTagger() = default;
 
   /**
    * Calculates select data quality metrics for a map and tags features with issues
    */
-  virtual void apply(OsmMapPtr& map);
+  void apply(OsmMapPtr& map) override;
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual QString getInitStatusMessage() const
+  QString getInitStatusMessage() const override
   { return "Calculating data quality metrics..."; }
 
-  virtual QString getCompletedStatusMessage() const
+  QString getCompletedStatusMessage() const override
   {
     return "Calculated data quality metrics.";
   }
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Calculates select data quality metrics for a map and tags features with issues"; }
 
   int getNumOrphanedNodes() const { return _orphanedNodes; }

--- a/hoot-core/src/main/cpp/hoot/core/ops/DuplicateElementMarker.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/DuplicateElementMarker.h
@@ -45,7 +45,7 @@ public:
   static QString className() { return "hoot::DuplicateElementMarker"; }
 
   DuplicateElementMarker();
-  virtual ~DuplicateElementMarker() = default;
+  ~DuplicateElementMarker() = default;
 
   /**
    * @see OsmMapOperation
@@ -64,20 +64,20 @@ public:
     const int coordinateComparisonSensitivity =
       ConfigOptions().getNodeComparisonCoordinateSensitivity());
 
-  virtual QString getInitStatusMessage() const { return "Marking duplicate elements..."; }
+  QString getInitStatusMessage() const override { return "Marking duplicate elements..."; }
 
-  virtual QString getCompletedStatusMessage() const
+  QString getCompletedStatusMessage() const override
   {
     return
       "Marked " + QString::number(_numAffected) + " duplicate element pairs out of " +
       QString::number(_numProcessed) + " elements total.";
   }
 
-  virtual QString getDescription() const { return "Adds a tag to elements who have duplicates"; }
+  QString getDescription() const override { return "Adds a tag to elements who have duplicates"; }
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
   std::set<QString> getContainingWayTypes() const { return _containingWayTypes; }
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/DuplicateNameRemover.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/DuplicateNameRemover.h
@@ -52,7 +52,7 @@ public:
   static QString className() { return "hoot::DuplicateNameRemover"; }
 
   DuplicateNameRemover();
-  virtual ~DuplicateNameRemover() = default;
+  ~DuplicateNameRemover() = default;
 
   void apply(std::shared_ptr<OsmMap>& map);
 
@@ -61,22 +61,22 @@ public:
    */
   static void removeDuplicates(std::shared_ptr<OsmMap> map);
 
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
   void setCaseSensitive(bool caseSensitive) { _caseSensitive = caseSensitive; }
 
-  virtual QString getInitStatusMessage() const { return "Removing duplicate name tags..."; }
+  QString getInitStatusMessage() const override { return "Removing duplicate name tags..."; }
 
-  virtual QString getCompletedStatusMessage() const
+  QString getCompletedStatusMessage() const override
   { return "Removed " + QString::number(_numAffected) + " duplicate name tags"; }
 
-  virtual QString getDescription() const { return "Removes duplicate name tags from a feature"; }
+  QString getDescription() const override { return "Removes duplicate name tags from a feature"; }
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual void setConflateInfoCache(const std::shared_ptr<ConflateInfoCache>& cache)
+  void setConflateInfoCache(const std::shared_ptr<ConflateInfoCache>& cache) override
   { _conflateInfoCache = cache; }
 
 private:

--- a/hoot-core/src/main/cpp/hoot/core/ops/DuplicateNodeRemover.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/DuplicateNodeRemover.h
@@ -63,13 +63,13 @@ public:
   static QString className() { return "hoot::DuplicateNodeRemover"; }
 
   DuplicateNodeRemover(Meters distanceThreshold = -1.0);
-  virtual ~DuplicateNodeRemover() = default;
+  ~DuplicateNodeRemover() = default;
 
-  virtual void apply(std::shared_ptr<OsmMap>& map);
+  void apply(std::shared_ptr<OsmMap>& map) override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
   /**
    * Removes duplicate nodes from a map
@@ -80,14 +80,14 @@ public:
    */
   static void removeNodes(std::shared_ptr<OsmMap> map, Meters distanceThreshold = -1);
 
-  virtual QString getDescription() const override { return "Removes duplicate nodes"; }
+  QString getDescription() const override { return "Removes duplicate nodes"; }
 
-  virtual QString getInitStatusMessage() const override { return "Removing duplicate nodes..."; }
+  QString getInitStatusMessage() const override { return "Removing duplicate nodes..."; }
 
-  virtual QString getCompletedStatusMessage() const override
+  QString getCompletedStatusMessage() const override
   { return "Merged " + StringUtils::formatLargeNumber(_numAffected) + " node pairs."; }
 
-  virtual void setConflateInfoCache(const std::shared_ptr<ConflateInfoCache>& cache)
+  void setConflateInfoCache(const std::shared_ptr<ConflateInfoCache>& cache) override
   { _conflateInfoCache = cache; }
 
 protected:

--- a/hoot-core/src/main/cpp/hoot/core/ops/DuplicateWayRemover.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/DuplicateWayRemover.h
@@ -53,9 +53,9 @@ public:
   static QString className() { return "hoot::DuplicateWayRemover"; }
 
   DuplicateWayRemover();
-  virtual ~DuplicateWayRemover() = default;
+  ~DuplicateWayRemover() = default;
 
-  void apply(OsmMapPtr& map);
+  void apply(OsmMapPtr& map) override;
 
   /**
    * Remove parts of ways that are duplicates.
@@ -75,23 +75,23 @@ public:
     _strictTagMatching = strictTagMatching;
   }
 
-  virtual QString getInitStatusMessage() const { return "Removing duplicate ways..."; }
+  QString getInitStatusMessage() const override { return "Removing duplicate ways..."; }
 
-  virtual QString getCompletedStatusMessage() const
+  QString getCompletedStatusMessage() const override
   { return "Removed " + QString::number(_numAffected) + " duplicate ways"; }
 
-  virtual QString getDescription() const { return "Removes duplicate ways from a map"; }
+  QString getDescription() const { return "Removes duplicate ways from a map"; }
 
   /**
    * @see FilteredByGeometryTypeCriteria
    */
-  virtual QStringList getCriteria() const;
+  QStringList getCriteria() const override;
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual void setConflateInfoCache(const std::shared_ptr<ConflateInfoCache>& cache)
+  void setConflateInfoCache(const std::shared_ptr<ConflateInfoCache>& cache) override
   { _conflateInfoCache = cache; }
 
 protected:

--- a/hoot-core/src/main/cpp/hoot/core/ops/ElementHashOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/ElementHashOp.h
@@ -50,15 +50,15 @@ public:
   static QString className() { return "hoot::ElementHashOp"; }
 
   ElementHashOp();
-  virtual ~ElementHashOp() = default;
+  ~ElementHashOp() = default;
 
-  virtual void apply(const OsmMapPtr& map);
+  void apply(const OsmMapPtr& map) override;
 
-  virtual QString getDescription() const { return _hashVis.getDescription(); }
+  QString getDescription() const override { return _hashVis.getDescription(); }
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
   QMap<QString, ElementId> getHashesToElementIds() const
   { return _hashVis.getHashesToElementIds(); }

--- a/hoot-core/src/main/cpp/hoot/core/ops/ElementIdRemapper.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/ElementIdRemapper.h
@@ -50,12 +50,12 @@ public:
   ElementIdRemapper(const ElementCriterionPtr& remapFilter);
   ElementIdRemapper(
     const ElementCriterionPtr& remapFilter, const ElementCriterionPtr& restoreFilter);
-  virtual ~ElementIdRemapper() = default;
+  ~ElementIdRemapper() = default;
 
   /**
    * @see OsmMapOperation
    */
-  virtual void apply(OsmMapPtr& map);
+  void apply(OsmMapPtr& map) override;
 
   /**
    * Restores all IDs in the map back to their original values
@@ -64,14 +64,14 @@ public:
    */
   void restore(OsmMapPtr& map);
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual QString getInitStatusMessage() const
+  QString getInitStatusMessage() const override
   { return "Remapping element IDs..."; }
 
-  virtual QString getCompletedStatusMessage() const
+  QString getCompletedStatusMessage() const override
   {
     return "Remapped " + StringUtils::formatLargeNumber(_numAffected) + " element IDs.";
   }
@@ -81,7 +81,7 @@ public:
     return "Restored " + StringUtils::formatLargeNumber(_restoredIds) + " element IDs.";
   }
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Remaps element IDs and is capable of restoring the IDs"; }
 
   QMap<ElementId, ElementId> getIdMappings() const { return _originalToRemappedElementIds; }

--- a/hoot-core/src/main/cpp/hoot/core/ops/ElementIdToVersionMapper.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/ElementIdToVersionMapper.h
@@ -42,24 +42,24 @@ public:
   static QString className() { return "hoot::ElementIdToVersionMapper"; }
 
   ElementIdToVersionMapper() = default;
-  virtual ~ElementIdToVersionMapper() = default;
+  ~ElementIdToVersionMapper() = default;
 
-  virtual void apply(const OsmMapPtr& map);
+  void apply(const OsmMapPtr& map) override;
 
   QMap<ElementId, long> getMappings() const { return _idToVersionMappings; }
 
-  virtual QString getInitStatusMessage() const
+  QString getInitStatusMessage() const override
   { return "Mapping element IDs to changeset versions..."; }
 
-  virtual QString getCompletedStatusMessage() const
+  QString getCompletedStatusMessage() const override
   { return "Mapped " +  StringUtils::formatLargeNumber(_numAffected) + " element IDs to versions."; }
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Maintains a mapping of element IDs to changeset versions"; }
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/ElementReplacer.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/ElementReplacer.h
@@ -46,25 +46,25 @@ public:
 
   ElementReplacer() = default;
   ElementReplacer(OsmMapPtr mapToReplaceFrom) : _mapToReplaceFrom(mapToReplaceFrom) { }
-  virtual ~ElementReplacer() = default;
+  ~ElementReplacer() = default;
 
   /**
    * @see OsmMapOperation
    */
-  virtual void apply(std::shared_ptr<OsmMap>& map) override;
+  void apply(std::shared_ptr<OsmMap>& map) override;
 
-  virtual QString getDescription() const override
+  QString getDescription() const override
   { return "Replace features in a map with those from another map"; }
 
-  virtual QString getInitStatusMessage() const
+  QString getInitStatusMessage() const override
   { return "Replacing elements..."; }
 
-  virtual QString getCompletedStatusMessage() const
+  QString getCompletedStatusMessage() const override
   { return "Replaced " + QString::number(_numAffected) + " elements"; }
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/FindIntersectionsOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/FindIntersectionsOp.h
@@ -53,18 +53,18 @@ public:
   FindIntersectionsOp() = default;
   virtual ~FindIntersectionsOp() = default;
 
-  virtual void apply(std::shared_ptr<OsmMap>& map) override;
+  void apply(std::shared_ptr<OsmMap>& map) override;
 
-  virtual QString getDescription() const override { return "Identifies generic intersections"; }
+  QString getDescription() const override { return "Identifies generic intersections"; }
 
   /**
    *  Pure virtual function called by constructor to create the intersection visitor
    */
   virtual std::shared_ptr<FindIntersectionsVisitor> createVisitor() = 0;
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 /**
@@ -75,17 +75,17 @@ class FindHighwayIntersectionsOp : public FindIntersectionsOp
 public:
 
   FindHighwayIntersectionsOp() = default;
-  virtual ~FindHighwayIntersectionsOp() = default;
+  ~FindHighwayIntersectionsOp() = default;
 
   static QString className() { return "hoot::FindHighwayIntersectionsOp"; }
 
-  virtual QString getDescription() const override { return "Identifies highway intersections"; }
+  QString getDescription() const override { return "Identifies highway intersections"; }
 
-  virtual std::shared_ptr<FindIntersectionsVisitor> createVisitor();
+  std::shared_ptr<FindIntersectionsVisitor> createVisitor() override;
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 /**
@@ -96,17 +96,17 @@ class FindRailwayIntersectionsOp : public FindIntersectionsOp
 public:
 
   FindRailwayIntersectionsOp() = default;
-  virtual ~FindRailwayIntersectionsOp() = default;
+  ~FindRailwayIntersectionsOp() = default;
 
   static QString className() { return "hoot::FindRailwayIntersectionsOp"; }
 
-  virtual QString getDescription() const override { return "Identifies railway intersections"; }
+  QString getDescription() const override { return "Identifies railway intersections"; }
 
-  virtual std::shared_ptr<FindIntersectionsVisitor> createVisitor();
+  std::shared_ptr<FindIntersectionsVisitor> createVisitor() override;
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/ops/FindStreetIntersectionsByName.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/FindStreetIntersectionsByName.h
@@ -51,34 +51,34 @@ public:
   static QString className() { return "hoot::FindStreetIntersectionsByName"; }
 
   FindStreetIntersectionsByName() = default;
-  virtual ~FindStreetIntersectionsByName() = default;
+  ~FindStreetIntersectionsByName() = default;
 
-  virtual void apply(OsmMapPtr& map) override;
+  void apply(OsmMapPtr& map) override;
 
   /**
    * @see Configurable
    */
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
   /**
    * @see ApiEntityInfo
    */
-  virtual QString getDescription() const override
+  QString getDescription() const override
   { return "Locates street intersections by street name"; }
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
-
-  /**
-   * @see OperationStatus
-   */
-  virtual QString getInitStatusMessage() const { return "Locating street intersections..."; }
+  QString getClassName() const override { return className(); }
 
   /**
    * @see OperationStatus
    */
-  virtual QString getCompletedStatusMessage() const
+  QString getInitStatusMessage() const override { return "Locating street intersections..."; }
+
+  /**
+   * @see OperationStatus
+   */
+  QString getCompletedStatusMessage() const override
   {
     return
       "Located " + StringUtils::formatLargeNumber(_numAffected) +

--- a/hoot-core/src/main/cpp/hoot/core/ops/GeometryModifierOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/GeometryModifierOp.h
@@ -61,7 +61,7 @@ namespace hoot
   public:
 
     GeometryModifierOp();
-    virtual ~GeometryModifierOp() = default;
+    ~GeometryModifierOp() = default;
 
     // OsmMapOperation
     static QString className() { return "hoot::GeometryModifierOp"; }
@@ -72,16 +72,16 @@ namespace hoot
     void apply(std::shared_ptr<OsmMap>& map);
 
     // OperationStatus
-    virtual QString getInitStatusMessage() const { return "Modifying geometry..."; }
-    virtual QString getCompletedStatusMessage() const
+    QString getInitStatusMessage() const override { return "Modifying geometry..."; }
+    QString getCompletedStatusMessage() const override
     { return "Modified " + QString::number(_numAffected) + " elements"; }
 
     // Configurable
-    virtual void setConfiguration(const Settings& conf);
+    void setConfiguration(const Settings& conf) override;
 
-    virtual QString getName() const { return className(); }
+    QString getName() const override { return className(); }
 
-    virtual QString getClassName() const override { return className(); }
+    QString getClassName() const override { return className(); }
 
   private:
     // json rules file name

--- a/hoot-core/src/main/cpp/hoot/core/ops/HighwayImpliedDividedMarker.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/HighwayImpliedDividedMarker.h
@@ -58,7 +58,7 @@ public:
 
   HighwayImpliedDividedMarker() = default;
   HighwayImpliedDividedMarker(const std::shared_ptr<const OsmMap>& map) : _inputMap(map) { }
-  virtual ~HighwayImpliedDividedMarker() = default;
+  ~HighwayImpliedDividedMarker() = default;
 
   void apply(std::shared_ptr<OsmMap>& map);
 
@@ -69,13 +69,13 @@ public:
 
   std::shared_ptr<OsmMap> markDivided();
 
-  virtual QString getInitStatusMessage() const
+  QString getInitStatusMessage() const override
   { return "Marking road sections that appear to be divided highways..."; }
 
-  virtual QString getCompletedStatusMessage() const
+  QString getCompletedStatusMessage() const override
   { return "Marked " + QString::number(_numAffected) + " road sections as divided highways"; }
 
-  virtual QString getDescription() const
+  QString getDescription() const override
   { return "Marks road sections that implicitly appear to be divided highways"; }
 
   /**
@@ -84,11 +84,11 @@ public:
    * This isn't actually using HighwayCriterion in the filtering, but for the purposes of reducing
    * unnecessary conflate ops we don't need to run it unless we're running road conflation.
    */
-  virtual QStringList getCriteria() const;
+  QStringList getCriteria() const override;
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/IdSwapOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/IdSwapOp.h
@@ -63,26 +63,26 @@ public:
    */
   IdSwapOp(ElementId e1, ElementId e2) : _idSwap(new IdSwap(e1,e2)) { }
 
-  virtual ~IdSwapOp() = default;
+  ~IdSwapOp() = default;
 
   /**
    * @brief apply - Apply the IdSwap op
    * @param pMap - Target map
    */
-  virtual void apply(const std::shared_ptr<OsmMap>& map) override;
+  void apply(const std::shared_ptr<OsmMap>& map) override;
 
-  virtual QString getDescription() const override
+  QString getDescription() const override
   { return "Swap IDs for ID preservation in Attribute Conflation"; }
 
-  virtual QString getInitStatusMessage() const override
+  QString getInitStatusMessage() const override
   { return "Swapping IDs..."; }
 
-  virtual QString getCompletedStatusMessage() const override
+  QString getCompletedStatusMessage() const override
   { return "Swapped " + QString::number(_numAffected) + " IDs."; }
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
   /**

--- a/hoot-core/src/main/cpp/hoot/core/ops/ImmediatelyConnectedOutOfBoundsWayTagger.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/ImmediatelyConnectedOutOfBoundsWayTagger.h
@@ -53,35 +53,35 @@ public:
 
   ImmediatelyConnectedOutOfBoundsWayTagger();
   ImmediatelyConnectedOutOfBoundsWayTagger(const bool strictBounds);
-  virtual ~ImmediatelyConnectedOutOfBoundsWayTagger() = default;
+  ~ImmediatelyConnectedOutOfBoundsWayTagger() = default;
 
   /**
    * @see OsmMapOperation
    */
-  virtual void apply(OsmMapPtr& map);
+  void apply(OsmMapPtr& map) override;
 
   /**
    * @see Boundable
    */
-  virtual void setBounds(std::shared_ptr<geos::geom::Geometry> bounds) override
+  void setBounds(std::shared_ptr<geos::geom::Geometry> bounds) override
   { _boundsChecker.setBounds(bounds); }
 
   // Why must this be explicitly called once the
   // setBounds(std::shared_ptr<geos::geom::Geometry> bounds) version is overridden to avoid compiler
   // errors?
-  virtual void setBounds(const geos::geom::Envelope& bounds) override
+  void setBounds(const geos::geom::Envelope& bounds) override
   { Boundable::setBounds(bounds); }
 
   /**
    * @see OperationStatus
    */
-  virtual QString getInitStatusMessage() const
+  QString getInitStatusMessage() const override
   { return "Adding tags to immediately connected out of bounds ways..."; }
 
   /**
    * @see OperationStatus
    */
-  virtual QString getCompletedStatusMessage() const
+  QString getCompletedStatusMessage() const override
   {
     return
       "Added " + StringUtils::formatLargeNumber(_numAffected) + " tags out of " +
@@ -91,7 +91,7 @@ public:
   /**
    * @see ApiEntityInfo
    */
-  virtual QString getDescription() const
+  QString getDescription() const override
   {
     return
       "Tags ways outside of a bounds but immediately connected to ways that cross the bounds";
@@ -99,9 +99,9 @@ public:
 
   long getNumTagged() const { return _numAffected; }
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/ManualMatchValidator.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/ManualMatchValidator.h
@@ -56,21 +56,21 @@ public:
   static QString className() { return "hoot::ManualMatchValidator"; }
 
   ManualMatchValidator();
-  virtual ~ManualMatchValidator() = default;
+  ~ManualMatchValidator() = default;
 
   /**
    * Validates all manual matches in the map and records the first error found for each element
    *
    * @param map
    */
-  virtual void apply(const OsmMapPtr& map);
+  void apply(const OsmMapPtr& map) override;
 
-  virtual QString getDescription() const { return "Validates manual matches"; }
+  QString getDescription() const override { return "Validates manual matches"; }
 
-  virtual QString getInitStatusMessage() const
+  QString getInitStatusMessage() const override
   { return "Validating manual matches..."; }
 
-  virtual QString getCompletedStatusMessage() const
+  QString getCompletedStatusMessage() const override
   { return "Validated " + QString::number(_numAffected) + " manual matches"; }
 
   /**
@@ -105,9 +105,9 @@ public:
   void setAllowUuidManualMatchIds(bool allow) { _allowUuidManualMatchIds = allow; }
   void setFullDebugOutput(bool fullDebugOutput) { _fullDebugOutput = fullDebugOutput; }
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/MapCleaner.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/MapCleaner.h
@@ -52,15 +52,15 @@ public:
 
   MapCleaner() = default;
   MapCleaner(const Progress& progress) : _progress(progress) { }
-  virtual ~MapCleaner() = default;
+  ~MapCleaner() = default;
 
-  virtual void apply(std::shared_ptr<OsmMap>& map) override;
+  void apply(std::shared_ptr<OsmMap>& map) override;
 
-  virtual QString getDescription() const override { return "Cleans map data"; }
+  QString getDescription() const override { return "Cleans map data"; }
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/MapCropper.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/MapCropper.h
@@ -59,21 +59,21 @@ public:
   static QString className() { return "hoot::MapCropper"; }
 
   MapCropper();
-  virtual ~MapCropper() = default;
+  ~MapCropper() = default;
 
-  virtual void apply(std::shared_ptr<OsmMap>& map);
+  void apply(std::shared_ptr<OsmMap>& map) override;
 
-  virtual void setConfiguration(const Settings& conf) override;
+  void setConfiguration(const Settings& conf) override;
 
-  virtual QString getName() const override { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
-  virtual QString getDescription() const override { return "Crops a map"; }
+  QString getDescription() const override { return "Crops a map"; }
 
-  virtual QString getInitStatusMessage() const override;
+  QString getInitStatusMessage() const override;
 
-  virtual QString getCompletedStatusMessage() const override
+  QString getCompletedStatusMessage() const override
   {
     return
       "Cropped " + StringUtils::formatLargeNumber(_numAffected) + " / " +

--- a/hoot-core/src/main/cpp/hoot/core/ops/MetadataExport.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/MetadataExport.h
@@ -65,19 +65,19 @@ public:
   static QString className() { return "hoot::MetadataExport"; }
 
   MetadataExport() = default;
-  virtual ~MetadataExport() = default;
+  ~MetadataExport() = default;
 
   // OsmMapOperation
-  virtual QString getDescription() const override { return "Creates and exports metadata"; }
+  QString getDescription() const override { return "Creates and exports metadata"; }
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 
   // MetadataOp
-  virtual void _apply();
+  void _apply() override;
 
   // private data
   QList<WayPtr> _modifiedDatasets;

--- a/hoot-core/src/main/cpp/hoot/core/ops/MetadataImport.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/MetadataImport.h
@@ -69,19 +69,19 @@ public:
   static QString className() { return "hoot::MetadataImport"; }
 
   MetadataImport() = default;
-  virtual ~MetadataImport() = default;
+  ~MetadataImport() = default;
 
   // OsmMapOperation
-  virtual QString getDescription() const override { return "Imports metadata"; }
+  QString getDescription() const override { return "Imports metadata"; }
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 private:
 
   // MetadataOp
-  virtual void _apply();
+  void _apply() override;
 
   // process sequence functions
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/MetadataOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/MetadataOp.h
@@ -60,19 +60,19 @@ public:
   virtual ~MetadataOp() = default;
 
   // OsmMapOperation
-  virtual void apply(std::shared_ptr<OsmMap>& pMap) override;
+  void apply(std::shared_ptr<OsmMap>& pMap) override;
 
   // OperationStatus
-  virtual QString getInitStatusMessage() const { return "Processing metadata..."; }
-  virtual QString getCompletedStatusMessage() const
+  QString getInitStatusMessage() const override { return "Processing metadata..."; }
+  QString getCompletedStatusMessage() const override
   { return "Modified " + QString::number(_numAffected) + " elements"; }
 
   // Configurable
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
-  virtual QString getName() const { return className(); }
+  QString getName() const override { return className(); }
 
-  virtual QString getClassName() const override { return className(); }
+  QString getClassName() const override { return className(); }
 
 protected:
 


### PR DESCRIPTION
Override should be used instead of virtual for derived functions

Refs #4561 