### PR TITLE
Run to OGR translations streaming by default

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -1143,14 +1143,6 @@ less confident matches.
 
 ID of the node that ContainsNodeCriterion should search for.
 
-=== convert.require.area.for.polygon
-
-* Data Type: bool
-* Default Value: `true`
-
-If true, an element must be classifiable as an area geometry in the Hootenanny schema in order to
-be converted to a GEOS polygon.
-
 === convert.ops
 
 * Data Type: list
@@ -1160,6 +1152,22 @@ be converted to a GEOS polygon.
 Specifies one or more semi-colon delimited map operations or visitors to apply before writing
 converted data.  This is only applicable to the convert command. 'hoot info --operators' displays
 information about the available operations.
+
+=== convert.require.area.for.polygon
+
+* Data Type: bool
+* Default Value: `true`
+
+If true, an element must be classifiable as an area geometry in the Hootenanny schema in order to
+be converted to a GEOS polygon.
+
+=== convert.translate.multithreaded
+
+* Data Type: bool
+* Default Value: `false`
+
+If enabled calling the convert command with a translation script will run a separate thread for
+translating. Multi-threaded translation is memory bound.
 
 === cookie.cutter.alpha
 

--- a/docs/user/SupportedDataFormats.asciidoc
+++ b/docs/user/SupportedDataFormats.asciidoc
@@ -37,6 +37,7 @@
 
 * (M1) = format requires reading entire dataset into memory during processing
 * (M2) = format requires reading entire dataset into memory during processing only if element ID output needs to remain sorted
+* If both the input being read from and written to are OGR formats, the operation will be memory bound.
 * All data read with a specified bounding box filter requires reading the entire dataset into memory during processing.
 
 All Hootenanny commands can be passed any supported input/output format unless otherwise stated in the command's documentation. See the Hootenanny User Guide for details.

--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.cpp
@@ -375,7 +375,6 @@ void DataConverter::_transToOgrMT(const QStringList& inputs, const QString& outp
     LOG_DEBUG("Reading: " << input);
 
     // Read all elements from an input
-    // TODO: We should figure out a way to make this not-memory bound in the future.
     _fillElementCache(input, pElementCache, elementQ);
   }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.cpp
@@ -45,6 +45,7 @@
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/StringUtils.h>
+#include <hoot/core/schema/SchemaUtils.h>
 #include <hoot/core/visitors/ElementVisitor.h>
 #include <hoot/core/visitors/ProjectToGeographicVisitor.h>
 #include <hoot/core/visitors/RemoveDuplicateWayNodesVisitor.h>
@@ -172,6 +173,7 @@ void ogrWriterThread::run()
 int DataConverter::logWarnCount = 0;
 
 DataConverter::DataConverter() :
+_translateMultithreaded(false),
 _ogrFeatureReadLimit(0),
 _printLengthMax(ConfigOptions().getProgressVarPrintLengthMax())
 {
@@ -179,17 +181,11 @@ _printLengthMax(ConfigOptions().getProgressVarPrintLengthMax())
 
 void DataConverter::setTranslation(const QString& translation)
 {
-  QFileInfo fileInfo(translation);
-  if (!fileInfo.exists())
+  if (!translation.isEmpty())
   {
-    throw IllegalArgumentException("Translation file does not exist: " + translation);
+    SchemaUtils::validateTranslationUrl(translation);
+    _translation = translation;
   }
-  else if (!translation.endsWith(".js") && !translation.endsWith(".py"))
-  {
-    throw IllegalArgumentException("Invalid translation file format: " + translation);
-  }
-
-  _translation = translation;
 }
 
 void DataConverter::setConfiguration(const Settings& conf)
@@ -206,7 +202,7 @@ void DataConverter::setConfiguration(const Settings& conf)
     setTranslation(config.getSchemaTranslationScript());
   }
   _translationDirection = config.getSchemaTranslationDirection().trimmed().toLower();
-  LOG_VARD(_convertOps);
+  _translateMultithreaded = config.getConvertTranslateMultithreaded();
 }
 
 void DataConverter::convert(const QString& input, const QString& output)
@@ -227,17 +223,12 @@ void DataConverter::convert(const QStringList& inputs, const QString& output)
     "Converting ..." + inputs.join(", ").right(_printLengthMax) + " to ..." +
     output.right(_printLengthMax) + "...");
 
-  // Due to the custom multithreading available for OGR reading, the fact that both OGR reading and
-  // writing do their translations inline (don't use SchemaTranslationOp or
-  // SchemaTranslationVisitor), and OGR reading support for layer names, conversions involving OGR
-  // data must follow a separate logic path from non-OGR data. It would be nice at some point to be
-  // able to do everything generically from within the _convert method.
-
-  // We require that a translation be present when converting to OGR, the translation direction be
-  // to OGR or unspecified, and that only one input is specified.
-  if (IoUtils::isSupportedOgrFormat(output, true) &&
-      !_translation.isEmpty() &&
-      (_translationDirection.isEmpty() || _translationDirection == "toogr"))
+  // There is a custom code path for converting to OGR formats where the schema translation runs
+  // in a separate thread. The code path is memory bound and configurable. Also if both input and
+  // output formats are OGR formats, a memory bound conversion must also be done.
+  if ((IoUtils::isSupportedOgrFormat(output, true) && _translateMultithreaded) ||
+      (IoUtils::areSupportedOgrFormats(inputs, true) &&
+       IoUtils::isSupportedOgrFormat(output, true)))
   {
     _convertToOgr(inputs, output);
   }
@@ -249,15 +240,11 @@ void DataConverter::convert(const QStringList& inputs, const QString& output)
   {
     _convertFromOgr(inputs, output);
   }
