### PR TITLE
updated vagrantfile and instructions to include NFS option for windows

### DIFF
--- a/docs/install/Vagrant.asciidoc
+++ b/docs/install/Vagrant.asciidoc
@@ -13,6 +13,12 @@ You will also need some Vagrant plugins:
 
     vagrant plugin install vagrant-bindfs vagrant-sshfs
 
+On Windows, an NFS plugin is useful as well as enabling NFS for file sharing between the host and guest VM:
+    # for windows install the winnfsd plugin
+    vagrant plugin install vagrant-winnfsd
+    # and apply the environment variables to use NFS mount file sharing such as this
+    WINNFS=true NFSSHARE=true vagrant up
+
 You may also need to enable hardware virtualization extensions in your BIOS.
 
 ==== Quick Start


### PR DESCRIPTION
In working on Windows, the vagrant file sync between host and guest was pretty rough.  I tried to use OpenSSH's FTP server initially and it was impossibly slow, this NFS plugin was much much better.  For anyone forced to be on Windows I think this should be a bit of an upgrade using a vagrant plugin and an environment variable that switches the mount options to something that works for that plugin (at least I know it must be NFS vers 3, and the rest of the mount options I used were the recommendation).