### PR TITLE
Road median to divided road conflation prototype

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -962,7 +962,15 @@ and then `$HOOT_HOME/conf/`.
 * Data Type: string
 * Default Value: `HighwayRfClassifier`
 
-The highway match classifier to use. This should only be used for testing and debugging.
+The classifier to use to classify road matches.
+
+=== conflate.match.highway.median.classifier
+
+* Data Type: string
+* Default Value: `MedianToDividedRoadClassifier`
+
+The highway match classifier to use to match road medians to divided highways if
+`highway.median.to.dual.highway.match` is enabled.
 
 === conflate.match.highway.model
 
@@ -1838,6 +1846,40 @@ for match. For example:
 
 * `highway=primary` vs `highway=secondary` has a diff of 0.2.
 * `highway=primary` vs `highway=footway` has a diff of 0.67.
+
+=== highway.median.identifying.tags
+
+* Data Type: list
+* Default Value:
+** `median=yes`
+
+List of tag kvps used to identify a road median feature between two divided road features (dual
+carriageways; arbitarily, the first tag found from the key list is used). The list is used to
+identify one to many secondary match feature candidates if `highway.median.to.dual.highway.match` is
+enabled and the conditions described in `highway.median.to.dual.highway.match` are satisfied for a
+road match.
+
+=== highway.median.to.dual.highway.match
+
+* Data Type: bool
+* Default Value: `false`
+
+If true, road matching will attempt a one to many match from a single input 2 road median feature to
+multiple input 1 divided road (dual carriageway) features. The road feature from input 2 must
+contain at least one of the tags identified in `highway.median.identifying.tags`. Only tag merging
+of selected tags identified in `highway.median.to.dual.highway.transfer.tags` will be performed with
+no geometry merging and no removal of the median feature, regardless of the conflation workflow in
+use.
+
+=== highway.median.to.dual.highway.transfer.keys
+
+* Data Type: list
+* Default Value:
+** ``
+
+List of keys for tags to transfer from input 2 road median features to input 1 divided road (dual
+carriageway) features if `highway.median.to.dual.highway.match` is enabled and the conditions
+described in `highway.median.to.dual.highway.match` are satisfied for a road match.
 
 === highway.miss.threshold
 
@@ -4446,9 +4488,9 @@ Sets that maximum angle, in degrees, that is still considered a railway match.
 * Data Type: bool
 * Default Value: `true`
 
-If true, `railway.one.to.many.match` is enabled, and the conditions specified in
-`railway.one.to.many.identifying.keys` are met, then matching secondary features will be deleted
-from conflated output.
+If this is enabled, `railway.one.to.many.match` is enabled, and the conditions specified in
+`railway.one.to.many.match` are met, then matching secondary rail features will be deleted from
+conflated output.
 
 === railway.one.to.many.identifying.keys
 
@@ -4456,10 +4498,10 @@ from conflated output.
 * Default Value:
 ** `passenger_lines`
 
-List of tag keys with values identifying how many tracks a particular rail has used if
-`railway.one.to.many.match` is enabled. If any of the tags are found in a rail from the second
-input, railway matching will attempt a one to many match from input 2 to input 1 (arbitarily,
-the first tag found from the key list is used). The default value of this option maps to the
+List of tag keys with values identifying how many tracks a particular rail feature uses (arbitarily,
+the first tag found from the key list is used). The list is used to identify one to many secondary
+match feature candidates if `railway.one.to.many.match` is enabled and the conditions described in
+`railway.one.to.many.match` are satisfied. The default value of this option maps to the
 OpenStreetMap tagging standard for railways. If your input data has other tag keys that identify
 your track count, either translate them to the default value here before hand or add them as
 additional entry values to this option.
@@ -4469,11 +4511,11 @@ additional entry values to this option.
 * Data Type: bool
 * Default Value: `false`
 
-If true, railway matching will attempt a one to many match from input 2 to input 1. The rail feature
-from input 2 must contain at least one of the tag having a key matching that in
-`railway.one.to.many.identifying.keys`. Only tag merging of selected tags identified in
-`railway.one.to.many.transfer.keys` will be performed with no geometry merging, regardless of the
-conflation workflow in use.
+If true, railway matching will attempt a one to many match from a single input 2 rail feature to
+multiple input 1 rail features. The rail feature from input 2 must contain at least one of the tag
+having a key matching that in `railway.one.to.many.identifying.keys`. Only tag merging of selected
+tags identified in `railway.one.to.many.transfer.keys` will be performed with no geometry merging,
+regardless of the conflation workflow in use.
 
 === railway.one.to.many.transfer.keys
 
@@ -4481,9 +4523,9 @@ conflation workflow in use.
 * Default Value:
 ** ``
 
-List of tags to transfer from input 2 rail feature to input 1 rail feature if
-`railway.one.to.many.match` is enabled and the match conditions described in
-`railway.one.to.many.identifying.keys` are satisfied.
+List of tags to transfer from input 2 rail features to input 1 rail features if
+`railway.one.to.many.match` is enabled and the conditions described in `railway.one.to.many.match`
+are satisfied for a railway match.
 
 === railway.subline.matcher
 

--- a/conf/services/conflationTypes.json
+++ b/conf/services/conflationTypes.json
@@ -171,6 +171,9 @@
         "matcher": "HighwayMatchCreator",
         "merger": "HighwayMergerCreator",
         "members": {
+            "highway.median.to.dual.highway.match": "Enable custom secondary road median to reference divided road feature matching",
+            "highway.median.identifying.tags": "Tag keys allowing for a tag transfer from secondary road medians to reference divided roads",
+            "highway.median.to.dual.highway.transfer.keys": "Tag keys to transfer from secondary road medians to reference divided roads",
             "highway.match.threshold": "Match threshold; 0.0 to 1.0",
             "search.radius.highway": "Search radius (m); -1 for default"
         }

--- a/docs/algorithms/RoadConflation.asciidoc
+++ b/docs/algorithms/RoadConflation.asciidoc
@@ -224,14 +224,24 @@ See also:
 
 * `tag.merger.default` configuration option <<hootuser>>
 
+=== Median To Divided Highway Matching
+
+Road conflation has an alternate workflow that allows for transferring selected tags from single
+secondary road median features to associated reference divided roads (dual carriageways). The 
+configuration option which enables median to divided road matching is 
+`highway.median.to.dual.highway.match`. The configuration option that identifies features as road 
+medians is `highway.median.identifying.tags`. If a feature has any tag in the option's list, it will 
+be considered a road median feature. 
+
+In this workflow, median to divided road merging is done with tags only. No geometry merging is
+performed. The keys of the tags transferred from secondary medians to reference divided roads are 
+identified in `highway.median.to.dual.highway.transfer.keys`.
+
 [[RoadConflationFutureWork]]
 === Future Work
 
-* Creating a custom index (rather than using the global index) will likely be
-  faster.
-* There has been discussion around creating a new conflation approach that uses
-  collective classifiers with intersections to improve performance.
-* Expand the training data to include a more diverse set of regions and input
-  types.
-
+* Creating a custom index (rather than using the global index) will likely be faster.
+* There has been discussion around creating a new conflation approach that uses collective 
+classifiers with intersections to improve performance.
+* Expand the training data to include a more diverse set of regions and input types.
 

--- a/docs/user/CommandLineExamples.asciidoc
+++ b/docs/user/CommandLineExamples.asciidoc
@@ -451,7 +451,9 @@ See the User Guide for more specific details on command usage. Most of these exa
       input1.osm input2.osm output.osm --differential
 -----
 
-==== Conflate railways with the https://github.com/ngageoint/hootenanny/blob/master/docs/algorithms/RailwayConflation.asciidoc#one-to-many-matching[One To Many Railway Conflation Workflow]:
+==== Conflate railways with the One To Many Railway Conflation Workflow:
+
+https://github.com/ngageoint/hootenanny/blob/master/docs/algorithms/RailwayConflation.asciidoc#one-to-many-matching[detail]
 
 -----
     # Conflate railways by transferring only the "name" tag from secondary to reference rail features.
@@ -460,7 +462,9 @@ See the User Guide for more specific details on command usage. Most of these exa
       -D railway.one.to.many.transfer.keys="name" input1.osm input2.osm output.osm
 -----
 
-==== Conflate roads with the https://github.com/ngageoint/hootenanny/blob/master/docs/algorithms/RoadConflation.asciidoc#median-to-divided-highway-matching[Road Median to Divided Road Conflation Workflow]:
+==== Conflate roads with the Road Median to Divided Road Conflation Workflow:
+
+https://github.com/ngageoint/hootenanny/blob/master/docs/algorithms/RoadConflation.asciidoc#median-to-divided-highway-matching[detail]
 
 -----
     # Conflate roads transferring only the "name" tag from secondary median features to reference divided road features.

--- a/docs/user/CommandLineExamples.asciidoc
+++ b/docs/user/CommandLineExamples.asciidoc
@@ -460,7 +460,7 @@ See the User Guide for more specific details on command usage. Most of these exa
       -D railway.one.to.many.transfer.keys="name" input1.osm input2.osm output.osm
 -----
 
-==== Conflate roads with the https://github.com/ngageoint/hootenanny/blob/5016/docs/algorithms/RoadConflation.asciidoc#median-to-divided-highway-matching[Road Median to Divided Road Conflation Workflow]:
+==== Conflate roads with the https://github.com/ngageoint/hootenanny/blob/master/docs/algorithms/RoadConflation.asciidoc#median-to-divided-highway-matching[Road Median to Divided Road Conflation Workflow]:
 
 -----
     # Conflate roads transferring only the "name" tag from secondary median features to reference divided road features.

--- a/docs/user/CommandLineExamples.asciidoc
+++ b/docs/user/CommandLineExamples.asciidoc
@@ -451,6 +451,24 @@ See the User Guide for more specific details on command usage. Most of these exa
       input1.osm input2.osm output.osm --differential
 -----
 
