### PR TITLE
Nodejs updates pre-upgrade

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/HootNetworkRequest.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootNetworkRequest.cpp
@@ -101,7 +101,7 @@ bool HootNetworkRequest::_networkRequest(const QUrl& url, int timeout,
   _error.clear();
   _timedOut = false;
   //  Do HTTP request
-  std::shared_ptr<QNetworkAccessManager> pNAM(new QNetworkAccessManager());
+  std::shared_ptr<QNetworkAccessManager> pNAM = std::make_shared<QNetworkAccessManager>();
   QNetworkRequest request(url);
 
   if (tempUrl.scheme().toLower() == "https")

--- a/hoot-js/src/main/cpp/hoot/js/HelloWorld.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/HelloWorld.cpp
@@ -54,7 +54,7 @@ public:
 
 HOOT_FACTORY_REGISTER_BASE(HootJsLoaded)
 
-void init(Handle<Object> exports)
+void init(Local<Object> exports)
 {
   JsRegistrar::Init(exports);
 }

--- a/hoot-js/src/main/cpp/hoot/js/JsRegistrar.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/JsRegistrar.cpp
@@ -48,14 +48,14 @@ JsRegistrar& JsRegistrar::getInstance()
   return instance;
 }
 
-void JsRegistrar::Init(Handle<Object> exports)
+void JsRegistrar::Init(Local<Object> exports)
 {
   LOG_DEBUG("JS registrar init...");
   Hoot::getInstance().init();
   getInstance().initAll(exports);
 }
 
-void JsRegistrar::initAll(Handle<Object> exports)
+void JsRegistrar::initAll(Local<Object> exports)
 {
   // Got this from the NodeJS docs. Seems to be a bit simpler than what we were doing.
   NODE_SET_METHOD(exports, "hello", Method);

--- a/hoot-js/src/main/cpp/hoot/js/JsRegistrar.h
+++ b/hoot-js/src/main/cpp/hoot/js/JsRegistrar.h
@@ -44,7 +44,7 @@ public:
 
   virtual ~ClassInitializer() = default;
 
-  virtual void Init(v8::Handle<v8::Object> exports) = 0;
+  virtual void Init(v8::Local<v8::Object> exports) = 0;
 
 private:
 
@@ -61,7 +61,7 @@ public:
 
   ~ClassInitializerTemplate() = default;
 
-  void Init(v8::Handle<v8::Object> exports) override
+  void Init(v8::Local<v8::Object> exports) override
   {
     T::Init(exports);
   }
@@ -76,9 +76,9 @@ public:
 
   static JsRegistrar& getInstance();
 
-  static void Init(v8::Handle<v8::Object> exports);
+  static void Init(v8::Local<v8::Object> exports);
 
-  void initAll(v8::Handle<v8::Object> exports);
+  void initAll(v8::Local<v8::Object> exports);
 
   void registerInitializer(const std::shared_ptr<ClassInitializer>& ci);
 

--- a/hoot-js/src/main/cpp/hoot/js/PluginContext.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/PluginContext.cpp
@@ -62,13 +62,13 @@ PluginContext::PluginContext()
 
   // Create a template for the global object where we set the
   // built-in global functions.
-  Handle<Object> global = ToLocal(&_context)->Global();
+  Local<Object> global = ToLocal(&_context)->Global();
 
   // Enter the created context for compiling and
   // running the hello world script.
   Context::Scope context_scope(ToLocal(&_context));
 
-  Handle<Object> hns = Object::New(current);
+  Local<Object> hns = Object::New(current);
   global->Set(String::NewFromUtf8(current, "hoot"), hns);
   JsRegistrar::getInstance().initAll(hns);
 
@@ -81,7 +81,7 @@ PluginContext::PluginContext()
   }
 }
 
-Local<Value> PluginContext::call(Handle<Object> obj, QString name, QList<QVariant> args)
+Local<Value> PluginContext::call(Local<Object> obj, QString name, QList<QVariant> args)
 {
   Isolate* current = obj->GetIsolate();
   EscapableHandleScope handleScope(current);
@@ -89,12 +89,12 @@ Local<Value> PluginContext::call(Handle<Object> obj, QString name, QList<QVarian
   if (obj->Has(context, String::NewFromUtf8(current, name.toUtf8().data())).ToChecked() == false)
     throw InternalErrorException("Unable to find method in JS: " + name);
 
-  Handle<Value> value = obj->Get(String::NewFromUtf8(current, name.toUtf8().data()));
+  Local<Value> value = obj->Get(String::NewFromUtf8(current, name.toUtf8().data()));
   if (value->IsFunction() == false)
     throw InternalErrorException("The specified object is not a function: " + name);
 
-  Handle<Function> func = Handle<Function>::Cast(value);
-  vector<Handle<Value>> jsArgs(args.size());
+  Local<Function> func = Local<Function>::Cast(value);
+  vector<Local<Value>> jsArgs(args.size());
 
   for (int i = 0; i < args.size(); i++)
   {
@@ -139,7 +139,7 @@ Local<Object> PluginContext::loadScript(QString filename, QString loadInto)
 
   QString text = QString::fromUtf8(fp.readAll());
 
-  Handle<Object> result = loadText(text, loadInto, filename);
+  Local<Object> result = loadText(text, loadInto, filename);
 
   return escapableHandleScope.Escape(result);
 }
@@ -180,7 +180,7 @@ Local<Object> PluginContext::loadText(QString text, QString loadInto, QString sc
 }
 
 
-double PluginContext::toNumber(Handle<Value> v, QString key, double defaultValue)
+double PluginContext::toNumber(Local<Value> v, QString key, double defaultValue)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   HandleScope handleScope(current);
@@ -189,9 +189,9 @@ double PluginContext::toNumber(Handle<Value> v, QString key, double defaultValue
   {
     throw IllegalArgumentException("Expected value to be an object.");
   }
-  Handle<Object> obj = Handle<Object>::Cast(v);
+  Local<Object> obj = Local<Object>::Cast(v);
 
-  Handle<String> keyStr = String::NewFromUtf8(current, key.toUtf8());
+  Local<String> keyStr = String::NewFromUtf8(current, key.toUtf8());
   double result = defaultValue;
   if (obj->Has(context, keyStr).ToChecked() == false)
   {
@@ -212,7 +212,7 @@ Local<Value> PluginContext::toValue(QVariant v)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope handleScope(current);
-  Handle<Value> result;
+  Local<Value> result;
   switch (v.type())
   {
   case QVariant::Int:

--- a/hoot-js/src/main/cpp/hoot/js/PluginContext.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/PluginContext.cpp
@@ -180,7 +180,7 @@ Local<Object> PluginContext::loadText(QString text, QString loadInto, QString sc
 }
 
 
-double PluginContext::toNumber(Local<Value> v, QString key, double defaultValue)
+double PluginContext::toNumber(Local<Value> v, QString key, double defaultValue) const
 {
   Isolate* current = v8::Isolate::GetCurrent();
   HandleScope handleScope(current);
@@ -208,7 +208,7 @@ double PluginContext::toNumber(Local<Value> v, QString key, double defaultValue)
   return result;
 }
 
-Local<Value> PluginContext::toValue(QVariant v)
+Local<Value> PluginContext::toValue(QVariant v) const
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope handleScope(current);

--- a/hoot-js/src/main/cpp/hoot/js/PluginContext.h
+++ b/hoot-js/src/main/cpp/hoot/js/PluginContext.h
@@ -58,7 +58,7 @@ public:
    * @param args - List of arguments to the function. Converted using "toValue"
    */
   v8::Local<v8::Value> call(
-    v8::Handle<v8::Object> obj, QString name, QList<QVariant> args = QList<QVariant>());
+    v8::Local<v8::Object> obj, QString name, QList<QVariant> args = QList<QVariant>());
 
   v8::Local<v8::Value> eval(QString e);
 
@@ -76,7 +76,7 @@ public:
    * the key doesn't exist. If you need to use UNSPECIFIED_DEFAULT as the default value, use
    * another method :P.
    */
-  double toNumber(v8::Handle<v8::Value> v, QString key, double defaultValue = UNSPECIFIED_DEFAULT);
+  double toNumber(v8::Local<v8::Value> v, QString key, double defaultValue = UNSPECIFIED_DEFAULT);
 
   v8::Local<v8::Value> toValue(QVariant v);
 

--- a/hoot-js/src/main/cpp/hoot/js/PluginContext.h
+++ b/hoot-js/src/main/cpp/hoot/js/PluginContext.h
@@ -76,9 +76,9 @@ public:
    * the key doesn't exist. If you need to use UNSPECIFIED_DEFAULT as the default value, use
    * another method :P.
    */
-  double toNumber(v8::Local<v8::Value> v, QString key, double defaultValue = UNSPECIFIED_DEFAULT);
+  double toNumber(v8::Local<v8::Value> v, QString key, double defaultValue = UNSPECIFIED_DEFAULT) const;
 
-  v8::Local<v8::Value> toValue(QVariant v);
+  v8::Local<v8::Value> toValue(QVariant v) const;
 
 private:
 

--- a/hoot-js/src/main/cpp/hoot/js/algorithms/aggregator/ValueAggregatorJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/algorithms/aggregator/ValueAggregatorJs.cpp
@@ -45,7 +45,7 @@ HOOT_JS_REGISTER(ValueAggregatorJs)
 
 Persistent<Function> ValueAggregatorJs::_constructor;
 
-void ValueAggregatorJs::Init(Handle<Object> target)
+void ValueAggregatorJs::Init(Local<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);

--- a/hoot-js/src/main/cpp/hoot/js/algorithms/aggregator/ValueAggregatorJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/algorithms/aggregator/ValueAggregatorJs.cpp
@@ -49,6 +49,8 @@ void ValueAggregatorJs::Init(Handle<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
+
   vector<QString> opNames =
     Factory::getInstance().getObjectNamesByBase(ValueAggregator::className());
 
@@ -66,7 +68,7 @@ void ValueAggregatorJs::Init(Handle<Object> target)
       PopulateConsumersJs::baseClass(),
       String::NewFromUtf8(current, ValueAggregator::className().toStdString().data()));
 
-    Persistent<Function> constructor(current, tpl->GetFunction());
+    Persistent<Function> constructor(current, tpl->GetFunction(context).ToLocalChecked());
     target->Set(String::NewFromUtf8(current, n), ToLocal(&constructor));
   }
 }

--- a/hoot-js/src/main/cpp/hoot/js/algorithms/aggregator/ValueAggregatorJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/algorithms/aggregator/ValueAggregatorJs.h
@@ -43,11 +43,11 @@ class ValueAggregatorJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   ValueAggregatorPtr getValueAggregator() { return _va; }
 
-  static v8::Handle<v8::Object> New(const ValueAggregatorPtr& va);
+  static v8::Local<v8::Object> New(const ValueAggregatorPtr& va);
 
   virtual ~ValueAggregatorJs() = default;
 
@@ -62,14 +62,14 @@ private:
   static v8::Persistent<v8::Function> _constructor;
 };
 
-inline void toCpp(v8::Handle<v8::Value> v, ValueAggregatorPtr& p)
+inline void toCpp(v8::Local<v8::Value> v, ValueAggregatorPtr& p)
 {
   if (!v->IsObject())
   {
     throw IllegalArgumentException("Expected an object, got: (" + toJson(v) + ")");
   }
 
-  v8::Handle<v8::Object> obj = v8::Handle<v8::Object>::Cast(v);
+  v8::Local<v8::Object> obj = v8::Local<v8::Object>::Cast(v);
   ValueAggregatorJs* vaj = nullptr;
   vaj = node::ObjectWrap::Unwrap<ValueAggregatorJs>(obj);
   if (vaj)

--- a/hoot-js/src/main/cpp/hoot/js/algorithms/aggregator/ValueAggregatorJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/algorithms/aggregator/ValueAggregatorJs.h
@@ -82,7 +82,7 @@ inline void toCpp(v8::Local<v8::Value> v, ValueAggregatorPtr& p)
   }
 }
 
-inline v8::Handle<v8::Value> toV8(const ValueAggregatorPtr& va)
+inline v8::Local<v8::Value> toV8(const ValueAggregatorPtr& va)
 {
   return ValueAggregatorJs::New(va);
 }

--- a/hoot-js/src/main/cpp/hoot/js/algorithms/extractors/FeatureExtractorJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/algorithms/extractors/FeatureExtractorJs.cpp
@@ -53,6 +53,7 @@ void FeatureExtractorJs::extract(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   FeatureExtractorJs* feJs = ObjectWrap::Unwrap<FeatureExtractorJs>(args.This());
 
@@ -61,9 +62,9 @@ void FeatureExtractorJs::extract(const FunctionCallbackInfo<Value>& args)
     throw IllegalArgumentException("Expected exactly three argument in extract (map, e1, e2)");
   }
 
-  OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject());
-  ElementJs* e1Js = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject());
-  ElementJs* e2Js = ObjectWrap::Unwrap<ElementJs>(args[2]->ToObject());
+  OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked());
+  ElementJs* e1Js = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked());
+  ElementJs* e2Js = ObjectWrap::Unwrap<ElementJs>(args[2]->ToObject(context).ToLocalChecked());
 
   double result =
     feJs->getFeatureExtractor()->extract(
@@ -83,6 +84,7 @@ void FeatureExtractorJs::Init(Handle<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   vector<QString> opNames =
     Factory::getInstance().getObjectNamesByBase(FeatureExtractor::className());
 
@@ -99,7 +101,7 @@ void FeatureExtractorJs::Init(Handle<Object> target)
     tpl->PrototypeTemplate()->Set(String::NewFromUtf8(current, "extract"),
         FunctionTemplate::New(current, extract));
 
-    Persistent<Function> constructor(current, tpl->GetFunction());
+    Persistent<Function> constructor(current, tpl->GetFunction(context).ToLocalChecked());
     target->Set(String::NewFromUtf8(current, n), ToLocal(&constructor));
   }
 }

--- a/hoot-js/src/main/cpp/hoot/js/algorithms/extractors/FeatureExtractorJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/algorithms/extractors/FeatureExtractorJs.cpp
@@ -63,8 +63,8 @@ void FeatureExtractorJs::extract(const FunctionCallbackInfo<Value>& args)
   }
 
   OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked());
-  ElementJs* e1Js = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked());
-  ElementJs* e2Js = ObjectWrap::Unwrap<ElementJs>(args[2]->ToObject(context).ToLocalChecked());
+  const ElementJs* e1Js = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked());
+  const ElementJs* e2Js = ObjectWrap::Unwrap<ElementJs>(args[2]->ToObject(context).ToLocalChecked());
 
   double result =
     feJs->getFeatureExtractor()->extract(

--- a/hoot-js/src/main/cpp/hoot/js/algorithms/extractors/FeatureExtractorJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/algorithms/extractors/FeatureExtractorJs.cpp
@@ -80,7 +80,7 @@ void FeatureExtractorJs::extract(const FunctionCallbackInfo<Value>& args)
   }
 }
 
-void FeatureExtractorJs::Init(Handle<Object> target)
+void FeatureExtractorJs::Init(Local<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);

--- a/hoot-js/src/main/cpp/hoot/js/algorithms/extractors/FeatureExtractorJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/algorithms/extractors/FeatureExtractorJs.h
@@ -47,7 +47,7 @@ class FeatureExtractorJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   FeatureExtractorPtr getFeatureExtractor() { return _fe; }
 

--- a/hoot-js/src/main/cpp/hoot/js/algorithms/string/StringDistanceJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/algorithms/string/StringDistanceJs.cpp
@@ -49,6 +49,7 @@ void StringDistanceJs::Init(Handle<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   vector<QString> opNames =
     Factory::getInstance().getObjectNamesByBase(StringDistance::className());
 
@@ -66,7 +67,7 @@ void StringDistanceJs::Init(Handle<Object> target)
       PopulateConsumersJs::baseClass(),
       String::NewFromUtf8(current, StringDistance::className().toStdString().data()));
 
-    Persistent<Function> constructor(current, tpl->GetFunction());
+    Persistent<Function> constructor(current, tpl->GetFunction(context).ToLocalChecked());
     target->Set(String::NewFromUtf8(current, n), ToLocal(&constructor));
   }
 }

--- a/hoot-js/src/main/cpp/hoot/js/algorithms/string/StringDistanceJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/algorithms/string/StringDistanceJs.cpp
@@ -45,7 +45,7 @@ HOOT_JS_REGISTER(StringDistanceJs)
 
 Persistent<Function> StringDistanceJs::_constructor;
 
-void StringDistanceJs::Init(Handle<Object> target)
+void StringDistanceJs::Init(Local<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);

--- a/hoot-js/src/main/cpp/hoot/js/algorithms/string/StringDistanceJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/algorithms/string/StringDistanceJs.h
@@ -45,11 +45,11 @@ class StringDistanceJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   StringDistancePtr getStringDistance() { return _sd; }
 
-  static v8::Handle<v8::Object> New(const StringDistancePtr& sd);
+  static v8::Local<v8::Object> New(const StringDistancePtr& sd);
 
   virtual ~StringDistanceJs() = default;
 
@@ -64,14 +64,14 @@ private:
   static v8::Persistent<v8::Function> _constructor;
 };
 
-inline void toCpp(v8::Handle<v8::Value> v, StringDistancePtr& p)
+inline void toCpp(v8::Local<v8::Value> v, StringDistancePtr& p)
 {
   if (!v->IsObject())
   {
     throw IllegalArgumentException("Expected an object, got: (" + toJson(v) + ")");
   }
 
-  v8::Handle<v8::Object> obj = v8::Handle<v8::Object>::Cast(v);
+  v8::Local<v8::Object> obj = v8::Local<v8::Object>::Cast(v);
   StringDistanceJs* sdj = nullptr;
   sdj = node::ObjectWrap::Unwrap<StringDistanceJs>(obj);
   if (sdj)
@@ -84,7 +84,7 @@ inline void toCpp(v8::Handle<v8::Value> v, StringDistancePtr& p)
   }
 }
 
-inline v8::Handle<v8::Value> toV8(const StringDistancePtr& sd)
+inline v8::Local<v8::Value> toV8(const StringDistancePtr& sd)
 {
   return StringDistanceJs::New(sd);
 }

--- a/hoot-js/src/main/cpp/hoot/js/algorithms/subline-matching/SublineStringMatcherJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/algorithms/subline-matching/SublineStringMatcherJs.cpp
@@ -63,13 +63,14 @@ void SublineStringMatcherJs::extractMatchingSublines(const FunctionCallbackInfo<
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   SublineStringMatcherJs* smJs = ObjectWrap::Unwrap<SublineStringMatcherJs>(args.This());
   SublineStringMatcherPtr sm = smJs->getSublineStringMatcher();
 
-  OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject());
-  ElementJs* e1Js = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject());
-  ElementJs* e2Js = ObjectWrap::Unwrap<ElementJs>(args[2]->ToObject());
+  OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked());
+  ElementJs* e1Js = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked());
+  ElementJs* e2Js = ObjectWrap::Unwrap<ElementJs>(args[2]->ToObject(context).ToLocalChecked());
   ConstOsmMapPtr m = mapJs->getConstMap();
   ConstElementPtr e1 = e1Js->getConstElement();
   ConstElementPtr e2 = e2Js->getConstElement();
@@ -160,6 +161,7 @@ void SublineStringMatcherJs::Init(Handle<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   vector<QString> opNames =
     Factory::getInstance().getObjectNamesByBase(SublineStringMatcher::className());
 
@@ -176,7 +178,7 @@ void SublineStringMatcherJs::Init(Handle<Object> target)
     tpl->PrototypeTemplate()->Set(String::NewFromUtf8(current, "extractMatchingSublines"),
         FunctionTemplate::New(current, extractMatchingSublines));
 
-    Persistent<Function> constructor(current, tpl->GetFunction());
+    Persistent<Function> constructor(current, tpl->GetFunction(context).ToLocalChecked());
     target->Set(String::NewFromUtf8(current, n), ToLocal(&constructor));
   }
 }

--- a/hoot-js/src/main/cpp/hoot/js/algorithms/subline-matching/SublineStringMatcherJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/algorithms/subline-matching/SublineStringMatcherJs.cpp
@@ -75,7 +75,7 @@ void SublineStringMatcherJs::extractMatchingSublines(const FunctionCallbackInfo<
   ConstElementPtr e1 = e1Js->getConstElement();
   ConstElementPtr e2 = e2Js->getConstElement();
 
-  Handle<Value> result;
+  Local<Value> result;
   try
   {
     // Some attempts were made to use cached subline matches here from SublineStringMatcherJs for
@@ -143,7 +143,7 @@ void SublineStringMatcherJs::extractMatchingSublines(const FunctionCallbackInfo<
     else
     {
       LOG_TRACE("match");
-      Handle<Object> obj = Object::New(current);
+      Local<Object> obj = Object::New(current);
       obj->Set(String::NewFromUtf8(current, "map"), OsmMapJs::create(copiedMap));
       obj->Set(String::NewFromUtf8(current, "match1"), ElementJs::New(match1));
       obj->Set(String::NewFromUtf8(current, "match2"), ElementJs::New(match2));
@@ -157,7 +157,7 @@ void SublineStringMatcherJs::extractMatchingSublines(const FunctionCallbackInfo<
   }
 }
 
-void SublineStringMatcherJs::Init(Handle<Object> target)
+void SublineStringMatcherJs::Init(Local<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);

--- a/hoot-js/src/main/cpp/hoot/js/algorithms/subline-matching/SublineStringMatcherJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/algorithms/subline-matching/SublineStringMatcherJs.cpp
@@ -69,8 +69,8 @@ void SublineStringMatcherJs::extractMatchingSublines(const FunctionCallbackInfo<
   SublineStringMatcherPtr sm = smJs->getSublineStringMatcher();
 
   OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked());
-  ElementJs* e1Js = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked());
-  ElementJs* e2Js = ObjectWrap::Unwrap<ElementJs>(args[2]->ToObject(context).ToLocalChecked());
+  const ElementJs* e1Js = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked());
+  const ElementJs* e2Js = ObjectWrap::Unwrap<ElementJs>(args[2]->ToObject(context).ToLocalChecked());
   ConstOsmMapPtr m = mapJs->getConstMap();
   ConstElementPtr e1 = e1Js->getConstElement();
   ConstElementPtr e2 = e2Js->getConstElement();

--- a/hoot-js/src/main/cpp/hoot/js/algorithms/subline-matching/SublineStringMatcherJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/algorithms/subline-matching/SublineStringMatcherJs.h
@@ -46,7 +46,7 @@ public:
 
   static int logWarnCount;
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   SublineStringMatcherPtr getSublineStringMatcher() { return _sm; }
 
@@ -63,14 +63,14 @@ private:
   SublineStringMatcherPtr _sm;
 };
 
-inline void toCpp(v8::Handle<v8::Value> v, SublineStringMatcherPtr& ptr)
+inline void toCpp(v8::Local<v8::Value> v, SublineStringMatcherPtr& ptr)
 {
   if (!v->IsObject())
   {
     throw IllegalArgumentException("Expected an object, got: (" + toJson(v) + ")");
   }
 
-  v8::Handle<v8::Object> obj = v8::Handle<v8::Object>::Cast(v);
+  v8::Local<v8::Object> obj = v8::Local<v8::Object>::Cast(v);
   SublineStringMatcherJs* ptrj = node::ObjectWrap::Unwrap<SublineStringMatcherJs>(obj);
   ptr = ptrj->getSublineStringMatcher();
 }

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/MatchFactoryJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/MatchFactoryJs.cpp
@@ -37,11 +37,11 @@ namespace hoot
 
 HOOT_JS_REGISTER(MatchFactoryJs)
 
-void MatchFactoryJs::Init(Handle<Object> exports)
+void MatchFactoryJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
-  Handle<Object> schema = Object::New(current);
+  Local<Object> schema = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "MatchFactory"), schema);
 }
 

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/MatchFactoryJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/MatchFactoryJs.h
@@ -40,7 +40,7 @@ class MatchFactoryJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   virtual ~MatchFactoryJs() = default;
 
@@ -49,9 +49,9 @@ private:
   MatchFactoryJs() = default;
 };
 
