### PR TITLE
Duplicate node remover speedup 3710

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/HttpTestServer.cpp
@@ -123,14 +123,22 @@ void HttpTestServer::stop()
   //  Interupt the threads
   _interupt = true;
   //  Close the acceptor
-  if (_acceptor->is_open())
+  try
   {
-    boost::system::error_code ec;
-    _acceptor->close(ec);
+    if (_acceptor && _acceptor->is_open())
+    {
+      boost::system::error_code ec;
+      _acceptor->close(ec);
+    }
   }
+  catch (...) {}
   //  Stop the IO service
-  if (!_io_service.stopped())
-    _io_service.stop();
+  try
+  {
+    if (!_io_service.stopped())
+      _io_service.stop();
+  }
+  catch (...) {}
 }
 
 void HttpTestServer::shutdown()
@@ -274,7 +282,7 @@ long HttpTestServer::parse_content_length(const std::string& headers)
       }
     }
   }
-  catch(...) {}
+  catch (...) {}
   return 0;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.cpp
@@ -1069,9 +1069,10 @@ void OsmMap::_replaceNodeInRelations(long oldId, long newId)
   ConstElementPtr newNode = getNode(newId);
   //  Use the index to get all relations containing the old node ID
   const std::shared_ptr<ElementToRelationMap>& mapping = getIndex().getElementToRelationMap();
-  const set<long>& relations = mapping->getRelationByElement(oldNodeId);
+  const set<long>& relation_map = mapping->getRelationByElement(oldNodeId);
+  vector<long> relations(relation_map.begin(), relation_map.end());
   //  Only iterate the relations that contain the old node ID
