### PR TITLE
Improve `merge.nearby.nodes` settings for UI

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -2653,14 +2653,6 @@ vs
 ...
 -----
 
-=== json.merge.nearby.nodes.convert
-
-* Data Type: bool
-* Default Value: `true`
-
-Insert, if not already specified, the `DuplicateNodeRemover` operation into the
-`convert.ops` list of operations for all JSON and GeoJSON inputs.
-
 === json.output.tasking.manager.aoi
 
 * Data Type: bool
@@ -3501,6 +3493,21 @@ If false, in order for a relation to be deemed not conflatable all of its member
 conflatable. If true, a relation can be deemed not conflatable even if any of its members are also
 conflatable.
 
+=== non.osm.convert.merge.nearby.nodes
+
+* Data Type: bool
+* Default Value: `true`
+
+Merges nearby nodes together when converting from a non-OSM format to OSM.
+
+=== non.osm.convert.simplify.complex.buildings
+
+* Data Type: bool
+* Default Value: `false`
+
+Implicitly merges certain individual building parts into a single part when converting from a non-OSM
+format to OSM.
+
 === offset.intersection.max
 
 * Data Type: double
@@ -3789,21 +3796,6 @@ hoot convert \
   test-files/io/SampleTranslation.osm \
   PG:"dbname='osm_gis2' host='localhost' port='5432' user='hoot' password='hoottest'"
 ----
-
-=== ogr2osm.merge.nearby.nodes
-
-* Data Type: bool
-* Default Value: `true`
-
-Merges nearby nodes together when converting from an OGR format to OSM.
-
-=== ogr2osm.simplify.complex.buildings
-
-* Data Type: bool
-* Default Value: `false`
-
-Implicitly merges certain individual building parts into a single part when converting from an OGR
-format to OSM.
 
 === osmapidb.bulk.inserter.disable.database.constraints.during.write
 