-inline v8::Handle<v8::Value> toV8(const CreatorDescription& d)
+inline v8::Local<v8::Value> toV8(const CreatorDescription& d)
 {
-  v8::Handle<v8::Object> result = v8::Object::New(v8::Isolate::GetCurrent());
+  v8::Local<v8::Object> result = v8::Object::New(v8::Isolate::GetCurrent());
   result->Set(toV8("className"), toV8(d.getClassName()));
   result->Set(toV8("description"), toV8(d.getDescription()));
   result->Set(toV8("experimental"), toV8(d.getExperimental()));

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.h
@@ -59,7 +59,7 @@ public:
    */
   ScriptMatch(
     const std::shared_ptr<PluginContext>& script, const v8::Persistent<v8::Object>& plugin,
-    const ConstOsmMapPtr& map, const v8::Handle<v8::Object>& mapObj, const ElementId& eid1,
+    const ConstOsmMapPtr& map, const v8::Local<v8::Object>& mapObj, const ElementId& eid1,
     const ElementId& eid2, const ConstMatchThresholdPtr& mt);
   ~ScriptMatch() = default;
 
@@ -121,10 +121,10 @@ private:
   mutable QHash<ConflictKey, bool> _conflicts;
 
   void _calculateClassification(
-    const ConstOsmMapPtr& map, v8::Handle<v8::Object> mapObj, v8::Handle<v8::Object> plugin);
+    const ConstOsmMapPtr& map, v8::Local<v8::Object> mapObj, v8::Local<v8::Object> plugin);
 
-  v8::Handle<v8::Value> _call(
-    const ConstOsmMapPtr& map, v8::Handle<v8::Object> mapObj, v8::Handle<v8::Object> plugin);
+  v8::Local<v8::Value> _call(
+    const ConstOsmMapPtr& map, v8::Local<v8::Object> mapObj, v8::Local<v8::Object> plugin);
 
   ConflictKey _getConflictKey() const { return ConflictKey(_eid1, _eid2); }
 
@@ -136,10 +136,10 @@ private:
    * Either creates a new match or retrieves an existing one from the global set of matches
    */
   std::shared_ptr<const ScriptMatch> _getMatch(
-    OsmMapPtr map, v8::Handle<v8::Object> mapJs, const ElementId& eid1, const ElementId& eid2,
+    OsmMapPtr map, v8::Local<v8::Object> mapJs, const ElementId& eid1, const ElementId& eid2,
     const QHash<QString, ConstMatchPtr>& matches) const;
 
-  v8::Handle<v8::Value> _callGetMatchFeatureDetails(const ConstOsmMapPtr& map) const;
+  v8::Local<v8::Value> _callGetMatchFeatureDetails(const ConstOsmMapPtr& map) const;
 };
 
 }

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatchCreator.cpp
@@ -138,7 +138,7 @@ public:
     Isolate* current = v8::Isolate::GetCurrent();
     HandleScope handleScope(current);
     Context::Scope context_scope(_script->getContext(current));
-    Handle<Object> plugin = getPlugin();
+    Local<Object> plugin = getPlugin();
 
     _candidateDistanceSigma = getNumber(plugin, "candidateDistanceSigma", 0.0, 1.0);
 
@@ -147,7 +147,7 @@ public:
       getNumber(plugin, "searchRadius", -1.0, ConfigOptions().getCircularErrorDefaultValue());
     LOG_VARD(_customSearchRadius);
 
-    Handle<Value> value = plugin->Get(toV8("getSearchRadius"));
+    Local<Value> value = plugin->Get(toV8("getSearchRadius"));
     if (value->IsUndefined())
     {
       // pass
@@ -158,7 +158,7 @@ public:
     }
     else
     {
-      _getSearchRadius.Reset(current, Handle<Function>::Cast(value));
+      _getSearchRadius.Reset(current, Local<Function>::Cast(value));
     }
   }
 
@@ -243,14 +243,14 @@ public:
 
   ConstOsmMapPtr getMap() const { return _map.lock(); }
 
-  static double getNumber(Handle<Object> obj, QString key, double minValue, double defaultValue)
+  static double getNumber(Local<Object> obj, QString key, double minValue, double defaultValue)
   {
     Isolate* current = v8::Isolate::GetCurrent();
     HandleScope handleScope(current);
     Local<Context> context = current->GetCurrentContext();
 
     double result = defaultValue;
-    Handle<String> cdtKey = String::NewFromUtf8(current, key.toUtf8());
+    Local<String> cdtKey = String::NewFromUtf8(current, key.toUtf8());
     if (obj->Has(context, cdtKey).ToChecked())
     {
       Local<Value> v = obj->Get(cdtKey);
@@ -280,15 +280,15 @@ public:
     EscapableHandleScope handleScope(current);
     Context::Scope context_scope(script->getContext(current));
     Local<Context> context = current->GetCurrentContext();
-    Handle<Object> global = script->getContext(current)->Global();
+    Local<Object> global = script->getContext(current)->Global();
 
     if (global->Has(context, String::NewFromUtf8(current, "plugin")).ToChecked() == false)
     {
       throw IllegalArgumentException("Expected the script to have exports.");
     }
 
-    Handle<Value> pluginValue = global->Get(String::NewFromUtf8(current, "plugin"));
-    Handle<Object> plugin(Handle<Object>::Cast(pluginValue));
+    Local<Value> pluginValue = global->Get(String::NewFromUtf8(current, "plugin"));
+    Local<Object> plugin(Local<Object>::Cast(pluginValue));
     if (plugin.IsEmpty() || plugin->IsObject() == false)
     {
       throw IllegalArgumentException("Expected plugin to be a valid object.");
@@ -333,12 +333,12 @@ public:
         Context::Scope context_scope(_script->getContext(current));
         Local<Context> context = current->GetCurrentContext();
 
-        Handle<Value> jsArgs[1];
+        Local<Value> jsArgs[1];
 
         int argc = 0;
         jsArgs[argc++] = ElementJs::New(e);
 
-        Handle<Value> f = ToLocal(&_getSearchRadius)->Call(context, getPlugin(), argc, jsArgs).ToLocalChecked();
+        Local<Value> f = ToLocal(&_getSearchRadius)->Call(context, getPlugin(), argc, jsArgs).ToLocalChecked();
 
         result = toCpp<Meters>(f) * _candidateDistanceSigma;
 
@@ -365,14 +365,14 @@ public:
     Local<Context> context = current->GetCurrentContext();
 
     Persistent<Object> plugin(current, getPlugin(_script));
-    Handle<String> initStr = String::NewFromUtf8(current, "calculateSearchRadius");
+    Local<String> initStr = String::NewFromUtf8(current, "calculateSearchRadius");
     // optional method, so don't throw an error
     if (ToLocal(&plugin)->Has(context, initStr).ToChecked() == false)
     {
       LOG_TRACE("calculateSearchRadius function not present.");
       return;
     }
-    Handle<Value> value = ToLocal(&plugin)->Get(initStr);
+    Local<Value> value = ToLocal(&plugin)->Get(initStr);
     if (value->IsFunction() == false)
     {
       LOG_TRACE("calculateSearchRadius function not present.");
@@ -381,8 +381,8 @@ public:
 
     LOG_DEBUG("Getting search radius for: " << _scriptPath << "...");
 
-    Handle<Function> func = Handle<Function>::Cast(value);
-    Handle<Value> jsArgs[1];
+    Local<Function> func = Local<Function>::Cast(value);
+    Local<Value> jsArgs[1];
     int argc = 0;
     HandleScope scope(current);  // This extra one might not be needed
     assert(getMap().get());
@@ -541,24 +541,24 @@ public:
     // the crit instead of the function; doing so causes this to crash; see #3047 and the history
     // of this file for the failing code that needs to be re-enabled
 
-    Handle<String> isMatchCandidateStr = String::NewFromUtf8(current, "isMatchCandidate");
+    Local<String> isMatchCandidateStr = String::NewFromUtf8(current, "isMatchCandidate");
     if (ToLocal(&plugin)->Has(context, isMatchCandidateStr).ToChecked() == false)
     {
       throw HootException("Error finding 'isMatchCandidate' function.");
     }
-    Handle<Value> value = ToLocal(&plugin)->Get(isMatchCandidateStr);
+    Local<Value> value = ToLocal(&plugin)->Get(isMatchCandidateStr);
     if (value->IsFunction() == false)
     {
       throw HootException("isMatchCandidate is not a function.");
     }
-    Handle<Function> func = Handle<Function>::Cast(value);
-    Handle<Value> jsArgs[2];
+    Local<Function> func = Local<Function>::Cast(value);
+    Local<Value> jsArgs[2];
 
     int argc = 0;
     jsArgs[argc++] = getOsmMapJs();
     jsArgs[argc++] = ElementJs::New(e);
 
-    Handle<Value> f = func->Call(context, ToLocal(&plugin), argc, jsArgs).ToLocalChecked();
+    Local<Value> f = func->Call(context, ToLocal(&plugin), argc, jsArgs).ToLocalChecked();
 
     result = f->BooleanValue(context).ToChecked();
 
@@ -788,7 +788,7 @@ MatchPtr ScriptMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId ei
     HandleScope handleScope(current);
     Context::Scope context_scope(_script->getContext(current));
 
-    Handle<Object> mapJs = OsmMapJs::create(map);
+    Local<Object> mapJs = OsmMapJs::create(map);
     Persistent<Object> plugin(current, ScriptMatchVisitor::getPlugin(_script));
 
     std::shared_ptr<ScriptMatch> match =
@@ -999,38 +999,38 @@ CreatorDescription ScriptMatchCreator::_getScriptDescription(QString path) const
   script->loadScript(path, "plugin");
 
   Persistent<Object> plugin(current, ScriptMatchVisitor::getPlugin(script));
-  Handle<String> descriptionStr = String::NewFromUtf8(current, "description");
+  Local<String> descriptionStr = String::NewFromUtf8(current, "description");
   if (ToLocal(&plugin)->Has(context, descriptionStr).ToChecked())
   {
-    Handle<Value> value = ToLocal(&plugin)->Get(descriptionStr);
+    Local<Value> value = ToLocal(&plugin)->Get(descriptionStr);
     result.setDescription(toCpp<QString>(value));
   }
-  Handle<String> experimentalStr = String::NewFromUtf8(current, "experimental");
+  Local<String> experimentalStr = String::NewFromUtf8(current, "experimental");
   if (ToLocal(&plugin)->Has(context, experimentalStr).ToChecked())
   {
-    Handle<Value> value = ToLocal(&plugin)->Get(experimentalStr);
+    Local<Value> value = ToLocal(&plugin)->Get(experimentalStr);
     result.setExperimental(toCpp<bool>(value));
   }
-  Handle<String> featureTypeStr = String::NewFromUtf8(current, "baseFeatureType");
+  Local<String> featureTypeStr = String::NewFromUtf8(current, "baseFeatureType");
   if (ToLocal(&plugin)->Has(context, featureTypeStr).ToChecked())
   {
-    Handle<Value> value = ToLocal(&plugin)->Get(featureTypeStr);
+    Local<Value> value = ToLocal(&plugin)->Get(featureTypeStr);
     result.setBaseFeatureType(CreatorDescription::stringToBaseFeatureType(toCpp<QString>(value)));
   }
-  Handle<String> geometryTypeStr = String::NewFromUtf8(current, "geometryType");
+  Local<String> geometryTypeStr = String::NewFromUtf8(current, "geometryType");
   if (ToLocal(&plugin)->Has(context, geometryTypeStr).ToChecked())
   {
-    Handle<Value> value = ToLocal(&plugin)->Get(geometryTypeStr);
+    Local<Value> value = ToLocal(&plugin)->Get(geometryTypeStr);
     result.setGeometryType(GeometryTypeCriterion::typeFromString(toCpp<QString>(value)));
   }
   // This controls which feature types a script conflates and is required. It allows for disabling
   // superfluous conflate ops. It should probably be integrated with isMatchCandidate somehow at
   // some point, if possible.
-  Handle<String> matchCandidateCriterionStr =
+  Local<String> matchCandidateCriterionStr =
     String::NewFromUtf8(current, "matchCandidateCriterion");
   if (ToLocal(&plugin)->Has(context, matchCandidateCriterionStr).ToChecked())
   {
-    Handle<Value> value = ToLocal(&plugin)->Get(matchCandidateCriterionStr);
+    Local<Value> value = ToLocal(&plugin)->Get(matchCandidateCriterionStr);
     const QString valueStr = toCpp<QString>(value);
     if (valueStr.contains(";"))
     {
@@ -1069,7 +1069,7 @@ std::shared_ptr<MatchThreshold> ScriptMatchCreator::getMatchThreshold()
     Isolate* current = v8::Isolate::GetCurrent();
     HandleScope handleScope(current);
     Context::Scope context_scope(_script->getContext(current));
-    Handle<Object> plugin = ScriptMatchVisitor::getPlugin(_script);
+    Local<Object> plugin = ScriptMatchVisitor::getPlugin(_script);
 
     double matchThreshold = -1.0;
     double missThreshold = -1.0;

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/AreaMergerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/AreaMergerJs.cpp
@@ -56,9 +56,10 @@ void AreaMergerJs::mergeAreas(OsmMapPtr map, const ElementId& mergeTargetId, Iso
   std::shared_ptr<PluginContext> script(new PluginContext());
   v8::HandleScope handleScope(current);
   v8::Context::Scope context_scope(script->getContext(current));
+  v8::Local<v8::Context> context = current->GetCurrentContext();
   script->loadScript(ConfPath::search("Area.js", "rules"), "plugin");
   v8::Handle<v8::Object> global = script->getContext(current)->Global();
-  if (global->Has(String::NewFromUtf8(current, "plugin")) == false)
+  if (global->Has(context, String::NewFromUtf8(current, "plugin")).ToChecked() == false)
   {
     throw IllegalArgumentException("Expected the script to have exports.");
   }

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/AreaMergerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/AreaMergerJs.cpp
@@ -58,13 +58,13 @@ void AreaMergerJs::mergeAreas(OsmMapPtr map, const ElementId& mergeTargetId, Iso
   v8::Context::Scope context_scope(script->getContext(current));
   v8::Local<v8::Context> context = current->GetCurrentContext();
   script->loadScript(ConfPath::search("Area.js", "rules"), "plugin");
-  v8::Handle<v8::Object> global = script->getContext(current)->Global();
+  v8::Local<v8::Object> global = script->getContext(current)->Global();
   if (global->Has(context, String::NewFromUtf8(current, "plugin")).ToChecked() == false)
   {
     throw IllegalArgumentException("Expected the script to have exports.");
   }
-  Handle<Value> pluginValue = global->Get(String::NewFromUtf8(current, "plugin"));
-  Persistent<Object> plugin(current, Handle<Object>::Cast(pluginValue));
+  Local<Value> pluginValue = global->Get(String::NewFromUtf8(current, "plugin"));
+  Persistent<Object> plugin(current, Local<Object>::Cast(pluginValue));
   if (plugin.IsEmpty() || ToLocal(&plugin)->IsObject() == false)
   {
     throw IllegalArgumentException("Expected plugin to be a valid object.");

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/ElementMergerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/ElementMergerJs.cpp
@@ -70,8 +70,9 @@ void ElementMergerJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   exports->Set(String::NewFromUtf8(current, "mergeElements"),
-               FunctionTemplate::New(current, mergeElements)->GetFunction());
+               FunctionTemplate::New(current, mergeElements)->GetFunction(context).ToLocalChecked());
 }
 
 void ElementMergerJs::mergeElements(const FunctionCallbackInfo<Value>& args)
@@ -82,6 +83,7 @@ void ElementMergerJs::mergeElements(const FunctionCallbackInfo<Value>& args)
   try
   {
     HandleScope scope(current);
+    Local<Context> context = current->GetCurrentContext();
     if (args.Length() != 1)
     {
       args.GetReturnValue().Set(
@@ -91,7 +93,7 @@ void ElementMergerJs::mergeElements(const FunctionCallbackInfo<Value>& args)
       return;
     }
 
-    OsmMapPtr map(node::ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject())->getMap());
+    OsmMapPtr map(node::ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked())->getMap());
     LOG_VART(map->getElementCount());
     _mergeElements(map, current);
     LOG_VART(map->getElementCount());

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/ElementMergerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/ElementMergerJs.cpp
@@ -66,7 +66,7 @@ namespace hoot
 
 HOOT_JS_REGISTER(ElementMergerJs)
 
-void ElementMergerJs::Init(Handle<Object> exports)
+void ElementMergerJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
@@ -98,7 +98,7 @@ void ElementMergerJs::mergeElements(const FunctionCallbackInfo<Value>& args)
     _mergeElements(map, current);
     LOG_VART(map->getElementCount());
 
-    Handle<Object> returnMap = OsmMapJs::create(map);
+    Local<Object> returnMap = OsmMapJs::create(map);
     args.GetReturnValue().Set(returnMap);
   }
   // This error handling has been proven to not work as it never returns the error message to the

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/ElementMergerJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/ElementMergerJs.h
@@ -72,7 +72,7 @@ public:
    BuildingToBuilding   // supports multiple
   };
 
- static void Init(v8::Handle<v8::Object> target);
+ static void Init(v8::Local<v8::Object> target);
  static void mergeElements(const v8::FunctionCallbackInfo<v8::Value>& args);
 
  virtual ~ElementMergerJs() = default;

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/LinearMergerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/LinearMergerJs.cpp
@@ -56,7 +56,7 @@ HOOT_JS_REGISTER(LinearMergerJs)
 
 Persistent<Function> LinearMergerJs::_constructor;
 
-void LinearMergerJs::Init(Handle<Object> target)
+void LinearMergerJs::Init(Local<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
@@ -135,8 +135,8 @@ void LinearMergerJs::apply(const FunctionCallbackInfo<Value>& args)
   merger->apply(map, replaced);
 
   // modify the parameter that was passed in
-  Handle<Array> newArr = Handle<Array>::Cast(toV8(replaced));
-  Handle<Array> arr = Handle<Array>::Cast(args[3]);
+  Local<Array> newArr = Local<Array>::Cast(toV8(replaced));
+  Local<Array> arr = Local<Array>::Cast(args[3]);
   arr->Set(String::NewFromUtf8(current, "length"), Integer::New(current, newArr->Length()));
   for (uint32_t i = 0; i < newArr->Length(); i++)
   {

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/LinearMergerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/LinearMergerJs.cpp
@@ -60,6 +60,8 @@ void LinearMergerJs::Init(Handle<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
+
   // Prepare constructor template
   Local<FunctionTemplate> tpl = FunctionTemplate::New(current, New);
   const QString name = "LinearMerger";
@@ -71,7 +73,7 @@ void LinearMergerJs::Init(Handle<Object> target)
   tpl->PrototypeTemplate()->Set(String::NewFromUtf8(current, "apply"),
       FunctionTemplate::New(current, apply));
 
-  _constructor.Reset(current, tpl->GetFunction());
+  _constructor.Reset(current, tpl->GetFunction(context).ToLocalChecked());
   target->Set(String::NewFromUtf8(current, name.toStdString().data()), ToLocal(&_constructor));
 }
 

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/LinearMergerJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/LinearMergerJs.h
@@ -46,7 +46,7 @@ class LinearMergerJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   virtual ~LinearMergerJs() = default;
 

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/PoiMergerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/PoiMergerJs.cpp
@@ -56,9 +56,11 @@ void PoiMergerJs::mergePois(OsmMapPtr map, const ElementId& mergeTargetId, Isola
   std::shared_ptr<PluginContext> script(new PluginContext());
   v8::HandleScope handleScope(current);
   v8::Context::Scope context_scope(script->getContext(current));
+  v8::Local<v8::Context> context = current->GetCurrentContext();
+
   script->loadScript(ConfPath::search("Poi.js", "rules"), "plugin");
   v8::Handle<v8::Object> global = script->getContext(current)->Global();
-  if (global->Has(String::NewFromUtf8(current, "plugin")) == false)
+  if (global->Has(context, String::NewFromUtf8(current, "plugin")).ToChecked() == false)
   {
     throw IllegalArgumentException("Expected the script to have exports.");
   }

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/PoiMergerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/PoiMergerJs.cpp
@@ -59,13 +59,13 @@ void PoiMergerJs::mergePois(OsmMapPtr map, const ElementId& mergeTargetId, Isola
   v8::Local<v8::Context> context = current->GetCurrentContext();
 
   script->loadScript(ConfPath::search("Poi.js", "rules"), "plugin");
-  v8::Handle<v8::Object> global = script->getContext(current)->Global();
+  v8::Local<v8::Object> global = script->getContext(current)->Global();
   if (global->Has(context, String::NewFromUtf8(current, "plugin")).ToChecked() == false)
   {
     throw IllegalArgumentException("Expected the script to have exports.");
   }
-  Handle<Value> pluginValue = global->Get(String::NewFromUtf8(current, "plugin"));
-  Persistent<Object> plugin(current, Handle<Object>::Cast(pluginValue));
+  Local<Value> pluginValue = global->Get(String::NewFromUtf8(current, "plugin"));
+  Persistent<Object> plugin(current, Local<Object>::Cast(pluginValue));
   if (plugin.IsEmpty() || ToLocal(&plugin)->IsObject() == false)
   {
     throw IllegalArgumentException("Expected plugin to be a valid object.");

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/RelationMergerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/RelationMergerJs.cpp
@@ -51,11 +51,13 @@ void RelationMergerJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
+
   Handle<Object> thisObj = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "RelationMerger"), thisObj);
 
   thisObj->Set(String::NewFromUtf8(current, "mergeRelations"),
-               FunctionTemplate::New(current, mergeRelations)->GetFunction());
+               FunctionTemplate::New(current, mergeRelations)->GetFunction(context).ToLocalChecked());
 }
 
 void RelationMergerJs::mergeRelations(const FunctionCallbackInfo<Value>& args)

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/RelationMergerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/RelationMergerJs.cpp
@@ -47,13 +47,13 @@ namespace hoot
 
 HOOT_JS_REGISTER(RelationMergerJs)
 
-void RelationMergerJs::Init(Handle<Object> exports)
+void RelationMergerJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> thisObj = Object::New(current);
+  Local<Object> thisObj = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "RelationMerger"), thisObj);
 
   thisObj->Set(String::NewFromUtf8(current, "mergeRelations"),

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/RelationMergerJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/RelationMergerJs.h
@@ -38,7 +38,7 @@ class RelationMergerJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   virtual ~RelationMergerJs() = default;
 

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMerger.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMerger.cpp
@@ -172,6 +172,7 @@ Handle<Value> ScriptMerger::_callMergePair(const OsmMapPtr& map) const
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope handleScope(current);
+  Local<Context> context = current->GetCurrentContext();
   Handle<Object> plugin =
     Handle<Object>::Cast(
       _script->getContext(current)->Global()->Get(String::NewFromUtf8(current, "plugin")));
@@ -192,8 +193,8 @@ Handle<Value> ScriptMerger::_callMergePair(const OsmMapPtr& map) const
   jsArgs[argc++] = ElementJs::New(map->getElement(_eid1));
   jsArgs[argc++] = ElementJs::New(map->getElement(_eid2));
 
-  TryCatch trycatch;
-  Handle<Value> result = func->Call(ToLocal(&_plugin), argc, jsArgs);
+  TryCatch trycatch(current);
+  Handle<Value> result = func->Call(context, ToLocal(&_plugin), argc, jsArgs).ToLocalChecked();
   HootExceptionJs::checkV8Exception(result, trycatch);
 
   if (result.IsEmpty() || result == Undefined(current))
@@ -210,6 +211,8 @@ void ScriptMerger::_callMergeSets(const OsmMapPtr& map,
   Isolate* current = v8::Isolate::GetCurrent();
   HandleScope handleScope(current);
   Context::Scope context_scope(_script->getContext(current));
+  Local<Context> context = current->GetCurrentContext();
+
   Handle<Object> plugin =
     Handle<Object>::Cast(
       _script->getContext(current)->Global()->Get(String::NewFromUtf8(current, "plugin")));
@@ -228,8 +231,8 @@ void ScriptMerger::_callMergeSets(const OsmMapPtr& map,
   jsArgs[argc++] = toV8(_pairs);
   jsArgs[argc++] = toV8(replaced);
 
-  TryCatch trycatch;
-  Handle<Value> result = func->Call(ToLocal(&_plugin), argc, jsArgs);
+  TryCatch trycatch(current);
+  Handle<Value> result = func->Call(context, ToLocal(&_plugin), argc, jsArgs).ToLocalChecked();
   HootExceptionJs::checkV8Exception(result, trycatch);
 
   // read the replaced values back out

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMerger.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMerger.cpp
@@ -136,9 +136,9 @@ void ScriptMerger::_applyMergePair(const OsmMapPtr& map,
   Isolate* current = v8::Isolate::GetCurrent();
   HandleScope handleScope(current);
   Context::Scope context_scope(_script->getContext(current));
-  Handle<Value> v = _callMergePair(map);
+  Local<Value> v = _callMergePair(map);
 
-  Handle<Object> o = Handle<Object>::Cast(v);
+  Local<Object> o = Local<Object>::Cast(v);
   ElementJs* newElementJs = ObjectWrap::Unwrap<ElementJs>(o);
   ConstElementPtr newElement = newElementJs->getConstElement();
 
@@ -168,23 +168,23 @@ void ScriptMerger::_applyMergeSets(const OsmMapPtr& map,
   // added to the map as needed).
 }
 
-Handle<Value> ScriptMerger::_callMergePair(const OsmMapPtr& map) const
+Local<Value> ScriptMerger::_callMergePair(const OsmMapPtr& map) const
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope handleScope(current);
   Local<Context> context = current->GetCurrentContext();
-  Handle<Object> plugin =
-    Handle<Object>::Cast(
+  Local<Object> plugin =
+    Local<Object>::Cast(
       _script->getContext(current)->Global()->Get(String::NewFromUtf8(current, "plugin")));
-  Handle<Value> value = plugin->Get(String::NewFromUtf8(current, "mergePair"));
+  Local<Value> value = plugin->Get(String::NewFromUtf8(current, "mergePair"));
 
   if (value.IsEmpty() || value->IsFunction() == false)
   {
     throw IllegalArgumentException("The merge function 'mergePair' was not found.");
   }
 
-  Handle<Function> func = Handle<Function>::Cast(value);
-  Handle<Value> jsArgs[3];
+  Local<Function> func = Local<Function>::Cast(value);
+  Local<Value> jsArgs[3];
 
   LOG_VART(map->getElement(_eid1));
   LOG_VART(map->getElement(_eid2));
@@ -194,7 +194,7 @@ Handle<Value> ScriptMerger::_callMergePair(const OsmMapPtr& map) const
   jsArgs[argc++] = ElementJs::New(map->getElement(_eid2));
 
   TryCatch trycatch(current);
-  Handle<Value> result = func->Call(context, ToLocal(&_plugin), argc, jsArgs).ToLocalChecked();
+  Local<Value> result = func->Call(context, ToLocal(&_plugin), argc, jsArgs).ToLocalChecked();
   HootExceptionJs::checkV8Exception(result, trycatch);
 
   if (result.IsEmpty() || result == Undefined(current))
@@ -213,18 +213,18 @@ void ScriptMerger::_callMergeSets(const OsmMapPtr& map,
   Context::Scope context_scope(_script->getContext(current));
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> plugin =
-    Handle<Object>::Cast(
+  Local<Object> plugin =
+    Local<Object>::Cast(
       _script->getContext(current)->Global()->Get(String::NewFromUtf8(current, "plugin")));
-  Handle<Value> value = plugin->Get(String::NewFromUtf8(current, "mergeSets"));
+  Local<Value> value = plugin->Get(String::NewFromUtf8(current, "mergeSets"));
 
   if (value.IsEmpty() || value->IsFunction() == false)
   {
     throw IllegalArgumentException("The merge function 'mergeSets' was not found.");
   }
 
-  Handle<Function> func = Handle<Function>::Cast(value);
-  Handle<Value> jsArgs[3];
+  Local<Function> func = Local<Function>::Cast(value);
+  Local<Value> jsArgs[3];
 
   int argc = 0;
   jsArgs[argc++] = OsmMapJs::create(map);
@@ -232,7 +232,7 @@ void ScriptMerger::_callMergeSets(const OsmMapPtr& map,
   jsArgs[argc++] = toV8(replaced);
 
   TryCatch trycatch(current);
-  Handle<Value> result = func->Call(context, ToLocal(&_plugin), argc, jsArgs).ToLocalChecked();
+  Local<Value> result = func->Call(context, ToLocal(&_plugin), argc, jsArgs).ToLocalChecked();
   HootExceptionJs::checkV8Exception(result, trycatch);
 
   // read the replaced values back out
@@ -244,10 +244,10 @@ bool ScriptMerger::hasFunction(QString name) const
   Isolate* current = v8::Isolate::GetCurrent();
   HandleScope handleScope(current);
   Context::Scope context_scope(_script->getContext(current));
-  Handle<Object> plugin =
-    Handle<Object>::Cast(_script->getContext(current)->Global()->Get(
+  Local<Object> plugin =
+    Local<Object>::Cast(_script->getContext(current)->Global()->Get(
       String::NewFromUtf8(current, "plugin")));
-  Handle<Value> value = plugin->Get(String::NewFromUtf8(current, name.toUtf8().data()));
+  Local<Value> value = plugin->Get(String::NewFromUtf8(current, name.toUtf8().data()));
 
   bool result = true;
   if (value.IsEmpty() || value->IsFunction() == false)

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMerger.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/ScriptMerger.h
@@ -86,7 +86,7 @@ protected:
   virtual void _applyMergeSets(
     const OsmMapPtr& map, std::vector<std::pair<ElementId, ElementId>>& replaced) const;
 
-  v8::Handle<v8::Value> _callMergePair(const OsmMapPtr& map) const;
+  v8::Local<v8::Value> _callMergePair(const OsmMapPtr& map) const;
   void _callMergeSets(const OsmMapPtr& map,
                       std::vector<std::pair<ElementId, ElementId>>& replaced) const;
 };

--- a/hoot-js/src/main/cpp/hoot/js/conflate/point/PoiSearchRadiusJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/point/PoiSearchRadiusJs.cpp
@@ -47,10 +47,11 @@ void PoiSearchRadiusJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   Handle<Object> thisObj = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "PoiSearchRadius"), thisObj);
   thisObj->Set(String::NewFromUtf8(current, "getSearchRadii"),
-               FunctionTemplate::New(current, getSearchRadii)->GetFunction());
+               FunctionTemplate::New(current, getSearchRadii)->GetFunction(context).ToLocalChecked());
 }
 
 bool PoiSearchRadiusJs::_searchRadiiOptionIsConfigFile(const QString data)

--- a/hoot-js/src/main/cpp/hoot/js/conflate/point/PoiSearchRadiusJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/point/PoiSearchRadiusJs.cpp
@@ -43,12 +43,12 @@ namespace hoot
 
 HOOT_JS_REGISTER(PoiSearchRadiusJs)
 
-void PoiSearchRadiusJs::Init(Handle<Object> exports)
+void PoiSearchRadiusJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
-  Handle<Object> thisObj = Object::New(current);
+  Local<Object> thisObj = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "PoiSearchRadius"), thisObj);
   thisObj->Set(String::NewFromUtf8(current, "getSearchRadii"),
                FunctionTemplate::New(current, getSearchRadii)->GetFunction(context).ToLocalChecked());

--- a/hoot-js/src/main/cpp/hoot/js/conflate/point/PoiSearchRadiusJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/point/PoiSearchRadiusJs.h
@@ -37,7 +37,7 @@ class PoiSearchRadiusJs : public node::ObjectWrap
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
   static void getSearchRadii(const v8::FunctionCallbackInfo<v8::Value>& args);
 
 private:

--- a/hoot-js/src/main/cpp/hoot/js/conflate/review/ReviewMarkerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/review/ReviewMarkerJs.cpp
@@ -48,10 +48,11 @@ void ReviewMarkerJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   Handle<Object> reviewMarker = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "ReviewMarker"), reviewMarker);
   reviewMarker->Set(String::NewFromUtf8(current, "mark"),
-                    FunctionTemplate::New(current, mark)->GetFunction());
+                    FunctionTemplate::New(current, mark)->GetFunction(context).ToLocalChecked());
 }
 
 void ReviewMarkerJs::mark(const FunctionCallbackInfo<Value>& args)

--- a/hoot-js/src/main/cpp/hoot/js/conflate/review/ReviewMarkerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/review/ReviewMarkerJs.cpp
@@ -44,12 +44,12 @@ namespace hoot
 
 HOOT_JS_REGISTER(ReviewMarkerJs)
 
-void ReviewMarkerJs::Init(Handle<Object> exports)
+void ReviewMarkerJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
-  Handle<Object> reviewMarker = Object::New(current);
+  Local<Object> reviewMarker = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "ReviewMarker"), reviewMarker);
   reviewMarker->Set(String::NewFromUtf8(current, "mark"),
                     FunctionTemplate::New(current, mark)->GetFunction(context).ToLocalChecked());

--- a/hoot-js/src/main/cpp/hoot/js/conflate/review/ReviewMarkerJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/review/ReviewMarkerJs.h
@@ -45,7 +45,7 @@ class ReviewMarkerJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   virtual ~ReviewMarkerJs() = default;
 

--- a/hoot-js/src/main/cpp/hoot/js/conflate/river/RiverMaximalSublineSettingOptimizerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/river/RiverMaximalSublineSettingOptimizerJs.cpp
@@ -41,12 +41,12 @@ namespace hoot
 
 HOOT_JS_REGISTER(RiverMaximalSublineSettingOptimizerJs)
 
-void RiverMaximalSublineSettingOptimizerJs::Init(Handle<Object> exports)
+void RiverMaximalSublineSettingOptimizerJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
-  Handle<Object> thisObj = Object::New(current);
+  Local<Object> thisObj = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "RiverMaximalSublineSettingOptimizer"), thisObj);
   thisObj->Set(String::NewFromUtf8(current, "getFindBestMatchesMaxRecursions"),
                FunctionTemplate::New(current, getFindBestMatchesMaxRecursions)->GetFunction(context).ToLocalChecked());

