### PR TITLE
Install command help

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -153,6 +153,8 @@ install-other:
 	rm -f tmp/other.tar
 	mkdir -p $(docdir)
 	cp LICENSE README.md docs/*.pdf $(docdir)
+	mkdir -p $(docdir)/commands
+	cp docs/commands/*.asciidoc $(docdir)/commands
 	mkdir -p $(sysconfdir)/profile.d/
 	mkdir -p $(sysconfdir)/asciidoc/filters/
 	cp -R docs/filters/* $(sysconfdir)/asciidoc/filters/


### PR DESCRIPTION
Copy the command asciidoc files during install for Hootenanny command errors to work.  The RPM `.spec` file is installing everything in the `docs` directory that is copied over but these files aren't being copied over in the install process of the `Makefile`.

Closes https://github.com/ngageoint/hootenanny-rpms/issues/296