### PR TITLE
Global coordinate removed

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayLocation.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WayLocation.cpp
@@ -46,8 +46,6 @@ namespace hoot
 
 int WayLocation::logWarnCount = 0;
 
-Coordinate c;
-
 const double WayLocation::SLOPPY_EPSILON = 1e-10;
 
 WayLocation::WayLocation() :


### PR DESCRIPTION
- [ ] [This function should be declared const.](https://sonarcloud.io/project/issues?id=hoot&open=AXcFAt7hcN8x-cd0lqH0&resolved=false&rules=cpp%3AS5817) (624)