--- a/hoot-js/src/main/cpp/hoot/js/conflate/river/RiverMaximalSublineSettingOptimizerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/river/RiverMaximalSublineSettingOptimizerJs.cpp
@@ -45,10 +45,11 @@ void RiverMaximalSublineSettingOptimizerJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   Handle<Object> thisObj = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "RiverMaximalSublineSettingOptimizer"), thisObj);
   thisObj->Set(String::NewFromUtf8(current, "getFindBestMatchesMaxRecursions"),
-               FunctionTemplate::New(current, getFindBestMatchesMaxRecursions)->GetFunction());
+               FunctionTemplate::New(current, getFindBestMatchesMaxRecursions)->GetFunction(context).ToLocalChecked());
 }
 
 void RiverMaximalSublineSettingOptimizerJs::getFindBestMatchesMaxRecursions(
@@ -56,8 +57,9 @@ void RiverMaximalSublineSettingOptimizerJs::getFindBestMatchesMaxRecursions(
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject());
+  OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked());
   const int maxRecursions =
     RiverMaximalSublineSettingOptimizer().getFindBestMatchesMaxRecursions(mapJs->getConstMap());
   LOG_VARD(maxRecursions);

--- a/hoot-js/src/main/cpp/hoot/js/conflate/river/RiverMaximalSublineSettingOptimizerJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/river/RiverMaximalSublineSettingOptimizerJs.h
@@ -40,7 +40,7 @@ class RiverMaximalSublineSettingOptimizerJs : public node::ObjectWrap
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   /**
    * Wraps RiverMaximalSublineSettingOptimizer::getFindBestMatchesMaxRecursions for JS usage

--- a/hoot-js/src/main/cpp/hoot/js/criterion/ElementCriterionJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/criterion/ElementCriterionJs.cpp
@@ -49,7 +49,7 @@ HOOT_JS_REGISTER(ElementCriterionJs)
 
 Persistent<Function> ElementCriterionJs::_constructor;
 
-void ElementCriterionJs::Init(Handle<Object> target)
+void ElementCriterionJs::Init(Local<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);

--- a/hoot-js/src/main/cpp/hoot/js/criterion/ElementCriterionJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/criterion/ElementCriterionJs.cpp
@@ -53,6 +53,7 @@ void ElementCriterionJs::Init(Handle<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   vector<QString> opNames =
     Factory::getInstance().getObjectNamesByBase(ElementCriterion::className());
 
@@ -72,7 +73,7 @@ void ElementCriterionJs::Init(Handle<Object> target)
     tpl->PrototypeTemplate()->Set(
       String::NewFromUtf8(current, "isSatisfied"), FunctionTemplate::New(current, isSatisfied));
 
-    _constructor.Reset(current, tpl->GetFunction());
+    _constructor.Reset(current, tpl->GetFunction(context).ToLocalChecked());
     target->Set(String::NewFromUtf8(current, n), ToLocal(&_constructor));
   }
 }
@@ -98,9 +99,10 @@ void ElementCriterionJs::isSatisfied(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   ElementCriterionPtr ec = ObjectWrap::Unwrap<ElementCriterionJs>(args.This())->getCriterion();
-  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   args.GetReturnValue().Set(Boolean::New(current, ec->isSatisfied(e)));
 }

--- a/hoot-js/src/main/cpp/hoot/js/criterion/ElementCriterionJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/criterion/ElementCriterionJs.h
@@ -41,7 +41,7 @@ class ElementCriterionJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   ElementCriterionPtr getCriterion() { return _c; }
 

--- a/hoot-js/src/main/cpp/hoot/js/criterion/JsFunctionCriterion.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/criterion/JsFunctionCriterion.cpp
@@ -44,7 +44,8 @@ bool JsFunctionCriterion::isSatisfied(const ConstElementPtr& e) const
 {
   Isolate* current = v8::Isolate::GetCurrent();
   HandleScope handleScope(current);
-  Context::Scope context_scope(current->GetCallingContext());
+  Context::Scope context_scope(current->GetCurrentContext());
+  Local<Context> context = current->GetCurrentContext();
 
   Handle<Value> jsArgs[3];
 
@@ -58,13 +59,12 @@ bool JsFunctionCriterion::isSatisfied(const ConstElementPtr& e) const
   int argc = 0;
   jsArgs[argc++] = elementObj;
 
-  TryCatch trycatch;
-  Handle<Value> funcResult =
-    ToLocal(&_func)->Call(current->GetCallingContext()->Global(), argc, jsArgs);
+  TryCatch trycatch(current);
+  MaybeLocal<Value> maybe_funcResult = ToLocal(&_func)->Call(context, context->Global(), argc, jsArgs);
   // avoids a warning, the default value of false should never be used.
   bool result = false;
 
-  if (funcResult.IsEmpty())
+  if (maybe_funcResult.IsEmpty())
   {
     Local<Value> exception = trycatch.Exception();
     if (HootExceptionJs::isHootException(exception))
@@ -78,14 +78,14 @@ bool JsFunctionCriterion::isSatisfied(const ConstElementPtr& e) const
       throw HootException(toJson(trycatch.Message()->Get()));
     }
   }
-  else if (funcResult->IsBoolean() == false)
+  else if (maybe_funcResult.ToLocalChecked()->IsBoolean() == false)
   {
     throw IllegalArgumentException("Expected a boolean to be returned from JsFunctionCriterion "
       "function.");
   }
   else
   {
-    result = funcResult->BooleanValue();
+    result = maybe_funcResult.ToLocalChecked()->BooleanValue(context).ToChecked();
   }
 
   return result;

--- a/hoot-js/src/main/cpp/hoot/js/criterion/JsFunctionCriterion.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/criterion/JsFunctionCriterion.cpp
@@ -47,14 +47,14 @@ bool JsFunctionCriterion::isSatisfied(const ConstElementPtr& e) const
   Context::Scope context_scope(current->GetCurrentContext());
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Value> jsArgs[3];
+  Local<Value> jsArgs[3];
 
   if (_func.IsEmpty())
   {
     throw IllegalArgumentException("JsFunctionCriterion must have a valid function.");
   }
 
-  Handle<Object> elementObj = ElementJs::New(e);
+  Local<Object> elementObj = ElementJs::New(e);
 
   int argc = 0;
   jsArgs[argc++] = elementObj;

--- a/hoot-js/src/main/cpp/hoot/js/elements/ElementGeometryUtilsJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/ElementGeometryUtilsJs.cpp
@@ -51,10 +51,11 @@ void ElementGeometryUtilsJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   Handle<Object> thisObj = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "ElementGeometryUtils"), thisObj);
   thisObj->Set(String::NewFromUtf8(current, "calculateLength"),
-               FunctionTemplate::New(current, calculateLength)->GetFunction());
+               FunctionTemplate::New(current, calculateLength)->GetFunction(context).ToLocalChecked());
 }
 
 void ElementGeometryUtilsJs::calculateLength(const FunctionCallbackInfo<Value>& args)

--- a/hoot-js/src/main/cpp/hoot/js/elements/ElementGeometryUtilsJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/ElementGeometryUtilsJs.cpp
@@ -47,12 +47,12 @@ namespace hoot
 
 HOOT_JS_REGISTER(ElementGeometryUtilsJs)
 
-void ElementGeometryUtilsJs::Init(Handle<Object> exports)
+void ElementGeometryUtilsJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
-  Handle<Object> thisObj = Object::New(current);
+  Local<Object> thisObj = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "ElementGeometryUtils"), thisObj);
   thisObj->Set(String::NewFromUtf8(current, "calculateLength"),
                FunctionTemplate::New(current, calculateLength)->GetFunction(context).ToLocalChecked());

--- a/hoot-js/src/main/cpp/hoot/js/elements/ElementGeometryUtilsJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/elements/ElementGeometryUtilsJs.h
@@ -37,7 +37,7 @@ class ElementGeometryUtilsJs : public HootBaseJs
 {
 public:
 
- static void Init(v8::Handle<v8::Object> target);
+ static void Init(v8::Local<v8::Object> target);
 
  virtual ~ElementGeometryUtilsJs() = default;
 

--- a/hoot-js/src/main/cpp/hoot/js/elements/ElementIdJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/ElementIdJs.cpp
@@ -48,6 +48,7 @@ void ElementIdJs::Init(Handle<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   // Prepare constructor template
   Local<FunctionTemplate> tpl = FunctionTemplate::New(current, New);
   tpl->SetClassName(String::NewFromUtf8(current, ElementId::className().toStdString().data()));
@@ -62,7 +63,7 @@ void ElementIdJs::Init(Handle<Object> target)
   tpl->PrototypeTemplate()->Set(String::NewFromUtf8(current, "toString"),
       FunctionTemplate::New(current, toString));
 
-  _constructor.Reset(current, tpl->GetFunction());
+  _constructor.Reset(current, tpl->GetFunction(context).ToLocalChecked());
   target->Set(String::NewFromUtf8(current, "ElementId"), ToLocal(&_constructor));
 }
 
@@ -70,8 +71,9 @@ Handle<Object> ElementIdJs::New(ElementId eid)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance();
+  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   ElementIdJs* from = ObjectWrap::Unwrap<ElementIdJs>(result);
   from->_eid = eid;
 

--- a/hoot-js/src/main/cpp/hoot/js/elements/ElementIdJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/ElementIdJs.cpp
@@ -44,7 +44,7 @@ HOOT_JS_REGISTER(ElementIdJs)
 
 Persistent<Function> ElementIdJs::_constructor;
 
-void ElementIdJs::Init(Handle<Object> target)
+void ElementIdJs::Init(Local<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
@@ -67,13 +67,13 @@ void ElementIdJs::Init(Handle<Object> target)
   target->Set(String::NewFromUtf8(current, "ElementId"), ToLocal(&_constructor));
 }
 
-Handle<Object> ElementIdJs::New(ElementId eid)
+Local<Object> ElementIdJs::New(ElementId eid)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
+  Local<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   ElementIdJs* from = ObjectWrap::Unwrap<ElementIdJs>(result);
   from->_eid = eid;
 

--- a/hoot-js/src/main/cpp/hoot/js/elements/ElementIdJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/elements/ElementIdJs.h
@@ -67,6 +67,8 @@ private:
 inline void toCpp(v8::Handle<v8::Value> v, ElementId& eid)
 {
   v8::Isolate* current = v8::Isolate::GetCurrent();
+  v8::HandleScope scope(current);
+  v8::Local<v8::Context> context = current->GetCurrentContext();
 
   // try as string first
   if (v->IsString())
@@ -94,8 +96,8 @@ inline void toCpp(v8::Handle<v8::Value> v, ElementId& eid)
   {
     eid = eidj->getElementId();
   }
-  else if (obj->Has(v8::String::NewFromUtf8(current, "id")) &&
-           obj->Has(v8::String::NewFromUtf8(current, "type")))
+  else if (obj->Has(context, v8::String::NewFromUtf8(current, "id")).ToChecked() &&
+           obj->Has(context, v8::String::NewFromUtf8(current, "type")).ToChecked())
   {
     long id;
     QString type;

--- a/hoot-js/src/main/cpp/hoot/js/elements/ElementIdJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/elements/ElementIdJs.h
@@ -43,11 +43,11 @@ class ElementIdJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   ElementId& getElementId() { return _eid; }
 
-  static v8::Handle<v8::Object> New(ElementId eid);
+  static v8::Local<v8::Object> New(ElementId eid);
 
   virtual ~ElementIdJs() = default;
 
@@ -64,7 +64,7 @@ private:
   static void toString(const v8::FunctionCallbackInfo<v8::Value>& args);
 };
 
-inline void toCpp(v8::Handle<v8::Value> v, ElementId& eid)
+inline void toCpp(v8::Local<v8::Value> v, ElementId& eid)
 {
   v8::Isolate* current = v8::Isolate::GetCurrent();
   v8::HandleScope scope(current);
@@ -83,7 +83,7 @@ inline void toCpp(v8::Handle<v8::Value> v, ElementId& eid)
     throw IllegalArgumentException("Expected an object, got: (" + toString(v) + ")");
   }
 
-  v8::Handle<v8::Object> obj = v8::Handle<v8::Object>::Cast(v);
+  v8::Local<v8::Object> obj = v8::Local<v8::Object>::Cast(v);
 
   QString className = str(obj->Get(PopulateConsumersJs::baseClass()));
   ElementIdJs* eidj = nullptr;
@@ -111,7 +111,7 @@ inline void toCpp(v8::Handle<v8::Value> v, ElementId& eid)
   }
 }
 
-inline v8::Handle<v8::Value> toV8(const ElementId& eid)
+inline v8::Local<v8::Value> toV8(const ElementId& eid)
 {
   return ElementIdJs::New(eid);
 }

--- a/hoot-js/src/main/cpp/hoot/js/elements/ElementJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/ElementJs.cpp
@@ -240,7 +240,7 @@ void ElementJs::setTags(const FunctionCallbackInfo<Value>& args)
   }
   else
   {
-    Tags& tags = ObjectWrap::Unwrap<TagsJs>(args[0]->ToObject(context).ToLocalChecked())->getTags();
+    const Tags& tags = ObjectWrap::Unwrap<TagsJs>(args[0]->ToObject(context).ToLocalChecked())->getTags();
     e->setTags(tags);
     args.GetReturnValue().SetUndefined();
   }

--- a/hoot-js/src/main/cpp/hoot/js/elements/ElementJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/ElementJs.cpp
@@ -135,11 +135,11 @@ void ElementJs::getTags(const FunctionCallbackInfo<Value>& args)
   args.GetReturnValue().Set(TagsJs::New(e->getTags()));
 }
 
-Handle<Object> ElementJs::New(ConstElementPtr e)
+Local<Object> ElementJs::New(ConstElementPtr e)
 {
   EscapableHandleScope scope(v8::Isolate::GetCurrent());
 
-  Handle<Object> result;
+  Local<Object> result;
 
   switch (e->getElementType().getEnum())
   {
@@ -168,11 +168,11 @@ Handle<Object> ElementJs::New(ConstElementPtr e)
   return scope.Escape(result);
 }
 
-Handle<Object> ElementJs::New(ElementPtr e)
+Local<Object> ElementJs::New(ElementPtr e)
 {
   EscapableHandleScope scope(v8::Isolate::GetCurrent());
 
-  Handle<Object> result;
+  Local<Object> result;
 
   switch (e->getElementType().getEnum())
   {

--- a/hoot-js/src/main/cpp/hoot/js/elements/ElementJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/ElementJs.cpp
@@ -228,6 +228,7 @@ void ElementJs::setTags(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   ElementPtr e = ObjectWrap::Unwrap<ElementJs>(args.This())->getElement();
 
@@ -239,7 +240,7 @@ void ElementJs::setTags(const FunctionCallbackInfo<Value>& args)
   }
   else
   {
-    Tags& tags = ObjectWrap::Unwrap<TagsJs>(args[0]->ToObject())->getTags();
+    Tags& tags = ObjectWrap::Unwrap<TagsJs>(args[0]->ToObject(context).ToLocalChecked())->getTags();
     e->setTags(tags);
     args.GetReturnValue().SetUndefined();
   }

--- a/hoot-js/src/main/cpp/hoot/js/elements/ElementJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/elements/ElementJs.h
@@ -52,8 +52,8 @@ public:
   virtual ConstElementPtr getConstElement() const = 0;
   virtual ElementPtr getElement() = 0;
 
-  static v8::Handle<v8::Object> New(ConstElementPtr e);
-  static v8::Handle<v8::Object> New(ElementPtr e);
+  static v8::Local<v8::Object> New(ConstElementPtr e);
+  static v8::Local<v8::Object> New(ElementPtr e);
 
   virtual ~ElementJs() = default;
 
@@ -82,32 +82,32 @@ private:
   static v8::Persistent<v8::Function> _constructor;
 };
 
-inline void toCpp(v8::Handle<v8::Value> v, ConstElementPtr& e)
+inline void toCpp(v8::Local<v8::Value> v, ConstElementPtr& e)
 {
   if (v.IsEmpty() || !v->IsObject())
   {
     throw IllegalArgumentException("Expected input to be an ElementJs object type.");
   }
-  v8::Handle<v8::Object> obj = v8::Handle<v8::Object>::Cast(v);
+  v8::Local<v8::Object> obj = v8::Local<v8::Object>::Cast(v);
   e = node::ObjectWrap::Unwrap<ElementJs>(obj)->getConstElement();
 }
 
-inline void toCpp(v8::Handle<v8::Value> v, ElementPtr& e)
+inline void toCpp(v8::Local<v8::Value> v, ElementPtr& e)
 {
   if (v.IsEmpty() || !v->IsObject())
   {
     throw IllegalArgumentException("Expected input to be an ElementJs object type.");
   }
-  v8::Handle<v8::Object> obj = v8::Handle<v8::Object>::Cast(v);
+  v8::Local<v8::Object> obj = v8::Local<v8::Object>::Cast(v);
   e = node::ObjectWrap::Unwrap<ElementJs>(obj)->getElement();
 }
 
-inline v8::Handle<v8::Value> toV8(const ConstElementPtr& e)
+inline v8::Local<v8::Value> toV8(const ConstElementPtr& e)
 {
   return ElementJs::New(e);
 }
 
-inline v8::Handle<v8::Value> toV8(const ElementPtr& e)
+inline v8::Local<v8::Value> toV8(const ElementPtr& e)
 {
   return ElementJs::New(e);
 }

--- a/hoot-js/src/main/cpp/hoot/js/elements/MapProjectorJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/MapProjectorJs.cpp
@@ -47,11 +47,12 @@ void MapProjectorJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   Handle<Object> obj = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "MapProjector"), obj);
 
   obj->Set(String::NewFromUtf8(current, "projectToPlanar"),
-           FunctionTemplate::New(current, projectToPlanar)->GetFunction());
+           FunctionTemplate::New(current, projectToPlanar)->GetFunction(context).ToLocalChecked());
 }
 
 void MapProjectorJs::projectToPlanar(const FunctionCallbackInfo<Value>& args)

--- a/hoot-js/src/main/cpp/hoot/js/elements/MapProjectorJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/MapProjectorJs.cpp
@@ -43,12 +43,12 @@ namespace hoot
 
 HOOT_JS_REGISTER(MapProjectorJs)
 
-void MapProjectorJs::Init(Handle<Object> exports)
+void MapProjectorJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
-  Handle<Object> obj = Object::New(current);
+  Local<Object> obj = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "MapProjector"), obj);
 
   obj->Set(String::NewFromUtf8(current, "projectToPlanar"),

--- a/hoot-js/src/main/cpp/hoot/js/elements/MapProjectorJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/elements/MapProjectorJs.h
@@ -38,7 +38,7 @@ class MapProjectorJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   virtual ~MapProjectorJs() = default;
 

--- a/hoot-js/src/main/cpp/hoot/js/elements/MapUtilsJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/MapUtilsJs.cpp
@@ -47,13 +47,14 @@ void MapUtilsJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   Handle<Object> obj = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "MapUtils"), obj);
 
   obj->Set(String::NewFromUtf8(current, "getFirstElementWithTag"),
-           FunctionTemplate::New(current, getFirstElementWithTag)->GetFunction());
+           FunctionTemplate::New(current, getFirstElementWithTag)->GetFunction(context).ToLocalChecked());
   obj->Set(String::NewFromUtf8(current, "getFirstElementWithNote"),
-           FunctionTemplate::New(current, getFirstElementWithNote)->GetFunction());
+           FunctionTemplate::New(current, getFirstElementWithNote)->GetFunction(context).ToLocalChecked());
 }
 
 void MapUtilsJs::getFirstElementWithTag(const FunctionCallbackInfo<Value>& args)

--- a/hoot-js/src/main/cpp/hoot/js/elements/MapUtilsJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/MapUtilsJs.cpp
@@ -43,12 +43,12 @@ namespace hoot
 
 HOOT_JS_REGISTER(MapUtilsJs)
 
-void MapUtilsJs::Init(Handle<Object> exports)
+void MapUtilsJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
-  Handle<Object> obj = Object::New(current);
+  Local<Object> obj = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "MapUtils"), obj);
 
   obj->Set(String::NewFromUtf8(current, "getFirstElementWithTag"),

--- a/hoot-js/src/main/cpp/hoot/js/elements/MapUtilsJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/elements/MapUtilsJs.h
@@ -38,7 +38,7 @@ class MapUtilsJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   virtual ~MapUtilsJs() = default;
 

--- a/hoot-js/src/main/cpp/hoot/js/elements/NodeJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/NodeJs.cpp
@@ -71,6 +71,7 @@ void NodeJs::Init(Handle<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   // Prepare constructor template
   Local<FunctionTemplate> tpl = FunctionTemplate::New(current, New);
   tpl->SetClassName(String::NewFromUtf8(current, Node::className().toStdString().data()));
@@ -82,7 +83,7 @@ void NodeJs::Init(Handle<Object> target)
       FunctionTemplate::New(current, getY));
   ElementJs::_addBaseFunctions(tpl);
 
-  _constructor.Reset(current, tpl->GetFunction());
+  _constructor.Reset(current, tpl->GetFunction(context).ToLocalChecked());
   target->Set(String::NewFromUtf8(current, "Node"), ToLocal(&_constructor));
 }
 
@@ -90,8 +91,9 @@ Handle<Object> NodeJs::New(ConstNodePtr node)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance();
+  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   NodeJs* from = ObjectWrap::Unwrap<NodeJs>(result);
   from->_setNode(node);
 
@@ -102,8 +104,9 @@ Handle<Object> NodeJs::New(NodePtr node)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance();
+  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   NodeJs* from = ObjectWrap::Unwrap<NodeJs>(result);
   from->_setNode(node);
 

--- a/hoot-js/src/main/cpp/hoot/js/elements/NodeJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/NodeJs.cpp
@@ -67,7 +67,7 @@ void NodeJs::getY(const FunctionCallbackInfo<Value>& args)
   args.GetReturnValue().Set(Number::New(current, n->getY()));
 }
 
-void NodeJs::Init(Handle<Object> target)
+void NodeJs::Init(Local<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
@@ -87,26 +87,26 @@ void NodeJs::Init(Handle<Object> target)
   target->Set(String::NewFromUtf8(current, "Node"), ToLocal(&_constructor));
 }
 
-Handle<Object> NodeJs::New(ConstNodePtr node)
+Local<Object> NodeJs::New(ConstNodePtr node)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
+  Local<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   NodeJs* from = ObjectWrap::Unwrap<NodeJs>(result);
   from->_setNode(node);
 
   return scope.Escape(result);
 }
 
-Handle<Object> NodeJs::New(NodePtr node)
+Local<Object> NodeJs::New(NodePtr node)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
+  Local<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   NodeJs* from = ObjectWrap::Unwrap<NodeJs>(result);
   from->_setNode(node);
 

--- a/hoot-js/src/main/cpp/hoot/js/elements/NodeJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/elements/NodeJs.h
@@ -44,15 +44,15 @@ class NodeJs : public ElementJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   ConstElementPtr getConstElement() const override { return getConstNode(); }
   ConstNodePtr getConstNode() const { return _constNode; }
   ElementPtr getElement() override { return getNode(); }
   NodePtr getNode() { assert(_node); return _node; }
 
-  static v8::Handle<v8::Object> New(ConstNodePtr n);
-  static v8::Handle<v8::Object> New(NodePtr n);
+  static v8::Local<v8::Object> New(ConstNodePtr n);
+  static v8::Local<v8::Object> New(NodePtr n);
 
 private:
 

--- a/hoot-js/src/main/cpp/hoot/js/elements/OsmMapJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/OsmMapJs.cpp
@@ -54,7 +54,7 @@ OsmMapJs::OsmMapJs()
   _setMap(OsmMapPtr(new OsmMap()));
 }
 
-void OsmMapJs::Init(Handle<Object> target)
+void OsmMapJs::Init(Local<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
@@ -83,26 +83,26 @@ void OsmMapJs::Init(Handle<Object> target)
   target->Set(String::NewFromUtf8(current, "OsmMap"), ToLocal(&_constructor));
 }
 
-Handle<Object> OsmMapJs::create(ConstOsmMapPtr map)
+Local<Object> OsmMapJs::create(ConstOsmMapPtr map)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
+  Local<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   OsmMapJs* from = ObjectWrap::Unwrap<OsmMapJs>(result);
   from->_setMap(map);
 
   return scope.Escape(result);
 }
 
-Handle<Object> OsmMapJs::create(OsmMapPtr map)
+Local<Object> OsmMapJs::create(OsmMapPtr map)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
+  Local<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   OsmMapJs* from = ObjectWrap::Unwrap<OsmMapJs>(result);
   from->_setMap(map);
 
@@ -142,7 +142,7 @@ void OsmMapJs::clone(const FunctionCallbackInfo<Value>& args)
   }
 
   const unsigned argc = 1;
-  Handle<Value> argv[argc] = { args[0] };
+  Local<Value> argv[argc] = { args[0] };
   Local<Object> result = ToLocal(&_constructor)->NewInstance(context, argc, argv).ToLocalChecked();
   OsmMapJs* obj = ObjectWrap::Unwrap<OsmMapJs>(result);
   if (newConstMap)
@@ -214,7 +214,7 @@ void OsmMapJs::visit(const FunctionCallbackInfo<Value>& args)
 
     if (args[0]->IsFunction())
     {
-      Local<Function> func(Handle<Function>::Cast(args[0]));
+      Local<Function> func(Local<Function>::Cast(args[0]));
 
       JsFunctionVisitor v;
       v.addFunction(current, func);

--- a/hoot-js/src/main/cpp/hoot/js/elements/OsmMapJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/OsmMapJs.cpp
@@ -58,6 +58,7 @@ void OsmMapJs::Init(Handle<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   // Prepare constructor template
   Local<FunctionTemplate> tpl = FunctionTemplate::New(current, New);
@@ -78,7 +79,7 @@ void OsmMapJs::Init(Handle<Object> target)
     PopulateConsumersJs::baseClass(),
     String::NewFromUtf8(current, OsmMap::className().toStdString().data()));
 
-  _constructor.Reset(current, tpl->GetFunction());
+  _constructor.Reset(current, tpl->GetFunction(context).ToLocalChecked());
   target->Set(String::NewFromUtf8(current, "OsmMap"), ToLocal(&_constructor));
 }
 
@@ -86,8 +87,9 @@ Handle<Object> OsmMapJs::create(ConstOsmMapPtr map)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance();
+  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   OsmMapJs* from = ObjectWrap::Unwrap<OsmMapJs>(result);
   from->_setMap(map);
 
@@ -98,8 +100,9 @@ Handle<Object> OsmMapJs::create(OsmMapPtr map)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance();
+  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   OsmMapJs* from = ObjectWrap::Unwrap<OsmMapJs>(result);
   from->_setMap(map);
 
@@ -121,6 +124,7 @@ void OsmMapJs::clone(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   OsmMapJs* from = ObjectWrap::Unwrap<OsmMapJs>(args.This());
 
@@ -139,7 +143,7 @@ void OsmMapJs::clone(const FunctionCallbackInfo<Value>& args)
 
   const unsigned argc = 1;
   Handle<Value> argv[argc] = { args[0] };
-  Local<Object> result = ToLocal(&_constructor)->NewInstance(argc, argv);
+  Local<Object> result = ToLocal(&_constructor)->NewInstance(context, argc, argv).ToLocalChecked();
   OsmMapJs* obj = ObjectWrap::Unwrap<OsmMapJs>(result);
   if (newConstMap)
   {
@@ -202,6 +206,7 @@ void OsmMapJs::visit(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   try
   {
@@ -219,7 +224,7 @@ void OsmMapJs::visit(const FunctionCallbackInfo<Value>& args)
     else
     {
       std::shared_ptr<ElementVisitor> v =
-        ObjectWrap::Unwrap<ElementVisitorJs>(args[0]->ToObject())->getVisitor();
+        ObjectWrap::Unwrap<ElementVisitorJs>(args[0]->ToObject(context).ToLocalChecked())->getVisitor();
 
       map->getMap()->visitRw(*v);
     }

--- a/hoot-js/src/main/cpp/hoot/js/elements/OsmMapJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/elements/OsmMapJs.h
@@ -40,10 +40,10 @@ class OsmMapJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
-  static v8::Handle<v8::Object> create(ConstOsmMapPtr map);
-  static v8::Handle<v8::Object> create(OsmMapPtr map);
+  static v8::Local<v8::Object> create(ConstOsmMapPtr map);
+  static v8::Local<v8::Object> create(OsmMapPtr map);
 
   OsmMapPtr& getMap();
   ConstOsmMapPtr& getConstMap() { return _constMap; }
@@ -70,26 +70,26 @@ private:
   void _setMap(ConstOsmMapPtr map) { _map.reset(); _constMap = map; }
 };
 
-inline void toCpp(v8::Handle<v8::Value> v, ConstOsmMapPtr& ptr)
+inline void toCpp(v8::Local<v8::Value> v, ConstOsmMapPtr& ptr)
 {
   if (!v->IsObject())
   {
     throw IllegalArgumentException("Expected an object, got: (" + toJson(v) + ")");
   }
 
-  v8::Handle<v8::Object> obj = v8::Handle<v8::Object>::Cast(v);
+  v8::Local<v8::Object> obj = v8::Local<v8::Object>::Cast(v);
   OsmMapJs* ptrj = node::ObjectWrap::Unwrap<OsmMapJs>(obj);
   ptr = ptrj->getConstMap();
 }
 
-inline void toCpp(v8::Handle<v8::Value> v, OsmMapPtr& ptr)
+inline void toCpp(v8::Local<v8::Value> v, OsmMapPtr& ptr)
 {
   if (!v->IsObject())
   {
     throw IllegalArgumentException("Expected an object, got: (" + toJson(v) + ")");
   }
 
-  v8::Handle<v8::Object> obj = v8::Handle<v8::Object>::Cast(v);
+  v8::Local<v8::Object> obj = v8::Local<v8::Object>::Cast(v);
   OsmMapJs* ptrj = node::ObjectWrap::Unwrap<OsmMapJs>(obj);
   ptr = ptrj->getMap();
 }

--- a/hoot-js/src/main/cpp/hoot/js/elements/RelationJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/RelationJs.cpp
@@ -52,6 +52,7 @@ void RelationJs::Init(Handle<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   // Prepare constructor template
   Local<FunctionTemplate> tpl = FunctionTemplate::New(current, New);
   tpl->SetClassName(String::NewFromUtf8(current, Relation::className().toStdString().data()));
@@ -61,7 +62,7 @@ void RelationJs::Init(Handle<Object> target)
   tpl->PrototypeTemplate()->Set(String::NewFromUtf8(current, "getType"),
       FunctionTemplate::New(current, getType));
 
-  _constructor.Reset(current, tpl->GetFunction());
+  _constructor.Reset(current, tpl->GetFunction(context).ToLocalChecked());
   target->Set(String::NewFromUtf8(current, "Relation"), ToLocal(&_constructor));
 }
 
@@ -69,8 +70,9 @@ Handle<Object> RelationJs::New(ConstRelationPtr relation)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance();
+  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   RelationJs* from = ObjectWrap::Unwrap<RelationJs>(result);
   from->_setRelation(relation);
 
@@ -81,8 +83,9 @@ Handle<Object> RelationJs::New(RelationPtr relation)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance();
+  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   RelationJs* from = ObjectWrap::Unwrap<RelationJs>(result);
   from->_setRelation(relation);
 

--- a/hoot-js/src/main/cpp/hoot/js/elements/RelationJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/RelationJs.cpp
@@ -48,7 +48,7 @@ HOOT_JS_REGISTER(RelationJs)
 
 Persistent<Function> RelationJs::_constructor;
 
-void RelationJs::Init(Handle<Object> target)
+void RelationJs::Init(Local<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
@@ -66,26 +66,26 @@ void RelationJs::Init(Handle<Object> target)
   target->Set(String::NewFromUtf8(current, "Relation"), ToLocal(&_constructor));
 }
 
-Handle<Object> RelationJs::New(ConstRelationPtr relation)
+Local<Object> RelationJs::New(ConstRelationPtr relation)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
+  Local<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   RelationJs* from = ObjectWrap::Unwrap<RelationJs>(result);
   from->_setRelation(relation);
 
   return scope.Escape(result);
 }
 
-Handle<Object> RelationJs::New(RelationPtr relation)
+Local<Object> RelationJs::New(RelationPtr relation)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
+  Local<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   RelationJs* from = ObjectWrap::Unwrap<RelationJs>(result);
   from->_setRelation(relation);
 

--- a/hoot-js/src/main/cpp/hoot/js/elements/RelationJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/elements/RelationJs.h
@@ -44,15 +44,15 @@ class RelationJs : public ElementJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   ConstElementPtr getConstElement() const override { return getConstRelation(); }
   ConstRelationPtr getConstRelation() const { return _constRelation; }
   ElementPtr getElement() override { return getRelation(); }
   RelationPtr getRelation() { assert(_relation); return _relation; }
 
-  static v8::Handle<v8::Object> New(ConstRelationPtr relation);
-  static v8::Handle<v8::Object> New(RelationPtr relation);
+  static v8::Local<v8::Object> New(ConstRelationPtr relation);
+  static v8::Local<v8::Object> New(RelationPtr relation);
 
 private:
 

--- a/hoot-js/src/main/cpp/hoot/js/elements/RelationMemberUtilsJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/RelationMemberUtilsJs.cpp
@@ -47,12 +47,12 @@ namespace hoot
 
 HOOT_JS_REGISTER(RelationMemberUtilsJs)
 
-void RelationMemberUtilsJs::Init(Handle<Object> exports)
+void RelationMemberUtilsJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
-  Handle<Object> obj = Object::New(current);
+  Local<Object> obj = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "RelationMemberUtils"), obj);
 
   obj->Set(String::NewFromUtf8(current, "isMemberOfRelationWithType"),

--- a/hoot-js/src/main/cpp/hoot/js/elements/RelationMemberUtilsJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/RelationMemberUtilsJs.cpp
@@ -51,21 +51,22 @@ void RelationMemberUtilsJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   Handle<Object> obj = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "RelationMemberUtils"), obj);
 
   obj->Set(String::NewFromUtf8(current, "isMemberOfRelationWithType"),
-           FunctionTemplate::New(current, isMemberOfRelationWithType)->GetFunction());
+           FunctionTemplate::New(current, isMemberOfRelationWithType)->GetFunction(context).ToLocalChecked());
   obj->Set(String::NewFromUtf8(current, "isMemberOfRelationInCategory"),
-           FunctionTemplate::New(current, isMemberOfRelationInCategory)->GetFunction());
+           FunctionTemplate::New(current, isMemberOfRelationInCategory)->GetFunction(context).ToLocalChecked());
   obj->Set(String::NewFromUtf8(current, "isMemberOfRelationWithTagKey"),
-           FunctionTemplate::New(current, isMemberOfRelationWithTagKey)->GetFunction());
+           FunctionTemplate::New(current, isMemberOfRelationWithTagKey)->GetFunction(context).ToLocalChecked());
   obj->Set(String::NewFromUtf8(current, "getNumRelationMemberNodes"),
-           FunctionTemplate::New(current, getNumRelationMemberNodes)->GetFunction());
+           FunctionTemplate::New(current, getNumRelationMemberNodes)->GetFunction(context).ToLocalChecked());
   obj->Set(String::NewFromUtf8(current, "relationsHaveConnectedWayMembers"),
-           FunctionTemplate::New(current, relationsHaveConnectedWayMembers)->GetFunction());
+           FunctionTemplate::New(current, relationsHaveConnectedWayMembers)->GetFunction(context).ToLocalChecked());
   obj->Set(String::NewFromUtf8(current, "isMemberOfRelationSatisfyingCriterion"),
-           FunctionTemplate::New(current, isMemberOfRelationSatisfyingCriterion)->GetFunction());
+           FunctionTemplate::New(current, isMemberOfRelationSatisfyingCriterion)->GetFunction(context).ToLocalChecked());
 }
 
 void RelationMemberUtilsJs::isMemberOfRelationWithType(const FunctionCallbackInfo<Value>& args)

--- a/hoot-js/src/main/cpp/hoot/js/elements/RelationMemberUtilsJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/elements/RelationMemberUtilsJs.h
@@ -38,7 +38,7 @@ class RelationMemberUtilsJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   virtual ~RelationMemberUtilsJs() = default;
 

--- a/hoot-js/src/main/cpp/hoot/js/elements/TagsJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/TagsJs.cpp
@@ -61,6 +61,7 @@ void TagsJs::Init(Handle<Object> target)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   // Prepare constructor template
   Local<FunctionTemplate> tpl = FunctionTemplate::New(current, New);
   tpl->SetClassName(String::NewFromUtf8(current, Tags::className().toStdString().data()));
@@ -83,15 +84,17 @@ void TagsJs::Init(Handle<Object> target)
   tpl->PrototypeTemplate()->Set(String::NewFromUtf8(current, "toString"),
       FunctionTemplate::New(current, toString));
 
-  _constructor.Reset(current, tpl->GetFunction());
+  _constructor.Reset(current, tpl->GetFunction(context).ToLocalChecked());
   target->Set(String::NewFromUtf8(current, "Tags"), ToLocal(&_constructor));
 }
 
 Handle<Object> TagsJs::New(const Tags& t)
 {
-  EscapableHandleScope scope(v8::Isolate::GetCurrent());
+  Isolate* current = v8::Isolate::GetCurrent();
+  EscapableHandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance();
+  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   TagsJs* from = ObjectWrap::Unwrap<TagsJs>(result);
   from->_setTags(t);
 
@@ -113,10 +116,11 @@ void TagsJs::get(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   Tags& t = ObjectWrap::Unwrap<TagsJs>(args.This())->getTags();
 
-  QString key = str(args[0]->ToString());
+  QString key = str(args[0]->ToString(context).ToLocalChecked());
   if (t.contains(key))
   {
     QString value = t.get(key);

--- a/hoot-js/src/main/cpp/hoot/js/elements/TagsJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/TagsJs.cpp
@@ -57,7 +57,7 @@ void TagsJs::contains(const FunctionCallbackInfo<Value>& args)
   args.GetReturnValue().Set(toV8(t.contains(key)));
 }
 
-void TagsJs::Init(Handle<Object> target)
+void TagsJs::Init(Local<Object> target)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   HandleScope scope(current);
@@ -88,13 +88,13 @@ void TagsJs::Init(Handle<Object> target)
   target->Set(String::NewFromUtf8(current, "Tags"), ToLocal(&_constructor));
 }
 
-Handle<Object> TagsJs::New(const Tags& t)
+Local<Object> TagsJs::New(const Tags& t)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
+  Local<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   TagsJs* from = ObjectWrap::Unwrap<TagsJs>(result);
   from->_setTags(t);
 

--- a/hoot-js/src/main/cpp/hoot/js/elements/TagsJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/elements/TagsJs.h
@@ -49,11 +49,11 @@ class TagsJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   Tags& getTags() { return _tags; }
 
-  static v8::Handle<v8::Object> New(const Tags& t);
+  static v8::Local<v8::Object> New(const Tags& t);
 
   virtual ~TagsJs() = default;
 
@@ -77,14 +77,14 @@ private:
   void _setTags(const Tags& t) { _tags = t; }
 };
 
-inline void toCpp(v8::Handle<v8::Value> v, Tags& t)
+inline void toCpp(v8::Local<v8::Value> v, Tags& t)
 {
   if (!v->IsObject())
   {
     throw IllegalArgumentException("Expected an object, got: (" + toJson(v) + ")");
   }
 
-  v8::Handle<v8::Object> obj = v8::Handle<v8::Object>::Cast(v);
+  v8::Local<v8::Object> obj = v8::Local<v8::Object>::Cast(v);
   TagsJs* js = nullptr;
   if (obj->InternalFieldCount() > 0)
   {

--- a/hoot-js/src/main/cpp/hoot/js/elements/WayJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/WayJs.cpp
@@ -47,7 +47,7 @@ HOOT_JS_REGISTER(WayJs)
 
 Persistent<Function> WayJs::_constructor;
 
-void WayJs::Init(Handle<Object> target)
+void WayJs::Init(Local<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
@@ -65,26 +65,26 @@ void WayJs::Init(Handle<Object> target)
   target->Set(String::NewFromUtf8(current, "Way"), ToLocal(&_constructor));
 }
 
-Handle<Object> WayJs::New(ConstWayPtr way)
+Local<Object> WayJs::New(ConstWayPtr way)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
+  Local<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   WayJs* from = ObjectWrap::Unwrap<WayJs>(result);
   from->_setWay(way);
 
   return scope.Escape(result);
 }
 
-Handle<Object> WayJs::New(WayPtr way)
+Local<Object> WayJs::New(WayPtr way)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
+  Local<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   WayJs* from = ObjectWrap::Unwrap<WayJs>(result);
   from->_setWay(way);
 

--- a/hoot-js/src/main/cpp/hoot/js/elements/WayJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/elements/WayJs.cpp
@@ -51,6 +51,7 @@ void WayJs::Init(Handle<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   // Prepare constructor template
   Local<FunctionTemplate> tpl = FunctionTemplate::New(current, New);
   tpl->SetClassName(String::NewFromUtf8(current, Way::className().toStdString().data()));
@@ -60,7 +61,7 @@ void WayJs::Init(Handle<Object> target)
   tpl->PrototypeTemplate()->Set(
     String::NewFromUtf8(current, "getNodeCount"), FunctionTemplate::New(current, getNodeCount));
 
-  _constructor.Reset(current, tpl->GetFunction());
+  _constructor.Reset(current, tpl->GetFunction(context).ToLocalChecked());
   target->Set(String::NewFromUtf8(current, "Way"), ToLocal(&_constructor));
 }
 
@@ -68,8 +69,9 @@ Handle<Object> WayJs::New(ConstWayPtr way)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance();
+  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   WayJs* from = ObjectWrap::Unwrap<WayJs>(result);
   from->_setWay(way);
 
@@ -80,8 +82,9 @@ Handle<Object> WayJs::New(WayPtr way)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance();
+  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   WayJs* from = ObjectWrap::Unwrap<WayJs>(result);
   from->_setWay(way);
 

--- a/hoot-js/src/main/cpp/hoot/js/elements/WayJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/elements/WayJs.h
@@ -44,15 +44,15 @@ class WayJs : public ElementJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   ConstElementPtr getConstElement() const override { return getConstWay(); }
   ConstWayPtr getConstWay() const { return _constWay; }
   ElementPtr getElement() override { return getWay(); }
   WayPtr getWay() { assert(_way); return _way; }
 
-  static v8::Handle<v8::Object> New(ConstWayPtr way);
-  static v8::Handle<v8::Object> New(WayPtr way);
+  static v8::Local<v8::Object> New(ConstWayPtr way);
+  static v8::Local<v8::Object> New(WayPtr way);
 
 private:
 

--- a/hoot-js/src/main/cpp/hoot/js/io/DataConvertJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/io/DataConvertJs.h
@@ -43,9 +43,9 @@ namespace hoot
 {
 
 template<typename T>
-T toCpp(v8::Handle<v8::Value> v);
+T toCpp(v8::Local<v8::Value> v);
 
-inline void toCpp(v8::Handle<v8::Value> v, bool& o)
+inline void toCpp(v8::Local<v8::Value> v, bool& o)
 {
   if (v->IsTrue())
   {
@@ -61,7 +61,7 @@ inline void toCpp(v8::Handle<v8::Value> v, bool& o)
   }
 }
 
-inline void toCpp(v8::Handle<v8::Value> v, int& o)
+inline void toCpp(v8::Local<v8::Value> v, int& o)
 {
   if (!v->IsInt32())
   {
@@ -73,7 +73,7 @@ inline void toCpp(v8::Handle<v8::Value> v, int& o)
   o = v->Int32Value(context).ToChecked();
 }
 
-inline void toCpp(v8::Handle<v8::Value> v, long& o)
+inline void toCpp(v8::Local<v8::Value> v, long& o)
 {
   if (!v->IsInt32())
   {
@@ -85,7 +85,7 @@ inline void toCpp(v8::Handle<v8::Value> v, long& o)
   o = v->Int32Value(context).ToChecked();
 }
 
-inline void toCpp(v8::Handle<v8::Value> v, Meters& o)
+inline void toCpp(v8::Local<v8::Value> v, Meters& o)
 {
   if (!v->IsNumber())
   {
@@ -98,14 +98,14 @@ inline void toCpp(v8::Handle<v8::Value> v, Meters& o)
 }
 
 template<typename T, typename U>
-void toCpp(v8::Handle<v8::Value> v, std::pair<T, U>& o)
+void toCpp(v8::Local<v8::Value> v, std::pair<T, U>& o)
 {
   if (!v->IsArray())
   {
     throw IllegalArgumentException("While converting a pair, expected an array. Got: (" +
                                    toJson(v) + ")");
   }
-  v8::Handle<v8::Array> arr = v8::Handle<v8::Array>::Cast(v);
+  v8::Local<v8::Array> arr = v8::Local<v8::Array>::Cast(v);
   if (arr->Length() != 2)
   {
     throw IllegalArgumentException("Expected an array of length 2, but got (" + toJson(v) + ")");
@@ -120,7 +120,7 @@ void toCpp(v8::Handle<v8::Value> v, std::pair<T, U>& o)
  * strings (e.g. number, string, bool), but not object types. This is simply because strings
  * may be automagically converted to primitive types. E.g. '1' may be turned into a number.
  */
