### PR TITLE
Enable non translation geojson duplicate node remover

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
@@ -127,7 +127,7 @@ private:
   /**
    * Sets I/O options for conversions from non-OGR formats
    */
-  void _handleNonOgrOutputTranslationOpts(const QStringList& inputs);
+  void _handleNonOgrOutputTranslationOpts();
 
   /**
    * Add option operations to the options if they aren't already set

--- a/test-files/cmd/slow/ConvertCmdTest.sh
+++ b/test-files/cmd/slow/ConvertCmdTest.sh
@@ -31,7 +31,7 @@ echo "Dir with no filter to single OSM..."
 echo ""
 # The input dir has duplicated files. Set to not load data source IDs to load in the duplicated 
 # elements. The output should have duplicated features in it.
-hoot convert $LOG_LEVEL $CONFIG -D reader.use.data.source.ids=false $RECURSIVE_INPUT $OUTPUT_DIR/recursive-out-1.osm --recursive "*"
+hoot convert $LOG_LEVEL $CONFIG -D non.osm.convert.merge.nearby.nodes=false -D reader.use.data.source.ids=false $RECURSIVE_INPUT $OUTPUT_DIR/recursive-out-1.osm --recursive "*"
 hoot diff $LOG_LEVEL $CONFIG $INPUT_DIR/recursive-out-1.osm $OUTPUT_DIR/recursive-out-1.osm
 
 echo ""


### PR DESCRIPTION
`DuplicateNodeRemover` was only being called on JSON files when there was a translation script provided.  It needs to be run by default unless turned off.