### PR TITLE
Simplify the coverage generation script

### DIFF
--- a/scripts/cover/coverGcov.sh
+++ b/scripts/cover/coverGcov.sh
@@ -13,53 +13,17 @@ else
     rm -f gcov/*
 fi
 
-# hoot-core coverage
-pushd hoot-core
-gcov -o $HOOT_HOME/hoot-core/tmp/debug/ $HOOT_HOME/hoot-core/tmp/debug/*.gcda
-# fix path
-sed -i "s|0:Source:src|0:Source:$HOOT_HOME/hoot-core/src|g" *.gcov
-mv *.gcov $HOOT_HOME/gcov
-popd
+GCOV_SCAN_PATHS = ( "hoot-core" "tbs" "tgs" "hoot-cmd" "hoot-js" "hoot-josm" )
 
-# tbs coverage
-pushd tbs
-gcov -o $HOOT_HOME/tbs/tmp/debug/ $HOOT_HOME/tbs/tmp/debug/*.gcda
-# fix path
-sed -i "s|0:Source:src|0:Source:$HOOT_HOME/tbs/src|g" *.gcov
-mv *.gcov $HOOT_HOME/gcov
-popd
-
-# tgs coverage
-pushd tgs
-gcov -o $HOOT_HOME/tgs/tmp/debug/ $HOOT_HOME/tgs/tmp/debug/*.gcda
-# fix path
-sed -i "s|0:Source:src|0:Source:$HOOT_HOME/tgs/src|g" *.gcov
-mv *.gcov $HOOT_HOME/gcov
-popd
-
-# hoot-cmd coverage
-pushd tgs
-gcov -o $HOOT_HOME/hoot-cmd/tmp/debug/ $HOOT_HOME/hoot-cmd/tmp/debug/*.gcda
-# fix path
-sed -i "s|0:Source:src|0:Source:$HOOT_HOME/hoot-cmd/src|g" *.gcov
-mv *.gcov $HOOT_HOME/gcov
-popd
-
-# hoot-js coverage
-pushd tgs
-gcov -o $HOOT_HOME/hoot-js/tmp/debug/ $HOOT_HOME/hoot-js/tmp/debug/*.gcda
-# fix path
-sed -i "s|0:Source:src|0:Source:$HOOT_HOME/hoot-js/src|g" *.gcov
-mv *.gcov $HOOT_HOME/gcov
-popd
-
-# hoot-josm coverage
-pushd hoot-josm
-gcov -o $HOOT_HOME/hoot-josm/tmp/debug/ $HOOT_HOME/hoot-josm/tmp/debug/*.gcda
-# fix path
-sed -i "s|0:Source:src|0:Source:$HOOT_HOME/hoot-josm/src|g" *.gcov
-mv *.gcov $HOOT_HOME/gcov
-popd
+for GCOV_PATH in ${GCOV_SCAN_PATHS[@]}; do
+    pushd $GCOV_PATH
+    # Create coverage
+    gcov --quiet -o $HOOT_HOME/$GCOV_PATH/tmp/debug/ $HOOT_HOME/$GCOV_PATH/tmp/debug/*.gcda
+    # Fix path
+    sed -i "s|0:Source:src|0:Source:$HOOT_HOME/$GCOV_PATH/src|g" *.gcov
+    mv *.gcov $HOOT_HOME/gcov
+    popd
+done
 
 # fix final paths
 sed -i "s|0:Source:../|0:Source:|g" gcov/*.gcov


### PR DESCRIPTION
Simplify the code coverage generation script to use an array of directories to process and then process them all the same.