-inline void toCpp(v8::Handle<v8::Value> v, QString& s)
+inline void toCpp(v8::Local<v8::Value> v, QString& s)
 {
   if (v.IsEmpty() || v->IsUndefined() || v->IsNull())
   {
@@ -137,13 +137,13 @@ inline void toCpp(v8::Handle<v8::Value> v, QString& s)
   }
 }
 
-inline void toCpp(v8::Handle<v8::Value> v, QStringList& o)
+inline void toCpp(v8::Local<v8::Value> v, QStringList& o)
 {
   if (!v->IsArray())
   {
     throw IllegalArgumentException("Expected an array. Got: (" + toJson(v) + ")");
   }
-  v8::Handle<v8::Array> arr = v8::Handle<v8::Array>::Cast(v);
+  v8::Local<v8::Array> arr = v8::Local<v8::Array>::Cast(v);
 
   o.reserve(arr->Length());
   for (uint32_t i = 0; i < arr->Length(); i++)
@@ -152,13 +152,13 @@ inline void toCpp(v8::Handle<v8::Value> v, QStringList& o)
   }
 }
 
-inline void toCpp(v8::Handle<v8::Value> v, QVariantList& l)
+inline void toCpp(v8::Local<v8::Value> v, QVariantList& l)
 {
   if (v.IsEmpty() || v->IsArray() == false)
   {
     throw IllegalArgumentException("Expected to get an array. Got: (" + toJson(v) + ")");
   }
-  v8::Handle<v8::Array> arr = v8::Handle<v8::Array>::Cast(v);
+  v8::Local<v8::Array> arr = v8::Local<v8::Array>::Cast(v);
 
   l.clear();
   l.reserve(arr->Length());
@@ -168,7 +168,7 @@ inline void toCpp(v8::Handle<v8::Value> v, QVariantList& l)
   }
 }
 
