### PR TITLE
Update translations to preserve area=yes and map to OSMTAGS

### DIFF
--- a/translations/ENCv311_to_OGR.js
+++ b/translations/ENCv311_to_OGR.js
@@ -189,7 +189,6 @@ enc311 = {
   {
     // Remove Hoot assigned tags for the source of the data
     delete tags['source:ingest:datetime'];
-    // delete tags.area;
     delete tags['error:circular'];
     delete tags['hoot:status'];
 

--- a/translations/dnc_core.js
+++ b/translations/dnc_core.js
@@ -758,7 +758,6 @@ dnc = {
   {
     // Remove Hoot assigned tags for the source of the data
     delete tags['source:ingest:datetime'];
-    delete tags.area;
     delete tags['error:circular'];
     delete tags['hoot:status'];
 

--- a/translations/ggdm30.js
+++ b/translations/ggdm30.js
@@ -1310,7 +1310,6 @@ ggdm30 = {
   {
     // Remove Hoot assigned tags for the source of the data
     delete tags['source:ingest:datetime'];
-    delete tags.area;
     delete tags['error:circular'];
     delete tags['hoot:status'];
 

--- a/translations/mgcp.js
+++ b/translations/mgcp.js
@@ -1148,7 +1148,6 @@ mgcp = {
   {
     // Remove Hoot assigned tags for the source of the data
     delete tags['source:ingest:datetime'];
-    delete tags.area;
     delete tags['error:circular'];
     delete tags['hoot:status'];
 

--- a/translations/tds40.js
+++ b/translations/tds40.js
@@ -1307,7 +1307,6 @@ tds40 = {
   {
     // Remove Hoot assigned tags for the source of the data
     delete tags['source:ingest:datetime'];
-    delete tags.area;
     delete tags['error:circular'];
     delete tags['hoot:status'];
 

--- a/translations/tds61.js
+++ b/translations/tds61.js
@@ -1302,7 +1302,6 @@ tds61 = {
   {
     // Remove Hoot assigned tags for the source of the data
     delete tags['source:ingest:datetime'];
-    delete tags.area;
     delete tags['error:circular'];
     delete tags['hoot:status'];
 

--- a/translations/tds70.js
+++ b/translations/tds70.js
@@ -1307,7 +1307,6 @@ tds70 = {
   {
     // Remove Hoot assigned tags for the source of the data
     delete tags['source:ingest:datetime'];
-    delete tags.area;
     delete tags['error:circular'];
     delete tags['hoot:status'];
 

--- a/translations/test/osmtags.js
+++ b/translations/test/osmtags.js
@@ -11,80 +11,99 @@ var server = require('../TranslationServer.js');
 
 describe('TranslationServer', function () {
 
-    it('should write OSMTAGS to osm tags when translating from mgcp -> osm', function() {
+    var schemas = [
+        'TDSv70',
+        'TDSv61',
+        'TDSv40',
+        'MGCP',
+        'GGDMv30'
+    ];
 
-        var data = '<osm version="0.6" upload="true" generator="hootenanny">\
-                        <node id="-10" action="modify" visible="true" lat="0.68307256979" lon="18.45073925651" />\
-                        <node id="-11" action="modify" visible="true" lat="0.68341620728" lon="18.45091527847" />\
-                        <node id="-12" action="modify" visible="true" lat="0.68306209303" lon="18.45157116983" />\
-                        <node id="-13" action="modify" visible="true" lat="0.68270797876" lon="18.45141400736" />\
-                        <way id="-19" action="modify" visible="true">\
-                            <nd ref="-10" />\
-                            <nd ref="-11" />\
-                            <nd ref="-12" />\
-                            <nd ref="-13" />\
-                            <nd ref="-10" />\
-                            <tag k="FCODE" v="AK190"/>\
-                            <tag k="OSMTAGS" v="{&quot;area&quot;:&quot;yes&quot;,&quot;source:imagery&quot;:&quot;DigitalGlobe&quot;}"/>\
-                        </way>\
-                    </osm>';
+    schemas.forEach(schema => {
+        var fcode_key = (schema === 'MGCP') ? 'FCODE' : 'F_CODE';
+        var fcode_value = (schema === 'MGCP') ? 'AK190' : 'BB081';
+        var osm_key = (schema === 'MGCP') ? 'man_made' : 'man_made';
+        var osm_value = (schema === 'MGCP') ? 'recreational_pier' : 'shoreline_construction';
 
-        var osm_xml = server.handleInputs({
-            osm: data,
-            method: 'POST',
-            translation: 'MGCP',
-            path: '/translateFrom'
+        it('should write OSMTAGS to osm tags when translating from ' + schema + ' -> OSM', function() {
+
+            var data = '<osm version="0.6" upload="true" generator="hootenanny">\
+                            <node id="-10" action="modify" visible="true" lat="0.68307256979" lon="18.45073925651" />\
+                            <node id="-11" action="modify" visible="true" lat="0.68341620728" lon="18.45091527847" />\
+                            <node id="-12" action="modify" visible="true" lat="0.68306209303" lon="18.45157116983" />\
+                            <node id="-13" action="modify" visible="true" lat="0.68270797876" lon="18.45141400736" />\
+                            <way id="-19" action="modify" visible="true">\
+                                <nd ref="-10" />\
+                                <nd ref="-11" />\
+                                <nd ref="-12" />\
+                                <nd ref="-13" />\
+                                <nd ref="-10" />\
+                                <tag k="' + fcode_key + '" v="' + fcode_value + '"/>\
+                                <tag k="OSMTAGS" v="{&quot;area&quot;:&quot;yes&quot;,&quot;source:imagery&quot;:&quot;DigitalGlobe&quot;}"/>\
+                            </way>\
+                        </osm>';
+
+            var osm_xml = server.handleInputs({
+                osm: data,
+                method: 'POST',
+                translation: schema,
+                path: '/translateFrom'
+            });
+
+            // console.log(osm_xml);
+
+            var xml = parser.parseFromString(osm_xml);
+            var gj = osmtogeojson(xml);
+
+            assert.equal(xml.getElementsByTagName("osm")[0].getAttribute("schema"), "OSM");
+
+            var tags = gj.features[0].properties;
+            assert.equal(tags[osm_key], osm_value);
+            assert.equal(tags['area'], 'yes');
+            assert.equal(tags['source:imagery'], 'DigitalGlobe');
         });
 
-        // console.log(osm_xml);
+        it('should write area=yes to OSMTAGS when translating from OSM -> ' + schema, function() {
 
-        var xml = parser.parseFromString(osm_xml);
-        var gj = osmtogeojson(xml);
+            var data = '<osm version="0.6" upload="true" generator="hootenanny">\
+                            <node id="-10" action="modify" visible="true" lat="0.68307256979" lon="18.45073925651" />\
+                            <node id="-11" action="modify" visible="true" lat="0.68341620728" lon="18.45091527847" />\
+                            <node id="-12" action="modify" visible="true" lat="0.68306209303" lon="18.45157116983" />\
+                            <node id="-13" action="modify" visible="true" lat="0.68270797876" lon="18.45141400736" />\
+                            <way id="-19" action="modify" visible="true">\
+                                <nd ref="-10" />\
+                                <nd ref="-11" />\
+                                <nd ref="-12" />\
+                                <nd ref="-13" />\
+                                <nd ref="-10" />\
+                                <tag k="' + osm_key + '" v="' + osm_value + '"/>\
+                                <tag k="source:imagery" v="DigitalGlobe"/>\
+                                <tag k="area" v="yes"/>\
+                            </way>\
+                        </osm>';
 
-        assert.equal(xml.getElementsByTagName("osm")[0].getAttribute("schema"), "OSM");
+            var osm_xml = server.handleInputs({
+                osm: data,
+                method: 'POST',
+                translation: schema,
+                path: '/translateTo'
+            });
 
-        var tags = gj.features[0].properties;
-        assert.equal(tags['man_made'], 'recreational_pier');
-        assert.equal(tags['area'], 'yes');
-        assert.equal(tags['source:imagery'], 'DigitalGlobe');
-    });
+            // console.log(osm_xml);
 
-    it('should write area=yes to OSMTAGS when translating from osm -> mgcp', function() {
+            var xml = parser.parseFromString(osm_xml);
+            var gj = osmtogeojson(xml);
 
-        var data = '<osm version="0.6" upload="true" generator="hootenanny">\
-                        <node id="-10" action="modify" visible="true" lat="0.68307256979" lon="18.45073925651" />\
-                        <node id="-11" action="modify" visible="true" lat="0.68341620728" lon="18.45091527847" />\
-                        <node id="-12" action="modify" visible="true" lat="0.68306209303" lon="18.45157116983" />\
-                        <node id="-13" action="modify" visible="true" lat="0.68270797876" lon="18.45141400736" />\
-                        <way id="-19" action="modify" visible="true">\
-                            <nd ref="-10" />\
-                            <nd ref="-11" />\
-                            <nd ref="-12" />\
-                            <nd ref="-13" />\
-                            <nd ref="-10" />\
-                            <tag k="man_made" v="recreational_pier"/>\
-                            <tag k="source:imagery" v="DigitalGlobe"/>\
-                            <tag k="area" v="yes"/>\
-                        </way>\
-                    </osm>';
+            assert.equal(xml.getElementsByTagName("osm")[0].getAttribute("schema"), schema);
 
-        var osm_xml = server.handleInputs({
-            osm: data,
-            method: 'POST',
-            translation: 'MGCP',
-            path: '/translateTo'
+            var tags = gj.features[0].properties;
+            assert.equal(tags[fcode_key], fcode_value);
+            if (schema === 'TDSv70') {
+                assert.equal(tags['OSMTAGS'], '{"area":"yes"}');
+                assert.equal(tags['ZI001_SDP'], 'DigitalGlobe');
+            } else {
+                assert.equal(tags['OSMTAGS'], '{"area":"yes","source:imagery":"DigitalGlobe"}');
+            }
         });
-
-        // console.log(osm_xml);
-
-        var xml = parser.parseFromString(osm_xml);
-        var gj = osmtogeojson(xml);
-
-        assert.equal(xml.getElementsByTagName("osm")[0].getAttribute("schema"), "MGCP");
-
-        var tags = gj.features[0].properties;
-        assert.equal(tags['FCODE'], 'AK190');
-        assert.equal(tags['OSMTAGS'], '{"area":"yes","source:imagery":"DigitalGlobe"}');
     });
-
 });

--- a/translations/test/osmtags.js
+++ b/translations/test/osmtags.js
@@ -1,0 +1,90 @@
+var assert = require('assert'),
+    http = require('http'),
+    xml2js = require('xml2js'),
+    fs = require('fs'),
+    httpMocks = require('node-mocks-http'),
+    osmtogeojson = require('osmtogeojson'),
+    DOMParser = new require('@xmldom/xmldom').DOMParser
+    parser = new DOMParser();
+
+var server = require('../TranslationServer.js');
+
+describe('TranslationServer', function () {
+
+    it('should write OSMTAGS to osm tags when translating from mgcp -> osm', function() {
+
+        var data = '<osm version="0.6" upload="true" generator="hootenanny">\
+                        <node id="-10" action="modify" visible="true" lat="0.68307256979" lon="18.45073925651" />\
+                        <node id="-11" action="modify" visible="true" lat="0.68341620728" lon="18.45091527847" />\
+                        <node id="-12" action="modify" visible="true" lat="0.68306209303" lon="18.45157116983" />\
+                        <node id="-13" action="modify" visible="true" lat="0.68270797876" lon="18.45141400736" />\
+                        <way id="-19" action="modify" visible="true">\
+                            <nd ref="-10" />\
+                            <nd ref="-11" />\
+                            <nd ref="-12" />\
+                            <nd ref="-13" />\
+                            <nd ref="-10" />\
+                            <tag k="FCODE" v="AK190"/>\
+                            <tag k="OSMTAGS" v="{&quot;area&quot;:&quot;yes&quot;,&quot;source:imagery&quot;:&quot;DigitalGlobe&quot;}"/>\
+                        </way>\
+                    </osm>';
+
+        var osm_xml = server.handleInputs({
+            osm: data,
+            method: 'POST',
+            translation: 'MGCP',
+            path: '/translateFrom'
+        });
+
+        // console.log(osm_xml);
+
+        var xml = parser.parseFromString(osm_xml);
+        var gj = osmtogeojson(xml);
+
+        assert.equal(xml.getElementsByTagName("osm")[0].getAttribute("schema"), "OSM");
+
+        var tags = gj.features[0].properties;
+        assert.equal(tags['man_made'], 'recreational_pier');
+        assert.equal(tags['area'], 'yes');
+        assert.equal(tags['source:imagery'], 'DigitalGlobe');
+    });
+
+    it('should write area=yes to OSMTAGS when translating from osm -> mgcp', function() {
+
+        var data = '<osm version="0.6" upload="true" generator="hootenanny">\
+                        <node id="-10" action="modify" visible="true" lat="0.68307256979" lon="18.45073925651" />\
+                        <node id="-11" action="modify" visible="true" lat="0.68341620728" lon="18.45091527847" />\
+                        <node id="-12" action="modify" visible="true" lat="0.68306209303" lon="18.45157116983" />\
+                        <node id="-13" action="modify" visible="true" lat="0.68270797876" lon="18.45141400736" />\
+                        <way id="-19" action="modify" visible="true">\
+                            <nd ref="-10" />\
+                            <nd ref="-11" />\
+                            <nd ref="-12" />\
+                            <nd ref="-13" />\
+                            <nd ref="-10" />\
+                            <tag k="man_made" v="recreational_pier"/>\
+                            <tag k="source:imagery" v="DigitalGlobe"/>\
+                            <tag k="area" v="yes"/>\
+                        </way>\
+                    </osm>';
+
+        var osm_xml = server.handleInputs({
+            osm: data,
+            method: 'POST',
+            translation: 'MGCP',
+            path: '/translateTo'
+        });
+
+        // console.log(osm_xml);
+
+        var xml = parser.parseFromString(osm_xml);
+        var gj = osmtogeojson(xml);
+
+        assert.equal(xml.getElementsByTagName("osm")[0].getAttribute("schema"), "MGCP");
+
+        var tags = gj.features[0].properties;
+        assert.equal(tags['FCODE'], 'AK190');
+        assert.equal(tags['OSMTAGS'], '{"area":"yes","source:imagery":"DigitalGlobe"}');
+    });
+
+});


### PR DESCRIPTION
This change makes it so translations don't remove the osm tag `area=yes` when translating to schemas.  Instead it will map to the `OSMTAGS` catch-all so it can be restored in the round-trip translation.