### PR TITLE
Allow for retrieving the appropriate available way snapping criteria for a given conflate config

### DIFF
--- a/docs/commands/info.asciidoc
+++ b/docs/commands/info.asciidoc
@@ -1,21 +1,19 @@
 [[info]]
 == info
 
-The +info+ command displays information about Hootenanny capabilities.
-
-For further detail on how to use this information see both the Hootenanny User and Developer Guides.
+The +info+ command displays information about Hootenanny capabilities. For further detail on how to use this information see both the Hootenanny User and Developer Guides.
 
 === Option Overview
 
-Only one of the following options can be passed to the command:
+Only one of the following options can be passed to the command per invocation:
 
 * +--cleaning-operations+      - Displays operations configured for cleaning map data
 * +--config-options+           - Displays available configuration options
 * +--conflatable-criteria+     - Displays criteria that identify conflatable elements
-* +--conflate-post-operations+ - Displays operations configured by default to run after a conflation job (can be customized via the
-                                 `conflate.post.ops` configuration option)
-* +--conflate-pre-operations+  - Displays operations configured by default to run before a conflation job (can be customized via the
-                                 `conflate.pre.ops` configuration option)
+* +--conflate-post-operations+ - Displays operations configured by default to run after a conflation job (can be 
+                                 customized via the `conflate.post.ops` configuration option)
+* +--conflate-pre-operations+  - Displays operations configured by default to run before a conflation job (can be 
+                                 customized via the `conflate.pre.ops` configuration option)
 * +--criterion-consumers+      - Displays operations capable of taking in an ElementCriterion as input
 * +--feature-extractors+       - Displays available feature extractors used in conflation model building
 * +--filters+                  - Displays a list of all criteria that can be used for element filtering
@@ -32,13 +30,23 @@ Only one of the following options can be passed to the command:
 * +--tag-mergers+              - Displays available feature tag mergers used during conflation
 * +--value-aggregators+        - Displays available feature tag value aggregators used in conflation model building
 * +--way-joiners+              - Displays available way joiners
+* +--way-snap-criteria+        - Displays available way criteria for snapping ways to each other.
+
+All configuration options (-D <option>) added to this command must be added to before the specified option. Example:
+
+--------
+hoot info -D match.creators="hoot::HighwayMatchCreator;hoot::ScriptMatchCreator,River.js" --way-snap-criteria
+--------
+
+Note how "--way-snap-criteria" is specified after the single configuration option.
 
 Each of the following sections describes an option that may be used with this command and its input parameters.
 
 === Cleaning Operations
 
-The +--cleaning-operations+ option prints out the currently configured map cleaning operations that are applied during conflation or with the
-'clean' command.  The configuration option 'map.cleaner.transforms' controls which operators are applied.
+The +--cleaning-operations+ option prints out the currently configured map cleaning operations that are applied 
+during conflation or with the 'clean' command.  The configuration option 'map.cleaner.transforms' controls which operators 
+are applied.
 
 ==== Usage
 
@@ -112,8 +120,8 @@ hoot info --conflatable-criteria
 
 === Conflate Post Operations
 
-The +--conflate-post-operations+ option prints out the currently configured operations to run immediately after a conflation job with the
-'conflate' command.  The configuration option 'conflate.post.ops' controls which operators are applied.
+The +--conflate-post-operations+ option prints out the currently configured operations to run immediately after a 
+conflation job with the 'conflate' command.  The configuration option 'conflate.post.ops' controls which operators are applied.
 
 ==== Usage
 
@@ -129,8 +137,8 @@ hoot info --conflate-post-operations
 
 === Conflate Pre Operations
 
-The +--conflate-pre-operations+ option prints out the currently configured operations to run immediately after a conflation job with the
-'conflate' command.  The configuration option 'conflate.pre.ops' controls which operators are applied.
+The +--conflate-pre-operations+ option prints out the currently configured operations to run immediately after a 
+conflation job with the 'conflate' command.  The configuration option 'conflate.pre.ops' controls which operators are applied.
 
 ==== Usage
 
@@ -146,8 +154,9 @@ hoot info --conflate-pre-operations
 
 === Element Criterion Consumers
 