-inline void toCpp(v8::Handle<v8::Value> v, QVariantMap& m)
+inline void toCpp(v8::Local<v8::Value> v, QVariantMap& m)
 {
   if (v.IsEmpty() || v->IsObject() == false)
   {
@@ -178,7 +178,7 @@ inline void toCpp(v8::Handle<v8::Value> v, QVariantMap& m)
   v8::HandleScope scope(current);
   v8::Local<v8::Context> context = current->GetCurrentContext();
 
-  v8::Handle<v8::Object> obj = v8::Handle<v8::Object>::Cast(v);
+  v8::Local<v8::Object> obj = v8::Local<v8::Object>::Cast(v);
 
   v8::Local<v8::Array> arr = obj->GetPropertyNames(context).ToLocalChecked();
   for (uint32_t i = 0; i < arr->Length(); i++)
@@ -190,7 +190,7 @@ inline void toCpp(v8::Handle<v8::Value> v, QVariantMap& m)
   }
 }
 
-inline void toCpp(v8::Handle<v8::Value> v, QVariant& qv)
+inline void toCpp(v8::Local<v8::Value> v, QVariant& qv)
 {
   v8::Isolate* current = v8::Isolate::GetCurrent();
   v8::HandleScope scope(current);
@@ -231,13 +231,13 @@ inline void toCpp(v8::Handle<v8::Value> v, QVariant& qv)
 }
 
 template<typename T>
-void toCpp(v8::Handle<v8::Value> v, std::vector<T>& o)
+void toCpp(v8::Local<v8::Value> v, std::vector<T>& o)
 {
   if (!v->IsArray())
   {
     throw IllegalArgumentException("Expected an array. Got: (" + toJson(v) + ")");
   }
-  v8::Handle<v8::Array> arr = v8::Handle<v8::Array>::Cast(v);
+  v8::Local<v8::Array> arr = v8::Local<v8::Array>::Cast(v);
 
   o.resize(arr->Length());
   for (uint32_t i = 0; i < arr->Length(); i++)
@@ -252,13 +252,13 @@ void toCpp(v8::Handle<v8::Value> v, std::vector<T>& o)
  * std::set is converted to a JavaScript Array. Using objects coerces all the keys into strings.
  */
 template<typename T>
-void toCpp(v8::Handle<v8::Value> v, std::set<T>& o)
+void toCpp(v8::Local<v8::Value> v, std::set<T>& o)
 {
   if (!v->IsArray())
   {
     throw IllegalArgumentException("Expected an array. Got: (" + toJson(v) + ")");
   }
-  v8::Handle<v8::Array> arr = v8::Handle<v8::Array>::Cast(v);
+  v8::Local<v8::Array> arr = v8::Local<v8::Array>::Cast(v);
   for (uint32_t i = 0; i < arr->Length(); i++)
   {
     T t;
@@ -268,29 +268,29 @@ void toCpp(v8::Handle<v8::Value> v, std::set<T>& o)
 }
 
 template<typename T>
-inline T toCpp(v8::Handle<v8::Value> v)
+inline T toCpp(v8::Local<v8::Value> v)
 {
   T t;
   toCpp(v, t);
   return t;
 }
 
-inline v8::Handle<v8::Value> toV8(bool v)
+inline v8::Local<v8::Value> toV8(bool v)
 {
   return v8::Boolean::New(v8::Isolate::GetCurrent(), v);
 }
 
-inline v8::Handle<v8::Value> toV8(int i)
+inline v8::Local<v8::Value> toV8(int i)
 {
   return v8::Integer::New(v8::Isolate::GetCurrent(), i);
 }
 
-inline v8::Handle<v8::Value> toV8(double v)
+inline v8::Local<v8::Value> toV8(double v)
 {
   return v8::Number::New(v8::Isolate::GetCurrent(),v);
 }
 
-inline v8::Handle<v8::Value> toV8(const std::string& s)
+inline v8::Local<v8::Value> toV8(const std::string& s)
 {
   return
     v8::String::NewFromUtf8(
@@ -298,18 +298,18 @@ inline v8::Handle<v8::Value> toV8(const std::string& s)
 }
 
 template<typename T, typename U>
-v8::Handle<v8::Value> toV8(const std::pair<T, U>& p)
+v8::Local<v8::Value> toV8(const std::pair<T, U>& p)
 {
-  v8::Handle<v8::Array> result = v8::Array::New(v8::Isolate::GetCurrent(), 2);
+  v8::Local<v8::Array> result = v8::Array::New(v8::Isolate::GetCurrent(), 2);
   result->Set(0, toV8(p.first));
   result->Set(1, toV8(p.second));
   return result;
 }
 
 template<typename T>
-v8::Handle<v8::Value> toV8(const std::vector<T>& v)
+v8::Local<v8::Value> toV8(const std::vector<T>& v)
 {
-  v8::Handle<v8::Array> result = v8::Array::New(v8::Isolate::GetCurrent(), v.size());
+  v8::Local<v8::Array> result = v8::Array::New(v8::Isolate::GetCurrent(), v.size());
   for (uint32_t i = 0; i < v.size(); i++)
   {
     result->Set(i, toV8(v[i]));
@@ -321,9 +321,9 @@ v8::Handle<v8::Value> toV8(const std::vector<T>& v)
  * std::set is converted to a JavaScript Array. Using objects coerces all the keys into strings.
  */
 template<typename T>
-v8::Handle<v8::Value> toV8(const std::set<T>& v)
+v8::Local<v8::Value> toV8(const std::set<T>& v)
 {
-  v8::Handle<v8::Array> result = v8::Array::New(v8::Isolate::GetCurrent(), v.size());
+  v8::Local<v8::Array> result = v8::Array::New(v8::Isolate::GetCurrent(), v.size());
   uint32_t i = 0;
   for (typename std::set<T>::const_iterator it = v.begin(); it != v.end(); ++it)
   {
@@ -332,12 +332,12 @@ v8::Handle<v8::Value> toV8(const std::set<T>& v)
   return result;
 }
 
-inline v8::Handle<v8::Value> toV8(const char* s)
+inline v8::Local<v8::Value> toV8(const char* s)
 {
   return v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), s);
 }
 
-inline v8::Handle<v8::Value> toV8(const QString& s)
+inline v8::Local<v8::Value> toV8(const QString& s)
 {
   QByteArray utf8 = s.toUtf8();
   return
@@ -346,9 +346,9 @@ inline v8::Handle<v8::Value> toV8(const QString& s)
       utf8.length()).ToLocalChecked();
 }
 
-inline v8::Handle<v8::Value> toV8(const QStringList& v)
+inline v8::Local<v8::Value> toV8(const QStringList& v)
 {
-  v8::Handle<v8::Array> result = v8::Array::New(v8::Isolate::GetCurrent(), v.size());
+  v8::Local<v8::Array> result = v8::Array::New(v8::Isolate::GetCurrent(), v.size());
   for (int i = 0; i < v.size(); i++)
   {
     result->Set(i, toV8(v[i]));
@@ -356,7 +356,7 @@ inline v8::Handle<v8::Value> toV8(const QStringList& v)
   return result;
 }
 
-inline v8::Handle<v8::Value> toV8(const QVariant& v)
+inline v8::Local<v8::Value> toV8(const QVariant& v)
 {
   v8::Isolate* current = v8::Isolate::GetCurrent();
   switch (v.type())
@@ -376,7 +376,7 @@ inline v8::Handle<v8::Value> toV8(const QVariant& v)
   case QVariant::List:
   {
     QVariantList l = v.toList();
-    v8::Handle<v8::Array> result = v8::Array::New(current, l.size());
+    v8::Local<v8::Array> result = v8::Array::New(current, l.size());
     for (int i = 0; i < l.size(); i++)
     {
       result->Set(i, toV8(l[i]));
@@ -385,7 +385,7 @@ inline v8::Handle<v8::Value> toV8(const QVariant& v)
   }
   case QVariant::Hash:
   {
-    v8::Handle<v8::Object> result = v8::Object::New(current);
+    v8::Local<v8::Object> result = v8::Object::New(current);
     QVariantHash m = v.toHash();
     for (QVariantHash::const_iterator i = m.begin(); i != m.end(); i++)
     {
@@ -395,7 +395,7 @@ inline v8::Handle<v8::Value> toV8(const QVariant& v)
   }
   case QVariant::Map:
   {
-    v8::Handle<v8::Object> result = v8::Object::New(current);
+    v8::Local<v8::Object> result = v8::Object::New(current);
     QVariantMap m = v.toMap();
     for (QVariantMap::const_iterator i = m.begin(); i != m.end(); i++)
     {
@@ -410,9 +410,9 @@ inline v8::Handle<v8::Value> toV8(const QVariant& v)
 }
 
 template<typename T, typename U>
-inline v8::Handle<v8::Value> toV8(const QHash<T, U>& m)
+inline v8::Local<v8::Value> toV8(const QHash<T, U>& m)
 {
-  v8::Handle<v8::Object> result = v8::Object::New(v8::Isolate::GetCurrent());
+  v8::Local<v8::Object> result = v8::Object::New(v8::Isolate::GetCurrent());
   typename QHash<T, U>::const_iterator i;
   for (i = m.begin(); i != m.end(); i++)
   {

--- a/hoot-js/src/main/cpp/hoot/js/io/DataConvertJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/io/DataConvertJs.h
@@ -67,7 +67,10 @@ inline void toCpp(v8::Handle<v8::Value> v, int& o)
   {
     throw IllegalArgumentException("Expected an integer. Got: (" + toJson(v) + ")");
   }
-  o = v->Int32Value();
+  v8::Isolate* current = v8::Isolate::GetCurrent();
+  v8::HandleScope scope(current);
+  v8::Local<v8::Context> context = current->GetCurrentContext();
+  o = v->Int32Value(context).ToChecked();
 }
 
 inline void toCpp(v8::Handle<v8::Value> v, long& o)
@@ -76,7 +79,10 @@ inline void toCpp(v8::Handle<v8::Value> v, long& o)
   {
     throw IllegalArgumentException("Expected an integer. Got: (" + toJson(v) + ")");
   }
-  o = v->Int32Value();
+  v8::Isolate* current = v8::Isolate::GetCurrent();
+  v8::HandleScope scope(current);
+  v8::Local<v8::Context> context = current->GetCurrentContext();
+  o = v->Int32Value(context).ToChecked();
 }
 
 inline void toCpp(v8::Handle<v8::Value> v, Meters& o)
@@ -85,7 +91,10 @@ inline void toCpp(v8::Handle<v8::Value> v, Meters& o)
   {
     throw IllegalArgumentException("Expected Meters (Number). Got: (" + toJson(v) + ")");
   }
-  o = v->NumberValue();
+  v8::Isolate* current = v8::Isolate::GetCurrent();
+  v8::HandleScope scope(current);
+  v8::Local<v8::Context> context = current->GetCurrentContext();
+  o = v->NumberValue(context).ToChecked();
 }
 
 template<typename T, typename U>
@@ -165,9 +174,13 @@ inline void toCpp(v8::Handle<v8::Value> v, QVariantMap& m)
   {
     throw IllegalArgumentException("Expected to get an object. Got: (" + toJson(v) + ")");
   }
+  v8::Isolate* current = v8::Isolate::GetCurrent();
+  v8::HandleScope scope(current);
+  v8::Local<v8::Context> context = current->GetCurrentContext();
+
   v8::Handle<v8::Object> obj = v8::Handle<v8::Object>::Cast(v);
 
-  v8::Local<v8::Array> arr = obj->GetPropertyNames();
+  v8::Local<v8::Array> arr = obj->GetPropertyNames(context).ToLocalChecked();
   for (uint32_t i = 0; i < arr->Length(); i++)
   {
     QString k = toCpp<QString>(arr->Get(i));
@@ -179,6 +192,9 @@ inline void toCpp(v8::Handle<v8::Value> v, QVariantMap& m)
 
 inline void toCpp(v8::Handle<v8::Value> v, QVariant& qv)
 {
+  v8::Isolate* current = v8::Isolate::GetCurrent();
+  v8::HandleScope scope(current);
+  v8::Local<v8::Context> context = current->GetCurrentContext();
   if (v.IsEmpty() || v->IsUndefined() || v->IsNull())
   {
     qv = QVariant();
@@ -192,11 +208,11 @@ inline void toCpp(v8::Handle<v8::Value> v, QVariant& qv)
     // Changed this since OGR is expecting Int and this makes a Long
     // It throws an error in OgrWriter.cpp:_addFeature
 //    qv.setValue(v->IntegerValue());
-    qv.setValue(v->Int32Value());
+    qv.setValue(v->Int32Value(context).ToChecked());
   }
   else if (v->IsNumber())
   {
-    qv.setValue(v->NumberValue());
+    qv.setValue(v->NumberValue(context).ToChecked());
   }
   else if (v->IsArray())
   {

--- a/hoot-js/src/main/cpp/hoot/js/io/MapIoJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/io/MapIoJs.cpp
@@ -48,7 +48,7 @@ namespace hoot
 
 HOOT_JS_REGISTER(MapIoJs)
 
-void MapIoJs::Init(Handle<Object> exports)
+void MapIoJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);

--- a/hoot-js/src/main/cpp/hoot/js/io/MapIoJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/io/MapIoJs.cpp
@@ -52,24 +52,26 @@ void MapIoJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   exports->Set(String::NewFromUtf8(current, "loadMap"),
-               FunctionTemplate::New(current, loadMap)->GetFunction());
+               FunctionTemplate::New(current, loadMap)->GetFunction(context).ToLocalChecked());
   exports->Set(String::NewFromUtf8(current, "loadMapFromString"),
-               FunctionTemplate::New(current, loadMapFromString)->GetFunction());
+               FunctionTemplate::New(current, loadMapFromString)->GetFunction(context).ToLocalChecked());
   exports->Set(String::NewFromUtf8(current, "loadMapFromStringPreserveIdAndStatus"),
-               FunctionTemplate::New(current, loadMapFromStringPreserveIdAndStatus)->GetFunction());
+               FunctionTemplate::New(current, loadMapFromStringPreserveIdAndStatus)->GetFunction(context).ToLocalChecked());
   exports->Set(String::NewFromUtf8(current, "saveMap"),
-               FunctionTemplate::New(current, saveMap)->GetFunction());
+               FunctionTemplate::New(current, saveMap)->GetFunction(context).ToLocalChecked());
 }
 
 void MapIoJs::loadMap(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   try
   {
-    OsmMapJs* map = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject());
+    OsmMapJs* map = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked());
 
     String::Utf8Value param1(args[1]->ToString());
     QString url = QString::fromUtf8(*param1);
@@ -77,13 +79,13 @@ void MapIoJs::loadMap(const FunctionCallbackInfo<Value>& args)
     bool useFileId = true;
     if (args.Length() >= 3)
     {
-      useFileId = args[2]->ToBoolean()->Value();
+      useFileId = args[2]->ToBoolean(context).ToLocalChecked()->Value();
     }
 
     Status status = Status::Invalid;
     if (args.Length() >= 4)
     {
-      status = (Status::Type)args[3]->ToInteger()->Value();
+      status = (Status::Type)args[3]->ToInteger(context).ToLocalChecked()->Value();
     }
 
     OsmMapReaderFactory::read(map->getMap(), url, useFileId, status);
@@ -100,8 +102,9 @@ void MapIoJs::loadMapFromString(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  OsmMapJs* map = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject());
+  OsmMapJs* map = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked());
   QString mapXml = toCpp<QString>(args[1]);
 
   OsmXmlReader reader;
@@ -112,7 +115,7 @@ void MapIoJs::loadMapFromString(const FunctionCallbackInfo<Value>& args)
   Status status = Status::Invalid;
   if (args.Length() >= 4)
   {
-    status = (Status::Type)args[3]->ToInteger()->Value();
+    status = (Status::Type)args[3]->ToInteger(context).ToLocalChecked()->Value();
     reader.setDefaultStatus(status);
   }
   reader.readFromString(mapXml, map->getMap());
@@ -124,8 +127,9 @@ void MapIoJs::loadMapFromStringPreserveIdAndStatus(const FunctionCallbackInfo<Va
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  OsmMapJs* map = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject());
+  OsmMapJs* map = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked());
   QString mapXml = toCpp<QString>(args[1]);
 
   OsmXmlReader reader;
@@ -140,8 +144,9 @@ void MapIoJs::saveMap(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  OsmMapPtr map = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject())->getMap();
+  OsmMapPtr map = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked())->getMap();
 
   MapProjector::projectToWgs84(map);
 

--- a/hoot-js/src/main/cpp/hoot/js/io/MapIoJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/io/MapIoJs.h
@@ -39,7 +39,7 @@ public:
 
   MapIoJs();
 
-  static void Init(v8::Handle<v8::Object> exports);
+  static void Init(v8::Local<v8::Object> exports);
 
   static void loadMap(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void loadMapFromString(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/hoot-js/src/main/cpp/hoot/js/io/OsmGeoJsonWriterJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/io/OsmGeoJsonWriterJs.cpp
@@ -39,11 +39,11 @@ namespace hoot
 
 HOOT_JS_REGISTER(OsmGeoJsonWriterJs)
 
-void OsmGeoJsonWriterJs::Init(Handle<Object> exports)
+void OsmGeoJsonWriterJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
-  Handle<Object> writer = Object::New(current);
+  Local<Object> writer = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "OsmGeoJsonWriter"), writer);
 }
 

--- a/hoot-js/src/main/cpp/hoot/js/io/OsmGeoJsonWriterJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/io/OsmGeoJsonWriterJs.h
@@ -37,7 +37,7 @@ class OsmGeoJsonWriterJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   virtual ~OsmGeoJsonWriterJs() = default;
 

--- a/hoot-js/src/main/cpp/hoot/js/io/OsmWriterJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/io/OsmWriterJs.cpp
@@ -39,12 +39,12 @@ namespace hoot
 
 HOOT_JS_REGISTER(OsmWriterJs)
 
-void OsmWriterJs::Init(Handle<Object> exports)
+void OsmWriterJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
-  Handle<Object> writer = Object::New(current);
+  Local<Object> writer = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "OsmWriter"), writer);
   writer->Set(String::NewFromUtf8(current, "toString"),
               FunctionTemplate::New(current, toString)->GetFunction(context).ToLocalChecked());

