### PR TITLE
updating y18n to the latest version

### DIFF
--- a/translations/package-lock.json
+++ b/translations/package-lock.json
@@ -4000,9 +4000,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
     },
     "yallist": {


### PR DESCRIPTION
I wanted to update y18n to the latest version since older versions are vulnerable to Prototype Pollution. Affecting y18n package, versions <3.2.2 || >=4.0.0 <4.0.1 || >=5.0.0 <5.0.5

PoC:
```
const y18n = require('y18n')();
 
y18n.setLocale('__proto__');
y18n.updateLocale({polluted: true});

console.log(polluted); // true

```
**Remote Code Execution:**
Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.
For example: eval(someobject.someattr). In this case, if the attacker pollutes Object.prototype.someattr they are likely to be able to leverage this in order to execute code.