### PR TITLE
StringUtils::insertAfter throws an exception (#5130)

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/util/StringUtilsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/util/StringUtilsTest.cpp
@@ -36,6 +36,7 @@ class StringUtilsTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(StringUtilsTest);
   CPPUNIT_TEST(runHasAlphabeticCharTest);
+  CPPUNIT_TEST(insertAfterTest);
   CPPUNIT_TEST(jsonParseTest);
   CPPUNIT_TEST_SUITE_END();
 
@@ -52,6 +53,19 @@ public:
     CPPUNIT_ASSERT(StringUtils::hasAlphabeticCharacter(" か しきあん"));
     CPPUNIT_ASSERT(!StringUtils::hasAlphabeticCharacter(""));
     CPPUNIT_ASSERT(!StringUtils::hasAlphabeticCharacter("  "));
+  }
+
+  void insertAfterTest()
+  {
+    // this should not
+    QStringList list("foo");
+    CPPUNIT_ASSERT(StringUtils::insertAfter(list, "foo", "bar"));
+    HOOT_STR_EQUALS(list, "[2]{foo, bar}");
+
+    // this should not insert bar a second time.
+    QStringList list2 = {"foo", "bar"};
+    CPPUNIT_ASSERT(!StringUtils::insertAfter(list2, "foo", "bar"));
+    HOOT_STR_EQUALS(list2, "[2]{foo, bar}");
   }
 
   void jsonParseTest()

--- a/hoot-core/src/main/cpp/hoot/core/util/StringUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/StringUtils.cpp
@@ -375,7 +375,7 @@ bool StringUtils::insertAfter(
     return false;
   }
 
-  if (strList.at(beforeIndex + 1) != strToInsert)
+  if (beforeIndex == strList.count() - 1 || strList.at(beforeIndex + 1) != strToInsert)
   {
     strList.insert(beforeIndex + 1, strToInsert);
     return true;


### PR DESCRIPTION
#5130 

* Fix error and add unit test