--- a/hoot-js/src/main/cpp/hoot/js/io/OsmWriterJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/io/OsmWriterJs.cpp
@@ -43,10 +43,11 @@ void OsmWriterJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   Handle<Object> writer = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "OsmWriter"), writer);
   writer->Set(String::NewFromUtf8(current, "toString"),
-              FunctionTemplate::New(current, toString)->GetFunction());
+              FunctionTemplate::New(current, toString)->GetFunction(context).ToLocalChecked());
 }
 
 void OsmWriterJs::toString(const FunctionCallbackInfo<Value>& args)

--- a/hoot-js/src/main/cpp/hoot/js/io/OsmWriterJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/io/OsmWriterJs.h
@@ -38,7 +38,7 @@ class OsmWriterJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   virtual ~OsmWriterJs() = default;
 

--- a/hoot-js/src/main/cpp/hoot/js/io/StreamUtilsJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/io/StreamUtilsJs.h
@@ -43,31 +43,31 @@ namespace hoot
  *  to report errors.
  * @return Parsed JSON value
  */
-inline v8::Handle<v8::Value> fromJson(QString qstr, QString fileName="")
+inline v8::Local<v8::Value> fromJson(QString qstr, QString fileName="")
 {
   v8::Isolate* current = v8::Isolate::GetCurrent();
   v8::EscapableHandleScope scope(current);
-  v8::Handle<v8::Context> context = current->GetCurrentContext();
-  v8::Handle<v8::Object> global = context->Global();
+  v8::Local<v8::Context> context = current->GetCurrentContext();
+  v8::Local<v8::Object> global = context->Global();
 
   QByteArray utf8 = qstr.toUtf8();
-  v8::Handle<v8::Value> str =
+  v8::Local<v8::Value> str =
     v8::String::NewFromUtf8(
       current, utf8.data(), v8::NewStringType::kNormal, utf8.length()).ToLocalChecked();
 
-  v8::Handle<v8::Object> JSON = global->Get(v8::String::NewFromUtf8(current, "JSON"))->ToObject(context).ToLocalChecked();
-  v8::Handle<v8::Function> JSON_parse =
-    v8::Handle<v8::Function>::Cast(JSON->Get(v8::String::NewFromUtf8(current, "parse")));
+  v8::Local<v8::Object> JSON = global->Get(v8::String::NewFromUtf8(current, "JSON"))->ToObject(context).ToLocalChecked();
+  v8::Local<v8::Function> JSON_parse =
+    v8::Local<v8::Function>::Cast(JSON->Get(v8::String::NewFromUtf8(current, "parse")));
 
-  v8::Handle<v8::Value> args[1];
+  v8::Local<v8::Value> args[1];
   args[0] = str;
 
   v8::TryCatch tc(current);
-  v8::Handle<v8::Value> result = JSON_parse->Call(context, JSON, 1, args).ToLocalChecked();
+  v8::Local<v8::Value> result = JSON_parse->Call(context, JSON, 1, args).ToLocalChecked();
 
   if (result.IsEmpty())
   {
-    v8::Handle<v8::Message> msg = tc.Message();
+    v8::Local<v8::Message> msg = tc.Message();
 
     // See ReportException in http://v8.googlecode.com/svn/trunk/samples/shell.cc
     if (fileName.isEmpty())
@@ -120,14 +120,14 @@ QString toJson(const v8::Local<T> object)
     v8::Local<v8::Object> global = context->Global();
 
     v8::Local<v8::Object> JSON = global->Get(v8::String::NewFromUtf8(current, "JSON"))->ToObject(context).ToLocalChecked();
-    v8::Handle<v8::Function> JSON_stringify =
-      v8::Handle<v8::Function>::Cast(JSON->Get(v8::String::NewFromUtf8(current, "stringify")));
+    v8::Local<v8::Function> JSON_stringify =
+      v8::Local<v8::Function>::Cast(JSON->Get(v8::String::NewFromUtf8(current, "stringify")));
 
-    v8::Handle<v8::Value> args[1];
+    v8::Local<v8::Value> args[1];
     args[0] = object;
 
-    v8::Handle<v8::Value> resultValue = JSON_stringify->Call(context, JSON, 1, args).ToLocalChecked();
-    v8::Handle<v8::String> s = v8::Handle<v8::String>::Cast(resultValue);
+    v8::Local<v8::Value> resultValue = JSON_stringify->Call(context, JSON, 1, args).ToLocalChecked();
+    v8::Local<v8::String> s = v8::Local<v8::String>::Cast(resultValue);
 
     size_t utf8Length = s->Utf8Length() + 1;
     std::unique_ptr<char[]> buffer(new char[utf8Length]);
@@ -139,10 +139,10 @@ QString toJson(const v8::Local<T> object)
   return result;
 }
 
-std::ostream& operator<<(std::ostream& o, const v8::Handle<v8::Function>& f);
+std::ostream& operator<<(std::ostream& o, const v8::Local<v8::Function>& f);
 
 template <class T>
-inline std::ostream& operator<<(std::ostream& o, const v8::Handle<T>& v)
+inline std::ostream& operator<<(std::ostream& o, const v8::Local<T>& v)
 {
   if (v.IsEmpty())
   {
@@ -158,7 +158,7 @@ inline std::ostream& operator<<(std::ostream& o, const v8::Handle<T>& v)
   }
   else if (v->IsFunction())
   {
-    v8::Handle<v8::Function> f = v8::Handle<v8::Function>::Cast(v);
+    v8::Local<v8::Function> f = v8::Local<v8::Function>::Cast(v);
     o << f;
   }
   else
@@ -168,7 +168,7 @@ inline std::ostream& operator<<(std::ostream& o, const v8::Handle<T>& v)
   return o;
 }
 
-inline std::ostream& operator<<(std::ostream& o, const v8::Handle<v8::Function>& f)
+inline std::ostream& operator<<(std::ostream& o, const v8::Local<v8::Function>& f)
 {
   QString name = toJson(f->GetName());
   if (name != "\"\"")
@@ -188,7 +188,7 @@ inline std::ostream& operator<<(std::ostream& o, const v8::TryCatch& tc)
   v8::HandleScope scope(current);
   v8::Local<v8::Context> context = current->GetCurrentContext();
 
-  v8::Handle<v8::Message> message = tc.Message();
+  v8::Local<v8::Message> message = tc.Message();
   if (message.IsEmpty())
   {
     o << tc.Exception();

--- a/hoot-js/src/main/cpp/hoot/js/ops/OsmMapOperationJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/ops/OsmMapOperationJs.cpp
@@ -57,6 +57,7 @@ void OsmMapOperationJs::Init(Handle<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   vector<QString> opNames =
     Factory::getInstance().getObjectNamesByBase(OsmMapOperation::className());
 
@@ -77,7 +78,7 @@ void OsmMapOperationJs::Init(Handle<Object> target)
       PopulateConsumersJs::baseClass(),
       String::NewFromUtf8(current, OsmMapOperation::className().toStdString().data()));
 
-    Persistent<Function> constructor(current, tpl->GetFunction());
+    Persistent<Function> constructor(current, tpl->GetFunction(context).ToLocalChecked());
     target->Set(String::NewFromUtf8(current, n), ToLocal(&constructor));
   }
 }
@@ -109,9 +110,10 @@ void OsmMapOperationJs::apply(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   OsmMapOperationJs* op = ObjectWrap::Unwrap<OsmMapOperationJs>(args.This());
-  OsmMapPtr& map = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject())->getMap();
+  OsmMapPtr& map = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked())->getMap();
 
   op->getMapOp()->apply(map);
 
@@ -122,9 +124,10 @@ void OsmMapOperationJs::applyAndGetResult(const FunctionCallbackInfo<Value>& arg
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   OsmMapOperationJs* op = ObjectWrap::Unwrap<OsmMapOperationJs>(args.This());
-  OsmMapPtr& map = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject())->getMap();
+  OsmMapPtr& map = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked())->getMap();
   op->getMapOp()->apply(map);
   boost::any result = op->getMapOp()->getResult();
 

--- a/hoot-js/src/main/cpp/hoot/js/ops/OsmMapOperationJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/ops/OsmMapOperationJs.cpp
@@ -53,7 +53,7 @@ namespace hoot
 
 HOOT_JS_REGISTER(OsmMapOperationJs)
 
-void OsmMapOperationJs::Init(Handle<Object> target)
+void OsmMapOperationJs::Init(Local<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);

--- a/hoot-js/src/main/cpp/hoot/js/ops/OsmMapOperationJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/ops/OsmMapOperationJs.h
@@ -45,7 +45,7 @@ class OsmMapOperationJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   OsmMapOperation* getMapOp() { return _op.get(); }
 

--- a/hoot-js/src/main/cpp/hoot/js/schema/JavaScriptSchemaTranslator.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/JavaScriptSchemaTranslator.cpp
@@ -196,12 +196,12 @@ void JavaScriptSchemaTranslator::_finalize()
     Context::Scope context_scope(_gContext->getContext(current));
     Local<Context> context = current->GetCurrentContext();
 
-    Handle<Object> tObj = _gContext->getContext(current)->Global();
+    Local<Object> tObj = _gContext->getContext(current)->Global();
 
     if (tObj->Has(context, String::NewFromUtf8(current, "finalize")).ToChecked())
     {
       TryCatch trycatch(current);
-      Handle<Value> finalize = _gContext->call(tObj,"finalize");
+      Local<Value> finalize = _gContext->call(tObj,"finalize");
       HootExceptionJs::checkV8Exception(finalize, trycatch);
     }
   }
@@ -238,13 +238,13 @@ void JavaScriptSchemaTranslator::_init()
   }
 
   // Less typing
-  Handle<Object> tObj = _gContext->getContext(current)->Global();
+  Local<Object> tObj = _gContext->getContext(current)->Global();
 
   // Run Initialize, if it exists
   if (tObj->Has(context, String::NewFromUtf8(current, "initialize")).ToChecked())
   {
     TryCatch trycatch(current);
-    Handle<Value> initial = _gContext->call(tObj,"initialize");
+    Local<Value> initial = _gContext->call(tObj,"initialize");
     HootExceptionJs::checkV8Exception(initial, trycatch);
   }
 
@@ -276,7 +276,7 @@ QString JavaScriptSchemaTranslator::getLayerNameFilter()
   Context::Scope context_scope(_gContext->getContext(current));
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> tObj = _gContext->getContext(current)->Global();
+  Local<Object> tObj = _gContext->getContext(current)->Global();
 
   LOG_TRACE("Getting layer name filter...");
   if (tObj->Has(context, String::NewFromUtf8(current, "layerNameFilter")).ToChecked())
@@ -334,7 +334,7 @@ std::shared_ptr<const Schema> JavaScriptSchemaTranslator::getOgrOutputSchema()
     Context::Scope context_scope(_gContext->getContext(current));
     Local<Context> context = current->GetCurrentContext();
 
-    Handle<Object> tObj = _gContext->getContext(current)->Global();
+    Local<Object> tObj = _gContext->getContext(current)->Global();
 
     if (!tObj->Has(context, String::NewFromUtf8(current, "getDbSchema")).ToChecked())
     {
@@ -342,7 +342,7 @@ std::shared_ptr<const Schema> JavaScriptSchemaTranslator::getOgrOutputSchema()
                           "(Missing schema)");
     }
 
-    Handle<Value> schemaJs(_gContext->call(tObj,"getDbSchema"));
+    Local<Value> schemaJs(_gContext->call(tObj,"getDbSchema"));
 
     if (schemaJs->IsArray())
     {
@@ -806,7 +806,7 @@ QVariantList JavaScriptSchemaTranslator::_translateToOgrVariants(Tags& tags,
   Context::Scope context_scope(_gContext->getContext(current));
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> v8tags = Object::New(current);
+  Local<Object> v8tags = Object::New(current);
   for (Tags::const_iterator it = tags.begin(); it != tags.end(); ++it)
   {
     v8tags->Set(toV8(it.key()), toV8(it.value()));
@@ -814,7 +814,7 @@ QVariantList JavaScriptSchemaTranslator::_translateToOgrVariants(Tags& tags,
 
   // Hardcoded to 3 arguments
   //  args << tagsJs << elementTypeJs << geometryTypeJs;
-  Handle<Value> args[3];
+  Local<Value> args[3];
   args[0] = v8tags;
   args[1] = toV8(elementType.toString());
 
@@ -846,11 +846,11 @@ QVariantList JavaScriptSchemaTranslator::_translateToOgrVariants(Tags& tags,
   }
 
 //  QScriptValue translated = _translateToOgrFunction->call(QScriptValue(), args);
-  Handle<Object> tObj = _gContext->getContext(current)->Global();
+  Local<Object> tObj = _gContext->getContext(current)->Global();
 
   // We assume this exists. we checked during Init.
-  Handle<Function> tFunc =
-    Handle<Function>::Cast(tObj->Get(String::NewFromUtf8(current, "translateToOgr")));
+  Local<Function> tFunc =
+    Local<Function>::Cast(tObj->Get(String::NewFromUtf8(current, "translateToOgr")));
 
   // Make sure we have a translation function. No easy way to do this earlier than now
   if (tFunc->IsUndefined())
@@ -915,7 +915,7 @@ void JavaScriptSchemaTranslator::_translateToOsm(Tags& t, const char* layerName,
   Context::Scope context_scope(_gContext->getContext(current));
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> tags = Object::New(current);
+  Local<Object> tags = Object::New(current);
   for (Tags::const_iterator it = t.begin(); it != t.end(); ++it)
   {
     LOG_VART(it.key());
@@ -923,15 +923,15 @@ void JavaScriptSchemaTranslator::_translateToOsm(Tags& t, const char* layerName,
     tags->Set(toV8(it.key()), toV8(it.value()));
   }
 
-  Handle<Value> args[3];
+  Local<Value> args[3];
   args[0] = tags;
   args[1] = toV8(layerName);
   args[2] = toV8(geomType);
 
-  Handle<Object> tObj = _gContext->getContext(current)->Global();
+  Local<Object> tObj = _gContext->getContext(current)->Global();
 
   // This has a variable since we don't know if it will be "translateToOsm" or "translateAttributes"
-  Handle<Function> tFunc = Handle<Function>::Cast(tObj->Get(toV8(_toOsmFunctionName)));
+  Local<Function> tFunc = Local<Function>::Cast(tObj->Get(toV8(_toOsmFunctionName)));
   TryCatch trycatch(current);
 
   // NOTE: the "3" here is the number of arguments
@@ -965,8 +965,8 @@ void JavaScriptSchemaTranslator::_translateToOsm(Tags& t, const char* layerName,
   else if (newTags->IsObject())
   {
     // Either do this or a cast. Not sure what is better/faster
-    // Handle<Object> obj = Handle<Object>::Cast(newTags);
-    Handle<Object> obj = newTags->ToObject(context).ToLocalChecked();
+    // Local<Object> obj = Local<Object>::Cast(newTags);
+    Local<Object> obj = newTags->ToObject(context).ToLocalChecked();
 
     Local<Array> arr = obj->GetPropertyNames(context).ToLocalChecked();
 

--- a/hoot-js/src/main/cpp/hoot/js/schema/JavaScriptSchemaTranslator.h
+++ b/hoot-js/src/main/cpp/hoot/js/schema/JavaScriptSchemaTranslator.h
@@ -113,7 +113,7 @@ protected:
   Tags* _tags;
   std::vector<double> _timing;
   QHash<QString, int> _logs;
-  v8::Handle<v8::Value> _empty[0]; // For function calls
+  v8::Local<v8::Value> _empty[0]; // For function calls
 
   Settings _conf;
 

--- a/hoot-js/src/main/cpp/hoot/js/schema/JsonOsmSchemaLoader.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/JsonOsmSchemaLoader.cpp
@@ -72,7 +72,7 @@ void JsonOsmSchemaLoader::load(QString path, OsmSchema& s)
   Context::Scope context_scope(ToLocal(&_context));
 
   // If needed, this will throw an exception with user readable(ish) error message.
-  Handle<Value> result = fromJson(QString::fromUtf8(ba.data(), ba.size()), path);
+  Local<Value> result = fromJson(QString::fromUtf8(ba.data(), ba.size()), path);
 
   QVariantList l = toCpp<QVariantList>(result);
 

--- a/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.cpp
@@ -60,58 +60,59 @@ void OsmSchemaJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   Handle<Object> schema = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "OsmSchema"), schema);
 
   schema->Set(String::NewFromUtf8(current, "getAllTags"),
-              FunctionTemplate::New(current, getAllTags)->GetFunction());
+              FunctionTemplate::New(current, getAllTags)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "getCategories"),
-              FunctionTemplate::New(current, getCategories)->GetFunction());
+              FunctionTemplate::New(current, getCategories)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "getChildTagsAsVertices"),
-              FunctionTemplate::New(current, getChildTagsAsVertices)->GetFunction());
+              FunctionTemplate::New(current, getChildTagsAsVertices)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "getSimilarTagsAsVertices"),
-              FunctionTemplate::New(current, getSimilarTagsAsVertices)->GetFunction());
+              FunctionTemplate::New(current, getSimilarTagsAsVertices)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "getTagVertex"),
-              FunctionTemplate::New(current, getTagVertex)->GetFunction());
+              FunctionTemplate::New(current, getTagVertex)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "isAncestor"),
-              FunctionTemplate::New(current, isAncestor)->GetFunction());
+              FunctionTemplate::New(current, isAncestor)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "isGeneric"),
-              FunctionTemplate::New(current, isGeneric)->GetFunction());
+              FunctionTemplate::New(current, isGeneric)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "hasType"),
-              FunctionTemplate::New(current, hasType)->GetFunction());
+              FunctionTemplate::New(current, hasType)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "explicitTypeMismatch"),
-              FunctionTemplate::New(current, explicitTypeMismatch)->GetFunction());
+              FunctionTemplate::New(current, explicitTypeMismatch)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "mostSpecificType"),
-              FunctionTemplate::New(current, mostSpecificType)->GetFunction());
+              FunctionTemplate::New(current, mostSpecificType)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "score"),
-              FunctionTemplate::New(current, score)->GetFunction());
+              FunctionTemplate::New(current, score)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "scoreTypes"),
-              FunctionTemplate::New(current, scoreTypes)->GetFunction());
+              FunctionTemplate::New(current, scoreTypes)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "scoreOneWay"),
-              FunctionTemplate::New(current, scoreOneWay)->GetFunction());
+              FunctionTemplate::New(current, scoreOneWay)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "hasName"),
-              FunctionTemplate::New(current, hasName)->GetFunction());
+              FunctionTemplate::New(current, hasName)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "isSpecificallyConflatable"),
-              FunctionTemplate::New(current, isSpecificallyConflatable)->GetFunction());
+              FunctionTemplate::New(current, isSpecificallyConflatable)->GetFunction(context).ToLocalChecked());
 
   schema->Set(String::NewFromUtf8(current, "isPolygon"),
-              FunctionTemplate::New(current, isPolygon)->GetFunction());
+              FunctionTemplate::New(current, isPolygon)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "isPoint"),
-              FunctionTemplate::New(current, isPoint)->GetFunction());
+              FunctionTemplate::New(current, isPoint)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "isLinear"),
-              FunctionTemplate::New(current, isLinear)->GetFunction());
+              FunctionTemplate::New(current, isLinear)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "isLinearWaterway"),
-              FunctionTemplate::New(current, isLinearWaterway)->GetFunction());
+              FunctionTemplate::New(current, isLinearWaterway)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "isPowerLine"),
-              FunctionTemplate::New(current, isPowerLine)->GetFunction());
+              FunctionTemplate::New(current, isPowerLine)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "isPoi"),
-              FunctionTemplate::New(current, isPoi)->GetFunction());
+              FunctionTemplate::New(current, isPoi)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "isRailway"),
-              FunctionTemplate::New(current, isRailway)->GetFunction());
+              FunctionTemplate::New(current, isRailway)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "isNonBuildingArea"),
-              FunctionTemplate::New(current, isNonBuildingArea)->GetFunction());
+              FunctionTemplate::New(current, isNonBuildingArea)->GetFunction(context).ToLocalChecked());
   schema->Set(String::NewFromUtf8(current, "isCollectionRelation"),
-              FunctionTemplate::New(current, isCollectionRelation)->GetFunction());
+              FunctionTemplate::New(current, isCollectionRelation)->GetFunction(context).ToLocalChecked());
 }
 
 void OsmSchemaJs::getAllTags(const FunctionCallbackInfo<Value>& args)
@@ -174,8 +175,9 @@ void OsmSchemaJs::isGeneric(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   const bool isGeneric = OsmSchema::getInstance().isGeneric(e->getTags());
   LOG_VART(isGeneric);
@@ -187,8 +189,9 @@ void OsmSchemaJs::hasType(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   const bool hasType = OsmSchema::getInstance().hasType(e->getTags());
   LOG_VART(hasType);
@@ -200,9 +203,10 @@ void OsmSchemaJs::explicitTypeMismatch(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e1 = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject())->getConstElement();
-  ConstElementPtr e2 = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject())->getConstElement();
+  ConstElementPtr e1 = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
+  ConstElementPtr e2 = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
   double minimumScore = toCpp<double>(args[2]);
 
   const bool hasExplicitTypeMismatch =
@@ -215,9 +219,10 @@ void OsmSchemaJs::isPoint(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject());
-  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject())->getConstElement();
+  OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked());
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
 
   args.GetReturnValue().Set(
     Boolean::New(current, PointCriterion(mapJs->getConstMap()).isSatisfied(e)));
@@ -227,8 +232,9 @@ void OsmSchemaJs::isLinear(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   args.GetReturnValue().Set(Boolean::New(current, LinearCriterion().isSatisfied(e)));
 }
@@ -237,9 +243,10 @@ void OsmSchemaJs::isPolygon(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject());
-  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject())->getConstElement();
+  OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked());
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
 
   args.GetReturnValue().Set(
     Boolean::New(current, PolygonCriterion(mapJs->getConstMap()).isSatisfied(e)));
@@ -249,8 +256,9 @@ void OsmSchemaJs::isLinearWaterway(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   args.GetReturnValue().Set(Boolean::New(current, LinearWaterwayCriterion().isSatisfied(e)));
 }
@@ -259,8 +267,9 @@ void OsmSchemaJs::isPowerLine(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   args.GetReturnValue().Set(Boolean::New(current, PowerLineCriterion().isSatisfied(e)));
 }
@@ -269,8 +278,9 @@ void OsmSchemaJs::isPoi(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   args.GetReturnValue().Set(Boolean::New(current, PoiCriterion().isSatisfied(e)));
 }
@@ -279,8 +289,9 @@ void OsmSchemaJs::isRailway(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   args.GetReturnValue().Set(Boolean::New(current, RailwayCriterion().isSatisfied(e)));
 }
@@ -289,9 +300,10 @@ void OsmSchemaJs::isNonBuildingArea(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject());
-  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject())->getConstElement();
+  OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked());
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
 
   args.GetReturnValue().Set(
     Boolean::New(current, NonBuildingAreaCriterion(mapJs->getConstMap()).isSatisfied(e)));
@@ -301,8 +313,9 @@ void OsmSchemaJs::isCollectionRelation(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   args.GetReturnValue().Set(
     Boolean::New(current, CollectionRelationCriterion().isSatisfied(e)));
@@ -314,12 +327,13 @@ void OsmSchemaJs::isSpecificallyConflatable(
 
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject());
+  OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked());
   NonConflatableCriterion crit(mapJs->getConstMap());
   crit.setIgnoreGenericConflators(true);
 
-  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
 
   const QString geometryTypeFilterStr = toCpp<QString>(args[2]).trimmed();
   if (!geometryTypeFilterStr.isEmpty())
@@ -337,8 +351,9 @@ void OsmSchemaJs::hasName(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   args.GetReturnValue().Set(Boolean::New(current, HasNameCriterion().isSatisfied(e)));
 }
@@ -384,8 +399,9 @@ void OsmSchemaJs::mostSpecificType(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr element = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject())->getConstElement();
+  ConstElementPtr element = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
   const QString kvp = OsmSchema::getInstance().mostSpecificType(element->getTags());
   args.GetReturnValue().Set(String::NewFromUtf8(current, kvp.toUtf8().data()));
 }

--- a/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.cpp
@@ -56,12 +56,12 @@ namespace hoot
 
 HOOT_JS_REGISTER(OsmSchemaJs)
 
-void OsmSchemaJs::Init(Handle<Object> exports)
+void OsmSchemaJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
-  Handle<Object> schema = Object::New(current);
+  Local<Object> schema = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "OsmSchema"), schema);
 
   schema->Set(String::NewFromUtf8(current, "getAllTags"),

--- a/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.h
@@ -40,7 +40,7 @@ class OsmSchemaJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   virtual ~OsmSchemaJs() = default;
 
@@ -86,10 +86,10 @@ private:
   static void hasName(const v8::FunctionCallbackInfo<v8::Value>& args);
 };
 
