### PR TITLE
Changes default logging level to `--status`

### DIFF
--- a/hoot-cmd/src/main/cpp/hoot/cmd/HelpCmd.cpp
+++ b/hoot-cmd/src/main/cpp/hoot/cmd/HelpCmd.cpp
@@ -178,12 +178,12 @@ private:
     _printCommands(rndCmds);
 
     cout << endl << "Log Levels:" << endl << endl;
-    cout << "  --trace" << endl;
-    cout << "  --debug" << endl;
-    cout << "  --info" << endl;
-    cout << "  --status" << endl;
-    cout << "  --warn" << endl;
     cout << "  --error" << endl;
+    cout << "  --warn" << endl;
+    cout << "  --status (default)" << endl;
+    cout << "  --info" << endl;
+    cout << "  --debug" << endl;
+    cout << "  --trace" << endl;
     cout << endl;
 
     cout << "List Option Operations:" << endl << endl;

--- a/hoot-core/src/main/cpp/hoot/core/Hoot.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/Hoot.cpp
@@ -76,10 +76,10 @@ Hoot& Hoot::getInstance()
 
 void Hoot::_init()
 {
-  //lower this log level temporarily *only* for debugging init issues; some hoot services
-  //functionality that parses log output is sensitive to extra logged statements and will fail
-  //when this is lowered
-  Log::getInstance().setLevel(Log::Info);
+  // Lower this log level temporarily *only* for debugging init issues. Some hoot services
+  // functionality that parses log output is sensitive to extra logged statements and will fail
+  // when this is lowered.
+  Log::getInstance().setLevel(Log::Status);
 
   LOG_DEBUG("Hoot instance init...");
 
@@ -125,7 +125,7 @@ void Hoot::_init()
   loadLibrary("HootJosm");
 # endif
 
-  Log::getInstance().setLevel(Log::Info);
+  Log::getInstance().setLevel(Log::Status);
   //  Registering these metatypes here removes warning messages
   //  in threads that use QNetworkAccessManager whose initialization
   //  routine isn't thread safe

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheetApplier.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheetApplier.cpp
@@ -34,6 +34,7 @@
 #include <hoot/core/io/IoUtils.h>
 #include <hoot/core/ops/MapCleaner.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/Settings.h>
@@ -44,8 +45,13 @@
 namespace hoot
 {
 
-void RubberSheetApplier::apply(const QString& transform, const QString& input, const QString& output)
+void RubberSheetApplier::apply(
+  const QString& transform, const QString& input, const QString& output)
 {
+  LOG_STATUS(
+    "Applying alignment transform from ..." << FileUtils::toLogFormat(input, 25) << " to " <<
+    FileUtils::toLogFormat(output, 25) << "...");
+
   OsmMapPtr map(new OsmMap());
   IoUtils::loadMap(map, input, true, Status::Unknown1);
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheetDeriver.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheetDeriver.cpp
@@ -34,6 +34,7 @@
 #include <hoot/core/io/IoUtils.h>
 #include <hoot/core/ops/MapCleaner.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/Settings.h>
@@ -44,10 +45,14 @@
 namespace hoot
 {
 
-void RubberSheetDeriver::derive(const QString& input1, const QString& input2,
-                                const QString& transform2To1, const QString& transform1To2,
-                                const bool ref)
+void RubberSheetDeriver::derive(
+  const QString& input1, const QString& input2, const QString& transform2To1,
+  const QString& transform1To2, const bool ref)
 {
+  LOG_STATUS(
+    "Deriving alignment transform for inputs ..." << FileUtils::toLogFormat(input1, 25) <<
+    " and " << FileUtils::toLogFormat(input2, 25) << "...");
+
   OsmMapPtr map(new OsmMap());
   IoUtils::loadMap(map, input1, false, Status::Unknown1);
   IoUtils::loadMap(map, input2, false, Status::Unknown2);

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheeter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/rubber-sheet/RubberSheeter.cpp
@@ -34,6 +34,7 @@
 #include <hoot/core/io/IoUtils.h>
 #include <hoot/core/ops/MapCleaner.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/HootException.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/Settings.h>
@@ -43,6 +44,11 @@ namespace hoot
 
 void RubberSheeter::rubberSheet(const QString& input1, const QString& input2, const QString& output)
 {
+  LOG_STATUS(
+    "Applying alignment transform for inputs ..." << FileUtils::toLogFormat(input1, 25) <<
+    " and " << FileUtils::toLogFormat(input2, 25) << "; writing output to " <<
+    FileUtils::toLogFormat(output, 25)  << "...");
+
   OsmMapPtr map(new OsmMap());
   IoUtils::loadMap(map, input1, false, Status::Unknown1);
   IoUtils::loadMap(map, input2, false, Status::Unknown2);

--- a/hoot-core/src/main/cpp/hoot/core/cmd/AlignCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/AlignCmd.cpp
@@ -48,7 +48,6 @@ public:
   AlignCmd() = default;
 
   QString getName() const override { return "align"; }
-
   QString getDescription() const override
   { return "Brings two maps into alignment using rubbersheeting"; }
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/AlphaShapeCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/AlphaShapeCmd.cpp
@@ -35,6 +35,7 @@
 #include <hoot/core/io/OsmGeoJsonWriter.h>
 #include <hoot/core/io/ShapefileWriter.h>
 #include <hoot/core/util/Factory.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/elements/MapProjector.h>
 #include <hoot/core/util/StringUtils.h>
@@ -55,7 +56,6 @@ public:
   AlphaShapeCmd() = default;
 
   QString getName() const override { return "alpha-shape"; }
-
   QString getDescription() const override
   { return "Generates a shape that covers a set of features in a map"; }
 
@@ -111,11 +111,14 @@ public:
     QString pointsPath = args[0];
     QString outputPath = args[1];
 
+    LOG_STATUS(
+      "Deriving alpha shape for input ..." << FileUtils::toLogFormat(pointsPath, 25) <<
+      " and writing output to " << FileUtils::toLogFormat(outputPath, 25) << "...");
+
     OsmMapPtr pointsMap(new OsmMap());
     IoUtils::loadMap(pointsMap, pointsPath, false, Status::Unknown1);
 
     AlphaShapeGenerator generator(alpha, buffer);
-    //generator.setManuallyCoverSmallPointClusters(false);
     OsmMapPtr result = generator.generateMap(pointsMap);
 
     // reproject back into lat/lng

--- a/hoot-core/src/main/cpp/hoot/core/cmd/BuildModelCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/BuildModelCmd.cpp
@@ -47,7 +47,6 @@ public:
   BuildModelCmd() = default;
 
   QString getName() const override { return "build-model"; }
-
   QString getDescription() const override
   { return "Builds a random forest model to be used by conflation"; }
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetApplyCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetApplyCmd.cpp
@@ -53,9 +53,7 @@ public:
   ChangesetApplyCmd() = default;
 
   QString getName() const override { return "changeset-apply"; }
-
-  QString getDescription() const override
-  { return "Writes an OSM changeset to an OSM data store"; }
+  QString getDescription() const override { return "Writes an OSM changeset to an OSM data store"; }
 
   int runSimple(QStringList& args) override
   {

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetDeriveCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ChangesetDeriveCmd.cpp
@@ -55,7 +55,6 @@ public:
   ChangesetDeriveCmd() = default;
 
   QString getName() const override { return "changeset-derive"; }
-
   QString getDescription() const override
   { return "Creates a changeset representing the difference between two maps"; }
 
@@ -171,8 +170,9 @@ private:
   {
     const int maxFilePrintLength = ConfigOptions().getProgressVarPrintLengthMax();
     LOG_STATUS(
-      "Generating standard changeset for inputs: ..." << FileUtils::toLogFormat(input1, maxFilePrintLength) <<
-      " and ..." << FileUtils::toLogFormat(input2, maxFilePrintLength) << " and output: ..." <<
+      "Generating standard changeset for inputs: ..." <<
+      FileUtils::toLogFormat(input1, maxFilePrintLength) << " and ..." <<
+      FileUtils::toLogFormat(input2, maxFilePrintLength) << " and output: ..." <<
       FileUtils::toLogFormat(output, maxFilePrintLength));
 
     // Note that we may need to eventually further restrict this to only data with relation having

--- a/hoot-core/src/main/cpp/hoot/core/cmd/CleanCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/CleanCmd.cpp
@@ -57,7 +57,6 @@ public:
   CleanCmd() = default;
 
   QString getName() const override { return "clean"; }
-
   QString getDescription() const override { return "Corrects erroneous map data"; }
 
   int runSimple(QStringList& args) override

--- a/hoot-core/src/main/cpp/hoot/core/cmd/CompareCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/CompareCmd.cpp
@@ -33,6 +33,7 @@
 #include <hoot/core/visitors/KeepHighwaysVisitor.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/io/IoUtils.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/StringUtils.h>
 #include <hoot/core/scoring/MapCompareUtils.h>
 
@@ -56,11 +57,15 @@ public:
   CompareCmd() = default;
 
   QString getName() const override { return "compare"; }
-
   QString getDescription() const override { return "Compares maps using metrics"; }
 
   int compareMaps(QString in1, QString in2, QString out)
   {
+    LOG_STATUS(
+      "Comparing maps ..." << FileUtils::toLogFormat(in1, 25) << " and ..." <<
+      FileUtils::toLogFormat(in2, 25) << "; writing output to ..." <<
+      FileUtils::toLogFormat(out, 25) << "...");
+
     OsmMapPtr map1 = loadMap(in1);
     if (map1->isEmpty())
     {

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.h
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.h
@@ -52,9 +52,7 @@ public:
   ConflateCmd() = default;
 
   QString getName() const override { return "conflate"; }
-
-  QString getDescription() const override
-  { return "Conflates two maps into a single map"; }
+  QString getDescription() const override { return "Conflates two maps into a single map"; }
 
   int runSimple(QStringList& args) override;
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ConvertCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ConvertCmd.cpp
@@ -55,7 +55,6 @@ public:
   ConvertCmd() = default;
 
   QString getName() const override { return "convert"; }
-
   QString getDescription() const override { return "Converts between map formats"; }
 
   int runSimple(QStringList& args) override

--- a/hoot-core/src/main/cpp/hoot/core/cmd/CropCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/CropCmd.cpp
@@ -34,6 +34,7 @@
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/geometry/GeometryUtils.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/FileUtils.h>
 
 // Qt
 #include <QStringList>
@@ -54,7 +55,6 @@ public:
   CropCmd() = default;
 
   QString getName() const override { return "crop"; }
-
   QString getDescription() const override { return "Crops a map to a bounds"; }
 
   int runSimple(QStringList& args) override
@@ -70,6 +70,10 @@ public:
     QString in = args[0];
     QString out = args[1];
 
+    LOG_STATUS(
+      "Cropping ..." << FileUtils::toLogFormat(in, 25) << " and writing output to ..." <<
+      FileUtils::toLogFormat(out, 25) << "...");
+
     BoundedCommand::runSimple(args);
 
     _env = GeometryUtils::boundsFromString(args[2]);
@@ -80,7 +84,6 @@ public:
     MapCropper cropper;
     cropper.setBounds(_env);
     cropper.setConfiguration(Settings::getInstance());
-    //cropper.setRemoveSuperflousFeatures(false);
     cropper.apply(map);
 
     IoUtils::saveMap(map, out);

--- a/hoot-core/src/main/cpp/hoot/core/cmd/CutCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/CutCmd.cpp
@@ -32,6 +32,7 @@
 #include <hoot/core/cmd/BaseCommand.h>
 #include <hoot/core/conflate/CookieCutter.h>
 #include <hoot/core/util/Factory.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/elements/MapProjector.h>
 #include <hoot/core/io/IoUtils.h>
@@ -53,7 +54,6 @@ public:
   CutCmd() = default;
 
   QString getName() const override { return "cut"; }
-
   QString getDescription() const override { return "Cuts out a portion from a map"; }
 
   int runSimple(QStringList& args) override
@@ -95,6 +95,11 @@ public:
             arg(args[i - 1]));
       }
     }
+
+    LOG_STATUS(
+      "Cutting ..." << FileUtils::toLogFormat(cutterShapePath, 25) << " out of ..." <<
+      FileUtils::toLogFormat(doughPath, 25) << " and writing output to ..." <<
+      FileUtils::toLogFormat(outputPath, 25) << "...");
 
     // load up the shape being cut out
     OsmMapPtr cutterShapeMap(new OsmMap());

--- a/hoot-core/src/main/cpp/hoot/core/cmd/DbDeleteCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/DbDeleteCmd.cpp
@@ -29,6 +29,7 @@
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/cmd/BaseCommand.h>
 #include <hoot/core/io/HootApiDbWriter.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/StringUtils.h>
 
 // Qt
@@ -48,7 +49,6 @@ public:
   DbDeleteCmd() = default;
 
   QString getName() const override { return "db-delete"; }
-
   QString getDescription() const override
   { return "Deletes a map from the Hootenanny Web Services database"; }
 
@@ -62,6 +62,8 @@ public:
       cout << getHelp() << endl << endl;
       throw HootException(QString("%1 takes one parameter.").arg(getName()));
     }
+
+    LOG_STATUS("Deleting ..." << FileUtils::toLogFormat(args[0], 25) << "...");
 
     HootApiDbWriter().deleteMap(args[0]);
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/DbListCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/DbListCmd.cpp
@@ -42,7 +42,6 @@ public:
   DbListCmd() = default;
 
   QString getName() const override { return "db-list"; }
-
   QString getDescription() const override
   { return "Lists maps in the Hootenanny Web Services database"; }
 
@@ -53,6 +52,8 @@ public:
       std::cout << getHelp() << std::endl << std::endl;
       throw HootException(QString("%1 takes one parameter.").arg(getName()));
     }
+
+    LOG_STATUS("Retrieving available maps...");
 
     HootApiDb mapReader;
     mapReader.open(args[0]);

--- a/hoot-core/src/main/cpp/hoot/core/cmd/DiffCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/DiffCmd.cpp
@@ -34,6 +34,7 @@
 #include <hoot/core/ops/DuplicateNodeRemover.h>
 #include <hoot/core/scoring/MapComparator.h>
 #include <hoot/core/util/Factory.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/Settings.h>
 #include <hoot/core/util/StringUtils.h>
@@ -57,7 +58,6 @@ public:
   DiffCmd() = default;
 
   QString getName() const override { return "diff"; }
-
   QString getDescription() const override
   { return "Calculates the difference between two maps or changesets"; }
 
@@ -108,6 +108,10 @@ public:
 
     QString pathname1 = args[0];
     QString pathname2 = args[1];
+
+    LOG_STATUS(
+      "Comparing ..." << FileUtils::toLogFormat(pathname1, 25) << " and ..." <<
+      FileUtils::toLogFormat(pathname2, 25) << "...");
 
     int result = 1;
     //  Compare changesets differently than all other types

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ExtentCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ExtentCmd.cpp
@@ -32,6 +32,7 @@
 #include <hoot/core/visitors/CalculateMapBoundsVisitor.h>
 #include <hoot/core/geometry/GeometryUtils.h>
 #include <hoot/core/io/IoUtils.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/StringUtils.h>
 
 // Qt
@@ -52,7 +53,6 @@ public:
   ExtentCmd() = default;
 
   QString getName() const override { return "extent"; }
-
   QString getDescription() const override { return "Calculates the bounds of a map"; }
 
   int runSimple(QStringList& args) override
@@ -76,7 +76,9 @@ public:
     conf().set(ConfigOptions::getWriterPrecisionKey(), 9);
 
     const QString input = args[0];
-    LOG_VARD(input);
+
+    LOG_STATUS("Calculating extent for ..." << FileUtils::toLogFormat(input, 25) << "...");
+
     OsmMapPtr map(new OsmMap());
     IoUtils::loadMap(map, input, true, Status::Invalid);
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/InfoCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/InfoCmd.cpp
@@ -53,9 +53,7 @@ public:
   InfoCmd() = default;
 
   QString getName() const override { return "info"; }
-
-  QString getDescription() const override
-  { return "Displays information about capabilities"; }
+  QString getDescription() const override { return "Displays information about capabilities"; }
 
   int runSimple(QStringList& args) override
   {

--- a/hoot-core/src/main/cpp/hoot/core/cmd/IsSortedCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/IsSortedCmd.cpp
@@ -31,6 +31,7 @@
 #include <hoot/core/io/OsmPbfReader.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
 #include <hoot/core/visitors/IsSortedVisitor.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/StringUtils.h>
 
 // Qt
@@ -50,7 +51,6 @@ public:
   IsSortedCmd() = default;
 
   QString getName() const override { return "is-sorted"; }
-
   QString getDescription() const override
   { return "Determines if a map is sorted to the OSM standard"; }
 
@@ -71,6 +71,8 @@ public:
     {
       throw HootException("Specified input: " + input + " does not exist.");
     }
+
+    LOG_STATUS("Determining if ..." << FileUtils::toLogFormat(input, 25) << " is sorted...");
 
     bool result = true;
     if (OsmPbfReader().isSupported(input))

--- a/hoot-core/src/main/cpp/hoot/core/cmd/SchemaCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/SchemaCmd.cpp
@@ -46,7 +46,6 @@ public:
   SchemaCmd() = default;
 
   QString getName() const override { return "schema"; }
-
   QString getDescription() const override { return "Displays the tag schema in use"; }
 
   int runSimple(QStringList& args) override
@@ -63,7 +62,8 @@ public:
       throw HootException(QString("%1 takes one optional parameter.").arg(getName()));
     }
 
-    // Great bit of code taken from TranslatedTagDifferencer
+    LOG_STATUS("Printing schema...");
+
     std::shared_ptr<ScriptSchemaTranslator> schemaPrinter(
       ScriptSchemaTranslatorFactory::getInstance().createTranslator(printScript));
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ScoreMatchesCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ScoreMatchesCmd.cpp
@@ -67,7 +67,6 @@ public:
   ScoreMatchesCmd() = default;
 
   QString getName() const override { return "score-matches"; }
-
   QString getDescription() const override
   { return "Scores conflation performance against a manually matched map"; }
 
@@ -111,11 +110,17 @@ public:
 
     vector<OsmMapPtr> maps;
     QString output = args.last();
+
     for (int i = 0; i < args.size() - 1; i += 2)
     {
       OsmMapPtr map(new OsmMap());
       const QString map1Path = args[i];
       const QString map2Path = args[i + 1];
+
+      LOG_STATUS(
+        "Scoring matches for ..." << FileUtils::toLogFormat(map1Path, 25) << " and ..." <<
+        FileUtils::toLogFormat(map2Path, 25) << "...");
+
       IoUtils::loadMap(map, map1Path, false, Status::Unknown1);
       IoUtils::loadMap(map, map2Path, false, Status::Unknown2);
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/SortCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/SortCmd.cpp
@@ -36,6 +36,7 @@
 #include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/io/IoUtils.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/StringUtils.h>
 
 // Qt
@@ -53,7 +54,6 @@ public:
   SortCmd() = default;
 
   QString getName() const override { return "sort"; }
-
   QString getDescription() const override { return "Sorts a map to the OSM standard"; }
 
   int runSimple(QStringList& args) override
@@ -69,8 +69,10 @@ public:
 
     const QString input = args[0];
     const QString output = args[1];
-    LOG_VARD(input);
-    LOG_VARD(output);
+
+    LOG_STATUS(
+      "Sorting maps ..." << FileUtils::toLogFormat(input, 25) << " and writing output to ..." <<
+      FileUtils::toLogFormat(output, 25) << "...");
 
     if (_inputIsSorted(input))
     {

--- a/hoot-core/src/main/cpp/hoot/core/cmd/SplitCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/SplitCmd.cpp
@@ -30,6 +30,7 @@
 #include <hoot/core/cmd/BaseCommand.h>
 #include <hoot/core/io/IoUtils.h>
 #include <hoot/core/util/Factory.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/StringUtils.h>
 
 // Qt
@@ -49,7 +50,6 @@ public:
   SplitCmd() = default;
 
   QString getName() const override { return "split"; }
-
   QString getDescription() const override { return "Splits a map into tiles"; }
 
   int runSimple(QStringList& args) override
@@ -65,21 +65,30 @@ public:
                           arg(getName()));
     }
 
+    const QString input1 = args[0];
+    const QString input2 = args[1];
+    const QString output = args[2];
+
+    LOG_STATUS(
+      "Splitting ..." << FileUtils::toLogFormat(input1, 25) << " and ..." <<
+      FileUtils::toLogFormat(input2, 25) << " and writing output to ..." <<
+      FileUtils::toLogFormat(output, 25) << "...");
+
     //  Load the tile map ignoring the file IDs
     OsmMapPtr tile_map(new OsmMap());
-    IoUtils::loadMap(tile_map, args[0], false);
+    IoUtils::loadMap(tile_map, input1, false);
     //  Don't introduce source:datetime or source:ingest:datetime
     conf().set(ConfigOptions::getReaderAddSourceDatetimeKey(), false);
     //  Load the actual map and use the file IDs
     OsmMapPtr map(new OsmMap());
-    IoUtils::loadMap(map, args[1], true, Status::Unknown1);
+    IoUtils::loadMap(map, input2, true, Status::Unknown1);
     //  Split the map up into smaller maps
     OsmMapSplitter mapSplitter(map, tile_map);
     mapSplitter.apply();
     //  Don't include error:circular
     conf().set(ConfigOptions::getWriterIncludeCircularErrorTagsKey(), false);
     //  Write the maps out to disk
-    mapSplitter.writeMaps(args[2]);
+    mapSplitter.writeMaps(output);
 
     LOG_STATUS("Map split in " << StringUtils::millisecondsToDhms(timer.elapsed()) << " total.");
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/StatCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/StatCmd.cpp
@@ -59,9 +59,7 @@ public:
   }
 
   QString getName() const override { return "stat"; }
-
-  QString getDescription() const override
-  { return "Calculates a single statistic for a map"; }
+  QString getDescription() const override { return "Calculates a single statistic for a map"; }
 
   int runSimple(QStringList& args) override
   {
@@ -76,25 +74,21 @@ public:
     }
 
     const QString input = args[0].trimmed();
-    LOG_VART(input);
-
     const QString visClassName = args[1].trimmed();
-    LOG_VARD(visClassName);
 
     QString statType = "total";
     if (args.size() == 3)
     {
       statType = args[2].trimmed();
     }
-    LOG_VARD(statType);
     if (!_isValidStatType(statType))
     {
       throw IllegalArgumentException("Invalid statistic type: " + statType);
     }
 
-    LOG_INFO(
+    LOG_STATUS(
       "Calculating statistic of type: " << statType << ", with visitor: " << visClassName <<
-      ", for input: " << FileUtils::toLogFormat(input, 25) << "...")
+      ", for " << FileUtils::toLogFormat(input, 25) << "...")
     const double stat = _calcStat(input, visClassName, statType);
     LOG_VART(stat);
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/StatsCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/StatsCmd.cpp
@@ -56,7 +56,6 @@ public:
   StatsCmd() = default;
 
   QString getName() const override { return "stats"; }
-
   QString getDescription() const override
   { return "Calculates a pre-configured set of statistics for a map"; }
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/TagCompareCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/TagCompareCmd.cpp
@@ -30,6 +30,7 @@
 #include <hoot/core/cmd/BaseCommand.h>
 #include <hoot/core/schema/AttributeCoOccurrence.h>
 #include <hoot/core/io/IoUtils.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/StringUtils.h>
 
 // Qt
@@ -49,9 +50,7 @@ public:
   TagCompareCmd() = default;
 
   QString getName() const override { return "tag-compare"; }
-
-  QString getDescription() const override
-  { return "Compares tags between two maps"; }
+  QString getDescription() const override { return "Compares tags between two maps"; }
 
   int runSimple(QStringList& args) override
   {
@@ -76,9 +75,16 @@ public:
                           arg(getName()));
     }
 
+    const QString input1 = args[0];
+    const QString input2 = args[1];
+
+    LOG_STATUS(
+      "Comparing tags for ..." << FileUtils::toLogFormat(input1, 25) << " and ..." <<
+      FileUtils::toLogFormat(input2, 25) << "...");
+
     OsmMapPtr map(new OsmMap());
-    IoUtils::loadMap(map, args[0], false, Status::Unknown1);
-    IoUtils::loadMap(map, args[1], false, Status::Unknown2);
+    IoUtils::loadMap(map, input1, false, Status::Unknown1);
+    IoUtils::loadMap(map, input2, false, Status::Unknown2);
 
     cooccurrence.addToMatrix(map);
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/TagDistributionCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/TagDistributionCmd.cpp
@@ -46,7 +46,6 @@ public:
   TagDistributionCmd() = default;
 
   QString getName() const override { return "tag-distribution"; }
-
   QString getDescription() const override
   { return "Calculates the distribution of values for specified tags in a map"; }
 
@@ -95,9 +94,7 @@ public:
       args.removeAt(limitIndex + 1);
       args.removeAt(limitIndex);
     }
-    LOG_VARD(sortByFrequency);
 
-    LOG_VARD(args.size());
     if (!nameKeysOnly && (args.size() < 2 || args.size() > 3))
     {
       std::cout << getHelp() << std::endl << std::endl;
@@ -112,7 +109,6 @@ public:
     }
 
     const QStringList inputs = args[0].split(";");
-    LOG_VART(inputs.size());
     QStringList tagKeys;
     if (nameKeysOnly)
     {
@@ -127,6 +123,8 @@ public:
     {
       criterionClassName = args[2];
     }
+
+    LOG_STATUS("Calculating tag distribution for ..." << inputs.size() << " inputs...");
 
     TagDistribution tagDist;
     tagDist.setCriterionClassName(criterionClassName);

--- a/hoot-core/src/main/cpp/hoot/core/cmd/TagInfoCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/TagInfoCmd.cpp
@@ -50,7 +50,6 @@ public:
   TagInfoCmd() = default;
 
   QString getName() const override { return "tag-info"; }
-
   QString getDescription() const override { return "Displays tag information for a map"; }
 
   int runSimple(QStringList& args) override
@@ -77,7 +76,6 @@ public:
       }
       args.removeAt(limitIndex + 1);
       args.removeAt(limitIndex);
-      LOG_VART(args);
     }
 
     QStringList keys;
@@ -87,7 +85,6 @@ public:
       keys = args.at(keysIndex + 1).trimmed().split(";");
       args.removeAt(keysIndex + 1);
       args.removeAt(keysIndex);
-      LOG_VART(args);
     }
 
     bool keysOnly = false;