+==== Conflate railways with the https://github.com/ngageoint/hootenanny/blob/master/docs/algorithms/RailwayConflation.asciidoc#one-to-many-matching[One To Many Railway Conflation Workflow]:
+
+-----
+    # Conflate railways by transferring only the "name" tag from secondary to reference rail features.
+    hoot conflate -C ReferenceConflation.conf -C UnifyingAlgorithm.conf \
+      -D railway.one.to.many.match=true -D railway.one.to.many.identifying.keys="passenger_lines" \
+      -D railway.one.to.many.transfer.keys="name" input1.osm input2.osm output.osm
+-----
+
+==== Conflate roads with the https://github.com/ngageoint/hootenanny/blob/5016/docs/algorithms/RoadConflation.asciidoc#median-to-divided-highway-matching[Road Median to Divided Road Conflation Workflow]:
+
+-----
+    # Conflate roads transferring only the "name" tag from secondary median features to reference divided road features.
+    hoot conflate -C ReferenceConflation.conf -C UnifyingAlgorithm.conf \
+      -D highway.median.to.dual.highway.match=true -D highway.median.identifying.tags="median=yes" \
+      -D highway.median.to.dual.highway.transfer.keys="name" input1.osm input2.osm output.osm
+-----
+
 === Conversion
 
 ==== Combine two maps into a single map without conflating:

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/AngleHistogramExtractor.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/AngleHistogramExtractor.h
@@ -62,7 +62,8 @@ public:
 
   void setConfiguration(const Settings& conf) override;
 
-  double extract(const OsmMap& map, const std::shared_ptr<const Element>& target,
+  double extract(
+    const OsmMap& map, const std::shared_ptr<const Element>& target,
     const std::shared_ptr<const Element>& candidate) const override;
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySublineMatch.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/linearreference/WaySublineMatch.h
@@ -27,6 +27,7 @@
 #ifndef WAYMATCHLOCATION_H
 #define WAYMATCHLOCATION_H
 
+// Hoot
 #include <hoot/core/algorithms/linearreference/WaySubline.h>
 
 namespace hoot
@@ -39,7 +40,7 @@ class WaySublineMatch
 public:
 
   WaySublineMatch();
-  WaySublineMatch(const WaySublineMatch& other, const ConstOsmMapPtr &newMap);
+  WaySublineMatch(const WaySublineMatch& other, const ConstOsmMapPtr& newMap);
   WaySublineMatch(const WaySubline& ws1, const WaySubline& ws2, bool reversed = false);
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/conflate/AbstractConflator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/AbstractConflator.h
@@ -159,6 +159,13 @@ private:
    */
   void _removeWholeGroups(std::vector<ConstMatchPtr>& matches, MatchSetVector& matchSets) const;
 
+  /**
+   * @brief _separateOneToManyMatches Separates one to many matches from one to one matches
+   * @param matches the matches to be separated
+   * @return the separated one to many matches
+   */
+  std::vector<ConstMatchPtr> _separateOneToManyMatches(std::vector<ConstMatchPtr>& matches) const;
+
   void _applyMergers(const std::vector<MergerPtr>& mergers, const OsmMapPtr& map);
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/RfExtractorClassifier.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/RfExtractorClassifier.cpp
@@ -47,7 +47,7 @@ namespace hoot
 int RfExtractorClassifier::logWarnCount = 0;
 
 MatchClassification RfExtractorClassifier::classify(
-  const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2) const
+  const ConstOsmMapPtr& map, const ElementId& eid1, const ElementId& eid2) const
 {
   LOG_TRACE("Determining classification for match between: " << eid1 << " and " << eid2 << "...");
 
@@ -81,7 +81,7 @@ const vector<std::shared_ptr<const FeatureExtractor>>& RfExtractorClassifier::_g
 }
 
 map<QString, double> RfExtractorClassifier::getFeatures(
-  const ConstOsmMapPtr& m, ElementId eid1, ElementId eid2) const
+  const ConstOsmMapPtr& m, const ElementId& eid1, const ElementId& eid2) const
 {
   map<QString, double> result;
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/RfExtractorClassifier.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/RfExtractorClassifier.h
@@ -52,13 +52,13 @@ public:
    * @brief classify classifies the match type of a building pair and returns the results.
    */
   virtual MatchClassification classify(
-    const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2) const;
+    const ConstOsmMapPtr& map, const ElementId& eid1, const ElementId& eid2) const;
 
   /**
    * See note in MatchDetails::getFeatures about the return type of this method.
    */
   virtual std::map<QString, double> getFeatures(
-    const ConstOsmMapPtr& m, ElementId eid1, ElementId eid2) const;
+    const ConstOsmMapPtr& m, const ElementId& eid1, const ElementId& eid2) const;
 
   void import(const QDomElement& docRoot);
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayClassifier.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayClassifier.h
@@ -48,14 +48,14 @@ public:
    * Classifies the match type of a subline match and returns the results.
    */
   virtual MatchClassification classify(
-    const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2,
+    const ConstOsmMapPtr& map, const ElementId& eid1, const ElementId& eid2,
     const WaySublineMatchString& match) = 0;
 
   /**
    * See note in MatchDetails::getFeatures about the return type of this method.
    */
   virtual std::map<QString, double> getFeatures(
-    const ConstOsmMapPtr& m, ElementId eid1, ElementId eid2,
+    const ConstOsmMapPtr& m, const ElementId& eid1, const ElementId& eid2,
     const WaySublineMatchString& match) const = 0;
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayExpertClassifier.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayExpertClassifier.cpp
@@ -40,8 +40,9 @@ namespace hoot
 
 HOOT_FACTORY_REGISTER(HighwayClassifier, HighwayExpertClassifier)
 