-  for (set<long>::const_iterator it = relations.begin(); it != relations.end(); ++it)
+  for (vector<long>::const_iterator it = relations.begin(); it != relations.end(); ++it)
   {
     RelationPtr currRelation = getRelation(*it);
     if (!currRelation || !currRelation->contains(oldNodeId))

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.cpp
@@ -1072,9 +1072,9 @@ void OsmMap::_replaceNodeInRelations(long oldId, long newId)
   const set<long>& relation_map = mapping->getRelationByElement(oldNodeId);
   vector<long> relations(relation_map.begin(), relation_map.end());
   //  Only iterate the relations that contain the old node ID
-  for (vector<long>::const_iterator it = relations.begin(); it != relations.end(); ++it)
+  for (vector<long>::const_iterator iter = relations.begin(); iter != relations.end(); ++iter)
   {
-    RelationPtr currRelation = getRelation(*it);
+    RelationPtr currRelation = getRelation(*iter);
     if (!currRelation || !currRelation->contains(oldNodeId))
       continue;
     LOG_TRACE("Trying to replace node " << oldNode->getId() << " with node " <<

--- a/hoot-core/src/main/cpp/hoot/core/elements/Way.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Way.cpp
@@ -392,7 +392,7 @@ void Way::replaceNode(long oldId, long newId)
       indices.emplace_back(i);
   }
 
-  if (indices.size() > 0)
+  if (!indices.empty())
   {
     LOG_TRACE("IDs before replacement: " << getNodeIds());
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/Way.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Way.cpp
@@ -384,17 +384,15 @@ void Way::replaceNode(long oldId, long newId)
 
   const vector<long>& ids = getNodeIds();
 
-  bool change = false;
+  vector<size_t> indices;
   for (size_t i = 0; i < ids.size(); i++)
   {
     const long id = ids[i];
     if (id == oldId)
-    {
-      change = true;
-    }
+      indices.emplace_back(i);
   }
 
-  if (change)
+  if (indices.size() > 0)
   {
     LOG_TRACE("IDs before replacement: " << getNodeIds());
 
@@ -406,13 +404,8 @@ void Way::replaceNode(long oldId, long newId)
 
     vector<long>& newIds = _wayData->getNodeIds();
     LOG_TRACE("Replacement IDs: " << newIds);
-    for (size_t i = 0; i < newIds.size(); i++)
-    {
-      if (newIds[i] == oldId)
-      {
-        newIds[i] = newId;
-      }
-    }
+    for (size_t i = 0; i < indices.size(); ++i)
+      newIds[indices[i]] = newId;
 
     _postGeometryChange();
 

--- a/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.cpp
@@ -41,10 +41,10 @@ namespace hoot
 static vector<long> init_match;
 
 ClosePointHash::ClosePointHash(double distance)
-  : _match(init_match)
+  : _binSize(distance * 2),
+    _distance(distance),
+    _match(init_match)
 {
-  _distance = distance;
-  _binSize = _distance * 2;
 }
 
 void ClosePointHash::addPoint(double x, double y, long id)

--- a/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.cpp
@@ -35,7 +35,13 @@ using namespace std;
 namespace hoot
 {
 
+/** init_match is an empty vector used only for the initialization of the
+ *  reference ClosePointHash::_match
+ */
+static vector<long> init_match;
+
 ClosePointHash::ClosePointHash(double distance)
+  : _match(init_match)
 {
   _distance = distance;
   _binSize = _distance * 2;
@@ -44,20 +50,20 @@ ClosePointHash::ClosePointHash(double distance)
 void ClosePointHash::addPoint(double x, double y, long id)
 {
   int64_t binIx = _toBin(x + _distance, y + _distance);
-  _bins[binIx].push_back(id);
-  _idTobin[id].push_back(binIx);
+  _bins[binIx].emplace_back(id);
+  _idTobin[id].emplace_back(binIx);
 
   binIx = _toBin(x + _distance, y - _distance);
-  _bins[binIx].push_back(id);
-  _idTobin[id].push_back(binIx);
+  _bins[binIx].emplace_back(id);
+  _idTobin[id].emplace_back(binIx);
 
   binIx =_toBin(x - _distance, y + _distance);
-  _bins[binIx].push_back(id);
-  _idTobin[id].push_back(binIx);
+  _bins[binIx].emplace_back(id);
+  _idTobin[id].emplace_back(binIx);
 
   binIx = _toBin(x - _distance, y - _distance);
-  _bins[binIx].push_back(id);
-  _idTobin[id].push_back(binIx);
+  _bins[binIx].emplace_back(id);
+  _idTobin[id].emplace_back(binIx);
 }
 
 const vector<long>& ClosePointHash::getMatch() const

--- a/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.h
+++ b/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.h
@@ -94,7 +94,7 @@ private:
 
   double _binSize;
   double _distance;
-  std::vector<long> _match;
+  std::vector<long>& _match;
 
   HashMap<int64_t, std::vector<long>> _bins;
   HashMap<int64_t, std::vector<long>>::const_iterator _it;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.cpp
@@ -295,23 +295,23 @@ void OsmXmlWriter::_writeMetadata(const Element* e) const
 
 void OsmXmlWriter::_writeTags(const ConstElementPtr& element)
 {
-  ElementPtr elementClone = element->clone();
-  _addExportTagsVisitor.visit(elementClone);
+  //  Rather than cloning the element, get the export tags from the visitor
+  Tags tags = _addExportTagsVisitor.getExportTags(element);
 
-  const ElementType type = elementClone->getElementType();
+  const ElementType type = element->getElementType();
   assert(type != ElementType::Unknown);
-  Tags& tags = elementClone->getTags();
+  tags.add(element->getTags());
 
   if (type == ElementType::Relation)
   {
-    ConstRelationPtr relation = std::dynamic_pointer_cast<const Relation>(elementClone);
+    ConstRelationPtr relation = std::dynamic_pointer_cast<const Relation>(element);
     if (relation->getType() != "")
       tags.insert("type", removeInvalidCharacters(relation->getType()));
   }
 
   if (type == ElementType::Way)
   {
-    ConstWayPtr way = std::dynamic_pointer_cast<const Way>(elementClone);
+    ConstWayPtr way = std::dynamic_pointer_cast<const Way>(element);
     //  Output the PID as a tag if desired for debugging purposes
     if (_includePid && way->hasPid())
       tags.insert(MetadataTags::HootSplitParentId(), QString("%1").arg(way->getPid()));

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.cpp
@@ -295,12 +295,13 @@ void OsmXmlWriter::_writeMetadata(const Element* e) const
 
 void OsmXmlWriter::_writeTags(const ConstElementPtr& element)
 {
+  //  Tag order is important here, current tags first and then add export tags
+  Tags tags = element->getTags();
   //  Rather than cloning the element, get the export tags from the visitor
-  Tags tags = _addExportTagsVisitor.getExportTags(element);
+  tags.add(_addExportTagsVisitor.getExportTags(element));
 
   const ElementType type = element->getElementType();
   assert(type != ElementType::Unknown);
-  tags.add(element->getTags());
 
   if (type == ElementType::Relation)
   {

--- a/hoot-core/src/main/cpp/hoot/core/util/DateTimeUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/DateTimeUtils.cpp
@@ -29,7 +29,7 @@
 
 // Qt
 #include <QDateTime>
-#include <QRegExp>
+#include <QRegularExpression>
 
 namespace hoot
 {
@@ -46,8 +46,9 @@ QString DateTimeUtils::toTimeString(quint64 timestamp)
 quint64 DateTimeUtils::fromTimeString(QString timestamp)
 {
   //2016-05-04T22:07:19Z
-  QRegExp timestampRegex("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z*");
-  if (!timestampRegex.exactMatch(timestamp))
+  static QRegularExpression timestampRegex("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z*",
+                                           QRegularExpression::OptimizeOnFirstUsageOption);
+  if (!timestampRegex.match(timestamp).hasMatch())
   {
     throw IllegalArgumentException("Invalid timestamp string: " + timestamp);
   }

--- a/hoot-core/src/main/cpp/hoot/core/visitors/AddExportTagsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/AddExportTagsVisitor.cpp
@@ -42,12 +42,18 @@ AddExportTagsVisitor::AddExportTagsVisitor()
 }
 
 void AddExportTagsVisitor::visit(const ElementPtr& pElement)
-{ 
-  Tags& tags = pElement->getTags();
+{
+  //  Add the export tags back to the element
+  pElement->addTags(getExportTags(pElement));
+}
+
+Tags AddExportTagsVisitor::getExportTags(const ConstElementPtr& pElement)
+{
+  const Tags& tags = pElement->getTags();
   ElementType type = pElement->getElementType();
   Status status = pElement->getStatus();
   bool isNode = type == ElementType::Node;
-  bool isRelation = type == ElementType::Relation;  
+  bool isRelation = type == ElementType::Relation;
   bool validStatus = status != Status::Invalid;
   bool hasStatus = tags.find(MetadataTags::HootStatus()) != tags.end();
   bool hasMappingTags = tags.getNonDebugCount() > 0;
@@ -61,21 +67,16 @@ void AddExportTagsVisitor::visit(const ElementPtr& pElement)
                           pElement->hasCircularError() &&
                           (!isNode || (isNode && hasMappingTags));
 
+  Tags newTags;
   if (addStatus)
-  {
-    tags[MetadataTags::HootStatus()] = _textStatus ? status.toTextStatus() : toCompatString(status);
-  }
-
+    newTags[MetadataTags::HootStatus()] = _textStatus ? status.toTextStatus() : toCompatString(status);
   if (_includeDebug || _includeIds)
-  {
-    tags[MetadataTags::HootId()] = QString::number(pElement->getId());
-  }
-
+    newTags[MetadataTags::HootId()] = QString::number(pElement->getId());
   if (addCircularError)
-  {
-    tags[MetadataTags::ErrorCircular()] = QString::number(pElement->getCircularError());
-  }
+    newTags[MetadataTags::ErrorCircular()] = QString::number(pElement->getCircularError());
+  return newTags;
 }
+
 
 void AddExportTagsVisitor::overrideDebugSettings()
 {

--- a/hoot-core/src/main/cpp/hoot/core/visitors/AddExportTagsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/AddExportTagsVisitor.h
@@ -68,6 +68,8 @@ public:
 
   void visit(const ElementPtr& pElement) override;
 
+  Tags getExportTags(const ConstElementPtr& pElement);
+
   void overrideDebugSettings();
 
   QString getName() const override { return className(); }

--- a/hoot-core/src/main/cpp/hoot/core/visitors/AddExportTagsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/AddExportTagsVisitor.h
@@ -68,6 +68,11 @@ public:
 
   void visit(const ElementPtr& pElement) override;
 
+  /**
+   * @brief getExportTags Create (not add) export tags for a specific element
+   * @param pElement element to base the new tags on
+   * @return all new export tags
+   */
   Tags getExportTags(const ConstElementPtr& pElement);
 
   void overrideDebugSettings();


### PR DESCRIPTION
Using `callgrind` converting a dataset of 1.8M elements there were three areas that were running slow in a `hoot convert` command.  Each area was optimized with the following results:
```
# Before
STATUS ...ore/io/OsmMapReaderFactory.cpp( 191) Read 1,875,175 elements from input in: 00:41.      
INFO   ...p/hoot/core/ops/OpExecutor.cpp( 230) 	Merged 351,283 node pairs. in 00:30
INFO   ...ore/io/OsmMapWriterFactory.cpp( 149) Wrote 1,523,892 elements to output in: 00:28.
STATUS ...p/hoot/core/cmd/ConvertCmd.cpp( 140) Data conversion completed in 01:42.
# After
STATUS ...ore/io/OsmMapReaderFactory.cpp( 191) Read 1,875,175 elements from input in: 00:37.      
INFO   ...p/hoot/core/ops/OpExecutor.cpp( 230) 	Merged 351,283 node pairs. in 00:17
INFO   ...ore/io/OsmMapWriterFactory.cpp( 149) Wrote 1,523,892 elements to output in: 00:19.
STATUS ...p/hoot/core/cmd/ConvertCmd.cpp( 140) Data conversion completed in 01:16.
```
Optimizations made:
* `OsmXmlReader` parsed date time strings using and older, non-compiled regular expression object on the stack, the creation of this object millions of times caused a big slowdown.  The variable is static local so it is initialized once, compiled on first use, and then reused for each element read, 1.8M times in this case.  _10% speed-up_
* During the duplicate node remover, any merged nodes where sent to `OsmMap::_replaceNodeInRelations` that iterated all relations for each node.  Now only nodes that are a part of a relation have only their relations iterated. _50% speed-up_
* `OsmXmlWriter` ran the `AddExportTagsVisitor` for each element to add in tags such as `error:circular` and the like.  In order to add this tag, the element had to be cloned so as not to modify the original element.  The tags are created by the visitor but the visitor no longer modifies the element, it just returns the new tags.  They are then added to the original tags and written out. _33% speed-up_

Refs #3710