-  // If this wasn't a to/from OGR conversion, or no translation was specified, or a translation
-  // direction different than what was expected for the input/output formats was specified, just
-  // call the generic convert routine. If no translation direction was specified, we'll try to guess
-  // it and let the user know that we did.
-  //
-  // Note that it still is possible an OGR format can go in here, if you didn't specify a
-  // translation. That seems a little odd and maybe worth rethinking. Most the time you are going to
-  // be specifying a translation when dealing with OGR formats, but if you're doing an additional
-  // conversion on a data file after an initial one you might not specify a translation.
+  // If this wasn't a to/from OGR conversion, multi-threaded translation was disable, no translation
+  // was specified, or a translation direction different than what was expected for the input/output
+  // formats was specified, we'll call the generic convert routine. If no translation direction was
+  // specified, we'll try to guess it and let the user know that we did. Note that it still is
+  // possible an OGR format can go in here, if you didn't specify a translation.
   else
   {
     _convert(inputs, output);
@@ -388,7 +375,7 @@ void DataConverter::_transToOgrMT(const QStringList& inputs, const QString& outp
     LOG_DEBUG("Reading: " << input);
 
     // Read all elements from an input
-    // TODO: We should figure out a way to make this not-memory bound in the future
+    // TODO: We should figure out a way to make this not-memory bound in the future.
     _fillElementCache(input, pElementCache, elementQ);
   }
 
@@ -427,7 +414,7 @@ void DataConverter::_transToOgrMT(const QStringList& inputs, const QString& outp
 
 void DataConverter::_convertToOgr(const QStringList& inputs, const QString& output)
 {
-  LOG_DEBUG("_convertToOgr (formerly known as osm2ogr)");
+  LOG_DEBUG("_convertToOgr");
 
   // This code path has always assumed translation to OGR and never reads the direction, but let's
   // warn callers that the opposite direction they specified won't be used.
@@ -438,9 +425,9 @@ void DataConverter::_convertToOgr(const QStringList& inputs, const QString& outp
       "OGR output...");
   }
 
-  // Set a config option so the translation script knows what the output format is
-  // For this, output format == file extension
-  // We are going to grab everything after the last "." in the output file name and use it as the file extension
+  // Set a config option so the translation script knows what the output format is. For this,
+  // output format == file extension. We are going to grab everything after the last "." in the
+  // output file name and use it as the file extension.
   QString outputFormat = "";
   if (output.lastIndexOf(".") > -1)
   {
@@ -450,21 +437,16 @@ void DataConverter::_convertToOgr(const QStringList& inputs, const QString& outp
 
   LOG_DEBUG(conf().getString(ConfigOptions::getOgrOutputFormatKey()));
 
-
   // Translation for going to OGR is always required and happens in the writer itself. It is not to
   // be done with convert ops, so let's ignore any translation ops that were specified.
   _convertOps.removeAll(SchemaTranslationOp::className());
   _convertOps.removeAll(SchemaTranslationVisitor::className());
   LOG_VARD(_convertOps);
 
-  //check to see if all of the i/o can be streamed
+  // check to see if all of the i/o can be streamed
   LOG_VARD(OsmMapReaderFactory::hasElementInputStream(inputs));
-
   if (OsmMapReaderFactory::hasElementInputStream(inputs) &&
       // multithreaded code doesn't support conversion ops. could it?
-      // TODO: if we have a single convert op that is a SchemaTranslationOp or
-      // SchemaTranslationVisitor should we pop it off and then run multithreaded with that
-      // translation?...seems like we should
       _convertOps.empty() &&
       // multithreaded code doesn't support a bounds...not sure if it could be made to at some point
       !ConfigUtils::boundsOptionEnabled())
@@ -659,7 +641,7 @@ void DataConverter::_setFromOgrOptions()
 
 void DataConverter::_convertFromOgr(const QStringList& inputs, const QString& output)
 {
-  LOG_DEBUG("_convertFromOgr (formerly known as ogr2osm)");
+  LOG_DEBUG("_convertFromOgr");
 
   QElapsedTimer timer;
   timer.start();
@@ -692,7 +674,6 @@ void DataConverter::_convertFromOgr(const QStringList& inputs, const QString& ou
   _setFromOgrOptions();
   // Inclined to do this: _convertOps.removeDuplicates();, but there could be some workflows where
   // the same op needs to be called more than once.
-  //
   LOG_VARD(_convertOps);
 
   // The number of task steps here must be updated as you add/remove job steps in the logic.
@@ -769,40 +750,33 @@ void DataConverter::_convertFromOgr(const QStringList& inputs, const QString& ou
   currentTask++;
 }
 
-void DataConverter::_handleGeneralConvertTranslationOpts(const QString& output)
+void DataConverter::_setToOgrOptions(const QString& output)
 {
-  //For non OGR conversions, the translation must be passed in as an op.
-  if (!_translation.trimmed().isEmpty())
+  // This code path has always assumed translation to OGR and never reads the direction, but let's
+  // warn callers that the opposite direction they specified won't be used.
+  if (_translationDirection == "toosm")
   {
-    //a previous check was done to make sure both a translation and export cols weren't specified
-    assert(!_shapeFileColumnsSpecified());
-
-    if (!_convertOps.contains(SchemaTranslationOp::className()) &&
-        !_convertOps.contains(SchemaTranslationVisitor::className()))
-    {
-      // If a translation script was specified but not the translation op, we'll add auto add the op
-      // as the first conversion operation. If the caller wants the translation done after some
-      // other op, then they need to explicitly add it to the op list. Always adding the visitor
-      // instead of the op, bc its streamable. However, if any other ops in the group aren't
-      // streamable it won't matter anyway.
-      _convertOps.prepend(SchemaTranslationVisitor::className());
-    }
-    else if (_convertOps.contains(SchemaTranslationOp::className()))
-    {
-      // replacing SchemaTranslationOp with SchemaTranslationVisitor for the reason mentioned above
-      _convertOps.replaceInStrings(
-        SchemaTranslationOp::className(), SchemaTranslationVisitor::className());
-    }
-    LOG_VARD(_convertOps);
-
-    // If the translation direction wasn't specified, try to guess it.
-    if (_translationDirection.isEmpty())
-    {
-      _translationDirection = _outputFormatToTranslationDirection(output);
-      // This gets read by the TranslationVisitor and cannot be empty.
-      conf().set(ConfigOptions::getSchemaTranslationDirectionKey(), _translationDirection);
-    }
+    LOG_INFO(
+      "Ignoring specified schema.translation.direction=toosm and using toogr to write to " <<
+      "OGR output...");
   }
+
+  // Set a config option so the translation script knows what the output format is. For this,
+  // output format == file extension. We are going to grab everything after the last "." in the
+  // output file name and use it as the file extension.
+  QString outputFormat = "";
+  if (output.lastIndexOf(".") > -1)
+  {
+    outputFormat = output.right(output.size() - output.lastIndexOf(".") - 1).toLower();
+  }
+  conf().set(ConfigOptions::getOgrOutputFormatKey(), outputFormat);
+
+  LOG_DEBUG(conf().getString(ConfigOptions::getOgrOutputFormatKey()));
+
+  // Translation for going to OGR is always required and happens in the writer itself. It is not to
+  // be done with convert ops, so let's ignore any translation ops that were specified.
+  _convertOps.removeAll(SchemaTranslationOp::className());
+  _convertOps.removeAll(SchemaTranslationVisitor::className());
 }
 
 QString DataConverter::_outputFormatToTranslationDirection(const QString& output) const
@@ -838,9 +812,25 @@ void DataConverter::_convert(const QStringList& inputs, const QString& output)
     _setFromOgrOptions();
   }
 
-  _handleGeneralConvertTranslationOpts(output);
+  // If the translation direction wasn't specified, try to guess it.
+  if (!_translation.trimmed().isEmpty() && _translationDirection.isEmpty())
+  {
+    _translationDirection = _outputFormatToTranslationDirection(output);
+    // This gets read by the TranslationVisitor and cannot be empty.
+    conf().set(ConfigOptions::getSchemaTranslationDirectionKey(), _translationDirection);
+  }
+
+  LOG_VARD(IoUtils::isSupportedOgrFormat(output, true));
+  if (IoUtils::isSupportedOgrFormat(output, true))
+  {
+    _setToOgrOptions(output);
+  }
+
+  LOG_VARD(_shapeFileColumnsSpecified());
 
   //check to see if all of the i/o can be streamed
+  LOG_VARD(ElementStreamer::areValidStreamingOps(_convertOps));
+  LOG_VARD(ElementStreamer::areStreamableIo(inputs, output));
   const bool isStreamable =
     ElementStreamer::areValidStreamingOps(_convertOps) &&
     ElementStreamer::areStreamableIo(inputs, output);
@@ -930,7 +920,7 @@ void DataConverter::_convert(const QStringList& inputs, const QString& output)
 void DataConverter::_exportToShapeWithCols(const QString& output, const QStringList& cols,
                                            const OsmMapPtr& map)
 {
-  LOG_DEBUG("_exportToShapeWithCols (formerly known as osm2shp)");
+  LOG_DEBUG("_exportToShapeWithCols");
 
   QElapsedTimer timer;
   timer.start();

--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
@@ -154,6 +154,8 @@ private:
   // sets ogr options only for _convert
   void _setFromOgrOptions();
   void _setToOgrOptions(const QString& output);
+  // This handles configures translations options correctly for non-OGR outputs.
+  void _handleNonOgrOutputTranslationOpts();
   QString _outputFormatToTranslationDirection(const QString& output) const;
   // If specific columns were specified for export to a shape file, then this is called.
   void _exportToShapeWithCols(const QString& output, const QStringList& cols, const OsmMapPtr& map);

--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
@@ -133,26 +133,30 @@ private:
 
   void _validateInput(const QStringList& inputs, const QString& output);
 
-  // converts from any input to an OGR output; a translation is required; operations are memory
-  // bound
+  // converts from any input to an OGR output; A translation is required, operations are memory
+  // bound, and if both input and output formats are OGR, this must be used.
   void _convertToOgr(const QStringList& inputs, const QString& output);
 
   // _convertToOgr will call this to run the translator in a separate thread for a performance
   // increase if certain pre-conditions are met.
   void _transToOgrMT(const QStringList& inputs, const QString& output);
+  void _fillElementCache(const QString& inputUrl, ElementCachePtr cachePtr,
+                         QQueue<ElementPtr>& workQ);
 
   // converts from an OGR input to any output; a translation is required
   void _convertFromOgr(const QStringList& inputs, const QString& output);
 
-  // This handles all conversions not done by _convertToOgr or _convertFromOgr.
+  /*
+   * This method handles all conversions including OGR conversions not done by _convertToOgr or
+   * _convertFromOgr. OGR conversions performed by this method will not be memory bound.
+   */
   void _convert(const QStringList& inputs, const QString& output);
+  // sets ogr options only for _convert
+  void _setFromOgrOptions();
   void _setToOgrOptions(const QString& output);
   QString _outputFormatToTranslationDirection(const QString& output) const;
   // If specific columns were specified for export to a shape file, then this is called.
   void _exportToShapeWithCols(const QString& output, const QStringList& cols, const OsmMapPtr& map);
-
-  void _fillElementCache(const QString& inputUrl, ElementCachePtr cachePtr,
-                         QQueue<ElementPtr>& workQ);
 
   /*
    * Attempts to determine the relative weighting of each layer in an OGR data source based on
@@ -164,8 +168,6 @@ private:
   QStringList _getOgrLayersFromPath(OgrReader& reader, QString& input);
 
   bool _shapeFileColumnsSpecified() { return !_shapeFileColumns.isEmpty(); }
-
-  void _setFromOgrOptions();
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
@@ -123,6 +123,7 @@ private:
 
   QString _translation;
   QString _translationDirection;
+  bool _translateMultithreaded;
   QStringList _shapeFileColumns;
   int _ogrFeatureReadLimit;
   QStringList _convertOps;
@@ -132,7 +133,8 @@ private:
 
   void _validateInput(const QStringList& inputs, const QString& output);
 
-  // converts from any input to an OGR output; a translation is required
+  // converts from any input to an OGR output; a translation is required; operations are memory
+  // bound
   void _convertToOgr(const QStringList& inputs, const QString& output);
 
   // _convertToOgr will call this to run the translator in a separate thread for a performance
@@ -144,7 +146,7 @@ private:
 
   // This handles all conversions not done by _convertToOgr or _convertFromOgr.
   void _convert(const QStringList& inputs, const QString& output);
-  void _handleGeneralConvertTranslationOpts(const QString& output);
+  void _setToOgrOptions(const QString& output);
   QString _outputFormatToTranslationDirection(const QString& output) const;
   // If specific columns were specified for export to a shape file, then this is called.
   void _exportToShapeWithCols(const QString& output, const QStringList& cols, const OsmMapPtr& map);

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.cpp
@@ -80,7 +80,7 @@ bool ElementStreamer::areStreamableIo(const QStringList& inputs, const QString& 
     {
       LOG_INFO(
         "Unable to stream I/O due to input: " << inputs.at(i).right(25) << " and/or output: " <<
-        output.right(25) << ". Loading entire map...");
+        output.right(25) << ". Loading entire map into memory...");
       return false;
     }
   }

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -63,6 +63,7 @@
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/geometry/ElementToGeometryConverter.h>
 #include <hoot/core/util/Factory.h>
+#include <hoot/core/util/StringUtils.h>
 #include <hoot/core/elements/MapProjector.h>
 #include <hoot/core/schema/MetadataTags.h>
 #include <hoot/core/util/Settings.h>
@@ -95,13 +96,15 @@ static OGRFieldType toOgrFieldType(QVariant::Type t)
 }
 
 OgrWriter::OgrWriter():
-  _elementCache(
-    new ElementCacheLRU(
-      ConfigOptions().getElementCacheSizeNode(),
-      ConfigOptions().getElementCacheSizeWay(),
-      ConfigOptions().getElementCacheSizeRelation())),
-  _wgs84(),
-  _failOnSkipRelation(false)
+_elementCache(
+  new ElementCacheLRU(
+    ConfigOptions().getElementCacheSizeNode(),
+    ConfigOptions().getElementCacheSizeWay(),
+    ConfigOptions().getElementCacheSizeRelation())),
+_wgs84(),
+_failOnSkipRelation(false),
+_numWritten(0),
+_statusUpdateInterval(ConfigOptions().getTaskStatusUpdateInterval() * 10)
 {
   setConfiguration(conf());
 
@@ -109,123 +112,86 @@ OgrWriter::OgrWriter():
   _wgs84.SetWellKnownGeogCS("WGS84");
 }
 
-void OgrWriter::_addFeature(OGRLayer* layer, const std::shared_ptr<Feature>& f,
-                            const std::shared_ptr<Geometry>& g)
+void OgrWriter::setConfiguration(const Settings& conf)
 {
-  OGRFeature* poFeature = OGRFeature::CreateFeature( layer->GetLayerDefn() );
+  ConfigOptions configOptions(conf);
+  setCreateAllLayers(configOptions.getOgrWriterCreateAllLayers());
+  setSchemaTranslationScript(configOptions.getOgrWriterScript());
+  setPrependLayerName(configOptions.getOgrWriterPreLayerName());
 
-  // set all the column values.
-  const QVariantMap& vm = f->getValues();
-
-  for (QVariantMap::const_iterator it = vm.constBegin(); it != vm.constEnd(); ++it)
+  _appendData = configOptions.getOgrAppendData();
+  QString strictStr = configOptions.getOgrStrictChecking();
+  if (strictStr == "on")
   {
-    const QVariant& v = it.value();
-    QByteArray ba = it.key().toUtf8();
-
-    // If the field DOESN'T exist in the output layer, skip it.
-    if (poFeature->GetFieldIndex(ba.constData()) == -1)
-    {
-      continue;
-    }
-
-    switch (v.type())
-    {
-    case QVariant::Invalid:
-      poFeature->UnsetField(poFeature->GetFieldIndex(ba.constData()));
-      break;
-    case QVariant::Int:
-      poFeature->SetField(ba.constData(), v.toInt());
-      break;
-    case QVariant::LongLong:
-      poFeature->SetField(ba.constData(), v.toLongLong());
-      break;
-    case QVariant::Double:
-      poFeature->SetField(ba.constData(), v.toDouble());
-      break;
-    case QVariant::String:
-    {
-      QByteArray vba = v.toString().toUtf8();
-
-      int fieldWidth =
-        poFeature->GetFieldDefnRef(poFeature->GetFieldIndex(ba.constData()))->GetWidth();
-
-      if (vba.length() > fieldWidth && fieldWidth > 0)
-      {
-        if (logWarnCount < Log::getWarnMessageLimit())
-        {
-          LOG_WARN(
-            "Truncating the " << it.key() << " attribute (" << vba.length() <<
-            " characters) to the output field width (" << fieldWidth << " characters).");
-        }
-        else if (logWarnCount == Log::getWarnMessageLimit())
-        {
-          LOG_WARN(className() << ": " << Log::LOG_WARN_LIMIT_REACHED_MESSAGE);
-        }
-        logWarnCount++;
-
-        vba.truncate(fieldWidth);
-      }
-
-      poFeature->SetField(ba.constData(), vba.constData());
-      break;
-    }
-    default:
-      strictError("Can't convert the provided value into an OGR value. (" + v.toString() + ")");
-      return;
-    }
+    _strictChecking = StrictOn;
   }
-
-  // convert the geometry.
-  std::shared_ptr<GeometryCollection> gc = std::dynamic_pointer_cast<GeometryCollection>(g);
-  if (gc.get() != nullptr)
+  else if (strictStr == "off")
   {
-    for (size_t i = 0; i < gc->getNumGeometries(); i++)
-    {
-      const Geometry* child = gc->getGeometryN(i);
-      _addFeatureToLayer(layer, f, child, poFeature);
-    }
+    _strictChecking = StrictOff;
+  }
+  else if (strictStr == "warn")
+  {
+    _strictChecking = StrictWarn;
   }
   else
   {
-    _addFeatureToLayer(layer, f, g.get(), poFeature);
+    throw HootException("Error setting strict checking. Expected on/off/warn. got: " + strictStr);
   }
 
-  OGRFeature::DestroyFeature(poFeature);
+  _statusUpdateInterval = configOptions.getTaskStatusUpdateInterval() * 10;
 }
 
-void OgrWriter::_addFeatureToLayer(OGRLayer* layer, const std::shared_ptr<Feature>& f,
-                                   const Geometry* g, OGRFeature* poFeature)
+void OgrWriter::setCacheCapacity(const unsigned long maxNodes, const unsigned long maxWays,
+                                 const unsigned long maxRelations)
 {
-  std::string wkt = g->toString();
-  char* t = (char*)wkt.data();
-  OGRGeometry* geom;
-  int errCode = OGRGeometryFactory::createFromWkt(&t, layer->GetSpatialRef(), &geom) ;
-  if (errCode != OGRERR_NONE)
+  _elementCache.reset();
+  _elementCache =
+    std::shared_ptr<ElementCache>(new ElementCacheLRU(maxNodes, maxWays, maxRelations));
+}
+
+void OgrWriter::strictError(const QString& warning)
+{
+  if (_strictChecking == StrictOn)
   {
-    throw HootException(
-      QString("Error parsing WKT (%1).  OGR Error Code: (%2)")
-        .arg(QString::fromStdString(wkt))
-        .arg(QString::number(errCode)));
+    throw HootException(warning);
   }
-
-  errCode = poFeature->SetGeometryDirectly(geom);
-  if (errCode != OGRERR_NONE)
+  else if (_strictChecking == StrictWarn)
   {
-    throw HootException(
-      QString("Error setting geometry - OGR Error Code: (%1)  Geometry: (%2)")
-        .arg(QString::number(errCode)).arg(QString::fromStdString(g->toString())));
+    LOG_WARN(warning);
   }
+}
 
-  // Unsetting the FID with SetFID(-1) before calling CreateFeature() to avoid reusing the same
-  // feature object for sequential insertions
-  poFeature->SetFID(-1);
+void OgrWriter::open(const QString& url)
+{
+  _numWritten = 0;
 
-  errCode = layer->CreateFeature(poFeature);
-  if (errCode != OGRERR_NONE)
+  // Initialize our translator - this will load the schema
+  initTranslator();
+
+  // Open output dataset
+  openOutput(url);
+
+  // Create all layers if _createAllLayers flag
+  createAllLayers();
+}
+
+void OgrWriter::openOutput(const QString& url)
+{
+  try
   {
-    throw HootException(
-      QString("Error creating feature - OGR Error Code: (%1) \nFeature causing error: (%2)")
-        .arg(QString::number(errCode)).arg(f->toString()));
+    _ds = OgrUtilities::getInstance().openDataSource(url, false);
+  }
+  catch(const HootException& openException)
+  {
+    try
+    {
+      _ds = OgrUtilities::getInstance().createDataSource(url);
+    }
+    catch(const HootException& createException)
+    {
+      throw HootException(QString("Error opening or creating data source. Opening error: \"%1\" "
+        "Creating error: \"%2\"").arg(openException.what()).arg(createException.what()));
+    }
   }
 }
 
@@ -236,166 +202,14 @@ void OgrWriter::close()
   _ds.reset();
 }
 
-void OgrWriter::_createLayer(const std::shared_ptr<const Layer>& layer)
-{
-  OGRLayer *poLayer;
-
-  OGRwkbGeometryType gtype;
-  switch(layer->getGeometryType())
-  {
-  case GEOS_POINT:
-    gtype = wkbPoint;
-    break;
-  case GEOS_LINESTRING:
-    gtype = wkbLineString;
-    break;
-  case GEOS_POLYGON:
-    gtype = wkbPolygon;
-    break;
-  default:
-    throw HootException("Unexpected geometry type.");
-  }
-
-  OgrOptions options;
-  if (_ds->GetDriver())
-  {
-    QString name = _ds->GetDriverName();
-    // if this is a CSV file
-    if (name == QString("CSV"))
-    {
-      // if we're exporting point data, then export with x/y at the front
-      if (gtype == wkbPoint)
-      {
-        options["GEOMETRY"] = "AS_XY";
-      }
-      // if we're exporting other geometries then export w/ WKT at the front.
-      else
-      {
-        options["GEOMETRY"] = "AS_WKT";
-      }
-      options["CREATE_CSVT"] = "YES";
-    }
-
-    if (name == QString("ESRI Shapefile"))
-    {
-      options["ENCODING"] = "UTF-8";
-      _maxFieldWidth = 254; // Shapefile DBF limit
-    }
-
-    // Add a Feature Dataset to a ESRI File GeoDatabase if requested
-    if (name == QString("FileGDB"))
-    {
-      if (layer->getFdName() != "")
-      {
-        options["FEATURE_DATASET"] = layer->getFdName();
-        // speed up bulk inserts.
-        // NOTE: Seems to be depreciated in GDAL 2.0+
-        //options["FGDB_BULK_LOAD"] = "YES";
-      }
-    }
-  }
-
-  QString layerName = _prependLayerName + layer->getName();
-  poLayer = _ds->GetLayerByName(layerName.toStdString().c_str());
-
-  // We only want to add to a layer IFF the config option "ogr.append.data" set
-  if (poLayer != nullptr && _appendData)
-  {
-    // Layer exists
-    _layers[layer->getName()] = poLayer;
-    // Loop through the fields making sure that they exist in the output. Print a warning if
-    // they don't exist
-    OGRFeatureDefn *poFDefn = poLayer->GetLayerDefn();
-    std::shared_ptr<const FeatureDefinition> fd = layer->getFeatureDefinition();
-
-
-    for (size_t i = 0; i < fd->getFieldCount(); i++)
-    {
-      std::shared_ptr<const FieldDefinition> f = fd->getFieldDefinition(i);
-
-      if (poFDefn->GetFieldIndex(f->getName().toLatin1()) == -1)
-      {
-        if (logWarnCount < Log::getWarnMessageLimit())
-        {
-          LOG_WARN("Unable to find field: " << QString(f->getName()) << " in layer " << layerName);
-        }
-        else if (logWarnCount == Log::getWarnMessageLimit())
-        {
-          LOG_WARN(className() << ": " << Log::LOG_WARN_LIMIT_REACHED_MESSAGE);
-        }
-        logWarnCount++;
-      }
-    }
-  }
-  else
-  {
-    LOG_DEBUG("Layer: " << layerName << " not found.  Creating layer...");
-    std::shared_ptr<OGRSpatialReference> projection = MapProjector::createWgs84Projection();
-    poLayer = _ds->CreateLayer(layerName.toLatin1(), projection.get(),
-                  gtype, options.getCrypticOptions());
-
-    if (poLayer == nullptr)
-    {
-      throw HootException(QString("Layer creation failed. %1").arg(layerName));
-    }
-    _layers[layer->getName()] = poLayer;
-    _projections[layer->getName()] = projection;
-
-    std::shared_ptr<const FeatureDefinition> fd = layer->getFeatureDefinition();
-    for (size_t i = 0; i < fd->getFieldCount(); i++)
-    {
-      std::shared_ptr<const FieldDefinition> f = fd->getFieldDefinition(i);
-      OGRFieldDefn oField(f->getName().toLatin1(), toOgrFieldType(f->getType()));
-
-      // Fix the field length but only for Strings
-      if (oField.GetType() == OFTString)
-      {
-        // If the schema sets a field width then use it.
-        if (f->getWidth() > 0)
-        {
-          oField.SetWidth(f->getWidth());
-        }
-        else if (_maxFieldWidth > 0) // Looking at you Shapefile.....
-        {
-          oField.SetWidth(_maxFieldWidth);
-        }
-      }
-
-      int errCode = poLayer->CreateField(&oField);
-      if (errCode != OGRERR_NONE)
-      {
-        throw HootException(
-          QString("Error creating field (%1)  OGR Error Code: (%2).")
-            .arg(f->getName()).arg(QString::number(errCode)));
-      }
-    }
-  } // End layer does not exist
-}
-
-OGRLayer* OgrWriter::_getLayer(const QString& layerName)
-{
-  if (!_layers.contains(layerName))
-  {
-    if (!_schema->hasLayer(layerName))
-    {
-      strictError("Layer specified is not part of the schema. (" + layerName + ")");
-      return nullptr;
-    }
-    else
-    {
-      _createLayer(_schema->getLayer(layerName));
-    }
-  }
-
-  return _layers[layerName];
-}
-
 bool OgrWriter::isSupported(const QString& url)
 {
+  LOG_VARD(_scriptPath.isEmpty());
   if (_scriptPath.isEmpty())
   {
     return false;
   }
+  LOG_VARD(OgrUtilities::getInstance().isReasonableUrl(url));
   return OgrUtilities::getInstance().isReasonableUrl(url);
 }
 
@@ -424,130 +238,9 @@ void OgrWriter::initTranslator()
   _schema = _translator->getOgrOutputSchema();
 }
 
-void OgrWriter::createAllLayers()
-{
-  if (_createAllLayers)
-  {
-    LOG_INFO("Creating all layers...");
-    for (size_t i = 0; i < _schema->getLayerCount(); ++i)
-    {
-      _createLayer(_schema->getLayer(i));
-    }
-  }
-}
-
-void OgrWriter::openOutput(const QString& url)
-{
-  try
-  {
-    _ds = OgrUtilities::getInstance().openDataSource(url, false);
-  }
-  catch(const HootException& openException)
-  {
-    try
-    {
-      _ds = OgrUtilities::getInstance().createDataSource(url);
-    }
-    catch(const HootException& createException)
-    {
-      throw HootException(QString("Error opening or creating data source. Opening error: \"%1\" "
-        "Creating error: \"%2\"").arg(openException.what()).arg(createException.what()));
-    }
-  }
-}
-
-void OgrWriter::open(const QString& url)
-{
-  // Initialize our translator - this will load the schema
-  initTranslator();
-
-  // Open output dataset
-  openOutput(url);
-
-  // Create all layers if _createAllLayers flag
-  createAllLayers();
-}
-
-void OgrWriter::setConfiguration(const Settings& conf)
-{
-  ConfigOptions configOptions(conf);
-  setCreateAllLayers(configOptions.getOgrWriterCreateAllLayers());
-  setSchemaTranslationScript(configOptions.getOgrWriterScript());
-  setPrependLayerName(configOptions.getOgrWriterPreLayerName());
-
-  _appendData = configOptions.getOgrAppendData();
-  QString strictStr = configOptions.getOgrStrictChecking();
-  if (strictStr == "on")
-  {
-    _strictChecking = StrictOn;
-  }
-  else if (strictStr == "off")
-  {
-    _strictChecking = StrictOff;
-  }
-  else if (strictStr == "warn")
-  {
-    _strictChecking = StrictWarn;
-  }
-  else
-  {
-    throw HootException("Error setting strict checking. Expected on/off/warn. got: " + strictStr);
-  }
-}
-
-std::shared_ptr<Geometry> OgrWriter::_toMulti(const std::shared_ptr<Geometry>& from)
-{
-  std::shared_ptr<Geometry> result;
-
-  switch (from->getGeometryTypeId())
-  {
-  case GEOS_POINT:
-  {
-    vector<Geometry*> v;
-    v.push_back(from.get());
-    result.reset(GeometryFactory::getDefaultInstance()->createMultiPoint(v));
-    break;
-  }
-  case GEOS_LINESTRING:
-  {
-    vector<Geometry*> v;
-    v.push_back(from.get());
-    result.reset(GeometryFactory::getDefaultInstance()->createMultiLineString(v));
-    break;
-  }
-  case GEOS_POLYGON:
-  {
-    vector<Geometry*> v;
-    v.push_back(from.get());
-    result.reset(GeometryFactory::getDefaultInstance()->createMultiPolygon(v));
-    break;
-  }
-  case GEOS_MULTIPOINT:
-  case GEOS_MULTILINESTRING:
-  case GEOS_MULTIPOLYGON:
-    result = from;
-    break;
-  default:
-    throw HootException("Unexpected geometry type: " + from->getGeometryType());
-  }
-
-  return result;
-}
-
-void OgrWriter::strictError(const QString& warning)
-{
-  if (_strictChecking == StrictOn)
-  {
-    throw HootException(warning);
-  }
-  else if (_strictChecking == StrictWarn)
-  {
-    LOG_WARN(warning);
-  }
-}
-
 void OgrWriter::write(const ConstOsmMapPtr& map)
 {
+  _numWritten = 0;
   ElementProviderPtr provider(std::const_pointer_cast<ElementProvider>(
     std::dynamic_pointer_cast<const ElementProvider>(map)));
 
@@ -583,13 +276,13 @@ void OgrWriter::write(const ConstOsmMapPtr& map)
   }
 }
 
-// Todo.. maybe return a reference or something, to avoid a copy
- void OgrWriter::translateToFeatures(
-          ElementProviderPtr& provider,
-          const ConstElementPtr& e,
-          std::shared_ptr<Geometry> &g, // output
-          std::vector<ScriptToOgrSchemaTranslator::TranslatedFeature> &tf) // output
+void OgrWriter::translateToFeatures(
+  ElementProviderPtr& provider, const ConstElementPtr& e,
+  std::shared_ptr<Geometry> &g, // output
+  std::vector<ScriptToOgrSchemaTranslator::TranslatedFeature> &tf) // output
 {
+  // TODO: maybe return a reference or something, to avoid a copy
+
   if (_translator.get() == nullptr)
   {
     throw HootException("You must call open before attempting to write.");
@@ -660,6 +353,13 @@ void OgrWriter::_writePartial(ElementProviderPtr& provider, const ConstElementPt
 
   translateToFeatures(provider, elementClone, g, tf);
   writeTranslatedFeature(g, tf);
+
+  _numWritten++;
+  if (_numWritten % _statusUpdateInterval == 0)
+  {
+    PROGRESS_STATUS(
+      "Wrote " << StringUtils::formatLargeNumber(_numWritten) << " elements to output.");
+  }
 }
 
 void OgrWriter::finalizePartial()
@@ -851,12 +551,329 @@ void OgrWriter::writeElement(ElementPtr &element)
   PartialOsmMapWriter::writePartial(element);
 }
 
-void OgrWriter::setCacheCapacity(const unsigned long maxNodes, const unsigned long maxWays,
-                                 const unsigned long maxRelations)
+void OgrWriter::createAllLayers()
 {
-  _elementCache.reset();
-  _elementCache =
-    std::shared_ptr<ElementCache>(new ElementCacheLRU(maxNodes, maxWays, maxRelations));
+  if (_createAllLayers)
+  {
+    LOG_INFO("Creating all layers...");
+    for (size_t i = 0; i < _schema->getLayerCount(); ++i)
+    {
+      _createLayer(_schema->getLayer(i));
+    }
+  }
+}
+
+void OgrWriter::_createLayer(const std::shared_ptr<const Layer>& layer)
+{
+  OGRLayer *poLayer;
+
+  OGRwkbGeometryType gtype;
+  switch(layer->getGeometryType())
+  {
+  case GEOS_POINT:
+    gtype = wkbPoint;
+    break;
+  case GEOS_LINESTRING:
+    gtype = wkbLineString;
+    break;
+  case GEOS_POLYGON:
+    gtype = wkbPolygon;
+    break;
+  default:
+    throw HootException("Unexpected geometry type.");
+  }
+
+  OgrOptions options;
+  if (_ds->GetDriver())
+  {
+    QString name = _ds->GetDriverName();
+    // if this is a CSV file
+    if (name == QString("CSV"))
+    {
+      // if we're exporting point data, then export with x/y at the front
+      if (gtype == wkbPoint)
+      {
+        options["GEOMETRY"] = "AS_XY";
+      }
+      // if we're exporting other geometries then export w/ WKT at the front.
+      else
+      {
+        options["GEOMETRY"] = "AS_WKT";
+      }
+      options["CREATE_CSVT"] = "YES";
+    }
+
+    if (name == QString("ESRI Shapefile"))
+    {
+      options["ENCODING"] = "UTF-8";
+      _maxFieldWidth = 254; // Shapefile DBF limit
+    }
+
+    // Add a Feature Dataset to a ESRI File GeoDatabase if requested
+    if (name == QString("FileGDB"))
+    {
+      if (layer->getFdName() != "")
+      {
+        options["FEATURE_DATASET"] = layer->getFdName();
+        // speed up bulk inserts.
+        // NOTE: Seems to be depreciated in GDAL 2.0+
+        //options["FGDB_BULK_LOAD"] = "YES";
+      }
+    }
+  }
+
+  QString layerName = _prependLayerName + layer->getName();
+  poLayer = _ds->GetLayerByName(layerName.toStdString().c_str());
+
+  // We only want to add to a layer IFF the config option "ogr.append.data" set
+  if (poLayer != nullptr && _appendData)
+  {
+    // Layer exists
+    _layers[layer->getName()] = poLayer;
+    // Loop through the fields making sure that they exist in the output. Print a warning if
+    // they don't exist
+    OGRFeatureDefn *poFDefn = poLayer->GetLayerDefn();
+    std::shared_ptr<const FeatureDefinition> fd = layer->getFeatureDefinition();
+
+
+    for (size_t i = 0; i < fd->getFieldCount(); i++)
+    {
+      std::shared_ptr<const FieldDefinition> f = fd->getFieldDefinition(i);
+
+      if (poFDefn->GetFieldIndex(f->getName().toLatin1()) == -1)
+      {
+        if (logWarnCount < Log::getWarnMessageLimit())
+        {
+          LOG_WARN("Unable to find field: " << QString(f->getName()) << " in layer " << layerName);
+        }
+        else if (logWarnCount == Log::getWarnMessageLimit())
+        {
+          LOG_WARN(className() << ": " << Log::LOG_WARN_LIMIT_REACHED_MESSAGE);
+        }
+        logWarnCount++;
+      }
+    }
+  }
+  else
+  {
+    LOG_DEBUG("Layer: " << layerName << " not found.  Creating layer...");
+    std::shared_ptr<OGRSpatialReference> projection = MapProjector::createWgs84Projection();
+    poLayer = _ds->CreateLayer(layerName.toLatin1(), projection.get(),
+                  gtype, options.getCrypticOptions());
+
+    if (poLayer == nullptr)
+    {
+      throw HootException(QString("Layer creation failed. %1").arg(layerName));
+    }
+    _layers[layer->getName()] = poLayer;
+    _projections[layer->getName()] = projection;
+
+    std::shared_ptr<const FeatureDefinition> fd = layer->getFeatureDefinition();
+    for (size_t i = 0; i < fd->getFieldCount(); i++)
+    {
+      std::shared_ptr<const FieldDefinition> f = fd->getFieldDefinition(i);
+      OGRFieldDefn oField(f->getName().toLatin1(), toOgrFieldType(f->getType()));
+
+      // Fix the field length but only for Strings
+      if (oField.GetType() == OFTString)
+      {
+        // If the schema sets a field width then use it.
+        if (f->getWidth() > 0)
+        {
+          oField.SetWidth(f->getWidth());
+        }
+        else if (_maxFieldWidth > 0) // Looking at you Shapefile.....
+        {
+          oField.SetWidth(_maxFieldWidth);
+        }
+      }
+
+      int errCode = poLayer->CreateField(&oField);
+      if (errCode != OGRERR_NONE)
+      {
+        throw HootException(
+          QString("Error creating field (%1)  OGR Error Code: (%2).")
+            .arg(f->getName()).arg(QString::number(errCode)));
+      }
+    }
+  } // End layer does not exist
+}
+
+OGRLayer* OgrWriter::_getLayer(const QString& layerName)
+{
+  if (!_layers.contains(layerName))
+  {
+    if (!_schema->hasLayer(layerName))
+    {
+      strictError("Layer specified is not part of the schema. (" + layerName + ")");
+      return nullptr;
+    }
+    else
+    {
+      _createLayer(_schema->getLayer(layerName));
+    }
+  }
+
+  return _layers[layerName];
+}
+
+void OgrWriter::_addFeature(OGRLayer* layer, const std::shared_ptr<Feature>& f,
+                            const std::shared_ptr<Geometry>& g)
+{
+  OGRFeature* poFeature = OGRFeature::CreateFeature( layer->GetLayerDefn() );
+
+  // set all the column values.
+  const QVariantMap& vm = f->getValues();
+
+  for (QVariantMap::const_iterator it = vm.constBegin(); it != vm.constEnd(); ++it)
+  {
+    const QVariant& v = it.value();
+    QByteArray ba = it.key().toUtf8();
+
+    // If the field DOESN'T exist in the output layer, skip it.
+    if (poFeature->GetFieldIndex(ba.constData()) == -1)
+    {
+      continue;
+    }
+
+    switch (v.type())
+    {
+    case QVariant::Invalid:
+      poFeature->UnsetField(poFeature->GetFieldIndex(ba.constData()));
+      break;
+    case QVariant::Int:
+      poFeature->SetField(ba.constData(), v.toInt());
+      break;
+    case QVariant::LongLong:
+      poFeature->SetField(ba.constData(), v.toLongLong());
+      break;
+    case QVariant::Double:
+      poFeature->SetField(ba.constData(), v.toDouble());
+      break;
+    case QVariant::String:
+    {
+      QByteArray vba = v.toString().toUtf8();
+
+      int fieldWidth =
+        poFeature->GetFieldDefnRef(poFeature->GetFieldIndex(ba.constData()))->GetWidth();
+
+      if (vba.length() > fieldWidth && fieldWidth > 0)
+      {
+        if (logWarnCount < Log::getWarnMessageLimit())
+        {
+          LOG_WARN(
+            "Truncating the " << it.key() << " attribute (" << vba.length() <<
+            " characters) to the output field width (" << fieldWidth << " characters).");
+        }
+        else if (logWarnCount == Log::getWarnMessageLimit())
+        {
+          LOG_WARN(className() << ": " << Log::LOG_WARN_LIMIT_REACHED_MESSAGE);
+        }
+        logWarnCount++;
+
+        vba.truncate(fieldWidth);
+      }
+
+      poFeature->SetField(ba.constData(), vba.constData());
+      break;
+    }
+    default:
+      strictError("Can't convert the provided value into an OGR value. (" + v.toString() + ")");
+      return;
+    }
+  }
+
+  // convert the geometry.
+  std::shared_ptr<GeometryCollection> gc = std::dynamic_pointer_cast<GeometryCollection>(g);
+  if (gc.get() != nullptr)
+  {
+    for (size_t i = 0; i < gc->getNumGeometries(); i++)
+    {
+      const Geometry* child = gc->getGeometryN(i);
+      _addFeatureToLayer(layer, f, child, poFeature);
+    }
+  }
+  else
+  {
+    _addFeatureToLayer(layer, f, g.get(), poFeature);
+  }
+
+  OGRFeature::DestroyFeature(poFeature);
+}
+
+void OgrWriter::_addFeatureToLayer(OGRLayer* layer, const std::shared_ptr<Feature>& f,
+                                   const Geometry* g, OGRFeature* poFeature)
+{
+  std::string wkt = g->toString();
+  char* t = (char*)wkt.data();
+  OGRGeometry* geom;
+  int errCode = OGRGeometryFactory::createFromWkt(&t, layer->GetSpatialRef(), &geom) ;
+  if (errCode != OGRERR_NONE)
+  {
+    throw HootException(
+      QString("Error parsing WKT (%1).  OGR Error Code: (%2)")
+        .arg(QString::fromStdString(wkt))
+        .arg(QString::number(errCode)));
+  }
+
+  errCode = poFeature->SetGeometryDirectly(geom);
+  if (errCode != OGRERR_NONE)
+  {
+    throw HootException(
+      QString("Error setting geometry - OGR Error Code: (%1)  Geometry: (%2)")
+        .arg(QString::number(errCode)).arg(QString::fromStdString(g->toString())));
+  }
+
+  // Unsetting the FID with SetFID(-1) before calling CreateFeature() to avoid reusing the same
+  // feature object for sequential insertions
+  poFeature->SetFID(-1);
+
+  errCode = layer->CreateFeature(poFeature);
+  if (errCode != OGRERR_NONE)
+  {
+    throw HootException(
+      QString("Error creating feature - OGR Error Code: (%1) \nFeature causing error: (%2)")
+        .arg(QString::number(errCode)).arg(f->toString()));
+  }
+}
+
+std::shared_ptr<Geometry> OgrWriter::_toMulti(const std::shared_ptr<Geometry>& from)
+{
+  std::shared_ptr<Geometry> result;
+
+  switch (from->getGeometryTypeId())
+  {
+  case GEOS_POINT:
+  {
+    vector<Geometry*> v;
+    v.push_back(from.get());
+    result.reset(GeometryFactory::getDefaultInstance()->createMultiPoint(v));
+    break;
+  }
+  case GEOS_LINESTRING:
+  {
+    vector<Geometry*> v;
+    v.push_back(from.get());
+    result.reset(GeometryFactory::getDefaultInstance()->createMultiLineString(v));
+    break;
+  }
+  case GEOS_POLYGON:
+  {
+    vector<Geometry*> v;
+    v.push_back(from.get());
+    result.reset(GeometryFactory::getDefaultInstance()->createMultiPolygon(v));
+    break;
+  }
+  case GEOS_MULTIPOINT:
+  case GEOS_MULTILINESTRING:
+  case GEOS_MULTIPOLYGON:
+    result = from;
+    break;
+  default:
+    throw HootException("Unexpected geometry type: " + from->getGeometryType());
+  }
+
+  return result;
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
@@ -172,11 +172,14 @@ protected:
 
 private:
 
-  //relations that weren't written on a first pass b/c they contained relations as a member which
-  //had not yet been written.
+  // relations that weren't written on a first pass b/c they contained relations as a member which
+  // had not yet been written.
   QList<long> _unwrittenFirstPassRelationIds;
   bool _failOnSkipRelation;
   int _maxFieldWidth;
+
+  int _numWritten;
+  int _statusUpdateInterval;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.cpp
@@ -66,7 +66,8 @@ bool OsmMapReaderFactory::hasElementInputStream(const QStringList& inputs)
     if (!hasElementInputStream(inputs.at(i)))
     {
       LOG_INFO(
-        "Unable to stream Inputs due to input: " << inputs.at(i).right(25) << ". Loading entire map...");
+        "Unable to stream Inputs due to input: " << inputs.at(i).right(25) <<
+        ". Loading entire map into memory...");
       return false;
     }
   }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.cpp
@@ -597,7 +597,6 @@ void OsmPbfReader::_loadOsmData()
   _loadWays();
   _loadRelations();
   // we don't handle change sets
-  // _loadChangeSets();
 }
 
 vector<OsmPbfReader::BlobLocation> OsmPbfReader::loadOsmDataBlobOffsets(istream& strm)
@@ -630,13 +629,14 @@ vector<OsmPbfReader::BlobLocation> OsmPbfReader::loadOsmDataBlobOffsets(istream&
     }
     _in->seekg(_d->blobHeader.datasize(), ios_base::cur);
     t = Tgs::Time::getTime();
-    if (Log::getInstance().getLevel() <= Log::Info && t - start > 5 && t - last >= 2)
+    if (t - start > 5 && t - last >= 2)
     {
       long pos = _in->tellg();
-      PROGRESS_INFO(QString("%1 / %2 - %3 MB/s                  ")
-                    .arg(pos / 1.0e6, 0, 'g', 1)
-                    .arg(length / 1.0e6, 0, 'g', 1)
-                    .arg(((_in->tellg() - lastPos) / (t - last)) / 1.0e6, 0, 'g', 2));
+      PROGRESS_STATUS(
+        QString("%1 / %2 - %3 MB/s                  ")
+          .arg(pos / 1.0e6, 0, 'g', 1)
+          .arg(length / 1.0e6, 0, 'g', 1)
+          .arg(((_in->tellg() - lastPos) / (t - last)) / 1.0e6, 0, 'g', 2));
       last = t;
       lastPos = _in->tellg();
     }
@@ -646,10 +646,11 @@ vector<OsmPbfReader::BlobLocation> OsmPbfReader::loadOsmDataBlobOffsets(istream&
   if (t - start > 5)
   {
     // print the final summary
-    LOG_INFO(QString("%1 / %2 - %3 MB/s                  ")
-             .arg(length / 1.0e6, 0, 'g', 1)
-             .arg(length / 1.0e6, 0, 'g', 1)
-             .arg((length / (t - start)) / 1.0e6, 0, 'g', 2));
+    PROGRESS_STATUS(
+      QString("%1 / %2 - %3 MB/s                  ")
+        .arg(length / 1.0e6, 0, 'g', 1)
+        .arg(length / 1.0e6, 0, 'g', 1)
+        .arg((length / (t - start)) / 1.0e6, 0, 'g', 2));
   }
 
   return result;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.cpp
@@ -446,7 +446,8 @@ void OsmXmlWriter::writePartial(const ConstNodePtr& n)
   _numWritten++;
   if (_numWritten % _statusUpdateInterval == 0)
   {
-    PROGRESS_INFO("Wrote " << StringUtils::formatLargeNumber(_numWritten) << " elements to output.");
+    PROGRESS_STATUS(
+      "Wrote " << StringUtils::formatLargeNumber(_numWritten) << " elements to output.");
   }
 }
 
@@ -524,7 +525,8 @@ void OsmXmlWriter::writePartial(const ConstWayPtr& w)
   _numWritten++;
   if (_numWritten % _statusUpdateInterval == 0)
   {
-    PROGRESS_INFO("Wrote " << StringUtils::formatLargeNumber(_numWritten) << " elements to output.");
+    PROGRESS_STATUS(
+      "Wrote " << StringUtils::formatLargeNumber(_numWritten) << " elements to output.");
   }
 }
 
@@ -556,7 +558,8 @@ void OsmXmlWriter::writePartial(const ConstRelationPtr& r)
   _numWritten++;
   if (_numWritten % _statusUpdateInterval == 0)
   {
-    PROGRESS_INFO("Wrote " << StringUtils::formatLargeNumber(_numWritten) << " elements to output.");
+    PROGRESS_STATUS(
+      "Wrote " << StringUtils::formatLargeNumber(_numWritten) << " elements to output.");
   }
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.h
@@ -136,8 +136,8 @@ private:
   int _encodingErrorCount;
   std::shared_ptr<QXmlStreamWriter> _writer;
   geos::geom::Envelope _bounds;
-  long _numWritten;
-  long _statusUpdateInterval;
+  int _numWritten;
+  int _statusUpdateInterval;
   AddExportTagsVisitor _addExportTagsVisitor;
 
   static QString _typeName(ElementType e);

--- a/hoot-core/src/main/cpp/hoot/core/io/PartialOsmMapWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/PartialOsmMapWriter.cpp
@@ -59,12 +59,7 @@ void PartialOsmMapWriter::writePartial(const ConstOsmMapPtr& map)
     writePartial((ConstRelationPtr)it->second);
   }
 }
-/*
-void PartialOsmMapWriter::writePartial(const OsmMapPtr& map)
-{
-  writePartial((const ConstOsmMapPtr)map);
-}
-*/
+
 void PartialOsmMapWriter::writePartial(const ConstElementPtr& e)
 {
   switch (e->getElementType().getEnum())

--- a/hoot-core/src/main/cpp/hoot/core/schema/SchemaUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/SchemaUtils.cpp
@@ -31,7 +31,9 @@
 #include <hoot/core/visitors/ElementCountVisitor.h>
 #include <hoot/core/visitors/FilteredVisitor.h>
 #include <hoot/core/criterion/HasTypeCriterion.h>
-#include <hoot/core/criterion/NoInformationCriterion.h>
+
+// Qt
+#include <QFileInfo>
 
 namespace hoot
 {
@@ -42,6 +44,19 @@ bool SchemaUtils::anyElementsHaveType(const ConstOsmMapPtr& map)
     (int)FilteredVisitor::getStat(
       ElementCriterionPtr(new HasTypeCriterion()),
       ElementVisitorPtr(new ElementCountVisitor()), map) > 0;
+}
+
+void SchemaUtils::validateTranslationUrl(const QString& url)
+{
+  QFileInfo fileInfo(url);
+  if (!fileInfo.exists())
+  {
+    throw IllegalArgumentException("Translation file does not exist: " + url);
+  }
+  else if (!url.endsWith(".js") && !url.endsWith(".py"))
+  {
+    throw IllegalArgumentException("Invalid translation file format: " + url);
+  }
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/schema/SchemaUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/SchemaUtils.h
@@ -50,6 +50,13 @@ public:
    * @return true if at least one feature has a type recognized by the schema; false otherwise
    */
   static bool anyElementsHaveType(const ConstOsmMapPtr& map);
+
+  /**
+   * TODO
+   *
+   * @param url
+   */
+  static void validateTranslationUrl(const QString& url);
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/schema/SchemaUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/schema/SchemaUtils.h
@@ -52,9 +52,11 @@ public:
   static bool anyElementsHaveType(const ConstOsmMapPtr& map);
 
   /**
-   * TODO
+   * Validates the path to a translation script.
    *
-   * @param url
+   * @param url URL pointing to a translation script
+   * @throws IllegalArgumentException if the script at the URL does not exist or is an unsupported
+   * format
    */
   static void validateTranslationUrl(const QString& url);
 };

--- a/hoot-core/src/main/cpp/hoot/core/visitors/SchemaTranslationVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/SchemaTranslationVisitor.cpp
@@ -61,7 +61,8 @@ void SchemaTranslationVisitor::setConfiguration(const Settings& conf)
 
   LOG_VARD(conf.hasKey(c.getSchemaTranslationScriptKey()));
   LOG_VARD(c.getSchemaTranslationScript());
-  if (conf.hasKey(ConfigOptions::getSchemaTranslationScriptKey()) && c.getSchemaTranslationScript() != "")
+  if (conf.hasKey(ConfigOptions::getSchemaTranslationScriptKey()) &&
+      c.getSchemaTranslationScript() != "")
   {
     setTranslationDirection(c.getSchemaTranslationDirection());
     setTranslationScript(c.getSchemaTranslationScript());

--- a/hoot-js/src/main/cpp/hoot/js/schema/JavaScriptSchemaTranslator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/JavaScriptSchemaTranslator.cpp
@@ -133,7 +133,7 @@ std::shared_ptr<Feature> JavaScriptSchemaTranslator::_createFeature(const QVaria
   tableName = vm["tableName"].toString();
   if (tableName.length() < 1)
   {
-    LOG_WARN("_createFeature: Empty tableName");
+    LOG_TRACE("_createFeature: Empty tableName");
     return std::shared_ptr<Feature>(); // Null feature
   }
 
@@ -285,22 +285,6 @@ void JavaScriptSchemaTranslator::_init()
   {
     _toOsmFunctionName = "translateAttributes";
   }
-//  else
-//  {
-//    throw HootException("A 'translateToOsm' function must be defined.");
-//  }
-
-  // Debug Stuff - Dump the object properties
-//  Handle<Object> hoot = tObj->Get(toV8("hoot"))->ToObject();
-
-//  cout << endl;
-//  cout << "JSTrans:" << endl;
-//  cout << "tObj Properties: " << tObj->GetPropertyNames() << endl;
-//  cout << endl;
-//  cout << "Hoot Properties: " << hoot->GetPropertyNames() << endl;
-//  cout << endl;
-//  cout << "End: JSTrans:" << endl;
-//  cout << endl;
 
   LOG_DEBUG("Translation script loaded.");
   _initialized = true;
@@ -373,9 +357,6 @@ bool JavaScriptSchemaTranslator::isValidScript()
 void JavaScriptSchemaTranslator::_featureWarn(const QString& message, const QString& fileName,
                                               const QString& functionName, int lineNumber)
 {
-//  stringstream ss;
-//  LOG_INFO(_tags);
-//  ss << message << " Input tags: " << *_tags;
   Log::getInstance().log(Log::Warn, message.toStdString(), fileName.toStdString(),
                          functionName.toStdString(), lineNumber);
 }

--- a/test-files/cmd/quick/ConvertGeoNames.sh
+++ b/test-files/cmd/quick/ConvertGeoNames.sh
@@ -11,6 +11,7 @@ GEONAMES_MIL=$INPUTDIR/ConvertGeoNames/ConvertGeoNamesMil.geonames
 
 # Output files
 OUT_ORG=$OUTPUTDIR/GeoNames.osm
+OUT_ORG_2=$OUTPUTDIR/GeoNames2.osm
 OUT_MIL=$OUTPUTDIR/GeoNamesMil.osm
 
 # Gold copy OSM
@@ -25,9 +26,13 @@ hoot convert --warn -C Testing.conf -D map.factory.writer=hoot::OsmXmlWriter \
   -D convert.ops=hoot::SchemaTranslationVisitor \
   -D schema.translation.script=$HOOT_HOME/translations/GeoNames_to_OSM.js \
   $GEONAMES_ORG $OUT_ORG
-
 hoot diff -C Testing.conf $GOLD_ORG $OUT_ORG || diff $GOLD_ORG $OUT_ORG
 
+# same as previous but make DataConverter add the translate visitor in
+hoot convert --warn -C Testing.conf -D map.factory.writer=hoot::OsmXmlWriter \
+  -D schema.translation.script=$HOOT_HOME/translations/GeoNames_to_OSM.js \
+  $GEONAMES_ORG $OUT_ORG_2
+hoot diff -C Testing.conf $GOLD_ORG $OUT_ORG_2 || diff $GOLD_ORG $OUT_ORG_2
 
 # geonames.nga.mil
 hoot convert --warn -C Testing.conf -D map.factory.writer=hoot::OsmXmlWriter \

--- a/translations/tds70.js
+++ b/translations/tds70.js
@@ -2287,7 +2287,7 @@ print('Many: Start');
         }
         else
         {
-          hoot.logWarn('Dropping invalid ' + ge4attr[i] + ' value: ' + attrs[ge4attr[i]]);
+          hoot.logTrace('Dropping invalid ' + ge4attr[i] + ' value: ' + attrs[ge4attr[i]]);
           delete attrs[ge4attr[i]];
         }
       }


### PR DESCRIPTION
Prior to this change all conversions with an OGR format as an output would run translation in a separate thread. Doing so is memory bound. This change makes running translations in separate thread optional and disabled by default (`convert.translate.multithreaded`). If both input *and* output format are OGR formats, however, multi-threaded translation is still optional but the operation will always be memory bound.