### PR TITLE
Fix a few minor annoyances tripping out QtCreator

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetTaskGridReplacer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetTaskGridReplacer.cpp
@@ -60,11 +60,11 @@ _tagQualityIssues(false)
 OsmMapPtr ChangesetTaskGridReplacer::replace(
   const QString& toReplace, const QString& replacement, const TaskGrid& taskGrid)
 {
-  if (!toReplace.toLower().startsWith("osmapidb://"))
+  if (!toReplace.startsWith("osmapidb://", Qt::CaseInsensitive))
   {
     throw IllegalArgumentException("Data being replaced must be from an OSM API database.");
   }
-  if (!replacement.toLower().startsWith("hootapidb://"))
+  if (!replacement.startsWith("hootapidb://", Qt::CaseInsensitive))
   {
     throw IllegalArgumentException("Replacement data must be from a Hootenanny API database.");
   }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/NodeDensityTaskGridGenerator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/NodeDensityTaskGridGenerator.cpp
@@ -132,7 +132,7 @@ TaskGrid NodeDensityTaskGridGenerator::_calcNodeDensityTaskGrid(OsmMapPtr map)
 
   const std::vector<std::vector<geos::geom::Envelope>> rawTaskGrid = _boundsCalc.getTiles();
       const std::vector<std::vector<long>> nodeCounts = _boundsCalc.getNodeCounts();
-  if (_output.toLower().endsWith(".geojson"))
+  if (_output.endsWith(".geojson", Qt::CaseInsensitive))
   {
     NodeDensityTaskGridWriter::writeTilesToGeoJson(
       rawTaskGrid, nodeCounts, _output, map->getSource(), _writeRandomCellOnly, _randomSeed);

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonTypeScoreExtractor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/extractors/poi-polygon/PoiPolygonTypeScoreExtractor.cpp
@@ -140,8 +140,8 @@ void PoiPolygonTypeScoreExtractor::_translateTagValue(const QString& tagKey, QSt
   LOG_VART(tagValue);
 
   //don't care about urls
-  if (tagValue.toLower().startsWith("http://") ||
-      tagValue.toLower().startsWith("https://"))
+  if (tagValue.startsWith("http://", Qt::CaseInsensitive) ||
+      tagValue.startsWith("https://", Qt::CaseInsensitive))
   {
     return;
   }

--- a/hoot-core/src/main/cpp/hoot/core/cmd/AlphaShapeCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/AlphaShapeCmd.cpp
@@ -138,11 +138,11 @@ private:
 
   void _writeOutput(const OsmMapPtr& map, const QString& path) const
   {
-    if (path.toLower().endsWith(".shp"))
+    if (path.endsWith(".shp", Qt::CaseInsensitive))
     {
       ShapefileWriter().writePolygons(map, path);
     }
-    else if (path.toLower().endsWith(".geojson"))
+    else if (path.endsWith(".geojson", Qt::CaseInsensitive))
     {
       OsmGeoJsonWriter writer;
       Settings s;

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
@@ -56,7 +56,7 @@ int ConflateCmd::runSimple(QStringList& args)
     displayStats = true;
     const int statsIndex = args.indexOf("--stats");
     if (statsIndex != -1 && statsIndex != (args.size() - 1) &&
-        args[statsIndex + 1].toLower().endsWith(".json"))
+        args[statsIndex + 1].endsWith(".json", Qt::CaseInsensitive))
     {
       outputStatsFile = args[statsIndex + 1];
       args.removeAll(outputStatsFile);

--- a/hoot-core/src/main/cpp/hoot/core/cmd/TaskGridCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/TaskGridCmd.cpp
@@ -309,7 +309,7 @@ private:
 
   void _validateOutput(const QString& output) const
   {
-    if (!output.toLower().endsWith(".geojson") && !output.toLower().endsWith(".osm"))
+    if (!output.endsWith(".geojson", Qt::CaseInsensitive) && !output.endsWith(".osm", Qt::CaseInsensitive))
     {
       throw IllegalArgumentException(
         "Invalid output file format: " + output + ". Only the GeoJSON (.geojson) and OSM " +

--- a/hoot-core/src/main/cpp/hoot/core/conflate/point/PoiSearchRadius.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/point/PoiSearchRadius.cpp
@@ -38,10 +38,10 @@
 namespace hoot
 {
 
-PoiSearchRadius::PoiSearchRadius(QString key, QString val, int distance) :
-_key(key),
-_value(val),
-_distance(distance)
+PoiSearchRadius::PoiSearchRadius(QString key, QString val, int distance)
+  : _key(key),
+    _value(val),
+    _distance(distance)
 {
 }
 
@@ -50,7 +50,7 @@ QList<PoiSearchRadius> PoiSearchRadius::readSearchRadii(const QString& jsonStrin
   LOG_DEBUG("Reading search radii from: " << jsonStringOrFile << "...");
 
   std::shared_ptr<boost::property_tree::ptree> propTree;
-  if (!jsonStringOrFile.toLower().endsWith(".json"))
+  if (!jsonStringOrFile.endsWith(".json", Qt::CaseInsensitive))
   {
     propTree = StringUtils::jsonStringToPropTree(jsonStringOrFile);
   }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/AttributeValueCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/AttributeValueCriterion.cpp
@@ -89,7 +89,7 @@ void AttributeValueCriterion::setConfiguration(const Settings& conf)
   _attributeType = ElementAttributeType::fromString(configOptions.getAttributeValueCriterionType());
   QString comparisonTypeStr =
     configOptions.getAttributeValueCriterionComparisonType().trimmed().toLower();
-  if (comparisonTypeStr.toLower().startsWith("text"))
+  if (comparisonTypeStr.startsWith("text", Qt::CaseInsensitive))
   {
     _comparisonType =
        TextComparisonType(

--- a/hoot-core/src/main/cpp/hoot/core/criterion/TagAdvancedCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/TagAdvancedCriterion.cpp
@@ -72,7 +72,7 @@ void TagAdvancedCriterion::setConfiguration(const Settings& s)
 void TagAdvancedCriterion::_parseFilterString(const QString& filterJsonStringOrPath)
 {
   std::shared_ptr<boost::property_tree::ptree> propTree;
-  if (!filterJsonStringOrPath.toLower().endsWith(".json"))
+  if (!filterJsonStringOrPath.endsWith(".json", Qt::CaseInsensitive))
   {
     propTree = StringUtils::jsonStringToPropTree(filterJsonStringOrPath);
   }

--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.cpp
@@ -163,7 +163,7 @@ void DataConverter::_validateInput(const QStringList& inputs, const QString& out
   //  format, but since cols were originally only used with osm2shp and there's no evidence of a need
   //  for anything other than an OSM input whe converting to shape, let's keep this check here for
   //  now.
-  if (_shapeFileColumnsSpecified() && !output.toLower().endsWith(".shp"))
+  if (_shapeFileColumnsSpecified() && !output.endsWith(".shp", Qt::CaseInsensitive))
     throw HootException("Columns may only be specified when converting to the shape file format.");
 
   //  Feature read limit currently is only implemented for OGR inputs.
@@ -275,7 +275,7 @@ void DataConverter::_convertMemoryBound(const QStringList& inputs, const QString
     (float)(currentTask - 1) / (float)numTasks,
     "Writing map: ..." + FileUtils::toLogFormat(output, _printLengthMax) + "...");
   MapProjector::projectToWgs84(map);
-  if (output.toLower().endsWith(".shp") && _shapeFileColumnsSpecified())
+  if (output.endsWith(".shp", Qt::CaseInsensitive) && _shapeFileColumnsSpecified())
   {
     //  If the user specified cols, then we want to export them. This requires a separate logic
     //  path from the generic convert logic.

--- a/hoot-core/src/main/cpp/hoot/core/io/GeoNamesReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/GeoNamesReader.cpp
@@ -66,7 +66,7 @@ bool GeoNamesReader::isSupported(const QString& url) const
 {
   QString path = QDir().absoluteFilePath(url);
   QFile f(path);
-  bool result = path.toLower().endsWith(".geonames") && f.exists();
+  bool result = path.endsWith(".geonames", Qt::CaseInsensitive) && f.exists();
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/IoUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/IoUtils.cpp
@@ -86,18 +86,18 @@ bool IoUtils::isSupportedOgrFormat(const QString& input, const bool allowDir)
   if (QFileInfo(justPath).isDir())
   {
     return
-      justPath.toLower().endsWith(".gdb") ||
+      justPath.endsWith(".gdb", Qt::CaseInsensitive) ||
       FileUtils::dirContainsFileWithExtension(QFileInfo(input).dir(), "shp");
   }
   // single input
   else
   {
     // The only zip file format we support are ones containing OGR inputs.
-    if (justPath.toLower().endsWith(".zip") ||
+    if (justPath.endsWith(".zip") ||
         // We only support this type of postgres URL for OGR inputs.
-        justPath.toLower().startsWith("pg:") ||
+        justPath.startsWith("pg:", Qt::CaseInsensitive) ||
         // Or, OGDI Vectors. Things like VPF (DNC, VMAP etc)
-        justPath.toLower().startsWith("gltp:"))
+        justPath.startsWith("gltp:", Qt::CaseInsensitive))
     {
       return true;
     }

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.cpp
@@ -147,7 +147,7 @@ std::shared_ptr<GDALDataset> OgrUtilities::createDataSource(const QString& url) 
     throw HootException("Error getting driver by name: " + QString(driverInfo._driverName));
 
   // If the user specifies a shapefile, then crop off the .shp and create a directory.
-  if (url.toLower().endsWith(".shp"))
+  if (url.endsWith(".shp", Qt::CaseInsensitive))
     source = url.mid(0, url.length() - 4);
 
   std::shared_ptr<GDALDataset> result(driver->Create(source.toLatin1(), 0, 0, 0, GDT_Unknown, nullptr));

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbBulkInserter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbBulkInserter.cpp
@@ -73,7 +73,7 @@ bool OsmApiDbBulkInserter::isSupported(const QString& urlStr) const
   QUrl url(urlStr);
   //if we ever want any other writers that the convert command invokes to output sql, then
   //this will have to be made more specific
-  return urlStr.toLower().endsWith(".sql") || _database.isSupported(url);
+  return urlStr.endsWith(".sql", Qt::CaseInsensitive) || _database.isSupported(url);
 }
 
 void OsmApiDbBulkInserter::open(const QString& url)
@@ -194,7 +194,7 @@ void OsmApiDbBulkInserter::_verifyOutputCopySettings() const
   if (_destinationIsDatabase() && !_outputFilesCopyLocation.isEmpty())
   {
     QFileInfo outputCopyLocationInfo(_outputFilesCopyLocation);
-    if (!outputCopyLocationInfo.completeSuffix().toLower().endsWith("sql"))
+    if (!outputCopyLocationInfo.completeSuffix().endsWith("sql", Qt::CaseInsensitive))
     {
       throw HootException(
         QString("Output file copy location should be set to a SQL file (.sql) when using the ") +
@@ -425,7 +425,7 @@ void OsmApiDbBulkInserter::finalizePartial()
 
 bool OsmApiDbBulkInserter::_destinationIsDatabase() const
 {
-  return _outputUrl.toLower().startsWith(MetadataTags::OsmApiDbScheme() + "://");
+  return _outputUrl.startsWith(MetadataTags::OsmApiDbScheme() + "://", Qt::CaseInsensitive);
 }
 
 void OsmApiDbBulkInserter::_writeDataToDbPsql()

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetFileWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetFileWriter.cpp
@@ -597,7 +597,7 @@ void OsmApiDbSqlChangesetFileWriter::_createTags(ConstElementPtr element)
     {
       if (metadataAlwaysIgnore.contains(key))
         continue;
-      else if (!_includeDebugTags && key.toLower().startsWith("hoot:") &&
+      else if (!_includeDebugTags && key.startsWith("hoot:", Qt::CaseInsensitive) &&
                // There are some instances where we want to explicitly allow some metadata tags.
                !_metadataAllowKeys.contains(key))
         continue;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxJsonWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxJsonWriter.h
@@ -64,7 +64,7 @@ public:
    * @param url Filename ending in ".gbdx"
    * @return
    */
-  bool isSupported(const QString& url) const override { return url.toLower().endsWith(".gbdx"); }
+  bool isSupported(const QString& url) const override { return url.endsWith(".gbdx", Qt::CaseInsensitive); }
 
   QString supportedFormats() const override { return ".gdbx"; }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxXmlWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxXmlWriter.h
@@ -49,7 +49,7 @@ public:
   OsmGbdxXmlWriter();
   ~OsmGbdxXmlWriter() override;
 
-  bool isSupported(const QString& url) const override { return url.toLower().endsWith(".gxml"); }
+  bool isSupported(const QString& url) const override { return url.endsWith(".gxml", Qt::CaseInsensitive); }
   QString supportedFormats() const override { return ".gxml"; }
   void open(const QString& url) override;
   void close() override;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonWriter.h
@@ -64,7 +64,7 @@ public:
    * @param url Filename ending in ".geojson"
    * @return
    */
-  bool isSupported(const QString& url) const override { return url.toLower().endsWith(".geojson"); }
+  bool isSupported(const QString& url) const override { return url.endsWith(".geojson", Qt::CaseInsensitive); }
   QString supportedFormats() const override { return ".geojson"; }
 
   QString toString(const ConstOsmMapPtr& map);

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonWriter.h
@@ -57,7 +57,7 @@ public:
 
   void setConfiguration(const Settings& conf) override;
 
-  bool isSupported(const QString& url) const override { return url.toLower().endsWith(".json"); }
+  bool isSupported(const QString& url) const override { return url.endsWith(".json", Qt::CaseInsensitive); }
   void open(const QString& url) override;
   virtual void close() { if (_fp.isOpen()) { _fp.close(); } }
   void write(const ConstOsmMapPtr& map) override;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapWriterFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapWriterFactory.cpp
@@ -183,7 +183,7 @@ void OsmMapWriterFactory::writeDebugMap(
         StringUtils::matchesWildcard(callingClass, includeClassFilter))
     {
       QString debugMapFileName = ConfigOptions().getDebugMapsFilename();
-      if (!debugMapFileName.toLower().endsWith(".osm"))
+      if (!debugMapFileName.endsWith(".osm", Qt::CaseInsensitive))
       {
         throw IllegalArgumentException("Debug maps must be written to an .osm file.");
       }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfReader.cpp
@@ -1195,7 +1195,7 @@ bool OsmPbfReader::isSupported(const QString& urlStr) const
   return
     //there is actually some test data that ends in .pbf instead of .osm.pbf, so allowing that
     //extension too for now
-    input.exists() && (urlStr.toLower().endsWith(".osm.pbf") || urlStr.toLower().endsWith(".pbf"));
+    input.exists() && (urlStr.endsWith(".osm.pbf", Qt::CaseInsensitive) || urlStr.endsWith(".pbf", Qt::CaseInsensitive));
 }
 
 bool OsmPbfReader::isSorted(const QString& file)

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfWriter.h
@@ -75,7 +75,7 @@ public:
   void finalizePartial() override;
 
   void initializePartial() override;
-  bool isSupported(const QString& url) const override { return url.toLower().endsWith("osm.pbf"); }
+  bool isSupported(const QString& url) const override { return url.endsWith("osm.pbf", Qt::CaseInsensitive); }
   void open(const QString& url) override;
   void close() override;
   QString supportedFormats() const override { return ".osm.pbf"; }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPgCsvWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPgCsvWriter.h
@@ -50,7 +50,7 @@ public:
    * @param url Filename ending in ".pgcsv"
    * @return
    */
-  bool isSupported(const QString& url) const override { return url.toLower().endsWith(".pgcsv"); }
+  bool isSupported(const QString& url) const override { return url.endsWith(".pgcsv", Qt::CaseInsensitive); }
   /**
    * @brief supportedFormats
    * @return

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlChangesetFileWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlChangesetFileWriter.cpp
@@ -505,7 +505,7 @@ void OsmXmlChangesetFileWriter::_writeTags(QXmlStreamWriter& writer, Tags& tags,
     {
       if (metadataAlwaysIgnore.contains(key))
         continue;
-      else if (!_includeDebugTags && key.toLower().startsWith("hoot:") &&
+      else if (!_includeDebugTags && key.startsWith("hoot:", Qt::CaseInsensitive) &&
                // There are some instances where we want to explicitly allow some metadata tags.
                !_metadataAllowKeys.contains(key))
         continue;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlChangesetFileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlChangesetFileWriter.h
@@ -80,7 +80,7 @@ public:
   /**
    * @see ChangesetFileWriter
    */
-  bool isSupported(const QString& output) const override { return output.endsWith(".osc"); }
+  bool isSupported(const QString& output) const override { return output.endsWith(".osc", Qt::CaseInsensitive); }
 
   void setConfiguration(const Settings &conf) override;
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.h
@@ -50,7 +50,7 @@ public:
   OsmXmlWriter();
   ~OsmXmlWriter() override;
 
-  bool isSupported(const QString& url) const override { return url.toLower().endsWith(".osm"); }
+  bool isSupported(const QString& url) const override { return url.endsWith(".osm", Qt::CaseInsensitive); }
   void open(const QString& url) override;
   void close() override;
   QString supportedFormats() const override { return ".osm"; }

--- a/hoot-core/src/main/cpp/hoot/core/io/ShapefileWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ShapefileWriter.cpp
@@ -161,7 +161,7 @@ void ShapefileWriter::_removeShapefile(const QString& path) const
 void ShapefileWriter::write(const ConstOsmMapPtr& map, const QString& path)
 {
   QString tempPath = path;
-  if (tempPath.toLower().endsWith(".shp"))
+  if (tempPath.endsWith(".shp", Qt::CaseInsensitive))
   {
     tempPath.remove(tempPath.size() - 4, tempPath.size());
   }

--- a/hoot-core/src/main/cpp/hoot/core/io/ShapefileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ShapefileWriter.h
@@ -53,7 +53,7 @@ public:
    */
   void setConfiguration(const Settings& conf) override;
 
-  bool isSupported(const QString& url) const override { return url.toLower().endsWith(".shp"); }
+  bool isSupported(const QString& url) const override { return url.endsWith(".shp", Qt::CaseInsensitive); }
   void open(const QString& url) override;
   /**
    * Will write out up to three files:

--- a/hoot-core/src/main/cpp/hoot/core/util/DbUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/DbUtils.cpp
@@ -166,12 +166,12 @@ bool DbUtils::isDbUrl(const QString& url)
 
 bool DbUtils::isHootApiDbUrl(const QString& url)
 {
-  return url.toLower().startsWith(MetadataTags::HootApiDbScheme() + "://");
+  return url.startsWith(MetadataTags::HootApiDbScheme() + "://", Qt::CaseInsensitive);
 }
 
 bool DbUtils::isOsmApiDbUrl(const QString& url)
 {
-  return url.toLower().startsWith(MetadataTags::OsmApiDbScheme() + "://");
+  return url.startsWith(MetadataTags::OsmApiDbScheme() + "://", Qt::CaseInsensitive);
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/util/FileUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/FileUtils.cpp
@@ -185,7 +185,7 @@ bool FileUtils::dirContainsFileWithExtension(const QDir& dir, const QString& ext
   const QStringList files = dir.entryList();
   for (int i = 0; i < files.size(); i++)
   {
-    if (files.at(i).toLower().endsWith(ext))
+    if (files.at(i).endsWith(ext, Qt::CaseInsensitive))
     {
       return true;
     }

--- a/hoot-core/src/main/cpp/hoot/core/util/HootException.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/HootException.h
@@ -164,7 +164,7 @@ public: \
   Name(QString str) : HootException(str) { } \
   Name(const Name& e) : HootException(e.getWhat()) { } \
   virtual ~Name() throw() {} \
-  virtual std::shared_ptr<HootException> clone() const { return std::make_shared<Name>(*this); } \
+  std::shared_ptr<HootException> clone() const override { return std::make_shared<Name>(*this); } \
   QString getName() const override { return className(); } \
 };
 
@@ -177,7 +177,7 @@ public: \
   Name(QString str) : HootException(str) { } \
   Name(const Name& e) : HootException(e.getWhat()) { } \
   virtual ~Name() throw() {} \
-  virtual std::shared_ptr<HootException> clone() const { return std::make_shared<Name>(*this); } \
+  std::shared_ptr<HootException> clone() const override { return std::make_shared<Name>(*this); } \
   QString getName() const override { return className(); } \
 };
 

--- a/hoot-js/src/main/cpp/hoot/js/conflate/point/PoiSearchRadiusJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/point/PoiSearchRadiusJs.cpp
@@ -56,14 +56,14 @@ void PoiSearchRadiusJs::Init(Local<Object> exports)
 bool PoiSearchRadiusJs::_searchRadiiOptionIsConfigFile(const QString data)
 {
   return
-    data.toLower().endsWith(".json") && !data.trimmed().startsWith("{") &&
+    data.endsWith(".json", Qt::CaseInsensitive) && !data.trimmed().startsWith("{") &&
     !data.trimmed().endsWith("}");
 }
 
 bool PoiSearchRadiusJs::_searchRadiiOptionIsJsonString(const QString data)
 {
   return
-    !data.toLower().endsWith(".json") && data.trimmed().startsWith("{") &&
+    !data.endsWith(".json", Qt::CaseInsensitive) && data.trimmed().startsWith("{") &&
     data.trimmed().endsWith("}");
 }
 

--- a/hoot-test/src/main/cpp/hoot/test/conflate/optimization/PertyTest.cpp
+++ b/hoot-test/src/main/cpp/hoot/test/conflate/optimization/PertyTest.cpp
@@ -72,7 +72,7 @@ void PertyTest::_parseScore()
     {
       line = inStream.readLine();
       LOG_VART(line);
-      if (line.toLower().startsWith("test run score (averaged)"))
+      if (line.startsWith("test run score (averaged)", Qt::CaseInsensitive))
       {
         _score = line.split(":")[1].trimmed().toDouble();
         LOG_VARD(_score);

--- a/hoot-test/src/main/cpp/hoot/test/conflate/optimization/ReleaseTest.cpp
+++ b/hoot-test/src/main/cpp/hoot/test/conflate/optimization/ReleaseTest.cpp
@@ -77,7 +77,7 @@ void ReleaseTest::_parseScore()
       {
         foundConflatedScoreLine = true;
       }
-      else if (foundConflatedScoreLine && line.toLower().startsWith("overall"))
+      else if (foundConflatedScoreLine && line.startsWith("overall", Qt::CaseInsensitive))
       {
         _score = line.split(" ")[1].trimmed().toDouble();
         LOG_VARD(_score);


### PR DESCRIPTION
Fix `override` in Hoot Exceptions.  Remove instances of `QString::toLower()` that makes an unnecessary copy of the strings that aren't needed.