-The +--criterion-consumers++ option prints out all operations that are capable of taking an `ElementCriterion` as input. Passing in an
-`ElementCriterion` to an operation can be useful when filtering elements before performing data transformations on them.
+The +--criterion-consumers++ option prints out all operations that are capable of taking an `ElementCriterion` as 
+input. Passing in an `ElementCriterion` to an operation can be useful when filtering elements before performing 
+data transformations on them.
 
 ==== Usage
 
@@ -163,8 +172,8 @@ hoot info --criterion-consumers
 
 === Feature Extractors
 
-The +--feature-extractors+ option prints out available feature extractors that can be used when building a conflation model with
-manually matched map training data.
+The +--feature-extractors+ option prints out available feature extractors that can be used when building a conflation 
+model with manually matched map training data.
 
 ==== Usage
 
@@ -180,8 +189,8 @@ hoot info --feature-extractors
 
 === Filters
 
-The +--filters++ option prints out all the element criteria classes, which are a subset of what is displayed with the +--operators+ option. 
-Element criteria can be used to filter elements during a conversion or conflation job.
+The +--filters++ option prints out all the element criteria classes, which are a subset of what is displayed with 
+the +--operators+ option. Element criteria can be used to filter elements during a conversion or conflation job.
 
 ==== Usage
 
@@ -238,7 +247,8 @@ hoot info --formats --output --ogr
 
 === Geometry Type Criteria
 
-The +--geometry-type-crieria++ option prints out all element criteria classes that can be used to identify an element's geometry.
+The +--geometry-type-crieria++ option prints out all element criteria classes that can be used to identify an 
+element's geometry.
 
 ==== Usage
 
@@ -254,8 +264,8 @@ hoot info --geometry-type-crieria
 
 === Matchers
 
-The +--matchers+ option prints out available conflate matchers that may be applied when conflating data.  Matchers contain the criteria to match
-a specific pair of features
+The +--matchers+ option prints out available conflate matchers that may be applied when conflating data.  Matchers 
+contain the criteria to match a specific pair of features
 
 ==== Usage
 
@@ -271,8 +281,8 @@ hoot info --matchers
 
 === Match Creators
 
-The +--match-creators+ option prints out available conflate match creators that may be applied when conflating data.  Match Creators are
-responsible for spawning matchers.
+The +--match-creators+ option prints out available conflate match creators that may be applied when conflating data. 
+Match Creators are responsible for spawning matchers.
 
 ==== Usage
 
@@ -288,8 +298,8 @@ hoot info --match-creators
 
 === Mergers
 
-The +--mergers+ option prints out available conflate mergers that may be applied when conflating data.  Mergers are created to merge a feature
-pair supported by a corresponding matcher.
+The +--mergers+ option prints out available conflate mergers that may be applied when conflating data.  Mergers are 
+created to merge a feature pair supported by a corresponding matcher.
 
 ==== Usage
 
@@ -305,8 +315,8 @@ hoot info --mergers
 
 === Merger Creators
 
-The +--merger-creators+ option prints out available conflate merger creators that may be applied when conflating data.  Merger Creators are
-responsible for spawning mergers.
+The +--merger-creators+ option prints out available conflate merger creators that may be applied when conflating data. 
+Merger Creators are responsible for spawning mergers.
 
 ==== Usage
 
@@ -322,8 +332,8 @@ hoot info --merger-creators
 
 === Operators
 
-The +--operators+ option prints out available inline operators that can be applied to map data in a Hootenanny command.  Map operators
-can be criterion, operations, or visitors.
+The +--operators+ option prints out available inline operators that can be applied to map data in a Hootenanny command.  
+Map operators can be criterion, operations, or visitors.
 
 * An example of an operation is DuplicateWayRemover, which removes all duplicate ways from a map.
 * An example of a criterion is NodeCriterion, which acts as a filter to return all nodes in a map.
@@ -340,16 +350,6 @@ info --operators
 --------------------------------------
 # lists all available operators
 hoot info --operators
-
-# criterion example - filters only nodes from the map to the output
-hoot convert -D convert.ops="hoot::RemoveElementsVisitor" -D remove.elements.visitor.element.criteria="hoot::NodeCriterion" \
-input1.osm input2.osm output.osm
-
-# operation example - writes a map based on the input data with all duplicate ways removed
-hoot convert -D convert.ops="hoot::DuplicateWayRemover" input1.osm input2.osm output.osm
-
-# visitor example - writes a map based on the input data with all of the specified tags removed from the nodes
-hoot convert -D convert.ops="hoot::RemoveTagsVisitor" -D remove.tags.visitor.element.criterion="hoot::WayCriterion" -D tag.filter.keys="source;error:circular" input1.osm input2.osm output.osm
 --------------------------------------
 
 === Subline Matchers