-inline v8::Handle<v8::Value> toV8(const SchemaVertex& tv)
+inline v8::Local<v8::Value> toV8(const SchemaVertex& tv)
 {
   v8::Isolate* current = v8::Isolate::GetCurrent();
-  v8::Handle<v8::Object> result = v8::Object::New(current);
+  v8::Local<v8::Object> result = v8::Object::New(current);
 
   if (tv.isEmpty())
   {

--- a/hoot-js/src/main/cpp/hoot/js/schema/TagDifferencerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/TagDifferencerJs.cpp
@@ -54,14 +54,15 @@ void TagDifferencerJs::diff(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   try
   {
     TagDifferencerJs* op = ObjectWrap::Unwrap<TagDifferencerJs>(args.This());
 
-    ConstOsmMapPtr& map = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject())->getConstMap();
-    ConstElementPtr e1 = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject())->getConstElement();
-    ConstElementPtr e2 = ObjectWrap::Unwrap<ElementJs>(args[2]->ToObject())->getConstElement();
+    ConstOsmMapPtr& map = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked())->getConstMap();
+    ConstElementPtr e1 = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
+    ConstElementPtr e2 = ObjectWrap::Unwrap<ElementJs>(args[2]->ToObject(context).ToLocalChecked())->getConstElement();
 
     if (!map || !e1 || !e2)
     {
@@ -85,6 +86,7 @@ void TagDifferencerJs::Init(Handle<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   vector<QString> opNames =
     Factory::getInstance().getObjectNamesByBase(TagDifferencer::className());
 
@@ -103,7 +105,7 @@ void TagDifferencerJs::Init(Handle<Object> target)
       PopulateConsumersJs::baseClass(),
       String::NewFromUtf8(current, TagDifferencer::className().toStdString().data()));
 
-    Persistent<Function> constructor(current, tpl->GetFunction());
+    Persistent<Function> constructor(current, tpl->GetFunction(context).ToLocalChecked());
     target->Set(String::NewFromUtf8(current, n), ToLocal(&constructor));
   }
 }

--- a/hoot-js/src/main/cpp/hoot/js/schema/TagDifferencerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/TagDifferencerJs.cpp
@@ -60,7 +60,7 @@ void TagDifferencerJs::diff(const FunctionCallbackInfo<Value>& args)
   {
     TagDifferencerJs* op = ObjectWrap::Unwrap<TagDifferencerJs>(args.This());
 
-    ConstOsmMapPtr& map = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked())->getConstMap();
+    const ConstOsmMapPtr& map = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked())->getConstMap();
     ConstElementPtr e1 = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
     ConstElementPtr e2 = ObjectWrap::Unwrap<ElementJs>(args[2]->ToObject(context).ToLocalChecked())->getConstElement();
 

--- a/hoot-js/src/main/cpp/hoot/js/schema/TagDifferencerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/TagDifferencerJs.cpp
@@ -82,7 +82,7 @@ void TagDifferencerJs::diff(const FunctionCallbackInfo<Value>& args)
   }
 }
 
-void TagDifferencerJs::Init(Handle<Object> target)
+void TagDifferencerJs::Init(Local<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);

--- a/hoot-js/src/main/cpp/hoot/js/schema/TagDifferencerJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/schema/TagDifferencerJs.h
@@ -45,7 +45,7 @@ class TagDifferencerJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   TagDifferencer* getDifferencer() { return _td.get(); }
 

--- a/hoot-js/src/main/cpp/hoot/js/schema/TagMergerFactoryJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/TagMergerFactoryJs.cpp
@@ -38,12 +38,12 @@ namespace hoot
 
 HOOT_JS_REGISTER(TagMergerFactoryJs)
 
-void TagMergerFactoryJs::Init(Handle<Object> exports)
+void TagMergerFactoryJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
-  Handle<Object> tagMergerFactory = Object::New(current);
+  Local<Object> tagMergerFactory = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "TagMergerFactory"), tagMergerFactory);
   tagMergerFactory->Set(String::NewFromUtf8(current, "mergeTags"),
     FunctionTemplate::New(current, mergeTags)->GetFunction(context).ToLocalChecked());

--- a/hoot-js/src/main/cpp/hoot/js/schema/TagMergerFactoryJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/TagMergerFactoryJs.cpp
@@ -42,18 +42,21 @@ void TagMergerFactoryJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   Handle<Object> tagMergerFactory = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "TagMergerFactory"), tagMergerFactory);
   tagMergerFactory->Set(String::NewFromUtf8(current, "mergeTags"),
-    FunctionTemplate::New(current, mergeTags)->GetFunction());
+    FunctionTemplate::New(current, mergeTags)->GetFunction(context).ToLocalChecked());
 }
 
 void TagMergerFactoryJs::mergeTags(const FunctionCallbackInfo<Value>& args)
 {
-  HandleScope scope(args.GetIsolate());
+  Isolate* current = args.GetIsolate();
+  HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
-  Tags t1 = toCpp<Tags>(args[0]->ToObject());
-  Tags t2 = toCpp<Tags>(args[1]->ToObject());
+  Tags t1 = toCpp<Tags>(args[0]->ToObject(context).ToLocalChecked());
+  Tags t2 = toCpp<Tags>(args[1]->ToObject(context).ToLocalChecked());
 
   args.GetReturnValue().Set(TagsJs::New(TagMergerFactory::mergeTags(t1, t2, ElementType::Unknown)));
 }

--- a/hoot-js/src/main/cpp/hoot/js/schema/TagMergerFactoryJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/schema/TagMergerFactoryJs.h
@@ -37,7 +37,7 @@ class TagMergerFactoryJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   virtual ~TagMergerFactoryJs() = default;
 

--- a/hoot-js/src/main/cpp/hoot/js/util/HootExceptionJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/util/HootExceptionJs.cpp
@@ -42,20 +42,20 @@ HOOT_JS_REGISTER(HootExceptionJs)
 
 Persistent<Function> HootExceptionJs::_constructor;
 
-Handle<Object> HootExceptionJs::create(const std::shared_ptr<HootException>& e)
+Local<Object> HootExceptionJs::create(const std::shared_ptr<HootException>& e)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   EscapableHandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
+  Local<Object> result = ToLocal(&_constructor)->NewInstance(context).ToLocalChecked();
   HootExceptionJs* from = ObjectWrap::Unwrap<HootExceptionJs>(result);
   from->_e = e;
 
   return scope.Escape(result);
 }
 
-void HootExceptionJs::Init(Handle<Object> target)
+void HootExceptionJs::Init(Local<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
@@ -69,7 +69,7 @@ void HootExceptionJs::Init(Handle<Object> target)
 
     // Prepare constructor template
     Local<FunctionTemplate> tpl = FunctionTemplate::New(current, New);
-    tpl->SetClassName(Handle<String>::Cast(toV8(opNames[i])));
+    tpl->SetClassName(Local<String>::Cast(toV8(opNames[i])));
     tpl->InstanceTemplate()->SetInternalFieldCount(2);
     // Prototype
     tpl->PrototypeTemplate()->Set(String::NewFromUtf8(current, "toString"),
@@ -82,13 +82,13 @@ void HootExceptionJs::Init(Handle<Object> target)
   }
 }
 
