### PR TITLE
Fix build - Google Chrome issue

### DIFF
--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -81,6 +81,7 @@ else
          gdal \
          gdal-devel \
          gdal-python-tools \
+         google-chrome-stable \
          libgeotiff \
          libgeotiff-devel \
          liboauthcpp \
@@ -105,6 +106,7 @@ sudo yum install -y \
      gdal-$GDAL_VERSION \
      gdal-devel-$GDAL_VERSION \
      gdal-python-tools-$GDAL_VERSION \
+     google-chrome-stable-$GOOGLE_CHROME_VERSION \
      libgeotiff-$LIBGEOTIFF_VERSION \
      libgeotiff-devel-$LIBGEOTIFF_VERSION \
      libphonenumber-$LIBPHONENUMBER_VERSION \
@@ -128,6 +130,7 @@ sudo yum versionlock add \
      gdal-$GDAL_VERSION \
      gdal-devel-$GDAL_VERSION \
      gdal-python-tools-$GDAL_VERSION \
+     google-chrome-stable-$GOOGLE_CHROME_VERSION \
      libgeotiff-$LIBGEOTIFF_VERSION \
      libgeotiff-devel-$LIBGEOTIFF_VERSION \
      libphonenumber-$LIBPHONENUMBER_VERSION \
@@ -266,7 +269,6 @@ bundle install
 cd ~
 
 # Install Google Chrome and ChromeDriver.
-$HOOT_HOME/scripts/chrome/chrome-install.sh
 $HOOT_HOME/scripts/chrome/driver-install.sh
 
 # Configure PostgreSQL

--- a/VagrantProvisionVars.sh
+++ b/VagrantProvisionVars.sh
@@ -5,11 +5,13 @@ export JDK_URL=http://download.oracle.com/otn-pub/java/jdk/8u161-b12/2f38c3b165b
 export JDK_TAR=jdk-8u161-linux-x64.tar.gz
 export JDK_MD5=99051574a0d90871ed24a91a5d321ed2
 
+# Hoot deps library versions
 export GLPK_VERSION=4.64
 export LIBOAUTHCPP_VERSION=0.1.0
 export LIBPHONENUMBER_VERSION=8.12.27
 export NODE_VERSION=14.16.1
 export STXXL_VERSION=1.3.1
+export GOOGLE_CHROME_VERSION=91.0.4472.114
 
 # Geoint deps library versions
 export ARMADILLO_VERSION=8.600.1

--- a/scripts/chrome/chrome-install.sh
+++ b/scripts/chrome/chrome-install.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+# Chrome has out grown CentOS 7 and can't install the current stable anymore
+exit
+
 CHROME_BASE_URL=https://dl.google.com/linux/direct
 CHROME_DEB=google-chrome-stable_current_amd64.deb
 CHROME_DEB_URL=$CHROME_BASE_URL/$CHROME_DEB


### PR DESCRIPTION
Install google chrome from hoot-deps instead of the latest which doesn't work in CentOS 7 anymore