@@ -370,8 +370,8 @@ hoot info --subline-matchers
 
 === Subline String Matchers
 
-The +--subline-string-matchers+ option prints out available subline string matchers that determine which method of multilinestring matching
-is used during conflation.
+The +--subline-string-matchers+ option prints out available subline string matchers that determine which method 
+of multilinestring matching is used during conflation.
 
 ==== Usage
 
@@ -425,8 +425,8 @@ hoot info --tag-mergers
 
 === Value Aggregators
 
-The +--value-aggregators+ option prints out available tag value aggregation methods that can be used when building a conflation model with
-manually matched map training data.
+The +--value-aggregators+ option prints out available tag value aggregation methods that can be used when building 
+a conflation model with manually matched map training data.
 
 ==== Usage
 
@@ -442,8 +442,8 @@ hoot info --value-aggregators
 
 === Way Joiners
 
-The +--way-joiners+ option prints out all way joiner class implementations that may either be used independently or in conjunction with
-the OsmMapOperation, `hoot::WayJoinerOp`.
+The +--way-joiners+ option prints out all way joiner class implementations that may either be used independently or 
+in conjunction with the OsmMapOperation, `hoot::WayJoinerOp`.
 
 ==== Usage
 
@@ -455,5 +455,33 @@ info --way-joiners
 
 --------------------------------------
 hoot info --way-joiners
+--------------------------------------
+
+=== Way Snap Criteria
+
+The +--way-snap-criteria+ option prints out all criterion class implementations that may used with `UnconnectedWaySnapper`
+to filter the types of ways that are snapped to each other. The list is restricted to a criterion that will snap all feature 
+types (hoot::LinearCriterion) or criteria that are both conflatable and represent linear geometry types 
+(e.g. hoot::HighwayCriterion). Unlike most other `info` options this prints out a delimited list of class names only with 
+no descriptions. Optionally, this command call takes in the `match.creators` configuration option to determine the 
+appropriate list of criterion that goes with a specific set of matchers. If `match.creators` is not passed in, then a 
+list with all available snapping criteria are returned. The list of available matchers can be obtained with 
+`hoot info --match-creators`.
+
+==== Usage
+
+--------------------------------------
+info --way-snap-criteria
+--------------------------------------
+
+==== Example
+
+--------------------------------------
+# return all criterion classes
+hoot info --way-snap-criteria
+
+# return just the criterion classes applicable to matchers matching highway and river features; the config
+# option must be added before --way-snap-criteria
+hoot info -D match.creators="hoot::HighwayMatchCreator;hoot::ScriptMatchCreator,River.js" --way-snap-criteria
 --------------------------------------
 

--- a/docs/user/CommandLineExamples.asciidoc
+++ b/docs/user/CommandLineExamples.asciidoc
@@ -1328,6 +1328,19 @@ Requires a language translation server installation.  See the Hootenanny Install
     hoot info --way-joiners
 -----
 
+===== List all way snap criteria for the current conflate configuration:
+
+-----
+    hoot info --way-snap-critera
+-----
+
+===== List all way snap criteria for a specific set of conflate matchers:
+
+-----
+    hoot info -D match.creators="hoot::HighwayMatchCreator;hoot::ScriptMatchCreator,River.js" \
+      --way-snap-critera
+-----
+
 ===== List the available JOSM validators:
 
 -----

--- a/hoot-core/src/main/cpp/hoot/core/cmd/BaseCommand.h
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/BaseCommand.h
@@ -46,7 +46,6 @@ class BaseCommand : public Command
 public:
 
   BaseCommand() = default;
-
   virtual ~BaseCommand() = default;
 
   QString getHelp() const override;

