### PR TITLE
Fix `make clean-all`

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -40,10 +40,10 @@ $(HOME)/.asciidoc/filters/gnuplot/gnuplot-filter.conf: filters/gnuplot/gnuplot-f
 	cp filters/gnuplot/* $(HOME)/.asciidoc/filters/gnuplot/
 
 clean: clean-schema
-	rm -rf tmp *.pdf *.png *.html *-docinfo.xml restDocs developer/CoreAPI schema.asciidoc 
+	rm -rf tmp *.html *-docinfo.xml restDocs developer/CoreAPI
 	
 clean-schema:
-	rm -f schema.png schema.dot
+	rm -f schema.dot
 
 node_modules:
 	npm install --silent xml2js htmlparser imagemagick mocha@1.20.1 express@3.1.2 async html-to-text restler


### PR DESCRIPTION
Certain doc files have been added to the repo and shouldn't get deleted now during 'clean-all'