@@ -95,7 +92,6 @@ public:
     {
       keysOnly = true;
       args.removeAt(args.indexOf("--keys-only"));
-      LOG_VART(args);
     }
 
     bool caseSensitive = true;
@@ -103,7 +99,6 @@ public:
     {
       caseSensitive = false;
       args.removeAt(args.indexOf("--case-insensitive"));
-      LOG_VART(args);
     }
 
     bool exactKeyMatch = true;
@@ -111,7 +106,6 @@ public:
     {
       exactKeyMatch = false;
       args.removeAt(args.indexOf("--partial-key-match"));
-      LOG_VART(args);
     }
 
     bool delimitedTextOutput = false;
@@ -125,7 +119,6 @@ public:
       }
       delimitedTextOutput = true;
       args.removeAt(args.indexOf("--delimited-text"));
-      LOG_VART(args);
     }
 
     // everything left is an input
@@ -134,6 +127,8 @@ public:
     {
       inputs.append(args[i]);
     }
+
+    LOG_STATUS("Displaying tag information for " << inputs.size() << "inputs...");
 
     TagInfo tagInfo(
       tagValuesPerKeyLimit, keys, keysOnly, caseSensitive, exactKeyMatch, delimitedTextOutput);

--- a/hoot-core/src/main/cpp/hoot/core/cmd/TypeSimilarityCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/TypeSimilarityCmd.cpp
@@ -44,7 +44,6 @@ public:
   TypeSimilarityCmd() = default;
 
   QString getName() const override { return "type-similarity"; }