-bool HootExceptionJs::isHootException(Handle<Value> v)
+bool HootExceptionJs::isHootException(Local<Value> v)
 {
   bool result = false;
 
   if (v->IsObject())
   {
-    Handle<Object> obj = Handle<Object>::Cast(v);
+    Local<Object> obj = Local<Object>::Cast(v);
     HootExceptionJs* e = nullptr;
     if (obj->InternalFieldCount() >= 1)
     {
@@ -115,7 +115,7 @@ void HootExceptionJs::New(const FunctionCallbackInfo<Value>& args)
   args.GetReturnValue().Set(args.This());
 }
 
-void HootExceptionJs::checkV8Exception(Handle<Value> result, TryCatch& tc)
+void HootExceptionJs::checkV8Exception(Local<Value> result, TryCatch& tc)
 {
   if (result.IsEmpty())
   {
@@ -137,7 +137,7 @@ void HootExceptionJs::throwAsHootException(TryCatch& tc)
   }
   else
   {
-    Handle<Message> msg = tc.Message();
+    Local<Message> msg = tc.Message();
     if (msg.IsEmpty())
     {
       if (exception.IsEmpty())

--- a/hoot-js/src/main/cpp/hoot/js/util/HootExceptionJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/util/HootExceptionJs.h
@@ -47,14 +47,14 @@ class HootExceptionJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
-  static v8::Handle<v8::Object> create(const HootException& e) { return create(std::shared_ptr<HootException>(e.clone())); }
-  static v8::Handle<v8::Object> create(const std::shared_ptr<HootException>& e);
+  static v8::Local<v8::Object> create(const HootException& e) { return create(std::shared_ptr<HootException>(e.clone())); }
+  static v8::Local<v8::Object> create(const std::shared_ptr<HootException>& e);
 
   std::shared_ptr<HootException> getException() const { return _e; }
 
-  static bool isHootException(v8::Handle<v8::Value> v);
+  static bool isHootException(v8::Local<v8::Value> v);
 
   /**
    * A convenience function for checking the result of a V8 call. This will throw an appropriate
@@ -63,7 +63,7 @@ public:
    * @param result Result of the V8 function call.
    * @param tc Try catch object. Must be instantiated before the V8 function is called.
    */
-  static void checkV8Exception(v8::Handle<v8::Value> result, v8::TryCatch& tc);
+  static void checkV8Exception(v8::Local<v8::Value> result, v8::TryCatch& tc);
 
   /**
    * This will throw an appropriate HootException based on the contents of tc.
@@ -86,11 +86,11 @@ private:
   static void toString(const v8::FunctionCallbackInfo<v8::Value>& args);
 };
 
-inline void toCpp(v8::Handle<v8::Value> v, std::shared_ptr<HootException>& e)
+inline void toCpp(v8::Local<v8::Value> v, std::shared_ptr<HootException>& e)
 {
   if (HootExceptionJs::isHootException(v))
   {
-    v8::Handle<v8::Object> obj = v8::Handle<v8::Object>::Cast(v);
+    v8::Local<v8::Object> obj = v8::Local<v8::Object>::Cast(v);
     HootExceptionJs* ex = node::ObjectWrap::Unwrap<HootExceptionJs>(obj);
 
     e = ex->getException();

--- a/hoot-js/src/main/cpp/hoot/js/util/LogJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/util/LogJs.cpp
@@ -45,12 +45,12 @@ HOOT_JS_REGISTER(LogJs)
 
 QHash<QString, int> LogJs::_logs;
 
-void LogJs::Init(Handle<Object> exports)
+void LogJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
-  Handle<Object> log = Object::New(current);
+  Local<Object> log = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "Log"), log);
   log->Set(String::NewFromUtf8(current, "setLogLevel"), FunctionTemplate::New(current, setLogLevel)->GetFunction(context).ToLocalChecked());
   log->Set(String::NewFromUtf8(current, "init"), FunctionTemplate::New(current, init)->GetFunction(context).ToLocalChecked());

--- a/hoot-js/src/main/cpp/hoot/js/util/LogJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/util/LogJs.cpp
@@ -49,23 +49,24 @@ void LogJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   Handle<Object> log = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "Log"), log);
-  log->Set(String::NewFromUtf8(current, "setLogLevel"), FunctionTemplate::New(current, setLogLevel)->GetFunction());
-  log->Set(String::NewFromUtf8(current, "init"), FunctionTemplate::New(current, init)->GetFunction());
+  log->Set(String::NewFromUtf8(current, "setLogLevel"), FunctionTemplate::New(current, setLogLevel)->GetFunction(context).ToLocalChecked());
+  log->Set(String::NewFromUtf8(current, "init"), FunctionTemplate::New(current, init)->GetFunction(context).ToLocalChecked());
 
-  exports->Set(String::NewFromUtf8(current, "log"), FunctionTemplate::New(current, logInfo)->GetFunction());
-  exports->Set(String::NewFromUtf8(current, "trace"), FunctionTemplate::New(current, logTrace)->GetFunction());
-  exports->Set(String::NewFromUtf8(current, "debug"), FunctionTemplate::New(current, logDebug)->GetFunction());
-  exports->Set(String::NewFromUtf8(current, "logTrace"), FunctionTemplate::New(current, logTrace)->GetFunction());
-  exports->Set(String::NewFromUtf8(current, "logDebug"), FunctionTemplate::New(current, logDebug)->GetFunction());
-  exports->Set(String::NewFromUtf8(current, "logInfo"), FunctionTemplate::New(current, logInfo)->GetFunction());
-  exports->Set(String::NewFromUtf8(current, "logStatus"), FunctionTemplate::New(current, logStatus)->GetFunction());
-  exports->Set(String::NewFromUtf8(current, "status"), FunctionTemplate::New(current, logStatus)->GetFunction());
-  exports->Set(String::NewFromUtf8(current, "warn"), FunctionTemplate::New(current, logWarn)->GetFunction());
-  exports->Set(String::NewFromUtf8(current, "logWarn"), FunctionTemplate::New(current, logWarn)->GetFunction());
-  exports->Set(String::NewFromUtf8(current, "logError"), FunctionTemplate::New(current, logError)->GetFunction());
-  exports->Set(String::NewFromUtf8(current, "logFatal"), FunctionTemplate::New(current, logFatal)->GetFunction());
+  exports->Set(String::NewFromUtf8(current, "log"), FunctionTemplate::New(current, logInfo)->GetFunction(context).ToLocalChecked());
+  exports->Set(String::NewFromUtf8(current, "trace"), FunctionTemplate::New(current, logTrace)->GetFunction(context).ToLocalChecked());
+  exports->Set(String::NewFromUtf8(current, "debug"), FunctionTemplate::New(current, logDebug)->GetFunction(context).ToLocalChecked());
+  exports->Set(String::NewFromUtf8(current, "logTrace"), FunctionTemplate::New(current, logTrace)->GetFunction(context).ToLocalChecked());
+  exports->Set(String::NewFromUtf8(current, "logDebug"), FunctionTemplate::New(current, logDebug)->GetFunction(context).ToLocalChecked());
+  exports->Set(String::NewFromUtf8(current, "logInfo"), FunctionTemplate::New(current, logInfo)->GetFunction(context).ToLocalChecked());
+  exports->Set(String::NewFromUtf8(current, "logStatus"), FunctionTemplate::New(current, logStatus)->GetFunction(context).ToLocalChecked());
+  exports->Set(String::NewFromUtf8(current, "status"), FunctionTemplate::New(current, logStatus)->GetFunction(context).ToLocalChecked());
+  exports->Set(String::NewFromUtf8(current, "warn"), FunctionTemplate::New(current, logWarn)->GetFunction(context).ToLocalChecked());
+  exports->Set(String::NewFromUtf8(current, "logWarn"), FunctionTemplate::New(current, logWarn)->GetFunction(context).ToLocalChecked());
+  exports->Set(String::NewFromUtf8(current, "logError"), FunctionTemplate::New(current, logError)->GetFunction(context).ToLocalChecked());
+  exports->Set(String::NewFromUtf8(current, "logFatal"), FunctionTemplate::New(current, logFatal)->GetFunction(context).ToLocalChecked());
 }
 
 int LogJs::getLogCount(QString log)

--- a/hoot-js/src/main/cpp/hoot/js/util/LogJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/util/LogJs.h
@@ -41,7 +41,7 @@ class LogJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   virtual ~LogJs() = default;
 

--- a/hoot-js/src/main/cpp/hoot/js/util/PopulateConsumersJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/util/PopulateConsumersJs.h
@@ -73,15 +73,18 @@ public:
   template <typename T>
   static void populateConsumers(T* consumer, const v8::Local<v8::Value>& v)
   {
+    v8::Isolate* current = v8::Isolate::GetCurrent();
+    v8::HandleScope scope(current);
+    v8::Local<v8::Context> context = current->GetCurrentContext();
     if (v->IsFunction())
     {
       populateFunctionConsumer<T>(consumer, v);
     }
     else if (v->IsObject())
     {
-      v8::Local<v8::Object> obj = v->ToObject();
+      v8::Local<v8::Object> obj = v->ToObject(context).ToLocalChecked();
 
-      if (obj->Has(baseClass()))
+      if (obj->Has(context, baseClass()).ToChecked())
       {
         if (str(obj->Get(baseClass())) == ElementCriterion::className())
         {
@@ -125,9 +128,13 @@ public:
   {
     LOG_TRACE("Populating configurable...");
 
+    v8::Isolate* current = v8::Isolate::GetCurrent();
+    v8::HandleScope scope(current);
+    v8::Local<v8::Context> context = current->GetCurrentContext();
+
     Settings settings = conf();
 
-    v8::Local<v8::Array> keys = obj->GetPropertyNames();
+    v8::Local<v8::Array> keys = obj->GetPropertyNames(context).ToLocalChecked();
     if (keys->Length() == 0)
     {
       LOG_WARN("Populating object with empty configuration. Is this what you wanted?");
@@ -135,8 +142,8 @@ public:
 
     for (uint32_t i = 0; i < keys->Length(); i++)
     {
-      v8::Local<v8::String> k = keys->Get(i)->ToString();
-      v8::Local<v8::String> v = obj->Get(k)->ToString();
+      v8::Local<v8::String> k = keys->Get(i)->ToString(current);
+      v8::Local<v8::String> v = obj->Get(k)->ToString(current);
       LOG_VART(str(k));
       LOG_VART(str(v));
       settings.set(str(k), str(v));
@@ -167,14 +174,18 @@ public:
   {
     LOG_TRACE("Populating criterion consumer...");
 
-    ElementCriterionJs* obj = node::ObjectWrap::Unwrap<ElementCriterionJs>(v->ToObject());
+    v8::Isolate* current = v8::Isolate::GetCurrent();
+    v8::HandleScope scope(current);
+    v8::Local<v8::Context> context = current->GetCurrentContext();
+
+    ElementCriterionJs* obj = node::ObjectWrap::Unwrap<ElementCriterionJs>(v->ToObject(context).ToLocalChecked());
     ElementCriterionConsumer* c = dynamic_cast<ElementCriterionConsumer*>(consumer);
 
     if (c == nullptr)
     {
       throw IllegalArgumentException(
         "Object does not accept ElementCriterion as an argument: " +
-        str(v->ToObject()->Get(baseClass())));
+        str(v->ToObject(context).ToLocalChecked()->Get(context, baseClass()).ToLocalChecked()));
     }
     else
     {
@@ -187,13 +198,17 @@ public:
   {
     LOG_TRACE("Populating element consumer...");
 
-    ElementJs* obj = node::ObjectWrap::Unwrap<ElementJs>(v->ToObject());
+    v8::Isolate* current = v8::Isolate::GetCurrent();
+    v8::HandleScope scope(current);
+    v8::Local<v8::Context> context = current->GetCurrentContext();
+
+    ElementJs* obj = node::ObjectWrap::Unwrap<ElementJs>(v->ToObject(context).ToLocalChecked());
     ElementConsumer* c = dynamic_cast<ElementConsumer*>(consumer);
 
     if (c == nullptr)
     {
       throw IllegalArgumentException(
-        "Object does not accept Element as an argument: " + str(v->ToObject()->Get(baseClass())));
+        "Object does not accept Element as an argument: " + str(v->ToObject(context).ToLocalChecked()->Get(context, baseClass()).ToLocalChecked()));
     }
     else
     {
@@ -206,7 +221,11 @@ public:
   {
     LOG_TRACE("Populating osm map consumer...");
 
-    OsmMapJs* obj = node::ObjectWrap::Unwrap<OsmMapJs>(v->ToObject());
+    v8::Isolate* current = v8::Isolate::GetCurrent();
+    v8::HandleScope scope(current);
+    v8::Local<v8::Context> context = current->GetCurrentContext();
+
+    OsmMapJs* obj = node::ObjectWrap::Unwrap<OsmMapJs>(v->ToObject(context).ToLocalChecked());
 
     if (obj->isConst())
     {
@@ -216,7 +235,7 @@ public:
       {
         throw IllegalArgumentException(
           "Object does not accept const OsmMap as an argument. Maybe try a non-const OsmMap?: " +
-          str(v->ToObject()->Get(baseClass())));
+          str(v->ToObject(context).ToLocalChecked()->Get(context, baseClass()).ToLocalChecked()));
       }
       else
       {
@@ -243,6 +262,10 @@ public:
   {
     LOG_TRACE("Populating string distance consumer...");
 
+    v8::Isolate* current = v8::Isolate::GetCurrent();
+    v8::HandleScope scope(current);
+    v8::Local<v8::Context> context = current->GetCurrentContext();
+
     StringDistancePtr sd = toCpp<StringDistancePtr>(v);
 
     StringDistanceConsumer* c = dynamic_cast<StringDistanceConsumer*>(consumer);
@@ -251,7 +274,7 @@ public:
     {
       throw IllegalArgumentException(
         "Object does not accept StringDistance as an argument: " +
-        str(v->ToObject()->Get(baseClass())));
+        str(v->ToObject(context).ToLocalChecked()->Get(context, baseClass()).ToLocalChecked()));
     }
     else
     {
@@ -264,6 +287,10 @@ public:
   {
     LOG_TRACE("Populating aggregator consumer...");
 
+    v8::Isolate* current = v8::Isolate::GetCurrent();
+    v8::HandleScope scope(current);
+    v8::Local<v8::Context> context = current->GetCurrentContext();
+
     ValueAggregatorPtr va = toCpp<ValueAggregatorPtr>(v);
 
     ValueAggregatorConsumer* c = dynamic_cast<ValueAggregatorConsumer*>(consumer);
@@ -272,7 +299,7 @@ public:
     {
       throw IllegalArgumentException(
         "Object does not accept ValueAggregator as an argument: " +
-        str(v->ToObject()->Get(baseClass())));
+        str(v->ToObject(context).ToLocalChecked()->Get(context, baseClass()).ToLocalChecked()));
     }
     else
     {
@@ -285,7 +312,11 @@ public:
   {
     LOG_TRACE("Populating visitor consumer...");
 
-    ElementVisitorJs* obj = node::ObjectWrap::Unwrap<ElementVisitorJs>(v->ToObject());
+    v8::Isolate* current = v8::Isolate::GetCurrent();
+    v8::HandleScope scope(current);
+    v8::Local<v8::Context> context = current->GetCurrentContext();
+
+    ElementVisitorJs* obj = node::ObjectWrap::Unwrap<ElementVisitorJs>(v->ToObject(context).ToLocalChecked());
 
     ElementVisitorConsumer* c = dynamic_cast<ElementVisitorConsumer*>(consumer);
 
@@ -293,7 +324,7 @@ public:
     {
       throw IllegalArgumentException(
         "Object does not accept ElementCriterion as an argument: " +
-        str(v->ToObject()->Get(baseClass())));
+        str(v->ToObject(context).ToLocalChecked()->Get(context, baseClass()).ToLocalChecked()));
     }
     else
     {

--- a/hoot-js/src/main/cpp/hoot/js/util/PrintJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/util/PrintJs.cpp
@@ -44,8 +44,9 @@ void PrintJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   exports->Set(String::NewFromUtf8(current, "print"),
-               FunctionTemplate::New(current, jsPrint)->GetFunction());
+               FunctionTemplate::New(current, jsPrint)->GetFunction(context).ToLocalChecked());
 }
 
 void PrintJs::jsPrint(const FunctionCallbackInfo<Value>& args)

--- a/hoot-js/src/main/cpp/hoot/js/util/PrintJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/util/PrintJs.cpp
@@ -40,7 +40,7 @@ namespace hoot
 
 HOOT_JS_REGISTER(PrintJs)
 
-void PrintJs::Init(Handle<Object> exports)
+void PrintJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);

--- a/hoot-js/src/main/cpp/hoot/js/util/PrintJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/util/PrintJs.h
@@ -37,7 +37,7 @@ class PrintJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   virtual ~PrintJs() = default;
 

--- a/hoot-js/src/main/cpp/hoot/js/util/RequireJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/util/RequireJs.cpp
@@ -49,8 +49,10 @@ HOOT_JS_REGISTER(RequireJs)
 void RequireJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
+  HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   exports->Set(String::NewFromUtf8(current, "require"),
-               FunctionTemplate::New(current, jsRequire)->GetFunction());
+               FunctionTemplate::New(current, jsRequire)->GetFunction(context).ToLocalChecked());
 }
 
 void RequireJs::jsRequire(const FunctionCallbackInfo<Value>& args)
@@ -58,13 +60,12 @@ void RequireJs::jsRequire(const FunctionCallbackInfo<Value>& args)
   Isolate* current = v8::Isolate::GetCurrent();
   HandleScope scope(current);
   Context::Scope context_scope(current->GetCurrentContext());
+  Local<Context> context = current->GetCurrentContext();
   try
   {
 
     if (args.Length() != 1)
-    {
       throw IllegalArgumentException("Expected exactly one argument to 'require'.");
-    }
 
     /*
     The new Hoot "include" files are all under $HOOT_HOME/translations & $HOOT_HOME/translations_local
@@ -72,9 +73,7 @@ void RequireJs::jsRequire(const FunctionCallbackInfo<Value>& args)
 
     const QString hootHome = ConfPath::getHootHome();
     if (hootHome.isEmpty())
-    {
       throw HootException("$HOOT_HOME is empty.");
-    }
 
     Settings conf;
     QStringList libPath = ConfigOptions(conf).getJavascriptSchemaTranslatorPath();
@@ -84,10 +83,7 @@ void RequireJs::jsRequire(const FunctionCallbackInfo<Value>& args)
 
     // Check for things like "/home/smurf" or "smurf.js"
     if (scriptName != QFileInfo(scriptName).baseName())
-    {
       throw HootException("Error: Script name is a path: " + scriptName);
-    }
-
 
     for (int i = 0; i < libPath.size(); i++)
     {
@@ -99,53 +95,49 @@ void RequireJs::jsRequire(const FunctionCallbackInfo<Value>& args)
 
         QFileInfo info(fullPath);
         if (info.exists())
-        {
           break;
-        }
 
         fullPath = "";
       }
     }
 
     if (fullPath.isEmpty())
-    {
       throw IllegalArgumentException("Unable to load required file: " + scriptName);
-    }
 
     QFile fp(fullPath);
     if (fp.open(QFile::ReadOnly) == false)
-    {
-      //      throw HootException("Error opening script: " + fullPath);
       throw HootException("Error opening script: " + fullPath);
-    }
 
     Handle<String> source;
-    Handle<Script> jsScript;
+    MaybeLocal<Script> maybeScript;
 
     LOG_TRACE("Loading script: " << fullPath);
 
     source = String::NewFromUtf8(current, fp.readAll().data());
 
-    TryCatch try_catch;
+    TryCatch try_catch(current);
     // Compile the source code.
-    jsScript = Script::Compile(source, String::NewFromUtf8(current, fullPath.toUtf8().data()));
+    maybeScript = Script::Compile(context, source);
 
-    if (jsScript.IsEmpty())
-    {
+    if (maybeScript.IsEmpty())
       HootExceptionJs::throwAsHootException(try_catch);
-    }
+
+    Local<Script> jsScript = maybeScript.ToLocalChecked();
 
     Local<Value> oldExports = current->GetCurrentContext()->Global()->Get(String::NewFromUtf8(current, "exports"));
 
     Handle<Object> exports(Object::New(current));
     current->GetCurrentContext()->Global()->Set(String::NewFromUtf8(current, "exports"), exports);
 
-    Handle<Value> result = jsScript->Run();
+    MaybeLocal<Value> result = jsScript->Run(context);
 
     current->GetCurrentContext()->Global()->Set(String::NewFromUtf8(current, "exports"), oldExports);
 
+    if (result.IsEmpty())
+      HootExceptionJs::throwAsHootException(try_catch);
+
     // Run the script to get the result.
-    HootExceptionJs::checkV8Exception(result, try_catch);
+    HootExceptionJs::checkV8Exception(result.ToLocalChecked(), try_catch);
 
     // Debug: Dump the Object
     //  Handle<Object> tObj = current->GetCurrentContext()->Global();

--- a/hoot-js/src/main/cpp/hoot/js/util/RequireJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/util/RequireJs.cpp
@@ -46,7 +46,7 @@ namespace hoot
 
 HOOT_JS_REGISTER(RequireJs)
 
-void RequireJs::Init(Handle<Object> exports)
+void RequireJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
@@ -108,7 +108,7 @@ void RequireJs::jsRequire(const FunctionCallbackInfo<Value>& args)
     if (fp.open(QFile::ReadOnly) == false)
       throw HootException("Error opening script: " + fullPath);
 
-    Handle<String> source;
+    Local<String> source;
     MaybeLocal<Script> maybeScript;
 
     LOG_TRACE("Loading script: " << fullPath);
@@ -126,7 +126,7 @@ void RequireJs::jsRequire(const FunctionCallbackInfo<Value>& args)
 
     Local<Value> oldExports = current->GetCurrentContext()->Global()->Get(String::NewFromUtf8(current, "exports"));
 
-    Handle<Object> exports(Object::New(current));
+    Local<Object> exports(Object::New(current));
     current->GetCurrentContext()->Global()->Set(String::NewFromUtf8(current, "exports"), exports);
 
     MaybeLocal<Value> result = jsScript->Run(context);
@@ -140,7 +140,7 @@ void RequireJs::jsRequire(const FunctionCallbackInfo<Value>& args)
     HootExceptionJs::checkV8Exception(result.ToLocalChecked(), try_catch);
 
     // Debug: Dump the Object
-    //  Handle<Object> tObj = current->GetCurrentContext()->Global();
+    //  Local<Object> tObj = current->GetCurrentContext()->Global();
     //  cout << "jsRequire" << endl;
     //  cout << "tObj Properties: " << tObj->GetPropertyNames() << endl;
     //  cout << endl;

--- a/hoot-js/src/main/cpp/hoot/js/util/RequireJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/util/RequireJs.h
@@ -40,7 +40,7 @@ class RequireJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   virtual ~RequireJs() = default;
 

--- a/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.cpp
@@ -46,42 +46,44 @@ void SettingsJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   Handle<Object> settings = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "Settings"), settings);
   exports->Set(String::NewFromUtf8(current, "get"),
-               FunctionTemplate::New(current, get)->GetFunction());
+               FunctionTemplate::New(current, get)->GetFunction(context).ToLocalChecked());
   settings->Set(String::NewFromUtf8(current, "get"),
-                FunctionTemplate::New(current, get)->GetFunction());
+                FunctionTemplate::New(current, get)->GetFunction(context).ToLocalChecked());
   exports->Set(String::NewFromUtf8(current, "set"),
-               FunctionTemplate::New(current, set)->GetFunction());
+               FunctionTemplate::New(current, set)->GetFunction(context).ToLocalChecked());
   settings->Set(String::NewFromUtf8(current, "set"),
-                FunctionTemplate::New(current, set)->GetFunction());
+                FunctionTemplate::New(current, set)->GetFunction(context).ToLocalChecked());
   exports->Set(String::NewFromUtf8(current, "appendToList"),
-               FunctionTemplate::New(current, appendToList)->GetFunction());
+               FunctionTemplate::New(current, appendToList)->GetFunction(context).ToLocalChecked());
   settings->Set(String::NewFromUtf8(current, "appendToList"),
-                FunctionTemplate::New(current, appendToList)->GetFunction());
+                FunctionTemplate::New(current, appendToList)->GetFunction(context).ToLocalChecked());
   exports->Set(String::NewFromUtf8(current, "prependToList"),
-               FunctionTemplate::New(current, prependToList)->GetFunction());
+               FunctionTemplate::New(current, prependToList)->GetFunction(context).ToLocalChecked());
   settings->Set(String::NewFromUtf8(current, "prependToList"),
-                FunctionTemplate::New(current, prependToList)->GetFunction());
+                FunctionTemplate::New(current, prependToList)->GetFunction(context).ToLocalChecked());
   exports->Set(String::NewFromUtf8(current, "removeFromList"),
-               FunctionTemplate::New(current, removeFromList)->GetFunction());
+               FunctionTemplate::New(current, removeFromList)->GetFunction(context).ToLocalChecked());
   settings->Set(String::NewFromUtf8(current, "removeFromList"),
-                FunctionTemplate::New(current, removeFromList)->GetFunction());
+                FunctionTemplate::New(current, removeFromList)->GetFunction(context).ToLocalChecked());
   exports->Set(String::NewFromUtf8(current, "replaceInList"),
-               FunctionTemplate::New(current, replaceInList)->GetFunction());
+               FunctionTemplate::New(current, replaceInList)->GetFunction(context).ToLocalChecked());
   settings->Set(String::NewFromUtf8(current, "replaceInList"),
-                FunctionTemplate::New(current, replaceInList)->GetFunction());
+                FunctionTemplate::New(current, replaceInList)->GetFunction(context).ToLocalChecked());
 }
 
 void SettingsJs::get(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   Settings* settings = &conf();
 
-  QString key = str(args[0]->ToString());
+  QString key = str(args[0]->ToString(context).ToLocalChecked());
   if (settings->hasKey(key))
   {
     QString value = settings->getString(key);
@@ -97,16 +99,17 @@ void SettingsJs::set(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   Settings* settings = &conf();
 
   if (args[0]->IsObject())
   {
-    Local<Array> keys = args[0]->ToObject()->GetPropertyNames();
+    Local<Array> keys = args[0]->ToObject(context).ToLocalChecked()->GetPropertyNames(context).ToLocalChecked();
     for (uint32_t i = 0; i < keys->Length(); i++)
     {
-      Local<String> k = keys->Get(i)->ToString();
-      Local<String> v = args[0]->ToObject()->Get(k)->ToString();
+      Local<String> k = keys->Get(i)->ToString(context).ToLocalChecked();
+      Local<String> v = args[0]->ToObject(context).ToLocalChecked()->Get(k)->ToString(context).ToLocalChecked();
       settings->set(str(k), str(v));
     }
     args.GetReturnValue().SetUndefined();
@@ -123,16 +126,17 @@ void SettingsJs::appendToList(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   Settings* settings = &conf();
 
   if (args[0]->IsObject())
   {
-    Local<Array> keys = args[0]->ToObject()->GetPropertyNames();
+    Local<Array> keys = args[0]->ToObject(context).ToLocalChecked()->GetPropertyNames(context).ToLocalChecked();
     for (uint32_t i = 0; i < keys->Length(); i++)
     {
-      Local<String> k = keys->Get(i)->ToString();
-      Local<String> v = args[0]->ToObject()->Get(k)->ToString();
+      Local<String> k = keys->Get(i)->ToString(context).ToLocalChecked();
+      Local<String> v = args[0]->ToObject(context).ToLocalChecked()->Get(k)->ToString(context).ToLocalChecked();
 
       QStringList settingVal = settings->getList(str(k));
       settingVal.append(str(v));
@@ -152,16 +156,17 @@ void SettingsJs::prependToList(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   Settings* settings = &conf();
 
   if (args[0]->IsObject())
   {
-    Local<Array> keys = args[0]->ToObject()->GetPropertyNames();
+    Local<Array> keys = args[0]->ToObject(context).ToLocalChecked()->GetPropertyNames(context).ToLocalChecked();
     for (uint32_t i = 0; i < keys->Length(); i++)
     {
-      Local<String> k = keys->Get(i)->ToString();
-      Local<String> v = args[0]->ToObject()->Get(k)->ToString();
+      Local<String> k = keys->Get(i)->ToString(context).ToLocalChecked();
+      Local<String> v = args[0]->ToObject(context).ToLocalChecked()->Get(k)->ToString(context).ToLocalChecked();
 
       QStringList settingVal = settings->getList(str(k));
       settingVal.prepend(str(v));
@@ -181,16 +186,17 @@ void SettingsJs::removeFromList(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   Settings* settings = &conf();
 
   if (args[0]->IsObject())
   {
-    Local<Array> keys = args[0]->ToObject()->GetPropertyNames();
+    Local<Array> keys = args[0]->ToObject(context).ToLocalChecked()->GetPropertyNames(context).ToLocalChecked();
     for (uint32_t i = 0; i < keys->Length(); i++)
     {
-      Local<String> k = keys->Get(i)->ToString();
-      Local<String> v = args[0]->ToObject()->Get(k)->ToString();
+      Local<String> k = keys->Get(i)->ToString(context).ToLocalChecked();
+      Local<String> v = args[0]->ToObject(context).ToLocalChecked()->Get(k)->ToString(context).ToLocalChecked();
 
       QStringList settingVal = settings->getList(str(k));
       settingVal.removeAll(str(v));
@@ -210,16 +216,17 @@ void SettingsJs::replaceInList(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* current = args.GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
 
   Settings* settings = &conf();
 
   if (args[0]->IsObject())
   {
-    Local<Array> keys = args[0]->ToObject()->GetPropertyNames();
+    Local<Array> keys = args[0]->ToObject(context).ToLocalChecked()->GetPropertyNames(context).ToLocalChecked();
     for (uint32_t i = 0; i < keys->Length(); i++)
     {
-      Local<String> k = keys->Get(i)->ToString();
-      Local<String> v = args[0]->ToObject()->Get(k)->ToString();
+      Local<String> k = keys->Get(i)->ToString(context).ToLocalChecked();
+      Local<String> v = args[0]->ToObject(context).ToLocalChecked()->Get(k)->ToString(context).ToLocalChecked();
 
       Settings::replaceListOptionEntryValues(*settings, str(k), str(v).split(";"));
     }

--- a/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.cpp
@@ -42,12 +42,12 @@ namespace hoot
 
 HOOT_JS_REGISTER(SettingsJs)
 
-void SettingsJs::Init(Handle<Object> exports)
+void SettingsJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
-  Handle<Object> settings = Object::New(current);
+  Local<Object> settings = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "Settings"), settings);
   exports->Set(String::NewFromUtf8(current, "get"),
                FunctionTemplate::New(current, get)->GetFunction(context).ToLocalChecked());

--- a/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.h
@@ -37,7 +37,7 @@ class SettingsJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   virtual ~SettingsJs() = default;
 

--- a/hoot-js/src/main/cpp/hoot/js/util/StringUtilsJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/util/StringUtilsJs.h
@@ -33,7 +33,7 @@
 namespace hoot
 {
 
-inline QString str(v8::Handle<v8::Value> ls)
+inline QString str(v8::Local<v8::Value> ls)
 {
   v8::String::Utf8Value param(ls->ToString());
   return QString::fromUtf8(*param);

--- a/hoot-js/src/main/cpp/hoot/js/util/UuidHelperJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/util/UuidHelperJs.cpp
@@ -46,12 +46,14 @@ void UuidHelperJs::Init(Handle<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
+
   Handle<Object> helpUuid = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "UuidHelper"), helpUuid);
   helpUuid->Set(String::NewFromUtf8(current, "createUuid"),
-                FunctionTemplate::New(current, createUuid)->GetFunction());
+                FunctionTemplate::New(current, createUuid)->GetFunction(context).ToLocalChecked());
   helpUuid->Set(String::NewFromUtf8(current, "createUuid5"),
-                FunctionTemplate::New(current, createUuid5)->GetFunction());
+                FunctionTemplate::New(current, createUuid5)->GetFunction(context).ToLocalChecked());
 }
 
 void UuidHelperJs::createUuid(const FunctionCallbackInfo<Value>& args)

--- a/hoot-js/src/main/cpp/hoot/js/util/UuidHelperJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/util/UuidHelperJs.cpp
@@ -42,13 +42,13 @@ namespace hoot
 
 HOOT_JS_REGISTER(UuidHelperJs)
 
-void UuidHelperJs::Init(Handle<Object> exports)
+void UuidHelperJs::Init(Local<Object> exports)
 {
   Isolate* current = exports->GetIsolate();
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Object> helpUuid = Object::New(current);
+  Local<Object> helpUuid = Object::New(current);
   exports->Set(String::NewFromUtf8(current, "UuidHelper"), helpUuid);
   helpUuid->Set(String::NewFromUtf8(current, "createUuid"),
                 FunctionTemplate::New(current, createUuid)->GetFunction(context).ToLocalChecked());

--- a/hoot-js/src/main/cpp/hoot/js/util/UuidHelperJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/util/UuidHelperJs.h
@@ -37,7 +37,7 @@ class UuidHelperJs : public HootBaseJs
 {
 public:
 
- static void Init(v8::Handle<v8::Object> target);
+ static void Init(v8::Local<v8::Object> target);
 
  virtual ~UuidHelperJs() = default;
 

--- a/hoot-js/src/main/cpp/hoot/js/visitors/ElementVisitorJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/visitors/ElementVisitorJs.cpp
@@ -47,7 +47,7 @@ namespace hoot
 
 HOOT_JS_REGISTER(ElementVisitorJs)
 
-void ElementVisitorJs::Init(Handle<Object> target)
+void ElementVisitorJs::Init(Local<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);

--- a/hoot-js/src/main/cpp/hoot/js/visitors/ElementVisitorJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/visitors/ElementVisitorJs.cpp
@@ -51,6 +51,7 @@ void ElementVisitorJs::Init(Handle<Object> target)
 {
   Isolate* current = target->GetIsolate();
   HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
   vector<QString> opNames =
     Factory::getInstance().getObjectNamesByBase(ElementVisitor::className());
 
@@ -68,7 +69,7 @@ void ElementVisitorJs::Init(Handle<Object> target)
        PopulateConsumersJs::baseClass(),
        String::NewFromUtf8(current, ElementVisitor::className().toStdString().data()));
 
-    Persistent<Function> constructor(current, tpl->GetFunction());
+    Persistent<Function> constructor(current, tpl->GetFunction(context).ToLocalChecked());
     target->Set(String::NewFromUtf8(current, n), ToLocal(&constructor));
   }
 }

--- a/hoot-js/src/main/cpp/hoot/js/visitors/ElementVisitorJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/visitors/ElementVisitorJs.h
@@ -42,7 +42,7 @@ class ElementVisitorJs : public HootBaseJs
 {
 public:
 
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
 
   std::shared_ptr<ElementVisitor> getVisitor() { return _v; }
 

--- a/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.cpp
@@ -45,7 +45,8 @@ void JsFunctionVisitor::visit(const ConstElementPtr& e)
 {
   Isolate* current = v8::Isolate::GetCurrent();
   HandleScope handleScope(current);
-  Context::Scope context_scope(current->GetCallingContext());
+  Context::Scope context_scope(current->GetCurrentContext());
+  Local<Context> context = current->GetCurrentContext();
 
   Handle<Value> jsArgs[3];
 
@@ -68,9 +69,9 @@ void JsFunctionVisitor::visit(const ConstElementPtr& e)
   int argc = 0;
   jsArgs[argc++] = elementObj;
 
-  TryCatch trycatch;
-  Handle<Value> funcResult =
-    ToLocal(&_func)->Call(current->GetCallingContext()->Global(), argc, jsArgs);
+  TryCatch trycatch(current);
+  MaybeLocal<Value> funcResult =
+    ToLocal(&_func)->Call(context, current->GetCurrentContext()->Global(), argc, jsArgs);
 
   if (funcResult.IsEmpty())
   {

--- a/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.cpp
@@ -48,14 +48,14 @@ void JsFunctionVisitor::visit(const ConstElementPtr& e)
   Context::Scope context_scope(current->GetCurrentContext());
   Local<Context> context = current->GetCurrentContext();
 
-  Handle<Value> jsArgs[3];
+  Local<Value> jsArgs[3];
 
   if (_func.IsEmpty())
   {
     throw IllegalArgumentException("JsFunctionVisitor must have a valid function.");
   }
 
-  Handle<Object> elementObj;
+  Local<Object> elementObj;
   if (_map)
   {
     ElementPtr nonConst = _map->getElement(e->getElementId());

--- a/hoot-js/src/test/cpp/hoot/js/PluginContextTest.cpp
+++ b/hoot-js/src/test/cpp/hoot/js/PluginContextTest.cpp
@@ -54,9 +54,9 @@ public:
     HandleScope handleScope(current);
     Context::Scope context_scope(_pc->getContext(current));
 
-    Handle<Object> exports = _pc->loadScript("rules/Polygon.js");
+    Local<Object> exports = _pc->loadScript("rules/Polygon.js");
 
-    Handle<Value> result = _pc->call(exports, "isWholeGroup");
+    Local<Value> result = _pc->call(exports, "isWholeGroup");
     HOOT_STR_EQUALS("true", result);
 
     result = _pc->call(_pc->getContext(current)->Global(), "testAdd",

--- a/test-files/cmd/quick/BadJavaScriptTranslation.sh.stdout
+++ b/test-files/cmd/quick/BadJavaScriptTranslation.sh.stdout
@@ -1,22 +1,19 @@
-20:26:27.831 INFO  ...ot/js/JavaScriptTranslator.cpp( 232) Loading script: test-files/cmd/slow/tSimple.js
+14:34:53.187 STATUS ...pp/hoot/core/util/Progress.cpp(  86) Convert (0%): Converting ...les/jakarta_raya_coastline.shp to ...k/BadJavaScriptTranslation.osm...
+14:34:53.193 STATUS ...pp/hoot/core/util/Progress.cpp(  86) Convert (0%): Loading maps: ...les/jakarta_raya_coastline.shp...
+14:34:53.195 INFO   ...JavaScriptSchemaTranslator.cpp( 215) Loading translation script: test-files/cmd/quick/tSimple.js...
 Initialize works!
-20:26:27.859 ERROR ...ot/js/JavaScriptTranslator.cpp( 353) Error initializing JavaScript: test-files/cmd/slow/tSimple.js (63) 
-    if (translate !== undefined)
-    ^ 
-ReferenceError: translate is not defined
-20:26:27.859 INFO  ...t/core/io/PythonTranslator.cpp(  68) Initializing Python
-20:26:27.859 INFO  ...t/core/io/PythonTranslator.cpp(  99) Python path: translations:PYTHONPATH:/home/vagrant/hoot/translations
-20:26:28.864 INFO  ...ot/js/JavaScriptTranslator.cpp( 232) Loading script: translations/BadSyntaxTest.js
-20:26:28.889 ERROR ...ot/js/JavaScriptTranslator.cpp( 353) Error initializing JavaScript: translations/BadSyntaxTest.js (4) 
+14:34:53.217 ERROR  ...JavaScriptSchemaTranslator.cpp( 309) Error initializing JavaScript: Function call 'initialize' returned an error.
+14:34:53.217 INFO   ...ema/PythonSchemaTranslator.cpp( 101) Using translation script: test-files/cmd/quick/tSimple.js
+14:34:53.795 STATUS ...pp/hoot/core/util/Progress.cpp(  86) Convert (0%): Converting ...les/jakarta_raya_coastline.shp to ...k/BadJavaScriptTranslation.osm...
+14:34:53.802 STATUS ...pp/hoot/core/util/Progress.cpp(  86) Convert (0%): Loading maps: ...les/jakarta_raya_coastline.shp...
+14:34:53.804 INFO   ...JavaScriptSchemaTranslator.cpp( 215) Loading translation script: translations/BadSyntaxTest.js...
+14:34:53.825 ERROR  ...JavaScriptSchemaTranslator.cpp( 309) Error initializing JavaScript: translations/BadSyntaxTest.js (4) 
 foo is bad.
     ^^ 
 SyntaxError: Unexpected identifier
-20:26:28.889 INFO  ...t/core/io/PythonTranslator.cpp(  68) Initializing Python
-20:26:28.889 INFO  ...t/core/io/PythonTranslator.cpp(  99) Python path: translations:PYTHONPATH:/home/vagrant/hoot/translations
-20:26:29.863 INFO  ...ot/js/JavaScriptTranslator.cpp( 232) Loading script: test-files/cmd/slow/BadRequire.js
-20:26:29.890 ERROR ...ot/js/JavaScriptTranslator.cpp( 353) Error initializing JavaScript: /home/vagrant/hoot/translations/BadSyntaxTest.js (4) 
-foo is bad.
-    ^^ 
-SyntaxError: Unexpected identifier
-20:26:29.891 INFO  ...t/core/io/PythonTranslator.cpp(  68) Initializing Python
-20:26:29.891 INFO  ...t/core/io/PythonTranslator.cpp(  99) Python path: translations:PYTHONPATH:/home/vagrant/hoot/translations
+14:34:53.825 INFO   ...ema/PythonSchemaTranslator.cpp( 101) Using translation script: translations/BadSyntaxTest.js
+14:34:54.348 STATUS ...pp/hoot/core/util/Progress.cpp(  86) Convert (0%): Converting ...les/jakarta_raya_coastline.shp to ...k/BadJavaScriptTranslation.osm...
+14:34:54.353 STATUS ...pp/hoot/core/util/Progress.cpp(  86) Convert (0%): Loading maps: ...les/jakarta_raya_coastline.shp...
+14:34:54.356 INFO   ...JavaScriptSchemaTranslator.cpp( 215) Loading translation script: test-files/cmd/quick/BadRequire.js...
+14:34:54.377 ERROR  ...JavaScriptSchemaTranslator.cpp( 309) Error initializing JavaScript: Expected a string. Got an empty value.
+14:34:54.377 INFO   ...ema/PythonSchemaTranslator.cpp( 101) Using translation script: test-files/cmd/quick/BadRequire.js


### PR DESCRIPTION
Begin using `v8::MaybeLocal` versions of functions as older versions will become deprecated with the next upgrade of NodeJs.  These new functions require calls to `ToChecked()` or `ToLocalChecked()` to convert the handles to `v8::Local` handles before using them.  Also `v8::Handle` has been deprecated and is now just an alias for `v8::Local` so all instances have been replaced.