--- a/hoot-core/src/main/cpp/hoot/core/cmd/InfoCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/InfoCmd.cpp
@@ -57,9 +57,11 @@ public:
 
   int runSimple(QStringList& args) override
   {
-    // only allowing one option per command
     const QStringList supportedOpts = _getSupportedOptions();
     QStringList specifiedOpts;
+    // Only allowing one option per info command by default. Options with more than sub-option
+    // are parsed separately after this.
+    LOG_VART(args);
     for (int i = 0; i < args.size(); i++)
     {
       const QString arg = args.at(i);
@@ -229,7 +231,7 @@ public:
         QString supportedOpt = supportedOpts.at(i);
         if (args.contains(supportedOpt))
         {
-          //should only be one of these
+          // should only be one of these
           args.removeAt(args.indexOf(supportedOpt));
           apiEntityType = supportedOpt.replace("--", "");
         }
@@ -278,6 +280,7 @@ private:
     options.append("--tag-mergers");
     options.append("--value-aggregators");
     options.append("--way-joiners");
+    options.append("--way-snap-criteria");
     return options;
   }
 };

--- a/hoot-core/src/main/cpp/hoot/core/conflate/SuperfluousConflateOpRemover.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/SuperfluousConflateOpRemover.cpp
@@ -232,7 +232,7 @@ QSet<QString> SuperfluousConflateOpRemover::getMatchCreatorGeometryTypeCrits(con
 
       if (addParents)
       {
-        // also add any generic geometry crits the crit inherits from
+        // Also, add any generic geometry crits the crit inherits from.
 
         const QStringList pointCrits =
           GeometryTypeCriterion::getCriterionClassNamesByGeometryType(

--- a/hoot-core/src/main/cpp/hoot/core/conflate/SuperfluousConflateOpRemover.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/SuperfluousConflateOpRemover.h
@@ -55,11 +55,13 @@ public:
   static void removeSuperfluousOps();
 
   /**
-   * Determines GeometryTypeCriterion compatible with conflate matches for the current configuration
+   * Determines GeometryTypeCriterion compatible with conflate matchers for the current
+   * configuration
    *
    * @param addParents if true, ancestor geometry types are included in the output; e.g.
    * PolygonCriterion will be included along with BuildingCriterion
    * @return a list of GeometryTypeCriterion class names
+   * @todo This belongs in a more generic utility class rather than in this one.
    */
   static QSet<QString> getMatchCreatorGeometryTypeCrits(const bool addParents = true);
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.h
@@ -97,8 +97,8 @@ public:
    * Returns a description for the match creator
    *
    * This is actually being done in order to track the script name in ScriptMatchCreator, so we
-   * need to do some refactoring to get rid of this.  Could be redundant with the CreatorDescription
-   * class.
+   * may need to do some refactoring to get rid of this. Could be redundant with the
+   * CreatorDescription class.
    *
    * @return a descriptive string
    */

--- a/hoot-core/src/main/cpp/hoot/core/info/ApiEntityDisplayInfo.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/info/ApiEntityDisplayInfo.cpp
@@ -34,6 +34,7 @@
 #include <hoot/core/algorithms/string/StringDistance.h>
 #include <hoot/core/algorithms/subline-matching/SublineMatcher.h>
 #include <hoot/core/algorithms/subline-matching/SublineStringMatcher.h>
+#include <hoot/core/conflate/SuperfluousConflateOpRemover.h>
 #include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/conflate/matching/MatchCreator.h>
 #include <hoot/core/conflate/merging/Merger.h>
@@ -148,7 +149,8 @@ QString ApiEntityDisplayInfo::getDisplayInfoOps(const QString& optName)
 
 QString ApiEntityDisplayInfo::getDisplayInfo(const QString& apiEntityType)
 {
-  DisableLog dl; // Disable this for debugging.
+  // The log must be disabled for this to display things correctly. Disable it for debugging only.
+  DisableLog dl;
   QString msg = " (prepend 'hoot::' before using";
   QString buffer;
   QTextStream ts(&buffer);
@@ -268,6 +270,12 @@ QString ApiEntityDisplayInfo::getDisplayInfo(const QString& apiEntityType)
     ts <<
       _getApiEntities<WayJoiner, WayJoiner>(
         WayJoiner::className(), "way joiner", false, MAX_NAME_SIZE - 10);
+  }
+  else if (apiEntityType == "way-snap-criteria")
+  {
+    // For this one we're just print a list of class names, rather than the descriptions as well, as
+    // that's all that's needed right now.
+    ts << _getWaySnapCriteria() << endl;
   }
   else if (apiEntityType == "conflatable-criteria")
   {
@@ -399,7 +407,7 @@ template<typename ApiEntity>
 QString ApiEntityDisplayInfo::_getApiEntitiesForMatchMergerCreators(
   const QString& apiEntityClassName)
 {
-  //the size of the longest names plus a 3 space buffer
+  // the size of the longest names plus a 3 space buffer
   const int maxNameSize = 48;
 
   std::vector<QString> names = Factory::getInstance().getObjectNamesByBase(apiEntityClassName);
@@ -459,6 +467,28 @@ QString ApiEntityDisplayInfo::_apiEntityTypeForBaseClass(const QString& classNam
     return "visitor";
   }
   return "";
+}
+
+QString ApiEntityDisplayInfo::_getWaySnapCriteria()
+{
+  QStringList filteredCritClassNames;
+  const QStringList linearCritClassNames =
+    ConflatableElementCriterion::getCriterionClassNamesByGeometryType(
+      GeometryTypeCriterion::GeometryType::Line);
+  LOG_VARD(linearCritClassNames);
+  const QSet<QString> matchCreatorCritClassNames =
+    SuperfluousConflateOpRemover::getMatchCreatorGeometryTypeCrits();
+  LOG_VARD(matchCreatorCritClassNames);
+  for (QSet<QString>::const_iterator itr = matchCreatorCritClassNames.begin();
+       itr != matchCreatorCritClassNames.end(); ++itr)
+  {
+    if (linearCritClassNames.contains(*itr))
+    {
+      filteredCritClassNames.append(*itr);
+    }
+  }
+  qSort(filteredCritClassNames);
+  return filteredCritClassNames.join(";");
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/info/ApiEntityDisplayInfo.h
+++ b/hoot-core/src/main/cpp/hoot/core/info/ApiEntityDisplayInfo.h
@@ -76,6 +76,8 @@ private:
 
   template<typename ApiEntity>
   static QString _getApiEntitiesForMatchMergerCreators(const QString& apiEntityClassName);
+
+  static QString _getWaySnapCriteria();
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/util/Factory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/Factory.cpp
@@ -76,6 +76,41 @@ vector<QString> Factory::getObjectNamesByBase(const QString& baseName)
   return result;
 }
 
+//template<typename BaseClass, typename ChildClass>
+//std::vector<QString> Factory::getChildObjectNames(/*const QString& baseName, const QString& childName*/)
+//{
+//  // TODO: This is a little redundant with code in ApiEntityDisplayInfo::_getApiEntities... can
+//  // probably be refactored to remove the duplication.
+
+//  // This could end up being an expensive call if repeated, so implement caching if needed.
+
+//  std::vector<QString> childClassNames;
+
+//  const std::vector<QString> baseClassNames = getObjectNamesByBase(baseName);
+//  for (size_t i = 0; i < baseClassNames.size(); i++)
+//  {
+//    QString baseClassName = baseClassNames[i];
+//    LOG_VARD(baseClassName);
+
+//    std::shared_ptr<BaseClass> baseImpl(
+//      Factory::getInstance().constructObject<BaseClass>(BaseClass::className()));
+
+//    std::shared_ptr<ChildClass> childImpl =
+//      std::dynamic_pointer_cast<ChildClass>(baseImpl);
+//    if (!childImpl.get())
+//    {
+//      throw IllegalArgumentException(childName + " is not a child of " + baseName);
+//    }
+
+//    //if (BaseClass::className() != ChildClass::className())
+//    //{
+//      childClassNames.push_back(childName);
+//    //}
+//  }
+
+//  return childClassNames;
+//}
+
 bool Factory::hasClass(const QString& name)
 {
   return _creators.find(name) != _creators.end();

--- a/hoot-core/src/main/cpp/hoot/core/util/Factory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/Factory.cpp
@@ -76,41 +76,6 @@ vector<QString> Factory::getObjectNamesByBase(const QString& baseName)
   return result;
 }
 
-//template<typename BaseClass, typename ChildClass>
-//std::vector<QString> Factory::getChildObjectNames(/*const QString& baseName, const QString& childName*/)
-//{
-//  // TODO: This is a little redundant with code in ApiEntityDisplayInfo::_getApiEntities... can
-//  // probably be refactored to remove the duplication.
-
-//  // This could end up being an expensive call if repeated, so implement caching if needed.
-
-//  std::vector<QString> childClassNames;
-
-//  const std::vector<QString> baseClassNames = getObjectNamesByBase(baseName);
-//  for (size_t i = 0; i < baseClassNames.size(); i++)
-//  {
-//    QString baseClassName = baseClassNames[i];
-//    LOG_VARD(baseClassName);
-
-//    std::shared_ptr<BaseClass> baseImpl(
-//      Factory::getInstance().constructObject<BaseClass>(BaseClass::className()));
-
-//    std::shared_ptr<ChildClass> childImpl =
-//      std::dynamic_pointer_cast<ChildClass>(baseImpl);
-//    if (!childImpl.get())
-//    {
-//      throw IllegalArgumentException(childName + " is not a child of " + baseName);
-//    }
-
-//    //if (BaseClass::className() != ChildClass::className())
-//    //{
-//      childClassNames.push_back(childName);
-//    //}
-//  }
-
-//  return childClassNames;
-//}
-
 bool Factory::hasClass(const QString& name)
 {
   return _creators.find(name) != _creators.end();

--- a/hoot-core/src/main/cpp/hoot/core/util/Factory.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Factory.h
@@ -85,12 +85,12 @@ public:
   }
 
   QString getBaseName() const override { return _baseName; }
-
   QString getName() const override { return _name; }
 
 private:
 
-  QString _name, _baseName;
+  QString _name;
+  QString _baseName;
 };
 
 /**
@@ -149,6 +149,16 @@ public:
   }
 
   std::vector<QString> getObjectNamesByBase(const QString& baseName);
+
+  /**
+   * TODO
+   *
+   * @param baseName
+   * @param childName
+   * @return
+   */
+//  template<typename BaseClass, typename ChildClass>
+//  std::vector<QString> getChildObjectNames(/*const QString& baseName, const QString& childName*/);
 
   bool hasClass(const QString& name);
 

--- a/hoot-core/src/main/cpp/hoot/core/util/Factory.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Factory.h
@@ -150,16 +150,6 @@ public:
 
   std::vector<QString> getObjectNamesByBase(const QString& baseName);
 
-  /**
-   * TODO
-   *
-   * @param baseName
-   * @param childName
-   * @return
-   */
-//  template<typename BaseClass, typename ChildClass>
-//  std::vector<QString> getChildObjectNames(/*const QString& baseName, const QString& childName*/);
-
   bool hasClass(const QString& name);
 
   /**

--- a/test-files/cmd/slow/InfoCmdTest.sh
+++ b/test-files/cmd/slow/InfoCmdTest.sh
@@ -179,6 +179,15 @@ echo ""
 hoot info $CONFIG --way-joiners | grep "WayJoinerAdvanced"
 echo ""
 
+# WAY SNAP CRITERIA
+echo "Listing way snap criteria..."
+echo ""
+# Check against the default conflate config.
+hoot info $CONFIG --way-snap-criteria
+# Check against a custom conflate config. Note that the config option goes before --way-snap-criteria.
+hoot info $CONFIG -D match.creators="hoot::HighwayMatchCreator;hoot::ScriptMatchCreator,River.js" --way-snap-criteria
+echo ""
+
 # CONFLATABLE CRITERIA
 echo "Listing conflatable criteria..."
 echo ""

--- a/test-files/cmd/slow/InfoCmdTest.sh.stdout
+++ b/test-files/cmd/slow/InfoCmdTest.sh.stdout
@@ -3729,6 +3729,11 @@ Listing way joiners...
 
   WayJoinerAdvanced                     Extends WayJoinerBasic with additional join pre-conditions.
 
+Listing way snap criteria...
+
+hoot::HighwayCriterion;hoot::LinearCriterion;hoot::LinearWaterwayCriterion;hoot::PowerLineCriterion;hoot::RailwayCriterion
+hoot::HighwayCriterion;hoot::LinearCriterion;hoot::LinearWaterwayCriterion
+
 Listing conflatable criteria...
 
   BuildingCriterion                     Identifies buildings


### PR DESCRIPTION
See added documentation for `hoot info --way-snap-criteria`.