--- a/conf/services/importTypes.json
+++ b/conf/services/importTypes.json
@@ -1,8 +1,8 @@
 {
   "Import": {
     "members": {
-      "ogr2osm.simplify.complex.buildings": "Simplify Complex Buildings",
-      "ogr2osm.merge.nearby.nodes": "Remove Duplicate Nodes",
+      "non.osm.convert.simplify.complex.buildings": "Simplify Complex Buildings",
+      "non.osm.convert.merge.nearby.nodes": "Remove Duplicate Nodes",
       "duplicate.node.remover.distance.threshold": "Remove Duplicate Nodes Distance Threshold (meters)"
     }
   }

--- a/docs/user/Translation.asciidoc
+++ b/docs/user/Translation.asciidoc
@@ -681,9 +681,8 @@ The astute reader may notice that a new way was created during this process. The
 [[Disabling-Complex-Buildings]]
 *_Disabling Complex Buildings_*
 
-By default the when using the convert command to convert an OGR format to OSM `ogr2osm.simplify.complex.buildings` is enabled.  If you would like to disable the automatic construction of complex buildings from the individual parts then simply set `ogr2osm.simplify.complex.buildings` to false.  For example:
+By default the when using the convert command to convert an OGR format to OSM `non.osm.convert.simplify.complex.buildings` is enabled.  If you would like to disable the automatic construction of complex buildings from the individual parts then simply set `non.osm.convert.simplify.complex.buildings` to false.  For example:
 
 ------
-hoot convert -D schema.translation.script=MyTranslation -D ogr2osm.simplify.complex.buildings=false MyInput.shp MyOutput.osm
+hoot convert -D schema.translation.script=MyTranslation -D non.osm.convert.simplify.complex.buildings=false MyInput.shp MyOutput.osm
 ------
-

--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.cpp
@@ -26,6 +26,7 @@
  */
 #include "DataConverter.h"
 
+//  Hoot
 #include <hoot/core/criterion/ElementCriterion.h>
 #include <hoot/core/elements/MapProjector.h>
 #include <hoot/core/io/ElementCacheLRU.h>
@@ -116,8 +117,8 @@ void DataConverter::convert(const QStringList& inputs, const QString& output)
   const bool isStreamable =
     IoUtils::areValidStreamingOps(_convertOps) && IoUtils::areStreamableIo(inputs, output);
   LOG_VARD(isStreamable);
-  // Running the translator in a separate thread from the writer is an option for OGR, but the I/O
-  // formats must be streamable.
+  //  Running the translator in a separate thread from the writer is an option for OGR, but the I/O
+  //  formats must be streamable.
   if (_translateMultithreaded && IoUtils::isSupportedOgrFormat(output, true) && isStreamable)
     _convertToOgrMT(inputs, output);
   else
@@ -152,27 +153,27 @@ void DataConverter::_validateInput(const QStringList& inputs, const QString& out
   if (output.trimmed().isEmpty())
     throw HootException("No output specified.");
 
-  // I don't think it would be possible for translation to work along with the export columns
-  // specified, as you'd be first changing your column names with the translation and then trying
-  // to export old column names.  If this isn't true, then we could remove this check and allow it.
+  //  I don't think it would be possible for translation to work along with the export columns
+  //  specified, as you'd be first changing your column names with the translation and then trying
+  //  to export old column names.  If this isn't true, then we could remove this check and allow it.
   if (!_translationScript.isEmpty() && _shapeFileColumnsSpecified())
     throw HootException("Cannot specify both a translation and export columns.");
 
-  // We may eventually be able to relax the restriction here of requiring the input be an OSM
-  // format, but since cols were originally only used with osm2shp and there's no evidence of a need
-  // for anything other than an OSM input whe converting to shape, let's keep this check here for
-  // now.
+  //  We may eventually be able to relax the restriction here of requiring the input be an OSM
+  //  format, but since cols were originally only used with osm2shp and there's no evidence of a need
+  //  for anything other than an OSM input whe converting to shape, let's keep this check here for
+  //  now.
   if (_shapeFileColumnsSpecified() && !output.toLower().endsWith(".shp"))
     throw HootException("Columns may only be specified when converting to the shape file format.");
 
-  // Feature read limit currently is only implemented for OGR inputs.
+  //  Feature read limit currently is only implemented for OGR inputs.
   if (_ogrFeatureReadLimit > 0 && !IoUtils::areSupportedOgrFormats(inputs, true))
     throw HootException("Read limit may only be specified when converting OGR inputs.");
 
   if (!IoUtils::isUrl(output))
   {
-    // write the output dir now so we don't get a nasty surprise at the end of a long job that it
-    // can't be written
+    //  Write the output dir now so we don't get a nasty surprise at the end of a long job that it
+    //  can't be written
     IoUtils::writeOutputDir(output);
   }
 }
@@ -181,7 +182,7 @@ void DataConverter::_convert(const QStringList& inputs, const QString& output)
 {
   LOG_DEBUG("_convert");
 
-  // This keeps the status and the tags.
+  //  This keeps the status and the tags.
   conf().set(ConfigOptions::getReaderUseFileStatusKey(), true);
   conf().set(ConfigOptions::getReaderKeepStatusTagKey(), true);
 
@@ -192,15 +193,15 @@ void DataConverter::_convert(const QStringList& inputs, const QString& output)
   else if (!_translationScript.trimmed().isEmpty())
     _handleNonOgrOutputTranslationOpts(inputs);
 
-  // If the translation direction wasn't specified, try to guess it.
+  //  If the translation direction wasn't specified, try to guess it.
   if (!_translationScript.trimmed().isEmpty() && _translationDirection.isEmpty())
   {
     _translationDirection = SchemaUtils::outputFormatToTranslationDirection(output);
-    // This gets read by the TranslationVisitor and cannot be empty.
+    //  This gets read by the TranslationVisitor and cannot be empty.
     conf().set(ConfigOptions::getSchemaTranslationDirectionKey(), _translationDirection);
   }
 
-  // Check to see if all of the i/o can be streamed.
+  //  Check to see if all of the i/o can be streamed.
   const bool isStreamable =
     IoUtils::areValidStreamingOps(_convertOps) && IoUtils::areStreamableIo(inputs, output);
   LOG_VARD(isStreamable);
@@ -212,8 +213,8 @@ void DataConverter::_convert(const QStringList& inputs, const QString& output)
 
 void DataConverter::_convertStreamable(const QStringList& inputs, const QString& output) const
 {
-  // Shape file output currently isn't streamable, so we know we won't see export cols here. If
-  // it is ever made streamable, then we'd have to refactor this and remove the assertion.
+  //  Shape file output currently isn't streamable, so we know we won't see export cols here. If
+  //  it is ever made streamable, then we'd have to refactor this and remove the assertion.
   LOG_VARD(_shapeFileColumnsSpecified());
   assert(!_shapeFileColumnsSpecified());
 
@@ -221,7 +222,7 @@ void DataConverter::_convertStreamable(const QStringList& inputs, const QString&
   int currentTask = 1;
   const float taskWeight = 1.0 / (float)numTasks;
 
-  // stream the i/o
+  //  Stream the i/o
   ElementStreamer(_translationScript).stream(
     inputs, output, _convertOps,
     Progress(
@@ -276,8 +277,8 @@ void DataConverter::_convertMemoryBound(const QStringList& inputs, const QString
   MapProjector::projectToWgs84(map);
   if (output.toLower().endsWith(".shp") && _shapeFileColumnsSpecified())
   {
-    // If the user specified cols, then we want to export them. This requires a separate logic
-    // path from the generic convert logic.
+    //  If the user specified cols, then we want to export them. This requires a separate logic
+    //  path from the generic convert logic.
     _exportToShapeWithCols(output, _shapeFileColumns, map);
   }
   else
@@ -299,7 +300,7 @@ void DataConverter::_exportToShapeWithCols(const QString& output, const QStringL
     OsmMapWriterFactory::createWriter(output);
   std::shared_ptr<ShapefileWriter> shapeFileWriter =
     std::dynamic_pointer_cast<ShapefileWriter>(writer);
-  // Currently there is only one shape file writer, and this is it.
+  //  Currently there is only one shape file writer, and this is it.
   assert(shapeFileWriter.get());
   shapeFileWriter->setColumns(cols);
   shapeFileWriter->open(output);
@@ -312,7 +313,7 @@ void DataConverter::_exportToShapeWithCols(const QString& output, const QStringL
 
 void DataConverter::_fillElementCacheMT(const QString& inputUrl, ElementCachePtr cachePtr, QQueue<ElementPtr>& workQ) const
 {
-  // Setup reader
+  //  Setup reader
   std::shared_ptr<OsmMapReader> reader =
     OsmMapReaderFactory::createReader(inputUrl);
   reader->open(inputUrl);
@@ -324,9 +325,7 @@ void DataConverter::_fillElementCacheMT(const QString& inputUrl, ElementCachePtr
   bool notGeographic = !projection->IsGeographic();
 
   if (notGeographic)
-  {
     visitor.initialize(projection);
-  }
 
   std::shared_ptr<geos::geom::Geometry> bounds = ConfigUtils::getBounds();
   while (streamReader->hasMoreElements())
@@ -336,9 +335,7 @@ void DataConverter::_fillElementCacheMT(const QString& inputUrl, ElementCachePtr
       continue;
 
     if (notGeographic)
-    {
       visitor.visit(pNewElement);
-    }
 
     workQ.enqueue(pNewElement);
     ConstElementPtr constElement(pNewElement);
@@ -371,16 +368,16 @@ void DataConverter::_convertToOgrMT(const QStringList& inputs, const QString& ou
     QString input = file.trimmed();
     LOG_DEBUG("Reading: " << input);
 
-    // Read all elements from an input.
+    //  Read all elements from an input.
     _fillElementCacheMT(input, pElementCache, elementQ);
   }
   LOG_DEBUG("Element Cache Filled");
 
   const QList<ElementVisitorPtr> ops = IoUtils::toStreamingOps(_convertOps);
 
-  // Note the OGR writer is the slowest part of this whole operation, but it's relatively opaque
-  // to us as a 3rd party library. So the best we can do right now is try to translate & write in
-  // parallel.
+  //  Note the OGR writer is the slowest part of this whole operation, but it's relatively opaque
+  //  to us as a 3rd party library. So the best we can do right now is try to translate & write in
+  //  parallel.
 
   // Setup & start translator thread.
   ElementTranslatorThread transThread;
@@ -395,7 +392,7 @@ void DataConverter::_convertToOgrMT(const QStringList& inputs, const QString& ou
   transThread.start();
   LOG_STATUS("Translation thread started...");
 
-  // Setup & start our writer thread.
+  //  Setup & start our writer thread.
   OgrWriterThread writerThread;
   writerThread.setTranslation(_translationScript);
   writerThread.setOutput(output);
@@ -412,47 +409,30 @@ void DataConverter::_convertToOgrMT(const QStringList& inputs, const QString& ou
 
 void DataConverter::_setFromOgrOptions(const QStringList& inputs)
 {
-  // The ordering for these added ops matters. Let's run them after any user specified convert ops
-  // to avoid unnecessary processing time. Also, if any of these ops gets added here, then we never
-  // have a streaming OGR read, since they all require a full map...don't love that...but not sure
-  // what can be done about it.
+  //  The ordering for these added ops matters. Let's run them after any user specified convert ops
+  //  to avoid unnecessary processing time. Also, if any of these ops gets added here, then we never
+  //  have a streaming OGR read, since they all require a full map...don't love that...but not sure
+  //  what can be done about it.
 
-  // Nodes that are very close together but with different IDs present a problem from OGR sources,
-  // so let's merge them together.
-  if (ConfigOptions().getOgr2osmMergeNearbyNodes() &&
-      !_convertOps.contains(DuplicateNodeRemover::className()))
-  {
-    _convertOps.append(DuplicateNodeRemover::className());
-    // Also run dupe way node removal.
-    _convertOps.append(RemoveDuplicateWayNodesVisitor::className());
-  }
+  //  Setup the merge nearby nodes ops
+  _addMergeNearbyNodesOps();
+  //  Setup the building simplification ops
+  _addSimplifyBuildingsOps();
 
-  // Complex building simplification is primarily meant for UFD buildings, commonly read from OGR
-  // sources.
-  if (ConfigOptions().getOgr2osmSimplifyComplexBuildings())
-  {
-    // Building outline updating needs to happen after building part merging, or we can end up with
-    // role verification warnings in JOSM.
-    if (!_convertOps.contains(BuildingPartMergeOp::className()))
-      _convertOps.append(BuildingPartMergeOp::className());
-    if (!_convertOps.contains(BuildingOutlineUpdateOp::className()))
-      _convertOps.append(BuildingOutlineUpdateOp::className());
-  }
-
-  // We require that a translation be present when converting from OGR, since OgrReader is tightly
-  // coupled to the translation logic.
+  //  We require that a translation be present when converting from OGR, since OgrReader is tightly
+  //  coupled to the translation logic.
   QStringList justPaths = inputs;
   IoUtils::ogrPathsAndLayersToPaths(justPaths);
   if (_translationScript.isEmpty() &&
-      // This check doesn't seem to make a lot of sense, so may not be correct. Without it, however,
-      // some conversion test from APIDB to shape file will fail with fewer tags written.
+      //  This check doesn't seem to make a lot of sense, so may not be correct. Without it, however,
+      //  some conversion test from APIDB to shape file will fail with fewer tags written.
       (StringUtils::endsWithAny(justPaths, ".gdb") || StringUtils::endsWithAny(justPaths, ".zip") ||
        FileUtils::anyAreDirs(justPaths)))
   {
     _translationScript = "translations/quick.js";
   }
 
-  // See similar note in _convertToOgr.
+  //  See similar note in _convertToOgr.
   _convertOps.removeAll(SchemaTranslationOp::className());
   _convertOps.removeAll(SchemaTranslationVisitor::className());
   LOG_VARD(_convertOps);
@@ -460,8 +440,8 @@ void DataConverter::_setFromOgrOptions(const QStringList& inputs)
 
 void DataConverter::_setToOgrOptions(const QString& output)
 {
-  // This code path has always assumed translation to OGR and never reads the direction, but let's
-  // warn callers that the opposite direction they specified won't be used.
+  //  This code path has always assumed translation to OGR and never reads the direction, but let's
+  //  warn callers that the opposite direction they specified won't be used.
   if (_translationDirection == "toosm")
   {
     LOG_INFO(
@@ -469,9 +449,9 @@ void DataConverter::_setToOgrOptions(const QString& output)
       "OGR output...");
   }
 
-  // Set a config option so the translation script knows what the output format is. For this,
-  // output format == file extension. We are going to grab everything after the last "." in the
-  // output file name and use it as the file extension.
+  //  Set a config option so the translation script knows what the output format is. For this,
+  //  output format == file extension. We are going to grab everything after the last "." in the
+  //  output file name and use it as the file extension.
   QString outputFormat = "";
   if (output.lastIndexOf(".") > -1)
     outputFormat = output.right(output.size() - output.lastIndexOf(".") - 1).toLower();
@@ -479,58 +459,83 @@ void DataConverter::_setToOgrOptions(const QString& output)
 
   LOG_DEBUG(conf().getString(ConfigOptions::getOgrOutputFormatKey()));
 
-  // Translation for going to OGR is always required and happens in the writer itself. It is not to
-  // be done with convert ops, so let's ignore any translation ops that were specified.
+  //  Translation for going to OGR is always required and happens in the writer itself. It is not to
+  //  be done with convert ops, so let's ignore any translation ops that were specified.
   _convertOps.removeAll(SchemaTranslationOp::className());
   _convertOps.removeAll(SchemaTranslationVisitor::className());
 }
 
 void DataConverter::_handleNonOgrOutputTranslationOpts(const QStringList& inputs)
 {
-  //a previous check was done to make sure both a translation and export cols weren't specified
+  //  A previous check was done to make sure both a translation and export cols weren't specified
   assert(!_shapeFileColumnsSpecified());
 
   //  JSON and GeoJSON files do not share nodes between ways and/or relations so there are duplicates
-  if (ConfigOptions().getJsonMergeNearbyNodesConvert() &&
-      !_convertOps.contains(DuplicateNodeRemover::className()))
+  bool jsonType = false;
+  //  Check all files for JSON and GeoJSON file types
+  for (const auto& filepath : inputs)
   {
-    bool addRemover = false;
-    //  Check all files for JSON and GeoJSON file types
-    for (const auto& filepath : inputs)
+    QString path = filepath.toLower();
+    if (path.endsWith(".json") || path.endsWith(".geojson"))
     {
-      QString path = filepath.toLower();
-      if (path.endsWith(".json") || path.endsWith(".geojson"))
-      {
-        addRemover = true;
-        break;
-      }
-    }
-    if (addRemover)
-    {
-      _convertOps.append(DuplicateNodeRemover::className());
-      // Also run dupe way node removal.
-      _convertOps.append(RemoveDuplicateWayNodesVisitor::className());
+      jsonType = true;
+      break;
     }
   }
+  //  Add the ops if they are set in the settings
+  if (jsonType)
+  {
+    _addMergeNearbyNodesOps();
+    _addSimplifyBuildingsOps();
+  }
 
-  // For non OGR conversions, the translation must be passed in as an operator.
+  //  For non OGR conversions, the translation must be passed in as an operator.
   if (!_convertOps.contains(SchemaTranslationOp::className()) &&
       !_convertOps.contains(SchemaTranslationVisitor::className()))
   {
-    // If a translation script was specified but not the translation op, we'll add auto add the op
-    // as the first conversion operation. If the caller wants the translation done after some
-    // other op, then they need to explicitly add it to the op list. Always adding the visitor
-    // instead of the op, bc its streamable. However, if any other ops in the group aren't
-    // streamable it won't matter anyway.
+    //  If a translation script was specified but not the translation op, we'll add auto add the op
+    //  as the first conversion operation. If the caller wants the translation done after some
+    //  other op, then they need to explicitly add it to the op list. Always adding the visitor
+    //  instead of the op, bc its streamable. However, if any other ops in the group aren't
+    //  streamable it won't matter anyway.
     _convertOps.prepend(SchemaTranslationVisitor::className());
   }
   else if (_convertOps.contains(SchemaTranslationOp::className()))
   {
-    // replacing SchemaTranslationOp with SchemaTranslationVisitor for the reason mentioned above
+    //  Replacing SchemaTranslationOp with SchemaTranslationVisitor for the reason mentioned above
     _convertOps.replaceInStrings(
       SchemaTranslationOp::className(), SchemaTranslationVisitor::className());
   }
   LOG_VARD(_convertOps);
+}
+
+void DataConverter::_addMergeNearbyNodesOps()
+{
+  //  Nodes that are very close together but with different IDs present a problem from OGR sources,
+  //  so let's merge them together.
+  if (ConfigOptions().getNonOsmConvertMergeNearbyNodes())
+  {
+    if (!_convertOps.contains(DuplicateNodeRemover::className()))
+      _convertOps.append(DuplicateNodeRemover::className());
+    //  Also run dupe way node removal.
+    if (!_convertOps.contains(RemoveDuplicateWayNodesVisitor::className()))
+      _convertOps.append(RemoveDuplicateWayNodesVisitor::className());
+  }
+}
+
+void DataConverter::_addSimplifyBuildingsOps()
+{
+  //  Complex building simplification is primarily meant for UFD buildings, commonly read from OGR
+  //  and GeoJSON sources.
+  if (ConfigOptions().getNonOsmConvertSimplifyComplexBuildings())
+  {
+    //  Building outline updating needs to happen after building part merging, or we can end up with
+    //  role verification warnings in JOSM.
+    if (!_convertOps.contains(BuildingPartMergeOp::className()))
+      _convertOps.append(BuildingPartMergeOp::className());
+    if (!_convertOps.contains(BuildingOutlineUpdateOp::className()))
+      _convertOps.append(BuildingOutlineUpdateOp::className());
+  }
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
@@ -29,8 +29,8 @@
 
 // Hoot
 #include <hoot/core/elements/OsmMap.h>
-#include <hoot/core/util/Configurable.h>
 #include <hoot/core/io/ElementCache.h>
+#include <hoot/core/util/Configurable.h>
 #include <hoot/core/util/Progress.h>
 
 // Qt
@@ -99,36 +99,48 @@ private:
 
   void _validateInput(const QStringList& inputs, const QString& output) const;
 
-  /*
+  /**
    * This method handles all non OGR output conversions.
    */
   void _convert(const QStringList& inputs, const QString& output);
-  /*
+  /**
    * streams I/O one feature at a time
    */
   void _convertStreamable(const QStringList& inputs, const QString& output) const;
-  /*
+  /**
    * reads entire input into memory before converting
    */
   void _convertMemoryBound(const QStringList& inputs, const QString& output);
-  // Runs the translator in a separate thread for a performance increase if certain pre-conditions
-  // are met.
+  /**
+   * Runs the translator in a separate thread for a performance increase if certain pre-conditions
+   * are met.
+   */
   void _convertToOgrMT(const QStringList& inputs, const QString& output);
 
-  // sets OGR I/O options for
+  /**
+   *  sets OGR I/O options for conversions to and from OGR formats
+   */
   void _setFromOgrOptions(const QStringList& inputs);
   void _setToOgrOptions(const QString& output);
-  void _handleNonOgrOutputTranslationOpts(const QStringList& inputs);
   QString _outputFormatToTranslationDirection(const QString& output) const;
+
+  /**
+   * Sets I/O options for conversions from non-OGR formats
+   */
+  void _handleNonOgrOutputTranslationOpts(const QStringList& inputs);
+
+  /**
+   * Add option operations to the options if they aren't already set
+   */
+  void _addMergeNearbyNodesOps();
+  void _addSimplifyBuildingsOps();
 
   // If specific columns were specified for export to a shape file, then this is called instaed of
   // using OgrWriter.
-  void _exportToShapeWithCols(
-    const QString& output, const QStringList& cols, const OsmMapPtr& map) const;
+  void _exportToShapeWithCols(const QString& output, const QStringList& cols, const OsmMapPtr& map) const;
   bool _shapeFileColumnsSpecified() const { return !_shapeFileColumns.isEmpty(); }
 
-  void _fillElementCacheMT(
-    const QString& inputUrl, ElementCachePtr cachePtr, QQueue<ElementPtr>& workQ) const;
+  void _fillElementCacheMT(const QString& inputUrl, ElementCachePtr cachePtr, QQueue<ElementPtr>& workQ) const;
 };
 
 }

--- a/hoot-services/src/test/java/hoot/services/controllers/ingest/ImportCommandTest.java
+++ b/hoot-services/src/test/java/hoot/services/controllers/ingest/ImportCommandTest.java
@@ -68,7 +68,7 @@ public class ImportCommandTest {
         List<String> options = new LinkedList<>();
         //options.add("osm2ogr.ops=DecomposeBuildingRelationsVisitor");
         options.add("hootapi.db.writer.overwrite.map=true");
-        options.add("ogr2osm.simplify.complex.buildings=true");
+        options.add("non.osm.convert.simplify.complex.buildings=true");
         options.add("hootapi.db.writer.create.user=true");
         options.add("api.db.email=test@test.com");
         options.add("schema.translation.script=" + translation);
@@ -177,7 +177,7 @@ public class ImportCommandTest {
 
         List<String> options = new LinkedList<>();
         //options.add("osm2ogr.ops=DecomposeBuildingRelationsVisitor");
-        options.add("hootapi.db.writer.overwrite.map=true");options.add("ogr2osm.simplify.complex.buildings=true");
+        options.add("hootapi.db.writer.overwrite.map=true");options.add("non.osm.convert.simplify.complex.buildings=true");
 
         options.add("hootapi.db.writer.create.user=true");
         options.add("api.db.email=test@test.com");

--- a/hoot-test/src/main/cpp/hoot/test/ProcessPool.cpp
+++ b/hoot-test/src/main/cpp/hoot/test/ProcessPool.cpp
@@ -300,7 +300,7 @@ void ProcessPool::addJob(const QString& test, JobType job_type)
     _serialCaseJobs.push(test);
   else if (job_type == SerialJob)
     _serialJobs.push(test);
-  else if (job_type == ConflateJob)
+  else if (job_type == ConflateJob && !_serialCaseJobs.contains(test))
     _caseJobs.push(test);
 }
 


### PR DESCRIPTION
Make a general setting for merge.nearby.nodes and simplify.complex.buildings and apply to OGR and GeoJSON.

@brianhatchl here is the fix.  The new options are:
`non.osm.convert.merge.nearby.nodes` and `non.osm.convert.simplify.complex.buildings`

JSON/GeoJSON conversions now can add building simplification is desired.

Closes #5135 