-
   QString getDescription() const override
   { return "Calculates a similarity score between two type tags"; }
 
@@ -58,6 +57,8 @@ public:
 
     const QString tag1 = args[0];
     const QString tag2 = args[1];
+
+    LOG_STATUS("Calculating type similarity score for " << tag1 << " and " << tag2 << "...");
 
     const QString invalidKvpMsg = "is not a valid key/value pair of the form: key=value.";
     if (!Tags::isValidKvp(tag1))

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
@@ -245,7 +245,7 @@ public:
     _numElementsVisited++;
     if (_numElementsVisited % (_taskStatusUpdateInterval /* 10*/) == 0)
     {
-      PROGRESS_INFO(
+      PROGRESS_STATUS(
         "Processed " << StringUtils::formatLargeNumber(_numElementsVisited) << " / " <<
         StringUtils::formatLargeNumber(_map->getWayCount() + _map->getRelationCount()) <<
         " elements.");

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchConflicts.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchConflicts.cpp
@@ -110,6 +110,8 @@ void MatchConflicts::calculateMatchConflicts(
     eidToMatchCount++;
     if (eidToMatchCount % 10 == 0)
     {
+      // TODO: would like this to be status, but it logs a separate line for each statement
+      // for some reason unfortunately.
       PROGRESS_INFO(
         "Processed matches for " << StringUtils::formatLargeNumber(eidToMatchCount) << " / " <<
         StringUtils::formatLargeNumber(eidToMatches.size()) << " elements. Found " <<

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
@@ -230,7 +230,7 @@ public:
     _numElementsVisited++;
     if (_numElementsVisited % (_taskStatusUpdateInterval * 100) == 0)
     {
-      PROGRESS_INFO(
+      PROGRESS_STATUS(
         "Processed " << StringUtils::formatLargeNumber(_numElementsVisited) << " / " <<
         StringUtils::formatLargeNumber(_map->getWayCount() + _map->getRelationCount()) <<
         " elements.");

--- a/hoot-core/src/main/cpp/hoot/core/scoring/RandomForestModelBuilder.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/RandomForestModelBuilder.cpp
@@ -36,6 +36,7 @@
 #include <hoot/core/scoring/MatchFeatureExtractor.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/Factory.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/Log.h>
 #include <hoot/core/util/StringUtils.h>
 
@@ -51,13 +52,15 @@
 namespace hoot
 {
 
-void RandomForestModelBuilder::build(const QStringList trainingData, QString output,
-                                     const bool exportArffOnly)
+void RandomForestModelBuilder::build(
+  const QStringList trainingData, QString output, const bool exportArffOnly)
 {
   if (output.endsWith(".rf"))
   {
     output = output.remove(output.size() - 3, 3);
   }
+
+  LOG_STATUS("Building RF model ..." << FileUtils::toLogFormat(output, 25) << "...");
 
   MatchFeatureExtractor mfe;
   QStringList creators = ConfigOptions().getMatchCreators();

--- a/hoot-core/src/main/cpp/hoot/core/util/Log.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Log.h
@@ -100,39 +100,32 @@ public:
 
   static Log& getInstance();
 
-  WarningLevel getLevel() const { return _level; }
-
-  static WarningLevel levelFromString(QString l);
-
-  static QString levelToString(WarningLevel l);
-
-  QString getLevelAsString() const;
-
   /**
    * May get called multiple times (e.g. before and after config settings are finalized).
    */
   void init();
 
-  bool isDebugEnabled() const { return _level <= Debug; }
+  static WarningLevel levelFromString(QString l);
+  static QString levelToString(WarningLevel l);
+  QString getLevelAsString() const;
 
+  bool isDebugEnabled() const { return _level <= Debug; }
   bool isInfoEnabled() const { return _level <= Info; }
 
   void log(WarningLevel level, const std::string& str);
-
   void log(WarningLevel level, const std::string& str, const std::string& filename,
     const std::string& prettyFunction, int lineNumber);
-
   void log(WarningLevel level, const QString& str, const QString& filename,
     const QString& prettyFunction, int lineNumber);
-
   void progress(WarningLevel level, const std::string& str, const std::string& filename,
     const std::string& functionName, int lineNumber);
-
-  void setLevel(WarningLevel l);
 
   static int getWarnMessageLimit();
 
   static std::string ellipsisStr(const std::string& str, uint count = 33);
+
+  WarningLevel getLevel() const { return _level; }
+  void setLevel(WarningLevel l);
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/util/LogGeneric.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/LogGeneric.cpp
@@ -52,7 +52,6 @@ void Log::log(WarningLevel level, const string& str)
 void Log::log(WarningLevel level, const string& str, const string& filename,
   const string& prettyFunction, int lineNumber)
 {  
-
   if (level >= _level && notFiltered(prettyFunction))
   {
     QDateTime dt = QDateTime::currentDateTime();

--- a/hoot-core/src/main/cpp/hoot/core/visitors/poi-polygon/PoiPolygonMatchVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/poi-polygon/PoiPolygonMatchVisitor.cpp
@@ -213,7 +213,7 @@ void PoiPolygonMatchVisitor::visit(const ConstElementPtr& e)
   _numElementsVisited++;
   if (_numElementsVisited % _taskStatusUpdateInterval == 0)
   {
-    PROGRESS_INFO(
+    PROGRESS_STATUS(
       "Processed " << StringUtils::formatLargeNumber(_numElementsVisited) << " / " <<
       StringUtils::formatLargeNumber(_map->getNodeCount()) << " nodes.");
     _timer.restart();

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.cpp
@@ -589,7 +589,7 @@ public:
     _numElementsVisited++;
     if (_numElementsVisited % _taskStatusUpdateInterval == 0)
     {
-      PROGRESS_INFO(
+      PROGRESS_STATUS(
         "Processed " << StringUtils::formatLargeNumber(_numElementsVisited) << " / " <<
         StringUtils::formatLargeNumber(_totalElementsToProcess) << " elements.");
        _timer.restart();

--- a/hoot-rnd/src/main/cpp/hoot/rnd/cmd/DeDuplicateCmd.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/cmd/DeDuplicateCmd.cpp
@@ -48,10 +48,8 @@ public:
   DeDuplicateCmd() = default;
 
   QString getName() const override { return "de-duplicate"; }
-
   QString getDescription() const override
   { return "Removes duplicate features within a single map or between two maps (experimental)"; }
-
   QString getType() const override { return "rnd"; }
 
   int runSimple(QStringList& args) override
@@ -83,7 +81,8 @@ public:
       input1 = args[0].trimmed();
       output1 = args[1].trimmed();
       LOG_STATUS(
-        "De-duplicating ...:" << FileUtils::toLogFormat(input1, 25) << " to ..." << FileUtils::toLogFormat(output1, 25) << "...");
+        "De-duplicating ...:" << FileUtils::toLogFormat(input1, 25) << " to ..." <<
+        FileUtils::toLogFormat(output1, 25) << "...");
     }
     else
     {
@@ -92,8 +91,10 @@ public:
       output1 = args[2].trimmed();
       output2 = args[3].trimmed();
       LOG_STATUS(
-        "De-duplicating ...:" << FileUtils::toLogFormat(input1, 25) << " to ..." << FileUtils::toLogFormat(output1, 25) << " and ..." <<
-        FileUtils::toLogFormat(input2, 25) << " to ..." << FileUtils::toLogFormat(output2, 25) << "...");
+        "De-duplicating ...:" << FileUtils::toLogFormat(input1, 25) << " to ..." <<
+        FileUtils::toLogFormat(output1, 25) << " and ..." <<
+        FileUtils::toLogFormat(input2, 25) << " to ..." << FileUtils::toLogFormat(output2, 25) <<
+        "...");
     }
     LOG_VARD(input1);
     LOG_VARD(input2);

--- a/hoot-rnd/src/main/cpp/hoot/rnd/cmd/InfoRndCmd.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/cmd/InfoRndCmd.cpp
@@ -48,10 +48,8 @@ public:
   InfoRndCmd() = default;
 
   QString getName() const override { return "info-rnd"; }
-
   QString getDescription() const override
   { return "Displays information about capabilities specific to the hoot-rnd module"; }
-
   QString getType() const override { return "rnd"; }
 
   int runSimple(QStringList& args) override

--- a/hoot-rnd/src/main/cpp/hoot/rnd/cmd/LoginCmd.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/cmd/LoginCmd.cpp
@@ -43,10 +43,8 @@ public:
   LoginCmd() = default;
 
   QString getName() const override { return "login"; }
-
   QString getDescription() const override
   { return "Logs a user into the Hootenanny Web Services"; }
-
   QString getType() const override { return "rnd"; }
 
   int runSimple(QStringList& args) override

--- a/hoot-rnd/src/main/cpp/hoot/rnd/cmd/LogoutCmd.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/cmd/LogoutCmd.cpp
@@ -45,10 +45,8 @@ public:
   LogoutCmd() = default;
 
   QString getName() const override { return "logout"; }
-
   QString getDescription() const override
   { return "Logs a user out of the Hootenanny Web Services"; }
-
   QString getType() const override { return "rnd"; }
 
   int runSimple(QStringList& args) override

--- a/hoot-rnd/src/main/cpp/hoot/rnd/cmd/MultiaryPoiConflateCmd.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/cmd/MultiaryPoiConflateCmd.cpp
@@ -66,10 +66,8 @@ public:
   MultiaryConflatePoiCmd() = default;
 
   QString getName() const override { return "multiary-poi-conflate"; }
-
   QString getDescription() const override
   { return "Conflates two or more POI maps into a single map (experimental) "; }
-
   QString getType() const override { return "rnd"; }
 
   int runSimple(QStringList& args) override
@@ -89,9 +87,9 @@ public:
     inputs = args.mid(0, args.length() - 1);
     output = args.last();
 
-    LOG_INFO(
+    LOG_STATUS(
       "Conflating " << FileUtils::toLogFormat(inputs) <<
-      " and writing the output to " << FileUtils::toLogFormat(output, 50));
+      " and writing the output to " << FileUtils::toLogFormat(output, 50) << "...");
 
     // read input 1
     OsmMapPtr map(new OsmMap());

--- a/hoot-rnd/src/main/cpp/hoot/rnd/cmd/MultiaryPoiIngestCmd.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/cmd/MultiaryPoiIngestCmd.cpp
@@ -29,6 +29,7 @@
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/cmd/BaseCommand.h>
 #include <hoot/rnd/io/MultiaryIngester.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/StringUtils.h>
 
 // Qt
@@ -44,10 +45,8 @@ public:
   static QString className() { return "hoot::MultiaryPoiIngestCmd"; }
 
   QString getName() const override { return "multiary-poi-ingest"; }
-
   QString getDescription() const override
   { return "Ingests POIs for use by multiary-poi-conflate (experimental) "; }
-
   QString getType() const override { return "rnd"; }
 
   int runSimple(QStringList& args) override
@@ -61,7 +60,18 @@ public:
       throw HootException(QString("%1 takes four parameters.").arg(getName()));
     }
 
-    MultiaryIngester().ingest(args[0], args[1], args[2], args[3]);
+    const QString input = args[0];
+    const QString translation = args[1];
+    const QString output = args[2];
+    const QString changesetOutput = args[3];
+
+    LOG_STATUS(
+      "Ingesting multiary POI data from ..." << FileUtils::toLogFormat(input, 25) <<
+      " using translation ..." << FileUtils::toLogFormat(translation, 25) <<
+      " and writing output to ..." << FileUtils::toLogFormat(output, 25) <<
+      " and changeset output to ..." << FileUtils::toLogFormat(changesetOutput, 25) << "...");
+
+    MultiaryIngester().ingest(input, translation, output, changesetOutput);
 
     LOG_STATUS(
       "Ingest completed in " << StringUtils::millisecondsToDhms(timer.elapsed()) << " total.");

--- a/hoot-rnd/src/main/cpp/hoot/rnd/cmd/MultiaryScorePoiMatchesCmd.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/cmd/MultiaryScorePoiMatchesCmd.cpp
@@ -61,6 +61,12 @@ public:
 
   MultiaryScorePoiMatchesCmd() = default;
 
+  QString getName() const override { return "multiary-score-poi-matches"; }
+  QString getDescription() const override
+  { return "Scores the performance of multiary-poi-conflate against a manually matched map (experimental) "; }
+  QString getType() const override { return "rnd"; }
+
+
   QString evaluateThreshold(OsmMapPtr map, QString output,
     std::shared_ptr<MatchThreshold> mt, bool showConfusion)
   {
@@ -105,13 +111,6 @@ public:
     return result;
   }
 
-  QString getName() const override { return "multiary-score-poi-matches"; }
-
-  QString getDescription() const override
-  { return "Scores the performance of multiary-poi-conflate against a manually matched map (experimental) "; }
-
-  QString getType() const override { return "rnd"; }
-
   int runSimple(QStringList& args) override
   {
     QElapsedTimer timer;
@@ -145,6 +144,8 @@ public:
         QString("%1 takes at least two parameters: two or more input maps")
           .arg(getName()));
     }
+
+    LOG_STATUS("Scoring multiary conflate matches from ..." << args.size() << " inputs...");
 
     // modifying the schema is necessary to ensure the conflation concatenates values.
     SchemaVertex id;

--- a/hoot-rnd/src/main/cpp/hoot/rnd/cmd/PlotNodeDensityCmd.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/cmd/PlotNodeDensityCmd.cpp
@@ -34,6 +34,7 @@
 #include <hoot/core/io/PartialOsmMapReader.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/OpenCv.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/StringUtils.h>
 #include <hoot/core/visitors/CalculateMapBoundsVisitor.h>
 
@@ -60,10 +61,7 @@ class PlotNodeDensityCmd : public BaseCommand
     PlotNodeDensityCmd() = default;
 
     QString getName() const override { return "plot-node-density"; }
-
-    QString getDescription() const override
-    { return "Creates a node density plot for a map"; }
-
+    QString getDescription() const override { return "Creates a node density plot for a map"; }
     QString getType() const { return "rnd"; }
 
     Envelope getEnvelope(const std::shared_ptr<OsmMapReader>& reader)
@@ -190,6 +188,10 @@ class PlotNodeDensityCmd : public BaseCommand
       {
         throw HootException("Expected a number > 0 for max size.");
       }
+
+      LOG_STATUS(
+        "Plotting node density for ..." << FileUtils::toLogFormat(input, 25) <<
+        " and writing output to ..." << FileUtils::toLogFormat(output, 25) << "...");
 
       // initialize to black
       QRgb baseColors = qRgba(0, 0, 0, 255);

--- a/hoot-rnd/src/main/cpp/hoot/rnd/cmd/ScoreMatchesDiffCmd.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/cmd/ScoreMatchesDiffCmd.cpp
@@ -29,6 +29,7 @@
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/cmd/BaseCommand.h>
 #include <hoot/rnd/conflate/matching/ScoreMatchesDiff.h>
+#include <hoot/core/util/FileUtils.h>
 #include <hoot/core/util/StringUtils.h>
 
 // Qt
@@ -47,9 +48,7 @@ public:
   ScoreMatchesDiffCmd() = default;
 
   QString getName() const override { return "score-matches-diff"; }
-
   QString getType() const override { return "rnd"; }
-
   QString getDescription() const override
   { return "Compares conflate performance between score-matches outputs (experimental)"; }
 
@@ -64,11 +63,20 @@ public:
       throw HootException(QString("%1 takes three parameters.").arg(getName()));
     }
 
+    const QString input1 = args[0].trimmed();
+    const QString input2 = args[1].trimmed();
+    const QString output = args[2].trimmed();
+
+    LOG_STATUS(
+      "Calculating conflate match difference between ..." << FileUtils::toLogFormat(input1, 25) <<
+      " and ..." << FileUtils::toLogFormat(input2, 25) << "; writing output to ..." <<
+      FileUtils::toLogFormat(output, 25) << "...");
+
     try
     {
       ScoreMatchesDiff diffGen;
-      diffGen.calculateDiff(args[0].trimmed(), args[1].trimmed());
-      diffGen.printDiff(args[2].trimmed());
+      diffGen.calculateDiff(input1, input2);
+      diffGen.printDiff(output);
     }
     catch (const HootException& e)
     {

--- a/hoot-rnd/src/main/cpp/hoot/rnd/cmd/SynchronizeElementIdsCmd.cpp
+++ b/hoot-rnd/src/main/cpp/hoot/rnd/cmd/SynchronizeElementIdsCmd.cpp
@@ -51,10 +51,8 @@ public:
   SynchronizeElementIdsCmd() = default;
 
   QString getName() const override { return "sync-element-ids"; }
-
   QString getDescription() const override
   { return "Copies IDs for identical elements from one map to another (experimental)"; }
-
   QString getType() const override { return "rnd"; }
 
   int runSimple(QStringList& args) override

--- a/hoot-test/src/main/cpp/hoot/test/main.cpp
+++ b/hoot-test/src/main/cpp/hoot/test/main.cpp
@@ -644,7 +644,7 @@ int main(int argc, char* argv[])
 
       listener.reset(new HootTestListener(false, suppressFailureDetail, -1));
       result.addListener(listener.get());
-      Log::getInstance().setLevel(Log::Info);
+      Log::getInstance().setLevel(Log::Status);
       populateTests(ALL, vAllTests, printDiff, suppressFailureDetail, true);
       CppUnit::Test* t = findTest(vAllTests, testName.toStdString());
       if (t == nullptr)
@@ -695,7 +695,7 @@ int main(int argc, char* argv[])
       if (type == CURRENT)
       {
         listener.reset(new HootTestListener(true, suppressFailureDetail, timeout));
-        Log::getInstance().setLevel(Log::Info);
+        Log::getInstance().setLevel(Log::Status);
       }
       else
         listener.reset(new HootTestListener(false, suppressFailureDetail, timeout));


### PR DESCRIPTION
`--status` is widely implemented throughout now after being introduced awhile back. `--info` is useful for more detailed job feedback but is just a little too verbose now for normal usage. This also adds initial status logging to all commands that didn't have it.