-MatchClassification HighwayExpertClassifier::classify(const ConstOsmMapPtr& map,
-  ElementId /*eid1*/, ElementId /*eid2*/, const WaySublineMatchString &match)
+MatchClassification HighwayExpertClassifier::classify(
+  const ConstOsmMapPtr& map, const ElementId& /*eid1*/, const ElementId& /*eid2*/,
+  const WaySublineMatchString& match)
 {
   // calculate the average classification. Is there a better approach? Max, min, mean? Dunno.
   MatchClassification result;
@@ -71,9 +72,8 @@ MatchClassification HighwayExpertClassifier::classify(
   MatchClassification result;
 
   OsmMapPtr mapCopy = std::make_shared<OsmMap>();
-  CopyMapSubsetOp(map,
-               match.getSubline1().getElementId(),
-               match.getSubline2().getElementId()).apply(mapCopy);
+  CopyMapSubsetOp(
+    map, match.getSubline1().getElementId(), match.getSubline2().getElementId()).apply(mapCopy);
 
   if (match.isValid() == false)
   {
@@ -119,7 +119,7 @@ MatchClassification HighwayExpertClassifier::classify(
 
   double p;
 
-  // if either of the lines are zero in length.
+  // if either of the lines are zero in length
   if (po1 == 0 || po2 == 0)
   {
     p = 0.0;
@@ -135,8 +135,9 @@ MatchClassification HighwayExpertClassifier::classify(
   return result;
 }
 
-map<QString, double> HighwayExpertClassifier::getFeatures(const ConstOsmMapPtr& /*m*/,
-  ElementId /*eid1*/, ElementId /*eid2*/, const WaySublineMatchString& /*match*/) const
+map<QString, double> HighwayExpertClassifier::getFeatures(
+  const ConstOsmMapPtr& /*m*/, const ElementId& /*eid1*/, const ElementId& /*eid2*/,
+  const WaySublineMatchString& /*match*/) const
 {
   return map<QString, double>();
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayExpertClassifier.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayExpertClassifier.h
@@ -43,14 +43,15 @@ public:
   HighwayExpertClassifier() = default;
   ~HighwayExpertClassifier() = default;
 
-  MatchClassification classify(const ConstOsmMapPtr& map,
-    ElementId eid1, ElementId eid2, const WaySublineMatchString& match) override;
+  MatchClassification classify(
+    const ConstOsmMapPtr& map, const ElementId& eid1, const ElementId& eid2,
+    const WaySublineMatchString& match) override;
+  MatchClassification classify(
+    const ConstOsmMapPtr& map, const WaySublineMatch& match) const;
 
-  MatchClassification classify(const ConstOsmMapPtr& map,
-    const WaySublineMatch& match) const;
-
-  std::map<QString, double> getFeatures(const ConstOsmMapPtr& m,
-    ElementId eid1, ElementId eid2, const WaySublineMatchString& match) const override;
+  std::map<QString, double> getFeatures(
+    const ConstOsmMapPtr& m, const ElementId& eid1, const ElementId& eid2,
+    const WaySublineMatchString& match) const override;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatch.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatch.h
@@ -104,7 +104,8 @@ private:
   double _calculateExpertProbability(const ConstOsmMapPtr& map) const;
 
   bool _isOrderedConflicting(
-    const ConstOsmMapPtr& map, ElementId sharedEid, ElementId other1, ElementId other2) const;
+    const ConstOsmMapPtr& map, const ElementId& sharedEid, const ElementId& other1,
+    const ElementId& other2) const;
 
   void _updateNonMatchDescriptionBasedOnGeometricProperties(
     QStringList& description, const ConstOsmMapPtr& map, const ConstElementPtr e1,

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatch.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatch.h
@@ -54,10 +54,10 @@ public:
   static const QString MATCH_NAME;
 
   HighwayMatch() = default;
-  HighwayMatch(const std::shared_ptr<HighwayClassifier>& classifier,
-               const std::shared_ptr<SublineStringMatcher>& sublineMatcher,
-               const ConstOsmMapPtr& map, const ElementId& eid1, const ElementId& eid2,
-               ConstMatchThresholdPtr mt);
+  HighwayMatch(
+    const std::shared_ptr<HighwayClassifier>& classifier,
+    const std::shared_ptr<SublineStringMatcher>& sublineMatcher, const ConstOsmMapPtr& map,
+    const ElementId& eid1, const ElementId& eid2, ConstMatchThresholdPtr mt);
   ~HighwayMatch() = default;
 
   /**
@@ -67,10 +67,11 @@ public:
   double getProbability() const override;
   double getScore() const override { return _score; }
   QString explain() const override { return _explainText; }
-  const MatchClassification& getClassification() const override { return _c; }
+  const MatchClassification& getClassification() const override { return _classification; }
   MatchMembers getMatchMembers() const override { return MatchMembers::Polyline; }
 
-  bool isConflicting(const ConstMatchPtr& other, const ConstOsmMapPtr& map,
+  bool isConflicting(
+    const ConstMatchPtr& other, const ConstOsmMapPtr& map,
     const QHash<QString, ConstMatchPtr>& matches = QHash<QString, ConstMatchPtr>()) const override;
 
   std::map<QString, double> getFeatures(const ConstOsmMapPtr& m) const override;
@@ -79,7 +80,6 @@ public:
   const std::shared_ptr<SublineStringMatcher>& getSublineMatcher() const { return _sublineMatcher; }
 
   QString toString() const override;
-
   QString getName() const override { return getHighwayMatchName(); }
   QString getClassName() const override { return className(); }
   QString getDescription() const override
@@ -90,7 +90,7 @@ public:
 private:
 
   std::shared_ptr<HighwayClassifier> _classifier;
-  MatchClassification _c;
+  MatchClassification _classification;
   double _score;
   QString _explainText;
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
@@ -154,12 +154,10 @@ public:
     _neighborCountMax = std::max(_neighborCountMax, neighborCount);
   }
 
-  static std::shared_ptr<HighwayMatch> createMatch(const ConstOsmMapPtr& map,
-    std::shared_ptr<HighwayClassifier> classifier,
-    std::shared_ptr<SublineStringMatcher> sublineMatcher,
-    ConstMatchThresholdPtr threshold,
-    std::shared_ptr<TagAncestorDifferencer> tagAncestorDiff,
-    ConstElementPtr e1, ConstElementPtr e2)
+  static std::shared_ptr<HighwayMatch> createMatch(
+    const ConstOsmMapPtr& map, std::shared_ptr<HighwayClassifier> classifier,
+    std::shared_ptr<SublineStringMatcher> sublineMatcher, ConstMatchThresholdPtr threshold,
+    std::shared_ptr<TagAncestorDifferencer> tagAncestorDiff, ConstElementPtr e1, ConstElementPtr e2)
   {
     std::shared_ptr<HighwayMatch> result;
 
@@ -249,7 +247,7 @@ public:
 
   bool isMatchCandidate(ConstElementPtr element) const
   {
-    // special tag is currently only used by roundabout processing to mark temporary features
+    // The special tag is currently only used by roundabout processing to mark temporary features.
     if (element->getTags().contains(MetadataTags::HootSpecial()) ||
         (_filter && !_filter->isSatisfied(element)))
     {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
@@ -76,8 +76,9 @@ class HighwayMatchVisitor : public ConstElementVisitor
 {
 public:
 
-  HighwayMatchVisitor(const ConstOsmMapPtr& map, vector<ConstMatchPtr>& result,
-                      ElementCriterionPtr filter = ElementCriterionPtr()) :
+  HighwayMatchVisitor(
+    const ConstOsmMapPtr& map, vector<ConstMatchPtr>& result,
+    ElementCriterionPtr filter = ElementCriterionPtr()) :
   _map(map),
   _result(result),
   _filter(filter)
@@ -90,8 +91,7 @@ public:
   HighwayMatchVisitor(const ConstOsmMapPtr& map,
     vector<ConstMatchPtr>& result, std::shared_ptr<HighwayClassifier> c,
     std::shared_ptr<SublineStringMatcher> sublineMatcher, Status matchStatus,
-    ConstMatchThresholdPtr threshold,
-    std::shared_ptr<TagAncestorDifferencer> tagAncestorDiff,
+    ConstMatchThresholdPtr threshold, std::shared_ptr<TagAncestorDifferencer> tagAncestorDiff,
     ElementCriterionPtr filter = ElementCriterionPtr()):
   _map(map),
   _result(result),

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
@@ -85,19 +85,18 @@ public:
   {
   }
 
-  /**
-   * @param matchStatus If the element's status matches this status, then it is checked for a match.
-   */
-  HighwayMatchVisitor(const ConstOsmMapPtr& map,
-    vector<ConstMatchPtr>& result, std::shared_ptr<HighwayClassifier> c,
-    std::shared_ptr<SublineStringMatcher> sublineMatcher, Status matchStatus,
-    ConstMatchThresholdPtr threshold, std::shared_ptr<TagAncestorDifferencer> tagAncestorDiff,
+  HighwayMatchVisitor(
+    const ConstOsmMapPtr& map, vector<ConstMatchPtr>& result,
+    std::shared_ptr<HighwayClassifier> classifier,
+    std::shared_ptr<HighwayClassifier> medianClassifier,
+    std::shared_ptr<SublineStringMatcher> sublineMatcher, ConstMatchThresholdPtr threshold,
+    std::shared_ptr<TagAncestorDifferencer> tagAncestorDiff,
     ElementCriterionPtr filter = ElementCriterionPtr()):
   _map(map),
   _result(result),
-  _c(c),
+  _classifier(classifier),
+  _medianClassifier(medianClassifier),
   _sublineMatcher(sublineMatcher),
-  _matchStatus(matchStatus),
   _neighborCountMax(-1),
   _neighborCountSum(0),
   _elementsEvaluated(0),
@@ -122,26 +121,50 @@ public:
   {
     LOG_VART(e->getElementId());
 
+    // Find other nearby candidates.
     std::shared_ptr<Envelope> env(e->getEnvelope(_map));
     env->expandBy(getSearchRadius(e));
-
-    // find other nearby candidates
     set<ElementId> neighbors =
       SpatialIndexer::findNeighbors(*env, getIndex(), _indexToEid, getMap());
-
-    ElementId from(e->getElementType(), e->getId());
+    ElementId elementBeingMatched(e->getElementType(), e->getId());
 
     _elementsEvaluated++;
     int neighborCount = 0;
 
+    const bool medianMatchEnabled = ConfigOptions().getHighwayMedianToDualHighwayMatch();
     for (set<ElementId>::const_iterator it = neighbors.begin(); it != neighbors.end(); ++it)
     {
-      if (from != *it)
+      if (elementBeingMatched != *it)
       {
-        const std::shared_ptr<const Element>& n = _map->getElement(*it);
-        // score each candidate and push it on the result vector
+        const std::shared_ptr<const Element>& neighbor = _map->getElement(*it);
+
+        std::shared_ptr<HighwayClassifier> classifier;
+
+        // Highway median to multiple divided road matching is separate matching routine from
+        // regular road conflate. Check to see if the conditions for it are satisfied, and if so,
+        // employ a different classifier.
+        bool medianTagFound = false;
+        if (medianMatchEnabled)
+        {
+          // neighbor always is a secondary feature (unknown2).
+          const QString kvp =
+            neighbor->getTags().getFirstMatchingKvp(
+              ConfigOptions().getHighwayMedianIdentifyingTags());
+          medianTagFound = !kvp.isEmpty();
+          LOG_VART(medianTagFound);
+          if (medianTagFound)
+          {
+            classifier = _medianClassifier;
+          }
+        }
+        if (!medianTagFound)
+        {
+          classifier = _classifier;
+        }
+
+        // Score each candidate.
         std::shared_ptr<HighwayMatch> match =
-          createMatch(_map, _c, _sublineMatcher, _threshold, _tagAncestorDiff, e, n);
+          createMatch(_map, classifier, _sublineMatcher, _threshold, _tagAncestorDiff, e, neighbor);
         if (match)
         {
           _result.push_back(match);
@@ -216,7 +239,7 @@ public:
 
   void visit(const ConstElementPtr& e) override
   {
-    if (e->getStatus() == _matchStatus && isMatchCandidate(e))
+    if (e->getStatus() == Status::Unknown1 && isMatchCandidate(e))
     {
       checkForMatch(e);
 
@@ -298,9 +321,9 @@ private:
   const ConstOsmMapPtr& _map;
   vector<ConstMatchPtr>& _result;
   set<ElementId> _empty;
-  std::shared_ptr<HighwayClassifier> _c;
+  std::shared_ptr<HighwayClassifier> _classifier;
+  std::shared_ptr<HighwayClassifier> _medianClassifier;
   std::shared_ptr<SublineStringMatcher> _sublineMatcher;
-  Status _matchStatus;
   int _neighborCountMax;
   int _neighborCountSum;
   int _elementsEvaluated;
@@ -323,6 +346,9 @@ HighwayMatchCreator::HighwayMatchCreator() :
 _classifier(
   Factory::getInstance().constructObject<HighwayClassifier>(
     ConfigOptions().getConflateMatchHighwayClassifier())),
+_medianClassifier(
+  Factory::getInstance().constructObject<HighwayClassifier>(
+    ConfigOptions().getConflateMatchHighwayMedianClassifier())),
 _sublineMatcher(
   SublineStringMatcherFactory::getMatcher(CreatorDescription::BaseFeatureType::Highway)),
 _tagAncestorDiff(std::make_shared<TagAncestorDifferencer>("highway"))
@@ -362,7 +388,7 @@ void HighwayMatchCreator::createMatches(
   const int matchesSizeBefore = matches.size();
 
   HighwayMatchVisitor v(
-    map, matches, _classifier, _sublineMatcher, Status::Unknown1, threshold, _tagAncestorDiff,
+    map, matches, _classifier, _medianClassifier, _sublineMatcher, threshold, _tagAncestorDiff,
     _filter);
   map->visitWaysRo(v);
   map->visitRelationsRo(v);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.h
@@ -81,9 +81,14 @@ public:
 
 private:
 
+  // TODO
   std::shared_ptr<HighwayClassifier> _classifier;
+  std::shared_ptr<HighwayClassifier> _medianClassifier;
+
   std::shared_ptr<SublineStringMatcher> _sublineMatcher;
+
   std::shared_ptr<MatchThreshold> _matchThreshold;
+
   std::shared_ptr<TagAncestorDifferencer> _tagAncestorDiff;
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.h
@@ -55,7 +55,8 @@ public:
   /**
    * Search the provided map for highway matches and add the matches to the matches vector.
    */
-  void createMatches(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& matches,
+  void createMatches(
+    const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& matches,
     ConstMatchThresholdPtr threshold) override;
 
   std::vector<CreatorDescription> getAllCreators() const override;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.h
@@ -81,14 +81,18 @@ public:
 
 private:
 
-  // TODO
+  // standard classifier used for road matching
   std::shared_ptr<HighwayClassifier> _classifier;
+  // classifier used for the road median to divided road tag transfer workflow
   std::shared_ptr<HighwayClassifier> _medianClassifier;
 
+  // geometry matcher
   std::shared_ptr<SublineStringMatcher> _sublineMatcher;
 
+  // threshold controlling the determined match classification
   std::shared_ptr<MatchThreshold> _matchThreshold;
 
+  // used to prevent roads of widely different types from matching
   std::shared_ptr<TagAncestorDifferencer> _tagAncestorDiff;
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.cpp
@@ -44,6 +44,11 @@ HighwayMergerCreator::HighwayMergerCreator()
   setConfiguration(conf());
 }
 
+void HighwayMergerCreator::setConfiguration(const Settings &conf)
+{
+  _minSplitSize = ConfigOptions(conf).getWayMergerMinSplitSize();
+}
+
 bool HighwayMergerCreator::createMergers(const MatchSet& matches, vector<MergerPtr>& mergers) const
 {
   LOG_TRACE("Creating mergers with " << className() << "...");
@@ -120,11 +125,6 @@ bool HighwayMergerCreator::isConflicting(const ConstOsmMapPtr& map, ConstMatchPt
   {
     return false;
   }
-}
-
-void HighwayMergerCreator::setConfiguration(const Settings &conf)
-{
-  _minSplitSize = ConfigOptions(conf).getWayMergerMinSplitSize();
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMergerCreator.h
@@ -50,7 +50,8 @@ public:
 
   std::vector<CreatorDescription> getAllCreators() const override;
 
-  bool isConflicting(const ConstOsmMapPtr& map, ConstMatchPtr m1, ConstMatchPtr m2,
+  bool isConflicting(
+    const ConstOsmMapPtr& map, ConstMatchPtr m1, ConstMatchPtr m2,
     const QHash<QString, ConstMatchPtr>& matches = QHash<QString, ConstMatchPtr>()) const override;
 
   void setConfiguration(const Settings &conf) override;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayRfClassifier.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayRfClassifier.cpp
@@ -54,7 +54,8 @@ int HighwayRfClassifier::logWarnCount = 0;
 HOOT_FACTORY_REGISTER(HighwayClassifier, HighwayRfClassifier)
 
 MatchClassification HighwayRfClassifier::classify(
-  const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2, const WaySublineMatchString& match)
+  const ConstOsmMapPtr& map, const ElementId& eid1, const ElementId& eid2,
+  const WaySublineMatchString& match)
 {
   _init();
 
@@ -119,7 +120,8 @@ void HighwayRfClassifier::_createExtractors() const
 }
 
 map<QString, double> HighwayRfClassifier::getFeatures(
-  const ConstOsmMapPtr& m, ElementId eid1, ElementId eid2, const WaySublineMatchString& match) const
+  const ConstOsmMapPtr& m, const ElementId& eid1, const ElementId& eid2,
+  const WaySublineMatchString& match) const
 {
   _init();
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayRfClassifier.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayRfClassifier.h
@@ -27,6 +27,7 @@
 #ifndef HIGHWAYRFCLASSIFIER_H
 #define HIGHWAYRFCLASSIFIER_H
 
+// Hoot
 #include <hoot/core/conflate/highway/HighwayClassifier.h>
 
 // tgs
@@ -47,11 +48,12 @@ public:
   ~HighwayRfClassifier() = default;
 
   MatchClassification classify(
-    const ConstOsmMapPtr& map, ElementId eid1, ElementId eid2,
+    const ConstOsmMapPtr& map, const ElementId& eid1, const ElementId& eid2,
     const WaySublineMatchString& match) override;
 
-  std::map<QString, double> getFeatures(const ConstOsmMapPtr& m,
-    ElementId eid1, ElementId eid2, const WaySublineMatchString& match) const override;
+  std::map<QString, double> getFeatures(
+    const ConstOsmMapPtr& m, const ElementId& eid1, const ElementId& eid2,
+    const WaySublineMatchString& match) const override;
 
 private:
 
@@ -65,8 +67,6 @@ private:
    * @todo At some point names will make sense, but for now there isn't enough name data (#4874).
    */
   void _createExtractors() const;
-
-  const std::vector<std::shared_ptr<const FeatureExtractor>>& _getExtractors() const;
 
   /**
    * This provides a lazy load and should be called before any private members are accessed. This

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/MedianToDividedRoadClassifier.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/MedianToDividedRoadClassifier.cpp
@@ -1,0 +1,119 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. Maxar
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2021 Maxar (http://www.maxar.com/)
+ */
+#include "MedianToDividedRoadClassifier.h"
+
+// hoot
+#include <hoot/core/algorithms/aggregator/MeanAggregator.h>
+#include <hoot/core/algorithms/aggregator/RmseAggregator.h>
+#include <hoot/core/algorithms/aggregator/SigmaAggregator.h>
+#include <hoot/core/algorithms/extractors/AngleHistogramExtractor.h>
+#include <hoot/core/algorithms/extractors/EdgeDistanceExtractor.h>
+#include <hoot/core/algorithms/extractors/WeightedMetricDistanceExtractor.h>
+#include <hoot/core/algorithms/linearreference/WaySublineCollection.h>
+#include <hoot/core/util/Factory.h>
+
+namespace hoot
+{
+
+HOOT_FACTORY_REGISTER(HighwayClassifier, MedianToDividedRoadClassifier)
+
+const QString MedianToDividedRoadClassifier::MEDIAN_MATCHED_SUBROUTINE_NAME = "MedianMatch";
+const QString MedianToDividedRoadClassifier::MEDIAN_MATCHED_DESCRIPTION =
+  "Matched by median to divided road matching routine.";
+
+MedianToDividedRoadClassifier::MedianToDividedRoadClassifier()
+{
+  _createExtractors();
+}
+
+MatchClassification MedianToDividedRoadClassifier::classify(
+  const ConstOsmMapPtr& map, const ElementId& eid1, const ElementId& eid2,
+  const WaySublineMatchString& match)
+{
+  MatchClassification classification;
+  classification.setMiss();
+
+  if (!match.isValid())
+  {
+    return classification;
+  }
+
+  ConstElementPtr element1 = map->getElement(eid1);
+  ConstElementPtr element2 = map->getElement(eid2);
+  if (element1 && element2)
+  {
+    for (QMap<std::shared_ptr<const FeatureExtractor>, double>::const_iterator extractorItr =
+           _extractors.begin();
+         extractorItr != _extractors.end(); ++extractorItr)
+    {
+      std::shared_ptr<const FeatureExtractor> featureExtractor = extractorItr.key();
+      const double minScore = extractorItr.value();
+      const double score = featureExtractor->extract(*map, element1, element2);
+      if (score < minScore)
+      {
+        LOG_TRACE(
+          featureExtractor->getClassName() << " failed with score: " << score << " for " <<
+          element1->getElementId() << " and " << element2->getElementId() <<
+          ". Minimum score allowed: " << minScore << ".")
+        return classification;
+      }
+    }
+    classification.setMatch();
+    LOG_TRACE("Match found between " << eid1 << " and " << eid2 << ".");
+  }
+
+  return classification;
+}
+
+void MedianToDividedRoadClassifier::_createExtractors()
+{
+  // We're basically copying and tweaking the default road feature extractors here. Since the
+  // original road extractors were used to build a model which we roughly treat as a black box when
+  // we use it for classification and we don't know the original score values used in the model,
+  // these min score values were determined experimentally and may need tweaking over time. A better
+  // long term solution is probably to train a separate model for median to divided road matching.
+  _extractors.clear();
+  _extractors[
+    std::make_shared<EdgeDistanceExtractor>(std::make_shared<RmseAggregator>())] = 0.955;
+  _extractors[
+     std::make_shared<EdgeDistanceExtractor>(std::make_shared<SigmaAggregator>())] = 0.997;
+  _extractors[std::make_shared<AngleHistogramExtractor>()] = 1.0;
+  _extractors[
+    std::make_shared<WeightedMetricDistanceExtractor>(
+      std::make_shared<MeanAggregator>(), std::make_shared<RmseAggregator>(),
+      ConfigOptions().getSearchRadiusHighway())] = 0.695;
+}
+
+std::map<QString, double> MedianToDividedRoadClassifier::getFeatures(
+  const ConstOsmMapPtr& /*m*/, const ElementId& /*eid1*/, const ElementId& /*eid2*/,
+   const WaySublineMatchString& /*match*/) const
+{
+  // not implemented
+  return std::map<QString, double>();
+}
+
+}

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/MedianToDividedRoadClassifier.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/MedianToDividedRoadClassifier.h
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. Maxar
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2021 Maxar (http://www.maxar.com/)
+ */
+#ifndef MEDIAN_TO_DIVIDED_ROAD_CLASSIFIER_H
+#define MEDIAN_TO_DIVIDED_ROAD_CLASSIFIER_H
+
+// Hoot
+#include <hoot/core/conflate/highway/HighwayClassifier.h>
+
+namespace hoot
+{
+
+class FeatureExtractor;
+
+/**
+ * @brief The MedianToDividedRoadClassifier class is used to classify road median to divided road
+ * (dual carriageway) matches.
+ *
+ * Its feature extractors have been derived directly from HighwayRfClassifer and may need tweaking
+ * over time. No actual RF model files has been generated to work with this classifier.
+ */
+class MedianToDividedRoadClassifier : public HighwayClassifier
+{
+public:
+
+  static QString className() { return "MedianToDividedRoadClassifier"; }
+
+  static const QString MEDIAN_MATCHED_SUBROUTINE_NAME;
+  static const QString MEDIAN_MATCHED_DESCRIPTION;
+
+  MedianToDividedRoadClassifier();
+  ~MedianToDividedRoadClassifier() = default;
+
+  /**
+   * @see HighwayClassifier
+   */
+  MatchClassification classify(
+    const ConstOsmMapPtr& map, const ElementId& eid1, const ElementId& eid2,
+    const WaySublineMatchString& match) override;
+
+  /**
+   * @see HighwayClassifier
+   */
+  std::map<QString, double> getFeatures(
+    const ConstOsmMapPtr& m, const ElementId& eid1, const ElementId& eid2,
+    const WaySublineMatchString& match) const override;
+
+private:
+
+  // feature extractors used to create the classifier; extractors mapped to their minimum allowable
+  // score for the classifier to classify a match
+  QMap<std::shared_ptr<const FeatureExtractor>, double> _extractors;
+
+  void _createExtractors();
+};
+
+}
+
+#endif // MEDIAN_TO_DIVIDED_ROAD_CLASSIFIER_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/Match.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/Match.cpp
@@ -39,7 +39,8 @@ long Match::_orderCount = 0;
 
 Match::Match(const std::shared_ptr<const MatchThreshold>& threshold) :
 _order(_orderCount++),
-_threshold(threshold)
+_threshold(threshold),
+_isOneToMany(false)
 {
 }
 
@@ -49,7 +50,8 @@ Match::Match(
 _order(_orderCount++),
 _threshold(threshold),
 _eid1(eid1),
-_eid2(eid2)
+_eid2(eid2),
+_isOneToMany(false)
 {
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/Match.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/Match.cpp
@@ -37,10 +37,6 @@ namespace hoot
 
 long Match::_orderCount = 0;
 
-/*
- * All of this order silliness maintains a consistent ordering of matches when they're placed
- * into a set as pointers.
- */
 Match::Match(const std::shared_ptr<const MatchThreshold>& threshold) :
 _order(_orderCount++),
 _threshold(threshold)

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/Match.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/Match.h
@@ -140,6 +140,23 @@ public:
   virtual MatchType getType() const;
 
   /**
+   * @brief isOneToMany determines if a match is a one to many element match
+   * @return true if the match is a one to many match; false otherwise
+   */
+  virtual bool isOneToMany() const { return _isOneToMany; }
+  /**
+   * @brief setIsOneToMany sets the variable that determines if a match is a one to many element
+   * match
+   * @param isOneToMany one to many value to set
+   */
+  virtual void setIsOneToMany(bool isOneToMany) { _isOneToMany = isOneToMany; }
+
+  /**
+   * @todo This already exists in ApiEntityInfo
+   */
+  virtual QString toString() const = 0;
+
+  /**
    * Returns a collection of matches indexed by the IDs of the elements involved
    *
    * @param matches the matches to index
@@ -157,11 +174,6 @@ public:
   static QString matchPairsToString(
     const std::set<std::pair<ElementId, ElementId>>& matchPairs);
 
-  /**
-   * @todo This already exists in ApiEntityInfo
-   */
-  virtual QString toString() const = 0;
-
   std::shared_ptr<const MatchThreshold> getThreshold() const { return _threshold; }
 
 protected:
@@ -177,6 +189,11 @@ protected:
   const std::shared_ptr<const MatchThreshold> _threshold;
 
   ElementId _eid1, _eid2;
+
+  // The original implementation of hoot matching always forced one to many matches into reviews.
+  // Follow on workflows (road median matching, etc.) have been created to meet the requirement of
+  // merging tags only from a single feature to many.
+  bool _isOneToMany;
 
   Match(const std::shared_ptr<const MatchThreshold>& threshold);
   Match(

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/Match.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/Match.h
@@ -45,8 +45,8 @@ using MatchPtr = std::shared_ptr<Match>;
 using ConstMatchPtr = std::shared_ptr<const Match>;
 
 /**
- * Describes a specific match between two sets of elements. e.g. the match between two
- * buildings or the match between an intersection and a round-a-bout.
+ * Describes a specific match between two sets of elements. e.g. the match between two buildings or
+ * the match between an intersection and a round-a-bout.
  *
  * This class is not re-entrant or thread safe.
  */
@@ -168,6 +168,9 @@ protected:
 
   friend class MatchPtrComparator;
 
+  /* All of this order silliness maintains a consistent ordering of matches when they're placed
+   * into a set as pointers.
+   */
   static long _orderCount;
   long _order;
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchClassification.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchClassification.h
@@ -70,6 +70,11 @@ public:
   double getMissP() const { return _miss; }
   double getReviewP() const { return _review; }
 
+  // These assume no contradictions in the scoring.
+  bool isMatch() const { return _match == 1.0; }
+  bool isMiss() const { return _miss == 1.0; }
+  bool isReview() const { return _review == 1.0; }
+
   void setMatch() { _miss = 0; _match = 1; _review = 0; }
   void setMatchP(double match) { _match = match; }
   void setMiss() { _miss = 1; _match = 0; _review = 0; }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.cpp
@@ -153,11 +153,12 @@ public:
     DisjointSetMap<ElementId> dsm;
     MatchSetVector result;
 
+    LOG_VART(_matches.size());
     for (size_t i = 0; i < _matches.size(); i++)
     {
       ConstMatchPtr m = _matches[i];
       MatchType type = m->getType();
-      // if this is a solid match, then add it into the group.
+      // If this is a solid match, then add it into the group.
       if (type == MatchType::Match)
       {
         set<pair<ElementId, ElementId>> eids = m->getMatchPairs();
@@ -167,7 +168,7 @@ public:
           dsm.joinT(it->first, it->second);
         }
       }
-      // if this is a match that requires review.
+      // if this is a match that requires review
       else if (type == MatchType::Review)
       {
         result.emplace_back();
@@ -189,11 +190,11 @@ public:
 
       for (size_t i = 0; i < v.size(); i++)
       {
-        // find all the matches that reference this element id and add them to the set.
+        // Find all the matches that reference this element id and add them to the set.
         _findMatches(v[i], matches);
       }
 
-      // while this is O(n^2) matches should generally be pretty small.
+      // While this is O(n^2), matches should generally be pretty small.
       for (MatchSet::const_iterator m1_it = matches.begin(); m1_it != matches.end(); ++m1_it)
       {
         ConstMatchPtr m1 = *m1_it;
@@ -203,14 +204,15 @@ public:
           if (m1 != m2 && checkForConflicts &&
               MergerFactory::getInstance().isConflicting(map, m1, m2, idIndexedMatches))
           {
-            LOG_INFO(m1->toString());
-            LOG_INFO(m2->toString());
+            LOG_TRACE(m1);
+            LOG_TRACE(m2);
             throw InternalErrorException("Found an unexpected conflicting match.");
           }
         }
       }
     }
 
+    LOG_VART(result.size());
     return result;
   }
 
@@ -285,11 +287,11 @@ private:
 
 };
 
-MatchGraph::MatchGraph()
+MatchGraph::MatchGraph() :
+_checkForConflicts(true),
+// The two classes share the matches vector.
+_d(std::make_shared<MatchGraphInternal>(_matches))
 {
-  _checkForConflicts = true;
-  // The two classes share the matches vector.
-  _d = std::make_shared<MatchGraphInternal>(_matches);
 }
 
 void MatchGraph::_resetGraph() const

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.h
@@ -72,6 +72,11 @@ public:
   void addMatches(InputIterator first, InputIterator last);
 
   /**
+   * @brief clearMatches TODO
+   */
+  void clearMatches() { _matches.clear(); }
+
+  /**
    * Defaults to true. If set to false then it will not check to make sure all subgraphs contain
    * no conflicts.
    */

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchGraph.h
@@ -72,7 +72,7 @@ public:
   void addMatches(InputIterator first, InputIterator last);
 
   /**
-   * @brief clearMatches TODO
+   * @brief clearMatches clears out the matches used by this class
    */
   void clearMatches() { _matches.clear(); }
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchThreshold.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchThreshold.h
@@ -54,8 +54,9 @@ public:
    * generally want to honor that range for thresholds. In some instances, though, we don't want to.
    * e.g. match feature extraction or Multiary Conflation
    */
-  MatchThreshold(double matchThreshold = 0.5, double missThreshold = 0.5,
-                 double reviewThreshold = 1.0, bool validateRange = true);
+  MatchThreshold(
+    double matchThreshold = 0.5, double missThreshold = 0.5, double reviewThreshold = 1.0,
+    bool validateRange = true);
 
   double getMatchThreshold() const { return _matchThreshold; }
   double getMissThreshold() const { return _missThreshold; }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearAverageMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearAverageMerger.cpp
@@ -58,7 +58,8 @@ LinearMergerAbstract(pairs, nullptr)
 }
 
 bool LinearAverageMerger::_mergePair(
-  ElementId eid1, ElementId eid2, std::vector<std::pair<ElementId, ElementId>>& replaced)
+  const ElementId& eid1, const ElementId& eid2,
+  std::vector<std::pair<ElementId, ElementId>>& replaced)
 {
   if (LinearMergerAbstract::_mergePair(eid1, eid2, replaced))
   {

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearAverageMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearAverageMerger.h
@@ -55,7 +55,7 @@ public:
 protected:
 
   bool _mergePair(
-    ElementId eid1, ElementId eid2,
+    const ElementId& eid1, const ElementId& eid2,
     std::vector<std::pair<ElementId, ElementId>>& replaced) override;
 
   /*

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearDiffMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearDiffMerger.cpp
@@ -80,7 +80,8 @@ void LinearDiffMerger::apply(
 }
 
 bool LinearDiffMerger::_mergePair(
-  ElementId eid1, ElementId eid2, std::vector<std::pair<ElementId, ElementId>>& replaced)
+  const ElementId& eid1, const ElementId& eid2,
+  std::vector<std::pair<ElementId, ElementId>>& replaced)
 {
   // Check for missing elements.
   ElementPtr e1 = _map->getElement(eid1);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearDiffMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearDiffMerger.h
@@ -69,7 +69,7 @@ public:
 protected:
 
   bool _mergePair(
-    ElementId eid1, ElementId eid2,
+    const ElementId& eid1, const ElementId& eid2,
     std::vector<std::pair<ElementId, ElementId>>& replaced) override;
 
   /*

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearMergerAbstract.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearMergerAbstract.cpp
@@ -148,7 +148,7 @@ void LinearMergerAbstract::_markNeedsReview(
 }
 
 bool LinearMergerAbstract::_mergePair(
-  ElementId eid1, ElementId eid2, vector<pair<ElementId, ElementId>>& /*replaced*/)
+  const ElementId& eid1, const ElementId& eid2, vector<pair<ElementId, ElementId>>& /*replaced*/)
 {
   ElementPtr e1 = _map->getElement(eid1);
   ElementPtr e2 = _map->getElement(eid2);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearMergerAbstract.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearMergerAbstract.h
@@ -117,7 +117,8 @@ protected:
   /*
    * Return true if pair needs review.
    */
-  virtual bool _mergePair(ElementId eid1, ElementId eid2,
+  virtual bool _mergePair(
+    const ElementId& eid1, const ElementId& eid2,
     std::vector<std::pair<ElementId, ElementId>>& replaced);
 
   virtual void _markNeedsReview(

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearMergerFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearMergerFactory.h
@@ -55,8 +55,9 @@ public:
    *
    * @param eids element IDs of the features to be merged
    * @param sublineMatcher the subline matcher to be used to match the features
-   * @param matchedBy optional text to mark a feature with the type of matcher that matched it
-   * @param matchedBySubroutine TODO
+   * @param matchedBy optional name of the matcher used to match the features being merged; used to
+   * mark a feature with the type of matcher that matched it
+   * @param matchedBySubroutine name of the matching subroutine used (e.g. road median matching)
    * @return a merger
    */
   static MergerPtr getMerger(
@@ -81,8 +82,9 @@ public:
 private:
 
   /**
-   * @brief _getMedianMerger TODO
-   * @return
+   * @brief _getMedianMerger creates a custom merger for the road median to divided road conflation
+   * workflow.
+   * @return a merger
    */
   static MergerPtr _getMedianMerger();
 };

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearMergerFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearMergerFactory.h
@@ -56,12 +56,13 @@ public:
    * @param eids element IDs of the features to be merged
    * @param sublineMatcher the subline matcher to be used to match the features
    * @param matchedBy optional text to mark a feature with the type of matcher that matched it
+   * @param matchedBySubroutine TODO
    * @return a merger
    */
   static MergerPtr getMerger(
     const std::set<std::pair<ElementId, ElementId>>& eids,
     const std::shared_ptr<SublineStringMatcher>& sublineMatcher,
-    const QString matchedBy = QString());
+    const QString matchedBy = QString(), const QString matchedBySubroutine = QString());
 
   /**
    * Creates a linear feature merger matched by the Network Algorithm.
@@ -76,6 +77,14 @@ public:
     const std::set<std::pair<ElementId, ElementId>>& eids,
     const QSet<ConstEdgeMatchPtr>& edgeMatches, const ConstNetworkDetailsPtr& details,
     const QString matchedBy = QString());
+
+private:
+
+  /**
+   * @brief _getMedianMerger TODO
+   * @return
+   */
+  static MergerPtr _getMedianMerger();
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearSnapMerger.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearSnapMerger.cpp
@@ -90,7 +90,7 @@ _markAddedMultilineStringRelations
 }
 
 bool LinearSnapMerger::_mergePair(
-  ElementId eid1, ElementId eid2, vector<pair<ElementId, ElementId>>& replaced)
+  const ElementId& eid1, const ElementId& eid2, vector<pair<ElementId, ElementId>>& replaced)
 {
   // An element null check is performed by this call.
   if (LinearMergerAbstract::_mergePair(eid1, eid2, replaced))

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearSnapMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearSnapMerger.h
@@ -70,7 +70,7 @@ protected:
   bool _markAddedMultilineStringRelations;
 
   bool _mergePair(
-    ElementId eid1, ElementId eid2,
+    const ElementId& eid1, const ElementId& eid2,
     std::vector<std::pair<ElementId, ElementId>>& replaced) override;
 
   /*

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearTagOnlyMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/LinearTagOnlyMerger.h
@@ -31,6 +31,7 @@
 #include <hoot/core/conflate/IdSwap.h>
 #include <hoot/core/conflate/merging/LinearSnapMerger.h>
 #include <hoot/core/conflate/network/PartialNetworkMerger.h>
+#include <hoot/core/schema/TagMerger.h>
 
 namespace hoot
 {
@@ -54,22 +55,26 @@ public:
   LinearTagOnlyMerger(
     const std::set<std::pair<ElementId, ElementId>>& pairs,
     std::shared_ptr<PartialNetworkMerger> networkMerger);
-
   ~LinearTagOnlyMerger() = default;
 
   QString getDescription() const override
   { return "Merges linear feature tags only with minimal geometry exceptions"; }
+  QString getName() const override { return className(); }
+  QString getClassName() const override { return className(); }
+
+  void setTagMerger(TagMergerPtr tagMerger) { _tagMerger = tagMerger; }
 
 protected:
 
   bool _mergePair(
-    ElementId eid1, ElementId eid2,
+    const ElementId& eid1, const ElementId& eid2,
     std::vector<std::pair<ElementId, ElementId>>& replaced) override;
 
 private:
 
   bool _performBridgeGeometryMerging;
   std::shared_ptr<PartialNetworkMerger> _networkMerger;
+  TagMergerPtr _tagMerger;
 
   void _determineKeeperFeature(
     ElementPtr element1, ElementPtr element2, ElementPtr& keeper, ElementPtr& toRemove,

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerBase.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/MergerBase.h
@@ -27,6 +27,7 @@
 #ifndef MERGERBASE_H
 #define MERGERBASE_H
 
+// Hoot
 #include <hoot/core/conflate/merging/Merger.h>
 
 namespace hoot

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMergerCreator.cpp
@@ -46,10 +46,10 @@ namespace hoot
 
 HOOT_FACTORY_REGISTER(MergerCreator, NetworkMergerCreator)
 
-NetworkMergerCreator::NetworkMergerCreator()
+NetworkMergerCreator::NetworkMergerCreator() :
+_map(nullptr),
+_minMatchOverlapPercentage(ConfigOptions().getNetworkMergerMinLargeMatchOverlapPercentage())
 {
-  _map = nullptr;
-  _minMatchOverlapPercentage = ConfigOptions().getNetworkMergerMinLargeMatchOverlapPercentage();
 }
 
 bool NetworkMergerCreator::createMergers(

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMergerCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkMergerCreator.cpp
@@ -84,6 +84,8 @@ bool NetworkMergerCreator::createMergers(
     const bool matchOverlap = _containsOverlap(matches);
     LOG_VART(matchOverlap);
 
+    // Note that the road median matching workflow is not supported by the Network alg currently.
+
     if (!matchOverlap)
     {
       // create a merger that can merge multiple partial matches

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementId.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementId.h
@@ -74,12 +74,10 @@ public:
    * Shorthand for ElementId(ElementType::Node, nid)
    */
   static ElementId node(long nid) { return ElementId(ElementType::Node, nid); }
-
   /**
    * Shorthand for ElementId(ElementType::Relation, rid)
    */
   static ElementId relation(long rid) { return ElementId(ElementType::Relation, rid); }
-
   /**
    * Shorthand for ElementId(ElementType::Way, wid)
    */

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/LinearMergerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/LinearMergerJs.cpp
@@ -27,9 +27,7 @@
 #include "LinearMergerJs.h"
 
 // hoot
-#include <hoot/core/conflate/merging/LinearAverageMerger.h>
 #include <hoot/core/conflate/merging/LinearMergerFactory.h>
-#include <hoot/core/conflate/merging/LinearTagOnlyMerger.h>
 #include <hoot/core/util/Factory.h>
 
 #include <hoot/js/JsRegistrar.h>

--- a/hoot-js/src/main/cpp/hoot/js/conflate/merging/LinearMergerJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/merging/LinearMergerJs.cpp
@@ -28,6 +28,7 @@
 
 // hoot
 #include <hoot/core/conflate/merging/LinearMergerFactory.h>
+#include <hoot/core/conflate/merging/MergerBase.h>
 #include <hoot/core/util/Factory.h>
 
 #include <hoot/js/JsRegistrar.h>

--- a/rules/Railway.js
+++ b/rules/Railway.js
@@ -91,12 +91,12 @@ exports.isWholeGroup = function()
 
 function geometryMismatch(map, e1, e2, minDistanceScore, minHausdorffDistanceScore, minEdgeDistanceScore)
 {
-  hoot.debug("Processing geometry...");
+  hoot.trace("Processing geometry...");
 
   var sublines;
-  hoot.debug("Extracting sublines with default...");
+  hoot.trace("Extracting sublines with default...");
   sublines = sublineStringMatcher.extractMatchingSublines(map, e1, e2);
-  hoot.debug(sublines);
+  hoot.trace(sublines);
   if (sublines)
   {
     var m = sublines.map;
@@ -108,25 +108,25 @@ function geometryMismatch(map, e1, e2, minDistanceScore, minHausdorffDistanceSco
      "REPTree".
     */
     var distanceScore = distanceScoreExtractor.extract(m, m1, m2);
-    hoot.debug("distanceScore: " + distanceScore);
+    hoot.trace("distanceScore: " + distanceScore);
     if (distanceScore >= minDistanceScore)
     {
       var hausdorffDistance = hausdorffDistanceExtractor.extract(m, m1, m2);
-      hoot.debug("hausdorffDistance: " + hausdorffDistance);
+      hoot.trace("hausdorffDistance: " + hausdorffDistance);
       if (hausdorffDistance >= minHausdorffDistanceScore)
       {
         var edgeDistance  = edgeDistanceExtractor.extract(m, m1, m2);
-        hoot.debug("edgeDistance: " + edgeDistance);
+        hoot.trace("edgeDistance: " + edgeDistance);
         if (edgeDistance >= minEdgeDistanceScore)
         {
-          hoot.debug("Geometry match");
+          hoot.trace("Geometry match");
           return false;
         }
       }
     }
   }
 
-  hoot.debug("Geometry mismatch");
+  hoot.trace("Geometry mismatch");
   return true;
 }
 
@@ -135,13 +135,13 @@ function typeMismatch(e1, e2)
   // TODO
   if (e1.getTags().onlyOneContainsKvp(e2.getTags(), "service=yard"))
   {
-    hoot.debug("service=yard mismatch");
+    hoot.trace("service=yard mismatch");
     return true;
   }
   // If both features have types and they aren't just generic types, let's do a detailed type
   // comparison and look for an explicit type mismatch.
   var typeScorePassesThreshold = !hoot.OsmSchema.explicitTypeMismatch(e1, e2, exports.typeThreshold);
-  hoot.debug("typeScorePassesThreshold: " + typeScorePassesThreshold);
+  hoot.trace("typeScorePassesThreshold: " + typeScorePassesThreshold);
   if (!typeScorePassesThreshold)
   {
     return true;
@@ -171,26 +171,26 @@ exports.matchScore = function(map, e1, e2)
   var tags1 = e1.getTags();
   var tags2 = e2.getTags();
 
-  hoot.debug("**********************************");
-  hoot.debug("e1: " + e1.getElementId() + ", " + tags1.get("name"));
+  hoot.trace("**********************************");
+  hoot.trace("e1: " + e1.getElementId() + ", " + tags1.get("name"));
   if (tags1.get("note"))
   {
-    hoot.debug("e1 note: " + tags1.get("note"));
+    hoot.trace("e1 note: " + tags1.get("note"));
   }
-  hoot.debug("e2: " + e2.getElementId() + ", " + tags2.get("name"));
+  hoot.trace("e2: " + e2.getElementId() + ", " + tags2.get("name"));
   if (tags2.get("note"))
   {
-    hoot.debug("e2 note: " + tags2.get("note"));
+    hoot.trace("e2 note: " + tags2.get("note"));
   }
-  hoot.debug("mostSpecificType 1: " + hoot.OsmSchema.mostSpecificType(e1));
-  hoot.debug("mostSpecificType 2: " + hoot.OsmSchema.mostSpecificType(e2));
+  hoot.trace("mostSpecificType 1: " + hoot.OsmSchema.mostSpecificType(e1));
+  hoot.trace("mostSpecificType 2: " + hoot.OsmSchema.mostSpecificType(e2));
 
   // Note: No need has been apparent *yet* to do match filtering via name.
 
   // Check for a type mismatch.
   if (typeMismatch(e1, e2))
   {
-    hoot.debug("type mismatch");
+    hoot.trace("type mismatch");
     return result;
   }
 
@@ -210,7 +210,7 @@ exports.matchScore = function(map, e1, e2)
   if (oneToManyMatchEnabled)
   {
     oneToManyTagKey = tags2.getFirstMatchingKey(oneToManyIdentifyingKeys);
-    hoot.debug("oneToManyTagKey: " + oneToManyTagKey);
+    hoot.trace("oneToManyTagKey: " + oneToManyTagKey);
     if (oneToManyTagKey !== "")
     {
       // Check the identifying tag to see how many rail tracks this single secondary feature
@@ -223,7 +223,7 @@ exports.matchScore = function(map, e1, e2)
       {
         if (parseInt(oneToManyMatches[e2.getElementId()]) >= totalMatchesAllowed)
         {
-          hoot.debug(e2.getElementId() + " has already reached its maximum allowed matches: " + totalMatchesAllowed + ". matched element IDs: " + oneToManyMatchIds[e2.getElementId()]);
+          hoot.trace(e2.getElementId() + " has already reached its maximum allowed matches: " + totalMatchesAllowed + ". matched element IDs: " + oneToManyMatchIds[e2.getElementId()]);
           return result;
         }
         else
@@ -244,8 +244,8 @@ exports.matchScore = function(map, e1, e2)
     return result;
   }
 
-  hoot.debug("railway match");
-  hoot.debug("currentMatchAttemptIsOneToMany: " + currentMatchAttemptIsOneToMany);
+  hoot.trace("railway match");
+  hoot.trace("currentMatchAttemptIsOneToMany: " + currentMatchAttemptIsOneToMany);
   if (currentMatchAttemptIsOneToMany)
   {
     // If we found a one to many match, increment our total matches for the secondary feature.
@@ -266,12 +266,12 @@ exports.matchScore = function(map, e1, e2)
       matchIds = String(e1.getElementId()) + ";";
     }
     oneToManyMatchIds[e2.getElementId()] = matchIds;
-    hoot.debug("total matches for " + e2.getElementId() + ": " + String(numTotalMatches));
+    hoot.trace("total matches for " + e2.getElementId() + ": " + String(numTotalMatches));
     if (!oneToManySecondaryMatchElementIds.includes(String(e2.getElementId().toString())))
     {
       oneToManySecondaryMatchElementIds.push(String(e2.getElementId().toString()));
     }
-    hoot.debug("oneToManySecondaryMatchElementIds: " + oneToManySecondaryMatchElementIds);
+    hoot.trace("oneToManySecondaryMatchElementIds: " + oneToManySecondaryMatchElementIds);
   }
   result = { match: 1.0, explain:"match" };
   return result;
@@ -292,14 +292,14 @@ exports.matchScore = function(map, e1, e2)
  */
 exports.mergeSets = function(map, pairs, replaced)
 {
-  hoot.debug("Merging railways...");
-  hoot.debug("oneToManySecondaryMatchElementIds: " + oneToManySecondaryMatchElementIds);
+  hoot.trace("Merging railways...");
+  hoot.trace("oneToManySecondaryMatchElementIds: " + oneToManySecondaryMatchElementIds);
   var secondaryElementsIdsMerged = [];
   var oneToManyMergeOccurred = false;
   // If the current match is one to many, we're only bringing over tags from secondary to
   // reference in our specified list and we're doing no geometry merging.
   hoot.set({'tag.merger.default': 'SelectiveOverwriteTag1Merger'});
-  hoot.debug("pairs.length: " + pairs.length);
+  hoot.trace("pairs.length: " + pairs.length);
   for (var i = 0; i < pairs.length; i++)
   {
     var elementIdPair = pairs[i];
@@ -307,8 +307,8 @@ exports.mergeSets = function(map, pairs, replaced)
     var element2 = map.getElement(elementIdPair[1]);
     if (element1 && element2)
     {
-      hoot.debug("element1.getElementId(): " + element1.getElementId());
-      hoot.debug("element2.getElementId(): " + element2.getElementId());
+      hoot.trace("element1.getElementId(): " + element1.getElementId());
+      hoot.trace("element2.getElementId(): " + element2.getElementId());
     }
     if (element1 && element2)
     {
@@ -333,7 +333,7 @@ exports.mergeSets = function(map, pairs, replaced)
 
       if (oneToManySecondaryMatchElementIds.includes(String(secondaryElement.getElementId().toString())))
       {
-        hoot.debug("Merging one to many tags for " + refElement.getElementId() + " and " + secondaryElement.getElementId() + "...");
+        hoot.trace("Merging one to many tags for " + refElement.getElementId() + " and " + secondaryElement.getElementId() + "...");
         var newTags = hoot.TagMergerFactory.mergeTags(refElement.getTags(), secondaryElement.getTags());
         refElement.setTags(newTags);
         refElement.setStatusString("conflated");
@@ -351,7 +351,7 @@ exports.mergeSets = function(map, pairs, replaced)
       }
     }
   }
-  hoot.debug("oneToManyMergeOccurred: " + oneToManyMergeOccurred);
+  hoot.trace("oneToManyMergeOccurred: " + oneToManyMergeOccurred);
 
   // *Think* this is the correct behavior...if we had any many to one merges earlier during this
   // merge call, then we shouldn't have any other types of merges to perform...not sure yet, though.
@@ -360,7 +360,7 @@ exports.mergeSets = function(map, pairs, replaced)
     // If its not a one to many match, business as usual...use the conflation behavior built into
     // the linear merger in use. Snap the ways in the second input to the first input. Use the
     // default tag merge method.
-    hoot.debug("Performing linear merge...");
+    hoot.trace("Performing linear merge...");
     // Go back to the original default tag merger.
     hoot.set({'tag.merger.default': defaultTagMerger});
     return new hoot.LinearMerger().apply(sublineStringMatcher, map, pairs, replaced, exports.baseFeatureType);

--- a/rules/Railway.js
+++ b/rules/Railway.js
@@ -132,7 +132,7 @@ function geometryMismatch(map, e1, e2, minDistanceScore, minHausdorffDistanceSco
 
 function typeMismatch(e1, e2)
 {
-  // TODO
+  // Don't match passenger rails against rails used internally by the railroad company.
   if (e1.getTags().onlyOneContainsKvp(e2.getTags(), "service=yard"))
   {
     hoot.trace("service=yard mismatch");

--- a/rules/Railway.js
+++ b/rules/Railway.js
@@ -272,6 +272,9 @@ exports.matchScore = function(map, e1, e2)
       oneToManySecondaryMatchElementIds.push(String(e2.getElementId().toString()));
     }
     hoot.trace("oneToManySecondaryMatchElementIds: " + oneToManySecondaryMatchElementIds);
+
+    // Technically, this match should also be labeled as a one to many match, but the script
+    // conflate workflow doesn't require that currently.
   }
   result = { match: 1.0, explain:"match" };
   return result;

--- a/test-files/cases/reference/unifying/highway/highway-5016-1/Config.conf
+++ b/test-files/cases/reference/unifying/highway/highway-5016-1/Config.conf
@@ -2,6 +2,5 @@
   "highway.median.to.dual.highway.match": "true",
   "highway.median.identifying.tags": "median=yes",
   "highway.median.to.dual.highway.transfer.keys": "name",
-  "writer.include.debug.tags": "true",
   "#": "end"
 }

--- a/test-files/cases/reference/unifying/highway/highway-5016-1/Config.conf
+++ b/test-files/cases/reference/unifying/highway/highway-5016-1/Config.conf
@@ -1,0 +1,7 @@
+{
+  "highway.median.to.dual.highway.match": "true",
+  "highway.median.identifying.tags": "median=yes",
+  "highway.median.to.dual.highway.transfer.keys": "name",
+  "writer.include.debug.tags": "true",
+  "#": "end"
+}

--- a/test-files/cases/reference/unifying/highway/highway-5016-1/Expected.osm
+++ b/test-files/cases/reference/unifying/highway/highway-5016-1/Expected.osm
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="38.91162475039" minlon="-77.02384293348" maxlat="38.91237400422" maxlon="-77.02208340436"/>
+    <node visible="true" id="-102485" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9123113927799977" lon="-77.0220834043600036">
+        <tag k="hoot:id" v="-102485"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-102484" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9117019719099986" lon="-77.0237919715000032">
+        <tag k="hoot:id" v="-102484"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-102483" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9122362589800019" lon="-77.0220941331999995">
+        <tag k="hoot:id" v="-102483"/>
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-102482" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9116247503899970" lon="-77.0238000181300038">
+        <tag k="hoot:id" v="-102482"/>
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-102480" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9123740042199984" lon="-77.0220968154099950">
+        <tag k="hoot:id" v="-102480"/>
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-102479" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9117645838800001" lon="-77.0238429334799974">
+        <tag k="hoot:id" v="-102479"/>
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <way visible="true" id="-102004" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-102484"/>
+        <nd ref="-102485"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="highway" v="primary"/>
+        <tag k="hoot:id" v="-102004"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:way:node:count" v="2"/>
+        <tag k="length" v="162.8"/>
+        <tag k="median" v="yes"/>
+        <tag k="name" v="Awesome Road"/>
+        <tag k="note" v="Component of Dual Carriageway; traffic flowing in one direction"/>
+        <tag k="seasonal" v="no"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source" v="DigitalGlobe"/>
+        <tag k="source:datetime" v="2021-08-30 19:03:11"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:imagery:datetime" v="2021-08-30 19:03:11"/>
+        <tag k="source:imagery:id" v="6cf8fbe6d6893920154edabe8a0d7237"/>
+        <tag k="source:imagery:layerName" v="Maxar Basemap +Vivid"/>
+        <tag k="source:imagery:sensor" v="WV01"/>
+        <tag k="surface" v="paved"/>
+    </way>
+    <way visible="true" id="-102003" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-102482"/>
+        <nd ref="-102483"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="highway" v="primary"/>
+        <tag k="hoot:id" v="-102003"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="hoot:way:node:count" v="2"/>
+        <tag k="length" v="162.7"/>
+        <tag k="name" v="Awesome Road"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:imagery:datetime" v="2021-08-30 19:03:11"/>
+        <tag k="source:imagery:id" v="6cf8fbe6d6893920154edabe8a0d7237"/>
+        <tag k="source:imagery:layerName" v="Maxar Basemap +Vivid"/>
+        <tag k="source:imagery:sensor" v="WV01"/>
+    </way>
+    <way visible="true" id="-102002" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-102479"/>
+        <nd ref="-102480"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="highway" v="primary"/>
+        <tag k="hoot:id" v="-102002"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="hoot:way:node:count" v="2"/>
+        <tag k="length" v="165.8"/>
+        <tag k="name" v="Awesome Road"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source:imagery" v="DigitalGlobe"/>
+        <tag k="source:imagery:datetime" v="2021-08-30 19:03:11"/>
+        <tag k="source:imagery:id" v="6cf8fbe6d6893920154edabe8a0d7237"/>
+        <tag k="source:imagery:layerName" v="Maxar Basemap +Vivid"/>
+        <tag k="source:imagery:sensor" v="WV01"/>
+    </way>
+</osm>

--- a/test-files/cases/reference/unifying/highway/highway-5016-1/Expected.osm
+++ b/test-files/cases/reference/unifying/highway/highway-5016-1/Expected.osm
@@ -1,38 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.91162475039" minlon="-77.02384293348" maxlat="38.91237400422" maxlon="-77.02208340436"/>
-    <node visible="true" id="-102485" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9123113927799977" lon="-77.0220834043600036">
-        <tag k="hoot:id" v="-102485"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-102484" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9117019719099986" lon="-77.0237919715000032">
-        <tag k="hoot:id" v="-102484"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-102483" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9122362589800019" lon="-77.0220941331999995">
-        <tag k="hoot:id" v="-102483"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-102482" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9116247503899970" lon="-77.0238000181300038">
-        <tag k="hoot:id" v="-102482"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-102480" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9123740042199984" lon="-77.0220968154099950">
-        <tag k="hoot:id" v="-102480"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-102479" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9117645838800001" lon="-77.0238429334799974">
-        <tag k="hoot:id" v="-102479"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
+    <node visible="true" id="-102485" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9123113927799977" lon="-77.0220834043600036"/>
+    <node visible="true" id="-102484" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9117019719099986" lon="-77.0237919715000032"/>
+    <node visible="true" id="-102483" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9122362589800019" lon="-77.0220941331999995"/>
+    <node visible="true" id="-102482" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9116247503899970" lon="-77.0238000181300038"/>
+    <node visible="true" id="-102480" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9123740042199984" lon="-77.0220968154099950"/>
+    <node visible="true" id="-102479" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.9117645838800001" lon="-77.0238429334799974"/>
     <way visible="true" id="-102004" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-102484"/>
         <nd ref="-102485"/>
         <tag k="error:circular" v="15"/>
         <tag k="highway" v="primary"/>
-        <tag k="hoot:id" v="-102004"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="hoot:way:node:count" v="2"/>
         <tag k="length" v="162.8"/>
         <tag k="median" v="yes"/>
         <tag k="name" v="Awesome Road"/>
@@ -53,9 +32,6 @@
         <nd ref="-102483"/>
         <tag k="error:circular" v="15"/>
         <tag k="highway" v="primary"/>
-        <tag k="hoot:id" v="-102003"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:way:node:count" v="2"/>
         <tag k="length" v="162.7"/>
         <tag k="name" v="Awesome Road"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
@@ -70,9 +46,6 @@
         <nd ref="-102480"/>
         <tag k="error:circular" v="15"/>
         <tag k="highway" v="primary"/>
-        <tag k="hoot:id" v="-102002"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="hoot:way:node:count" v="2"/>
         <tag k="length" v="165.8"/>
         <tag k="name" v="Awesome Road"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>

--- a/test-files/cases/reference/unifying/highway/highway-5016-1/Input1.osm
+++ b/test-files/cases/reference/unifying/highway/highway-5016-1/Input1.osm
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-102479' action='modify' visible='true' lat='38.91176458388' lon='-77.02384293348' />
+  <node id='-102480' action='modify' visible='true' lat='38.91237400422' lon='-77.02209681541' />
+  <node id='-102482' action='modify' visible='true' lat='38.91162475039' lon='-77.02380001813' />
+  <node id='-102483' action='modify' visible='true' lat='38.91223625898' lon='-77.0220941332' />
+  <way id='-102002' action='modify' visible='true'>
+    <nd ref='-102479' />
+    <nd ref='-102480' />
+    <tag k='highway' v='primary' />
+    <tag k='length' v='165.8' />
+    <tag k='security:classification' v='UNCLASSIFIED' />
+    <tag k='source:imagery' v='DigitalGlobe' />
+    <tag k='source:imagery:datetime' v='2021-08-30 19:03:11' />
+    <tag k='source:imagery:id' v='6cf8fbe6d6893920154edabe8a0d7237' />
+    <tag k='source:imagery:layerName' v='Maxar Basemap +Vivid' />
+    <tag k='source:imagery:sensor' v='WV01' />
+  </way>
+  <way id='-102003' action='modify' visible='true'>
+    <nd ref='-102482' />
+    <nd ref='-102483' />
+    <tag k='highway' v='primary' />
+    <tag k='length' v='162.7' />
+    <tag k='security:classification' v='UNCLASSIFIED' />
+    <tag k='source:imagery' v='DigitalGlobe' />
+    <tag k='source:imagery:datetime' v='2021-08-30 19:03:11' />
+    <tag k='source:imagery:id' v='6cf8fbe6d6893920154edabe8a0d7237' />
+    <tag k='source:imagery:layerName' v='Maxar Basemap +Vivid' />
+    <tag k='source:imagery:sensor' v='WV01' />
+  </way>
+</osm>

--- a/test-files/cases/reference/unifying/highway/highway-5016-1/Input2.osm
+++ b/test-files/cases/reference/unifying/highway/highway-5016-1/Input2.osm
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-98980777' action='modify' visible='true' lat='38.91170197191' lon='-77.0237919715' />
+  <node id='-98980778' action='modify' visible='true' lat='38.91231139278' lon='-77.02208340436' />
+  <way id='-98884337' action='modify' visible='true'>
+    <nd ref='-98980777' />
+    <nd ref='-98980778' />
+    <tag k='highway' v='primary' />
+    <tag k='length' v='162.8' />
+    <tag k='median' v='yes' />
+    <tag k='name' v='Awesome Road' />
+    <tag k='note' v='Component of Dual Carriageway; traffic flowing in one direction' />
+    <tag k='seasonal' v='no' />
+    <tag k='security:classification' v='UNCLASSIFIED' />
+    <tag k='source' v='DigitalGlobe' />
+    <tag k='source:datetime' v='2021-08-30 19:03:11' />
+    <tag k='source:imagery' v='DigitalGlobe' />
+    <tag k='source:imagery:datetime' v='2021-08-30 19:03:11' />
+    <tag k='source:imagery:id' v='6cf8fbe6d6893920154edabe8a0d7237' />
+    <tag k='source:imagery:layerName' v='Maxar Basemap +Vivid' />
+    <tag k='source:imagery:sensor' v='WV01' />
+    <tag k='surface' v='paved' />
+  </way>
+</osm>

--- a/test-files/cases/reference/unifying/highway/highway-5016-1/README.txt
+++ b/test-files/cases/reference/unifying/highway/highway-5016-1/README.txt
@@ -1,0 +1,2 @@
+This is a test of transferring secondary road median tags over to reference divided roads. The name
+tag in the single secondary road should transfer over to both reference roads.


### PR DESCRIPTION
Road median to divided road conflation lets you match a secondary road median to the reference divided roads it sits between and transfer selected tags from the median over to the divided roads. This workflow is available when using the Unifying Algorithm only. It has been tested with the Reference Conflation workflow only but may work with other workflows. 

It can be enabled from the UI advanced options with: "Enable custom secondary road median to reference divided road feature matching" (`highway.median.to.dual.highway.match`). Once enabled, it will identify secondary road features as those possessing tags found in the option: "Tag keys allowing for a tag transfer from secondary road medians to reference divided roads" (`highway.median.identifying.tags`). The tags transferred are controlled by the option: "Tag keys to transfer from secondary road medians to reference divided roads" (`highway.median.to.dual.highway.transfer.keys`). *No geometry merging occurs in this workflow* and the secondary feature is preserved.

Notes:

* While the medians are identified via tag, there isn't any identification going on currently for the divided roads (i.e. look for `oneway=yes`). That may need to change.