### PR TITLE
Valgrind not working with current hoot

### DIFF
--- a/scripts/tomcat/CopyWebAppsToTomcat.sh
+++ b/scripts/tomcat/CopyWebAppsToTomcat.sh
@@ -13,23 +13,30 @@ else # Centos
   source ~/.bash_profile
 fi
 
-sudo -u $USER -g tomcat rm -f $TOMCAT8_HOME/webapps/hoot-services.war
+sudo rm -f $TOMCAT8_HOME/webapps/hoot-services.war
 
 # Need to make sure we don't die due to nfs funkyness
-sudo -u $USER -g tomcat rm -rf $TOMCAT8_HOME/webapps/hoot-services/
-sudo -u $USER -g tomcat rm -rf $TOMCAT8_HOME/webapps/hoot-services/
+sudo rm -rf $TOMCAT8_HOME/webapps/hoot-services/
+sudo rm -rf $TOMCAT8_HOME/webapps/hoot-services/
 
-sudo -u $USER -g tomcat cp `ls -t hoot-services/target/hoot-services-*.war | sed -n 1p` $TOMCAT8_HOME/webapps/hoot-services.war
+sudo cp `ls -t hoot-services/target/hoot-services-*.war | sed -n 1p` $TOMCAT8_HOME/webapps/hoot-services.war
+sudo chown $USER:tomcat $TOMCAT8_HOME/webapps/hoot-services.war
 
 # Copy hootenanny-ui web files
-sudo -u $USER -g tomcat rm -rf $TOMCAT8_HOME/webapps/hootenanny-id-legacy/
-sudo -u $USER -g tomcat cp -R hoot-ui/dist $TOMCAT8_HOME/webapps/hootenanny-id-legacy
-sudo -u $USER -g tomcat mkdir -p $TOMCAT8_HOME/webapps/hootenanny-id-legacy/data
-sudo -u $USER -g tomcat cp hoot-ui/data/osm-plus-taginfo.csv $TOMCAT8_HOME/webapps/hootenanny-id-legacy/data
-sudo -u $USER -g tomcat cp hoot-ui/data/tdsv61_field_values.json $TOMCAT8_HOME/webapps/hootenanny-id-legacy/data
+sudo rm -rf $TOMCAT8_HOME/webapps/hootenanny-id-legacy/
+sudo cp -R hoot-ui/dist $TOMCAT8_HOME/webapps/hootenanny-id-legacy/
+sudo chown -R $USER:tomcat $TOMCAT8_HOME/webapps/hootenanny-id-legacy/
+
+sudo mkdir -p $TOMCAT8_HOME/webapps/hootenanny-id-legacy/data/
+sudo chown -R $USER:tomcat $TOMCAT8_HOME/webapps/hootenanny-id-legacy/data/
+
+sudo cp hoot-ui/data/osm-plus-taginfo.csv $TOMCAT8_HOME/webapps/hootenanny-id-legacy/data/
+sudo cp hoot-ui/data/tdsv61_field_values.json $TOMCAT8_HOME/webapps/hootenanny-id-legacy/data/
+sudo chown -R $USER:tomcat $TOMCAT8_HOME/webapps/hootenanny-id-legacy/data/
 
 #Copy hootenanny-ui2x we files
-sudo -u $USER -g tomcat rm -rf $TOMCAT8_HOME/webapps/hootenanny-id/
-sudo -u $USER -g tomcat cp -R hoot-ui-2x/dist $TOMCAT8_HOME/webapps/hootenanny-id
+sudo rm -rf $TOMCAT8_HOME/webapps/hootenanny-id/
+sudo cp -R hoot-ui-2x/dist $TOMCAT8_HOME/webapps/hootenanny-id/
+sudo chown -R $USER:tomcat $TOMCAT8_HOME/webapps/hootenanny-id/
 
 echo Web application files deployed.


### PR DESCRIPTION
In some instances on AWS the `CopyWebAppsToTomcat.sh` won't delete the old webapp causing builds to fail, use `root` to remove, copy, and then `chown` them.

Closes #4942 