### PR TITLE
Replace Diff Conflate CLI options with config options

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -917,6 +917,28 @@ this list is empty, no circular error will be parsed from input features and a t
 
 Path to this file. Only modified during the testing of the `info` command.
 
+=== conflate.differential
+
+* Data Type: bool
+* Default Value: `false`
+
+Enable differential conflation through a setting instead of a command line option
+
+=== conflate.differential.include.tags
+
+* Data Type: bool
+* Default Value: `false`
+
+Includes a check for modified tags when the `conflation.differential` option is enabled
+
+=== conflate.differential.tags.separate.output
+
+* Data Type: bool
+* Default Value: `false`
+
+Writes separate output files for geometry and tag changes. Valid only when the
+`conflate.differential` and `conflate.differential.include.tags` options are used.
+
 === conflate.element.criterion
 
 * Data Type: string
@@ -5865,15 +5887,15 @@ Conflation capability.
 * Data Type: bool
 * Default Value: `false`
 
-When activated, this runs the conflate case test conflate command with the `--differential` option.
+When activated, this runs the conflate case test conflate command with the `conflate.differential` option.
 
 === test.case.conflate.differential.include.tags
 
 * Data Type: bool
 * Default Value: `false`
 
-When activated, this runs the conflate case test conflate command with both the `--differential`
-and `--include-tags` options (setting this to true automatically sets
+When activated, this runs the conflate case test conflate command with both the `conflate.differential`
+and `conflate.differential.include.tags` options (setting this to true automatically sets
 `test.case.conflate.differential` to true).
 
 === test.force.orthographic.projection

--- a/conf/core/DifferentialConflation.conf
+++ b/conf/core/DifferentialConflation.conf
@@ -2,6 +2,7 @@
   "#": "Only add entries here that have different default values than the options in ",
   "#": "ConfigOptions.asciidoc.",
   "#": "Differential shouldn't include any deletes, create and modify only",
+  "conflate.differential" : "true",
   "changeset.allow.deleting.reference.features" : "false",
   "geometry.linear.merger.default": "LinearDiffMerger",
   "hootapi.db.writer.preserve.version.on.insert": "true",

--- a/docs/algorithms/DifferentialConflation.asciidoc
+++ b/docs/algorithms/DifferentialConflation.asciidoc
@@ -23,9 +23,9 @@ match any elements in the first input.
 
 So now we have all of the "new" geometry from the second input isolated as output, but what if there 
 were also new or updated tags on some of the elements in the second input? How can we capture those 
-new tags? If the `--include-tags` option is enabled, we simply go back through the matches derived 
-in the previous step, and compare the tags of the elements involved in the match. If the element 
-from the second input contains new tag keys or tag values different from the first input element, 
+new tags? If the `conflate.differential.include.tags` option is enabled, we simply go back through the
+matches derived in the previous step, and compare the tags of the elements involved in the match. If the
+element from the second input contains new tag keys or tag values different from the first input element,
 the tags are merged using an overwriting algorithm. All key/value pairs are kept from the first 
 input, all key/value pairs from the second input are appended, and any keys that conflict are 
 assigned the value from the second input, as it is assumed that the second input contains updated 
@@ -37,7 +37,8 @@ Unifying Roads Algorithm, it calculates the differential against partial linear 
 rather than whole matches. This generally generates a more granular differential. Differentials 
 generated with river data, however, do not seem to benefit from partial linear match removal the 
 majority of the time. There may, however, be situations when a less granular differential is 
-desired, and the default behavior for linear non-river features may be turned off by enabling the `differential.remove.linear.partial.matches.as.whole` configuration option (enable "Remove features 
+desired, and the default behavior for linear non-river features may be turned off by enabling the
+`differential.remove.linear.partial.matches.as.whole` configuration option (enable "Remove features
 involved in linear partial matches completely" option in the UI). To control river partial matching 
 with Differential Conflation, use the `differential.remove.river.partial.matches.as.whole` ("Remove 
 rivers involved in river partial matches completely" option in the UI).

--- a/docs/commands/conflate.asciidoc
+++ b/docs/commands/conflate.asciidoc
@@ -9,20 +9,13 @@ The `conflate` command conflates two maps into a single map.
                           Conflation workflow, this is treated as reference data.
 * `input2`              - The second input; may be any supported input format (e.g. osm file).
 * `output`              - Output; may be any supported map output format (e.g. osm file) or any supported changeset 
-                          format (e.g. .osc or .osc.sql file) if the `--differential` option is specified. 
+                          format (e.g. .osc or .osc.sql file) if the `conflate.differential` option is specified.
 * `--changeset-stats`   - Displays changeset statistics and may be optionally followed by an output JSON file to be 
-                          written to. Valid only if the `--differential` option is specified and the output format is 
-                          changeset XML (.osc). If the `--include-tags`` option is specified, tag changeset statistics are 
-                          also output.
-* `--differential`      - Calculates the the differential between two conflation inputs. The output will be all elements 
-                          in input2 that do not exist in input1.
-* `--include-tags`      - Includes a check for modified tags when using the `--differential` option. The output will 
-                          include unmodified geometries from input1 with new/updated tags from input2. Valid only when the 
-                          `--differential` option is used.
+                          written to. Valid only if the `conflate.differential` option is specified and the output format is
+                          changeset XML (.osc). If the `conflate.differential.include.tags` option is specified, tag changeset
+                          statistics are also output.
 * `--osmApiDatabaseUrl` - Target OSM API database the derived changeset is to be applied, used to maintain element 
                           ID continuity. Required only if the changeset output format is SQL (.osc.sql).
-* `--separate-output`   - Writes separate output files for geometry and tag changes. Valid only when the `--differential`
-                          and `--include-tags`` options are used.
 * `--stats`             - Displays map statistics and may be optionally followed by an output JSON file name to be written to. 
 * `--write-bounds`      - If the `bounds` configuration option is specified, optionally outputs a file containing the 
                           input bounds. The location of the file is controlled via the `bounds.output.file` 
@@ -32,8 +25,8 @@ The `conflate` command conflates two maps into a single map.
 
 --------------------------------------
 hoot conflate [-C workflowConfigFile] [-C algorithmConfigFile] (input1) (input2) (output) \
-  [--changeset-stats geometry-stats-filename tags-stats-filename] [--differential] [--include-tags] \
-  [--osmApiDatabaseUrl url] [--separate-output] [--stats filename] 
+  [--changeset-stats geometry-stats-filename tags-stats-filename] [--osmApiDatabaseUrl url] \
+  [--stats filename]
 --------------------------------------
 
 https://github.com/ngageoint/hootenanny/blob/master/docs/user/CommandLineExamples.asciidoc#conflation[Examples]

--- a/docs/user/CommandLineExamples.asciidoc
+++ b/docs/user/CommandLineExamples.asciidoc
@@ -291,7 +291,7 @@ See the User Guide for more specific details on command usage. Most of these exa
 
 -----
     hoot conflate -C DifferentialConflation.conf -C UnifyingAlgorithm.conf input1.osm input2.osm \
-      output.osm --differential
+      output.osm
 -----
 
 ==== Conflate only tags from a second map into a first map without changing the first map's geometry (Attribute Conflation):
@@ -345,7 +345,7 @@ See the User Guide for more specific details on command usage. Most of these exa
 
 -----
     hoot conflate -C DifferentialConflation.conf -C UnifyingAlgorithm.conf --include-tags \
-      input1.osm input2.osm output.osm --differential
+      input1.osm input2.osm output.osm
 -----
 
 ==== Conflate over a bounding box (not supported by all input formats):
@@ -448,7 +448,7 @@ See the User Guide for more specific details on command usage. Most of these exa
 -----
     hoot conflate -C ReferenceConflation.conf -C UnifyingAlgorithm.conf \
       -D conflate.post.ops+="ResolveReviewsOp" \
-      input1.osm input2.osm output.osm --differential
+      input1.osm input2.osm output.osm
 -----
 
 ==== Conflate railways with the One To Many Railway Conflation Workflow:

--- a/docs/user/ConflationSteps.asciidoc
+++ b/docs/user/ConflationSteps.asciidoc
@@ -174,9 +174,9 @@ workflow may be found in the `changeset-derive` command documentation:
 Differential Conflation derives an output that consists of new data from the second input not in the
 first input. A detailed explanation is provided in the related documentation under Algorithms.
 
-To use, pass `DifferentialConflation.conf` to the conflate command with the `--differential` option. Example:
+To use, pass `DifferentialConflation.conf` to the conflate command. Example:
 --------
-hoot conflate -C DifferentialConflation.conf -C UnifyingAlgorithm.conf input1.osm input2.osm output.osm --differential
+hoot conflate -C DifferentialConflation.conf -C UnifyingAlgorithm.conf input1.osm input2.osm output.osm
 --------
 
 More details: <<hootuser, DifferentialConflation>>

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/NodeDensityTaskGridGenerator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/NodeDensityTaskGridGenerator.cpp
@@ -129,8 +129,8 @@ TaskGrid NodeDensityTaskGridGenerator::_calcNodeDensityTaskGrid(OsmMapPtr map)
   for (size_t idx = 0; idx < rawTaskGrid.size(); idx++)
   {
     TaskGrid::TaskGridCell taskGridCell;
-    taskGridCell.id = idx + 1;
-    taskGridCell.replacementNodeCount = nodeCounts[idx];
+    taskGridCell.id = static_cast<int>(idx + 1);
+    taskGridCell.replacementNodeCount = static_cast<int>(nodeCounts[idx]);
     taskGridCell.bounds = rawTaskGrid[idx];
     taskGrid.addCell(taskGridCell);
   }

--- a/hoot-core/src/main/cpp/hoot/core/cmd/BaseCommand.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/BaseCommand.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "BaseCommand.h"
@@ -83,9 +83,8 @@ QStringList BaseCommand::toQStringList(char* argv[], int argc)
 {
   QStringList result;
   for (int i = 0; i < argc; i++)
-  {
     result << argv[i];
-  }
+
   return result;
 }
 
@@ -106,9 +105,8 @@ QStringList BaseCommand::_parseRecursiveInputParameter(QStringList& args, bool& 
     const QString filter = args.at(recursiveIndex + 1).trimmed();
     // "*" denotes no filtering
     if (filter != "*")
-    {
       inputFilters = filter.split(";");
-    }
+
     args.removeAt(recursiveIndex + 1);
     args.removeAt(recursiveIndex);
   }

--- a/hoot-core/src/main/cpp/hoot/core/cmd/BoundedCommand.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/BoundedCommand.cpp
@@ -22,22 +22,22 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "BoundedCommand.h"
 
 // Hoot
-#include <hoot/core/util/ConfigOptions.h>
-#include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/geometry/GeometryUtils.h>
+#include <hoot/core/io/OsmMapWriterFactory.h>
+#include <hoot/core/util/ConfigOptions.h>
 
 namespace hoot
 {
 
-BoundedCommand::BoundedCommand() :
-BaseCommand(),
-_writeInternalEnvelope(false)
+BoundedCommand::BoundedCommand()
+  : BaseCommand(),
+    _writeInternalEnvelope(false)
 {
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ConflateCmd.cpp
@@ -22,16 +22,16 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "ConflateCmd.h"
 
 // Hoot
-#include <hoot/core/util/ConfigOptions.h>
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/conflate/ConflateExecutor.h>
 #include <hoot/core/conflate/ConflateUtils.h>
+#include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Factory.h>
 
 using namespace std;
 using namespace Tgs;
@@ -71,7 +71,7 @@ int ConflateCmd::runSimple(QStringList& args)
   bool isDiffConflate = false;
   bool diffConflateEnableTags = false;
 
-  if (args.contains("--differential"))
+  if (ConfigOptions().getConflateDifferential())
   {
     // Setting these diff specific properties here on ConflateExecutor feels a little kludgy. This
     // may need some refactoring.
@@ -94,30 +94,26 @@ int ConflateCmd::runSimple(QStringList& args)
     conflator.setIsDiffConflate(true);
     conflator.setDiffRemoveLinearPartialMatchesAsWhole(removeDiffLinearPartialMatchesAsWhole);
     conflator.setDiffRemoveRiverPartialMatchesAsWhole(removeDiffRiverPartialMatchesAsWhole);
-    args.removeAt(args.indexOf("--differential"));
 
-    if (args.contains("--include-tags"))
+    if (ConfigOptions().getConflateDifferentialIncludeTags())
     {
       diffConflateEnableTags = true;
       conflator.setDiffConflateEnableTags(diffConflateEnableTags);
-      args.removeAt(args.indexOf("--include-tags"));
-    }
+   }
   }
   LOG_VARD(isDiffConflate);
 
   // Check for separate output files (for geometry & tags)
   bool separateOutput = false;
-  if (args.contains("--separate-output"))
+  if (ConfigOptions().getConflateDifferentialTagsSeparateOutput())
   {
     const QString errorMsg =
-      QString("--separate-output is only valid when combiend with the --differential and ") +
-      QString("--include-tags options.");
+      QString("conflate.differential.tags.separate.output is only valid when combined with the conflate.differential and ") +
+      QString("conflate.differential.include.tags options.");
     if (!isDiffConflate || !diffConflateEnableTags)
-    {
       throw IllegalArgumentException(errorMsg);
-    }
+
     separateOutput = true;
-    args.removeAt(args.indexOf("--separate-output"));
   }
   LOG_VARD(separateOutput);
   conflator.setDiffConflateSeparateOutput(separateOutput);
@@ -129,7 +125,7 @@ int ConflateCmd::runSimple(QStringList& args)
     if (!isDiffConflate)
     {
       throw IllegalArgumentException(
-        "--changeset-stats is only valid when combined with the --differential option.");
+        "--changeset-stats is only valid when combined with the conflate.differential option.");
     }
     else
     {
@@ -146,13 +142,9 @@ int ConflateCmd::runSimple(QStringList& args)
         outputChangesetStatsFile = args[statsIndex + 1];
         QFileInfo changesetStatsInfo(outputChangesetStatsFile);
         if (!ChangesetStatsFormat::isValidFileOutputFormat(changesetStatsInfo.completeSuffix()))
-        {
           outputChangesetStatsFile = "";
-        }
         else
-        {
           args.removeAll(outputChangesetStatsFile);
-        }
       }
       args.removeAll("--changeset-stats");
     }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/DiffConflator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef DIFFCONFLATOR_H
 #define DIFFCONFLATOR_H
@@ -30,9 +30,9 @@
 // hoot
 #include <hoot/core/algorithms/changeset/ChangesetDeriver.h>
 #include <hoot/core/algorithms/changeset/MemChangesetProvider.h>
+#include <hoot/core/conflate/AbstractConflator.h>
 #include <hoot/core/criterion/ElementCriterion.h>
 #include <hoot/core/io/ChangesetStatsFormat.h>
-#include <hoot/core/conflate/AbstractConflator.h>
 #include <hoot/core/ops/UnconnectedWaySnapper.h>
 
 namespace hoot
@@ -63,15 +63,15 @@ class MatchThreshold;
  * - Remove unconflatable elements (optional and enabled by default; generally only turned off for
  * debugging)
  * - Find matches
- * - Calc tag diff against the matches (optional; used when --separate-output is specified)
+ * - Calc tag diff against the matches (optional; used when conflate.differential.separate.output is true)
  * - Optimize linear matches (only happens when differential.remove.linear.partial.matches.as.whole
  * is disabled and a linear feature matcher has been specified in the configuration)
  * - Remove secondary match elements
  * - Snap secondary roads back to ref roads (optional; not enabled by default)
  * - Remove ref match elements
  * - Remove some metadata tags
- * - Get the tag diff (optional; used when --separate-output is specified)
- * - Add tag changes to back to the map (optional; used when --separate-output is specified)
+ * - Get the tag diff (optional; used when conflate.differential.separate.output is true)
+ * - Add tag changes to back to the map (optional; used when conflate.differential.separate.output is true)
  */
 class DiffConflator : public AbstractConflator
 {
@@ -281,8 +281,8 @@ private:
    * The element criteria that must be met in order for an element involved in a match to be
    * completely removed
    */
-  bool _satisfiesCompleteElementRemovalCondition(
-    const ConstElementPtr& element, const Status& status, const ConstMatchPtr& match) const;
+  bool _satisfiesCompleteElementRemovalCondition(const ConstElementPtr& element, const Status& status,
+                                                 const ConstMatchPtr& match) const;
   /**
    * Removes match elements from a match completely regardless of whether only part of their
    * geometry is involved in a match (if linear).

--- a/hoot-core/src/main/cpp/hoot/core/io/IoUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/IoUtils.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef IOUTILS_H
@@ -124,8 +124,8 @@ public:
    * @param nameFilters wildcard filters for path exclusion; e.g. *myFile*, *.json
    * @return a list of file paths
    */
-  static QStringList getSupportedInputsRecursively(
-    const QStringList& topLevelPaths, const QStringList& nameFilters = QStringList());
+  static QStringList getSupportedInputsRecursively(const QStringList& topLevelPaths,
+                                                   const QStringList& nameFilters = QStringList());
   /**
    * Returns all valid input file paths expanding any paths by looking inside of VSI files
    *
@@ -202,8 +202,8 @@ public:
    * @param ops a list of Hoot operation class names to use for inline filtering on the input stream
    * @return an input stream
    */
-  static ElementInputStreamPtr getFilteredInputStream(
-    ElementInputStreamPtr streamToFilter, const QStringList& ops);
+  static ElementInputStreamPtr getFilteredInputStream(ElementInputStreamPtr streamToFilter,
+                                                      const QStringList& ops);
 
   /**
     Loads an OSM map into an OsmMap object
@@ -221,10 +221,9 @@ public:
     @param numTasks number of job tasks being performed for status reporting; applicable to OGR
     inputs only; ignored otherwise
     */
-  static void loadMap(
-    const OsmMapPtr& map, const QString& path, bool useFileId = true,
-    Status defaultStatus = Status::Invalid, const QString& translationScript = "",
-    const int ogrFeatureLimit = -1, const QString& jobSource = "", const int numTasks = -1);
+  static void loadMap(const OsmMapPtr& map, const QString& path, bool useFileId = true,
+                      Status defaultStatus = Status::Invalid, const QString& translationScript = "",
+                      const int ogrFeatureLimit = -1, const QString& jobSource = "", const int numTasks = -1);
   /**
     Loads multiple OSM maps into an OsmMap object
 
@@ -241,10 +240,9 @@ public:
     @param numTasks number of job tasks being performed for status reporting; applicable to OGR
     inputs only; ignored otherwise
     */
-  static void loadMaps(
-    const OsmMapPtr& map, const QStringList& paths, bool useFileId,
-    Status defaultStatus = Status::Invalid, const QString& translationScript = "",
-    const int ogrFeatureLimit = -1, const QString& jobSource = "", const int numTasks = -1);
+  static void loadMaps(const OsmMapPtr& map, const QStringList& paths, bool useFileId,
+                       Status defaultStatus = Status::Invalid, const QString& translationScript = "",
+                       const int ogrFeatureLimit = -1, const QString& jobSource = "", const int numTasks = -1);
   /**
     Saves an OSM map to an OsmMap object
 
@@ -261,8 +259,8 @@ public:
     * @param keepConnectedOobWays if true any way falling outside of the bounds but directly
     * connected to a way within the bounds will be kept
     */
-   static void cropToBounds(
-     OsmMapPtr& map, const geos::geom::Envelope& bounds, const bool keepConnectedOobWays = false);
+   static void cropToBounds(OsmMapPtr& map, const geos::geom::Envelope& bounds,
+                            const bool keepConnectedOobWays = false);
   /**
    * Crops a map to a given bounds
    *
@@ -271,9 +269,8 @@ public:
    * @param keepConnectedOobWays if true any way falling outside of the bounds but directly
    * connected to a way within the bounds will be kept
    */
-  static void cropToBounds(
-    OsmMapPtr& map, const std::shared_ptr<geos::geom::Geometry>& bounds,
-    const bool keepConnectedOobWays = false);
+  static void cropToBounds(OsmMapPtr& map, const std::shared_ptr<geos::geom::Geometry>& bounds,
+                           const bool keepConnectedOobWays = false);
 
   /**
    * Determines if an input string is a URL by the hoot definition
@@ -298,8 +295,8 @@ public:
    * output directory extension (e.g. shp); not option if appendText is not specified
    * @return a URL
    */
-  static QString getOutputUrlFromInput(
-    const QString& inputUrl, const QString& appendText = "", const QString& outputFormat = "");
+  static QString getOutputUrlFromInput(const QString& inputUrl, const QString& appendText = "",
+                                       const QString& outputFormat = "");
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
@@ -751,21 +751,23 @@ bool OsmXmlReader::startElement(const QString& /*namespaceURI*/, const QString& 
   return true;
 }
 
-bool OsmXmlReader::_setElementCircularError(const Tags& tags, const QString& key)
+bool OsmXmlReader::_setElementCircularError(const Tags& tags, const QString& key) const
 {
+  bool result = false;
   try
   {
     Meters circularError = tags.getLength(key).value();
     if (circularError > 0)
     {
       _element->setCircularError(circularError);
-      return true;
+      result = true;
     }
   }
-  catch (const HootException&)
+  catch (const HootException& e)
   {
+    LOG_TRACE("Set circular error failed: " + e.getWhat());
   }
-  return false;
+  return result;
 }
 
 bool OsmXmlReader::endElement(const QString& /* namespaceURI */,

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.h
@@ -195,7 +195,7 @@ private:
   double _parseDouble(const QString& s) const;
   long _parseLong(const QString& s) const;
 
-  bool _setElementCircularError(const Tags& tags, const QString& key);
+  bool _setElementCircularError(const Tags& tags, const QString& key) const;
 
   const QString& _saveMemory(const QString& s);
 

--- a/hoot-services/src/main/java/hoot/services/controllers/conflation/ConflateCommand.java
+++ b/hoot-services/src/main/java/hoot/services/controllers/conflation/ConflateCommand.java
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 package hoot.services.controllers.conflation;
 
@@ -149,15 +149,12 @@ class ConflateCommand extends ExternalCommand {
         // Detect Differential Conflation
         String conflationCommand = params.getConflationCommand();
         String diffTags = "";
-        String differential = "";
         if (conflationCommand != null && conflationCommand.contains("differential-tags")){
           conflationCommand = "conflate";
-          differential = "--differential";
-          diffTags = "--include-tags";
+          options.add("conflate.differential.include.tags=true");
         }
         else if (conflationCommand != null && conflationCommand.contains("differential")){
           conflationCommand = "conflate";
-          differential = "--differential";
         }
 
         if (params.getAdvancedOptions() != null && !params.getAdvancedOptions().isEmpty()) { // hoot 1
@@ -280,13 +277,11 @@ class ConflateCommand extends ExternalCommand {
         substitutionMap.put("INPUT1", input1);
         substitutionMap.put("INPUT2", input2);
         substitutionMap.put("OUTPUT", output);
-        substitutionMap.put("DIFFERENTIAL", differential);
-        substitutionMap.put("DIFF_TAGS", diffTags);
         substitutionMap.put("STATS", stats);
 
         String command;
         if (params.getHoot2() == null) { // hoot1
-            command = "hoot.bin ${CONFLATION_COMMAND} --${DEBUG_LEVEL} ${HOOT_OPTIONS} ${INPUT1} ${INPUT2} ${OUTPUT} ${DIFFERENTIAL} ${DIFF_TAGS} ${STATS}";
+            command = "hoot.bin ${CONFLATION_COMMAND} --${DEBUG_LEVEL} ${HOOT_OPTIONS} ${INPUT1} ${INPUT2} ${OUTPUT} ${STATS}";
         } else {
 
             if (conflationType != null) {

--- a/hoot-services/src/main/java/hoot/services/controllers/grail/RunDiffCommand.java
+++ b/hoot-services/src/main/java/hoot/services/controllers/grail/RunDiffCommand.java
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 package hoot.services.controllers.grail;
 
@@ -78,6 +78,11 @@ class RunDiffCommand extends GrailCommand {
             options.add("bounds=" + params.getBounds());
         }
 
+        if (params.getApplyTags()) {
+            //Add include tags
+            options.add("conflate.differential.include.tags=true");
+        }
+
         Map<String, Object> substitutionMap = new HashMap<>();
         substitutionMap.put("HOOT_OPTIONS", toHootOptions(options));
         substitutionMap.put("INPUT1", params.getInput1());
@@ -89,8 +94,7 @@ class RunDiffCommand extends GrailCommand {
 
         String command = "hoot.bin conflate --${DEBUG_LEVEL} -C DifferentialConflation.conf"
                 + (!algorithm.equals("") ? " -C ${ROAD_ALGORITHM}" : "")
-                + " ${HOOT_OPTIONS} ${INPUT1} ${INPUT2} ${OUTPUT} --differential --changeset-stats ${STATS_FILE}"
-                + (params.getApplyTags() ? " --include-tags" : "");
+                + " ${HOOT_OPTIONS} ${INPUT1} ${INPUT2} ${OUTPUT} --changeset-stats ${STATS_FILE}";
 
         super.configureCommand(command, substitutionMap, caller);
     }

--- a/hoot-services/src/test/java/hoot/services/controllers/conflation/ConflateCommandTest.java
+++ b/hoot-services/src/test/java/hoot/services/controllers/conflation/ConflateCommandTest.java
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 package hoot.services.controllers.conflation;
 
@@ -385,7 +385,7 @@ public class ConflateCommandTest {
         String debugLevel = "error";
         ConflateCommand conflateCommand = new ConflateCommandFactory().build(jobId, conflateParams, debugLevel, this.getClass());
 
-        String expectedCommand = "hoot.bin conflate --error -C DifferentialConflation.conf -D hootapi.db.writer.overwrite.map=true -D writer.text.status=true -D job.id=38c74757-d444-49aa-b746-3ee29fc49cf7 -D api.db.email=test@test.com hootapidb://${HOOTAPI_DB_USER}:${HOOTAPI_DB_PASSWORD}@${HOOTAPI_DB_HOST}:${HOOTAPI_DB_PORT}/${HOOTAPI_DB_NAME}/DcGisRoads hootapidb://${HOOTAPI_DB_USER}:${HOOTAPI_DB_PASSWORD}@${HOOTAPI_DB_HOST}:${HOOTAPI_DB_PORT}/${HOOTAPI_DB_NAME}/DcTigerRoads hootapidb://${HOOTAPI_DB_USER}:${HOOTAPI_DB_PASSWORD}@${HOOTAPI_DB_HOST}:${HOOTAPI_DB_PORT}/${HOOTAPI_DB_NAME}/Merged_Roads_e0d --differential --stats";
+        String expectedCommand = "hoot.bin conflate --error -C DifferentialConflation.conf -D hootapi.db.writer.overwrite.map=true -D writer.text.status=true -D job.id=38c74757-d444-49aa-b746-3ee29fc49cf7 -D api.db.email=test@test.com hootapidb://${HOOTAPI_DB_USER}:${HOOTAPI_DB_PASSWORD}@${HOOTAPI_DB_HOST}:${HOOTAPI_DB_PORT}/${HOOTAPI_DB_NAME}/DcGisRoads hootapidb://${HOOTAPI_DB_USER}:${HOOTAPI_DB_PASSWORD}@${HOOTAPI_DB_HOST}:${HOOTAPI_DB_PORT}/${HOOTAPI_DB_NAME}/DcTigerRoads hootapidb://${HOOTAPI_DB_USER}:${HOOTAPI_DB_PASSWORD}@${HOOTAPI_DB_HOST}:${HOOTAPI_DB_PORT}/${HOOTAPI_DB_NAME}/Merged_Roads_e0d --stats";
         CommandLine actualCommand = ExternalCommandRunnerImpl.parse(conflateCommand.getCommand(), conflateCommand.getSubstitutionMap());
         assertEquals(expectedCommand, actualCommand.getExecutable() + " " + StringUtils.join(actualCommand.getArguments(), " "));
 
@@ -411,7 +411,7 @@ public class ConflateCommandTest {
         String debugLevel = "error";
         ConflateCommand conflateCommand = new ConflateCommandFactory().build(jobId, conflateParams, debugLevel, this.getClass());
 
-        String expectedCommand = "hoot.bin conflate --error -C DifferentialConflation.conf -D hootapi.db.writer.overwrite.map=true -D writer.text.status=true -D job.id=38c74757-d444-49aa-b746-3ee29fc49cf7 -D api.db.email=test@test.com hootapidb://${HOOTAPI_DB_USER}:${HOOTAPI_DB_PASSWORD}@${HOOTAPI_DB_HOST}:${HOOTAPI_DB_PORT}/${HOOTAPI_DB_NAME}/DcGisRoads hootapidb://${HOOTAPI_DB_USER}:${HOOTAPI_DB_PASSWORD}@${HOOTAPI_DB_HOST}:${HOOTAPI_DB_PORT}/${HOOTAPI_DB_NAME}/DcTigerRoads hootapidb://${HOOTAPI_DB_USER}:${HOOTAPI_DB_PASSWORD}@${HOOTAPI_DB_HOST}:${HOOTAPI_DB_PORT}/${HOOTAPI_DB_NAME}/Merged_Roads_e0d --differential --include-tags";
+        String expectedCommand = "hoot.bin conflate --error -C DifferentialConflation.conf -D hootapi.db.writer.overwrite.map=true -D writer.text.status=true -D job.id=38c74757-d444-49aa-b746-3ee29fc49cf7 -D api.db.email=test@test.com -D conflate.differential.include.tags=true hootapidb://${HOOTAPI_DB_USER}:${HOOTAPI_DB_PASSWORD}@${HOOTAPI_DB_HOST}:${HOOTAPI_DB_PORT}/${HOOTAPI_DB_NAME}/DcGisRoads hootapidb://${HOOTAPI_DB_USER}:${HOOTAPI_DB_PASSWORD}@${HOOTAPI_DB_HOST}:${HOOTAPI_DB_PORT}/${HOOTAPI_DB_NAME}/DcTigerRoads hootapidb://${HOOTAPI_DB_USER}:${HOOTAPI_DB_PASSWORD}@${HOOTAPI_DB_HOST}:${HOOTAPI_DB_PORT}/${HOOTAPI_DB_NAME}/Merged_Roads_e0d";
         CommandLine actualCommand = ExternalCommandRunnerImpl.parse(conflateCommand.getCommand(), conflateCommand.getSubstitutionMap());
         assertEquals(expectedCommand, actualCommand.getExecutable() + " " + StringUtils.join(actualCommand.getArguments(), " "));
 

--- a/hoot-test/src/main/cpp/hoot/test/ConflateCaseTest.cpp
+++ b/hoot-test/src/main/cpp/hoot/test/ConflateCaseTest.cpp
@@ -57,17 +57,12 @@ void ConflateCaseTest::_runConflateCmd() const
     LOG_WARN("Please create a meaningful README.txt in " + _d.path());
   }
   QFileInfo in1(_d, "Input1.osm");
-  if (in1.exists() == false)
-  {
-    throw TestConfigurationException(
-      "Unable to find Input1.osm in conflate case: " + _d.absolutePath());
-  }
+  if (!in1.exists())
+    throw TestConfigurationException("Unable to find Input1.osm in conflate case: " + _d.absolutePath());
+
   QFileInfo in2(_d, "Input2.osm");
-  if (in2.exists() == false)
-  {
-    throw TestConfigurationException(
-      "Unable to find Input2.osm in conflate case: " + _d.absolutePath());
-  }
+  if (!in2.exists())
+    throw TestConfigurationException("Unable to find Input2.osm in conflate case: " + _d.absolutePath());
 
   // This is also set in Testing.conf.
   conf().set(ConfigOptions::getConflateTagDisableValueTruncationKey(), "true");
@@ -78,21 +73,6 @@ void ConflateCaseTest::_runConflateCmd() const
   args << in1.absoluteFilePath();
   args << in2.absoluteFilePath();
   args << testOutput;
-  bool differential = ConfigOptions().getTestCaseConflateDifferential();
-  const bool differentialWithTags = ConfigOptions().getTestCaseConflateDifferentialIncludeTags();
-  if (differentialWithTags)
-  {
-    // let this override and correct what would otherwise be an invalid config
-    differential = true;
-  }
-  if (differential)
-  {
-    args << "--differential";
-  }
-  if (differentialWithTags)
-  {
-    args << "--include-tags";
-  }
 
   int result = -1;
   try
@@ -105,11 +85,8 @@ void ConflateCaseTest::_runConflateCmd() const
   }
 
   QFileInfo expected(_d, "Expected.osm");
-  if (expected.exists() == false)
-  {
-    throw TestConfigurationException(
-      "Unable to find Expected.osm in conflate case: " + _d.absolutePath());
-  }
+  if (!expected.exists())
+    throw TestConfigurationException("Unable to find Expected.osm in conflate case: " + _d.absolutePath());
 
   if (result != 0)
   {

--- a/test-files/cases/differential/network/highway/roundabout-3580/Config.conf
+++ b/test-files/cases/differential/network/highway/roundabout-3580/Config.conf
@@ -1,4 +1,5 @@
 {
-  "test.case.conflate.differential.include.tags": "true",
+  "conflate.differential.include.tags" : "true",
+  "test.case.conflate.differential.include.tags" : "true",
   "#": "end"
 }

--- a/test-files/cases/differential/unifying/highway/roundabout-3580/Config.conf
+++ b/test-files/cases/differential/unifying/highway/roundabout-3580/Config.conf
@@ -1,5 +1,6 @@
 {
-  "test.case.conflate.differential.include.tags": "true",
-  "differential.remove.linear.partial.matches.as.whole": "true",
+  "conflate.differential.include.tags" : "true",
+  "test.case.conflate.differential.include.tags" : "true",
+  "differential.remove.linear.partial.matches.as.whole" : "true",
   "#": "end"
 }

--- a/test-files/cmd/glacial/DiffConflateCmdTest.sh
+++ b/test-files/cmd/glacial/DiffConflateCmdTest.sh
@@ -11,6 +11,8 @@ CONFIG="-C DifferentialConflation.conf -C NetworkAlgorithm.conf -C Testing.conf"
 # remove partial match elements in a partial fashion at this time, so change the default setting to 
 # avoid a warning.
 GENERAL_OPTS="-D differential.remove.linear.partial.matches.as.whole=true"
+INCLUDE_TAGS="-D conflate.differential.include.tags=true"
+SEPARATE_OUTPUT="-D conflate.differential.tags.separate.output=true"
 source scripts/core/ScriptTestUtils.sh
 
 # Run differential conflation to produce a map output
@@ -18,7 +20,7 @@ echo ""
 echo "Running diff..."
 echo ""
 hoot conflate $LOG_LEVEL $CONFIG $GENERAL_OPTS \
-  $INPUT_DIR/input1.osm $INPUT_DIR/input2.osm $OUTPUT_DIR/output.osm --differential
+  $INPUT_DIR/input1.osm $INPUT_DIR/input2.osm $OUTPUT_DIR/output.osm
 if [ -f "test-output/test-validation-enabled" ]; then
   hoot validate $LOG_LEVEL $CONFIG $OUTPUT_DIR/output.osm \
     --report-output $OUTPUT_DIR/output-validation-report --output $OUTPUT_DIR/output-validated.osm
@@ -33,32 +35,32 @@ validateTestOutput $OUTPUT_DIR/output.osm \
 echo ""
 echo "Running diff changeset with tags..."
 echo ""
-hoot conflate $LOG_LEVEL $CONFIG $GENERAL_OPTS  \
+hoot conflate $LOG_LEVEL $CONFIG $GENERAL_OPTS $INCLUDE_TAGS \
  $INPUT_DIR/input1.osm $INPUT_DIR/input2.osm \
- $OUTPUT_DIR/output_unified.osc --differential --include-tags --changeset-stats $OUTPUT_DIR/output_unified_changeset_stats.json
+ $OUTPUT_DIR/output_unified.osc --changeset-stats $OUTPUT_DIR/output_unified_changeset_stats.json
 # Check command line display of stats
-hoot conflate $LOG_LEVEL $CONFIG $GENERAL_OPTS  \
+hoot conflate $LOG_LEVEL $CONFIG $GENERAL_OPTS $INCLUDE_TAGS \
  $INPUT_DIR/input1.osm $INPUT_DIR/input2.osm \
- $OUTPUT_DIR/output_unified.osc --differential --include-tags --changeset-stats
+ $OUTPUT_DIR/output_unified.osc --changeset-stats
 
 # Run changeset w/tags to produce a unified map (osm) output
 echo ""
 echo "Running diff with tags..."
 echo ""
-hoot conflate $LOG_LEVEL $CONFIG $GENERAL_OPTS \
- $INPUT_DIR/input1.osm $INPUT_DIR/input2.osm $OUTPUT_DIR/output_unified.osm --differential --include-tags
+hoot conflate $LOG_LEVEL $CONFIG $GENERAL_OPTS $INCLUDE_TAGS \
+ $INPUT_DIR/input1.osm $INPUT_DIR/input2.osm $OUTPUT_DIR/output_unified.osm
 
 # Run changeset w/tags to produce separate outputs for geometry and tags
 echo ""
 echo "Running diff changeset with tags, separate outputs..."
 echo ""
-hoot conflate $LOG_LEVEL $CONFIG $GENERAL_OPTS \
+hoot conflate $LOG_LEVEL $CONFIG $GENERAL_OPTS $INCLUDE_TAGS $SEPARATE_OUTPUT \
  $INPUT_DIR/input1.osm $INPUT_DIR/input2.osm \
- $OUTPUT_DIR/output.osc --differential --include-tags --changeset-stats $OUTPUT_DIR/output_changeset_stats.json --separate-output
+ $OUTPUT_DIR/output.osc --changeset-stats $OUTPUT_DIR/output_changeset_stats.json
 # Check command line display of stats
-hoot conflate $LOG_LEVEL $CONFIG $GENERAL_OPTS \
+hoot conflate $LOG_LEVEL $CONFIG $GENERAL_OPTS $INCLUDE_TAGS $SEPARATE_OUTPUT \
  $INPUT_DIR/input1.osm $INPUT_DIR/input2.osm \
- $OUTPUT_DIR/output.osc --differential --include-tags --changeset-stats --separate-output
+ $OUTPUT_DIR/output.osc --changeset-stats
 
 echo ""
 echo "Checking differential output..."
@@ -155,18 +157,18 @@ hoot conflate $LOG_LEVEL $CONFIG $GENERAL_OPTS \
  -D writer.include.debug.tags=true -D differential.snap.unconnected.features=true \
  -D snap.unconnected.ways.snap.criteria=HighwayCriterion \
  $INPUT_DIR/input3.osm $INPUT_DIR/input4.osm \
- $OUTPUT_DIR/snapped-output.osm --differential
+ $OUTPUT_DIR/snapped-output.osm
 hoot diff --warn -C Testing.conf $OUTPUT_DIR/snapped-output.osm $INPUT_DIR/snapped-output.osm || \
   diff $OUTPUT_DIR/snapped-output.osm $INPUT_DIR/snapped-output.osm
 
 echo ""
 echo "Checking conflation with road snapping and w/ tags..."
 echo ""
-hoot conflate $LOG_LEVEL $CONFIG $GENERAL_OPTS \
+hoot conflate $LOG_LEVEL $CONFIG $GENERAL_OPTS $INCLUDE_TAGS \
  -D writer.include.debug.tags=true -D differential.snap.unconnected.features=true \
  -D snap.unconnected.ways.snap.criteria=HighwayCriterion \
  $INPUT_DIR/input3.osm $INPUT_DIR/input4.osm \
- $OUTPUT_DIR/snapped-with-tags-output.osm --differential --include-tags
+ $OUTPUT_DIR/snapped-with-tags-output.osm
 hoot diff --warn -C Testing.conf $OUTPUT_DIR/snapped-with-tags-output.osm $INPUT_DIR/snapped-with-tags-output.osm || \
   diff $OUTPUT_DIR/snapped-with-tags-output.osm $INPUT_DIR/snapped-with-tags-output.osm
 
@@ -178,7 +180,7 @@ hoot conflate $LOG_LEVEL $CONFIG $GENERAL_OPTS \
  -D snap.unconnected.ways.snap.criteria=HighwayCriterion \
  -D differential.remove.reference.data=false \
  $INPUT_DIR/input3.osm $INPUT_DIR/input4.osm \
- $OUTPUT_DIR/snapped-with-ref-output.osm --differential
+ $OUTPUT_DIR/snapped-with-ref-output.osm
 hoot diff --warn -C Testing.conf $OUTPUT_DIR/snapped-with-ref-output.osm \
   $INPUT_DIR/snapped-with-ref-output.osm || \
   diff $OUTPUT_DIR/snapped-with-ref-output.osm $INPUT_DIR/snapped-with-ref-output.osm
@@ -201,7 +203,7 @@ hoot conflate $LOG_LEVEL $CONFIG $GENERAL_OPTS \
  -D snap.unconnected.ways.snap.criteria=HighwayCriterion \
  -D differential.remove.reference.snapped.data=true \
  $INPUT_DIR/input3.osm $INPUT_DIR/input4.osm \
- $OUTPUT_DIR/snapped-with-all-ref-removed-output.osm --differential
+ $OUTPUT_DIR/snapped-with-all-ref-removed-output.osm
 hoot diff --warn -C Testing.conf $OUTPUT_DIR/snapped-with-all-ref-removed-output.osm \
   $INPUT_DIR/snapped-with-all-ref-removed-output.osm || \
   diff $OUTPUT_DIR/snapped-with-all-ref-removed-output.osm $INPUT_DIR/snapped-with-all-ref-removed-output.osm
@@ -213,6 +215,6 @@ echo ""
 # retaining wall from the second dataset, which hoot is unable to conflate, will pass through to output.
 hoot conflate $LOG_LEVEL $CONFIG $GENERAL_OPTS \
  -D differential.remove.unconflatable.data=false $INPUT_DIR/input1.osm $INPUT_DIR/input2.osm \
- $OUTPUT_DIR/output-keep-unconflatable.osm --differential
+ $OUTPUT_DIR/output-keep-unconflatable.osm
 hoot diff --warn -C Testing.conf $OUTPUT_DIR/output-keep-unconflatable.osm $INPUT_DIR/output-keep-unconflatable.osm || \
      diff $OUTPUT_DIR/output-keep-unconflatable.osm $INPUT_DIR/output-keep-unconflatable.osm

--- a/test-files/cmd/glacial/DiffConflatePartialLinearMatchTest.sh
+++ b/test-files/cmd/glacial/DiffConflatePartialLinearMatchTest.sh
@@ -14,14 +14,14 @@ source scripts/core/ScriptTestUtils.sh
  
 # Remove partial linear matches partially. This results in a more granular diff.
 hoot conflate $LOG_LEVEL $CONFIG -D differential.remove.linear.partial.matches.as.whole=false \
-  $INPUT_DIR/input1.osm $INPUT_DIR/input2.osm $OUTPUT_DIR/output-partial.osm --differential
+  $INPUT_DIR/input1.osm $INPUT_DIR/input2.osm $OUTPUT_DIR/output-partial.osm
 hoot diff $LOG_LEVEL -C Testing.conf $INPUT_DIR/output-partial.osm $OUTPUT_DIR/output-partial.osm
 validateTestOutput $OUTPUT_DIR/output-partial.osm $OUTPUT_DIR/output-partial-validation-report \
   $OUTPUT_DIR/output-partial-validated.osm $INPUT_DIR/output-partial-validation-report
 
 # Remove partial linear matches completely. This results in a less granular diff.
 hoot conflate $LOG_LEVEL $CONFIG -D differential.remove.linear.partial.matches.as.whole=true \
-  $INPUT_DIR/input1.osm $INPUT_DIR/input2.osm $OUTPUT_DIR/output-complete.osm --differential
+  $INPUT_DIR/input1.osm $INPUT_DIR/input2.osm $OUTPUT_DIR/output-complete.osm
 hoot diff $LOG_LEVEL -C Testing.conf $INPUT_DIR/output-complete.osm $OUTPUT_DIR/output-complete.osm
 validateTestOutput $OUTPUT_DIR/output-complete.osm $OUTPUT_DIR/output-complete-validation-report \
   $OUTPUT_DIR/output-complete-validated.osm $INPUT_DIR/output-complete-validation-report
@@ -31,7 +31,7 @@ validateTestOutput $OUTPUT_DIR/output-complete.osm $OUTPUT_DIR/output-complete-v
 hoot conflate $LOG_LEVEL $CONFIG -D differential.remove.linear.partial.matches.as.whole=false \
   -D differential.sec.way.removal.criteria="HighwayCriterion" \
   -D differential.sec.way.removal.length.threshold=15.0 $INPUT_DIR/input1.osm \
-  $INPUT_DIR/input2.osm $OUTPUT_DIR/output-partial-cleaned.osm --differential
+  $INPUT_DIR/input2.osm $OUTPUT_DIR/output-partial-cleaned.osm
 hoot diff $LOG_LEVEL -C Testing.conf \
   $INPUT_DIR/output-partial-cleaned.osm $OUTPUT_DIR/output-partial-cleaned.osm
 if [ -f "test-output/test-validation-enabled" ]; then

--- a/test-files/cmd/glacial/PowerLineDiffConflateTest.sh
+++ b/test-files/cmd/glacial/PowerLineDiffConflateTest.sh
@@ -15,7 +15,7 @@ source scripts/core/ScriptTestUtils.sh
 
 # remove partial matches partially
 hoot conflate $LOG_LEVEL $CONFIG -D differential.remove.linear.partial.matches.as.whole=false \
-  $IN_DIR_2/power-line-1.osm $IN_DIR_2/power-line-2.osm $OUT_DIR/output-partial.osm --differential
+  $IN_DIR_2/power-line-1.osm $IN_DIR_2/power-line-2.osm $OUT_DIR/output-partial.osm
 hoot diff $LOG_LEVEL -C Testing.conf $IN_DIR/output-partial.osm $OUT_DIR/output-partial.osm || \
   diff $IN_DIR/output-partial.osm $OUT_DIR/output-partial.osm
 validateTestOutput $OUT_DIR/output-partial.osm $OUT_DIR/output-partial-validation-report \
@@ -23,7 +23,7 @@ validateTestOutput $OUT_DIR/output-partial.osm $OUT_DIR/output-partial-validatio
 
 # remove partial matches completely
 hoot conflate $LOG_LEVEL $CONFIG -D differential.remove.linear.partial.matches.as.whole=true \
-  $IN_DIR_2/power-line-1.osm $IN_DIR_2/power-line-2.osm $OUT_DIR/output-complete.osm --differential
+  $IN_DIR_2/power-line-1.osm $IN_DIR_2/power-line-2.osm $OUT_DIR/output-complete.osm
 hoot diff $LOG_LEVEL -C Testing.conf $IN_DIR/output-complete.osm $OUT_DIR/output-complete.osm || \
   diff $IN_DIR/output-complete.osm $OUT_DIR/output-complete.osm
 validateTestOutput $OUT_DIR/output-complete.osm $OUT_DIR/output-complete-validation-report \

--- a/test-files/cmd/glacial/RiverMaxSublineRecursionTest.sh
+++ b/test-files/cmd/glacial/RiverMaxSublineRecursionTest.sh
@@ -17,4 +17,13 @@ OUT_DIR=test-output/cmd/glacial/$TEST_NAME
 mkdir -p $OUT_DIR
 
 # Its very expensive to only remove partial matches for this dataset, so we disable that feature.
-hoot conflate $LOG_LEVEL -C DifferentialConflation.conf -C NetworkAlgorithm.conf -C Testing.conf -D differential.remove.linear.partial.matches.as.whole=true -D differential.remove.river.partial.matches.as.whole=true -D match.creators=ScriptMatchCreator,River.js -D merger.creators=ScriptMergerCreator -D differential.snap.unconnected.features=true -D snap.unconnected.ways.snap.criteria=HighwayCriterion $IN_DIR/Input1.osm $IN_DIR/Input2.osm $OUT_DIR/diff.osc --differential --changeset-stats $OUT_DIR/stats.json --include-tags --separate-output
+hoot conflate $LOG_LEVEL -C DifferentialConflation.conf -C NetworkAlgorithm.conf -C Testing.conf \
+ -D differential.remove.linear.partial.matches.as.whole=true \
+ -D differential.remove.river.partial.matches.as.whole=true \
+ -D match.creators=ScriptMatchCreator,River.js \
+ -D merger.creators=ScriptMergerCreator \
+ -D differential.snap.unconnected.features=true \
+ -D snap.unconnected.ways.snap.criteria=HighwayCriterion \
+ -D conflate.differential.include.tags=true \
+ -D conflate.differential.tags.separate.output=true \
+ $IN_DIR/Input1.osm $IN_DIR/Input2.osm $OUT_DIR/diff.osc --changeset-stats $OUT_DIR/stats.json

--- a/test-files/cmd/slow/DiffConflateTagChangeDifferingGeometriesTest.sh
+++ b/test-files/cmd/slow/DiffConflateTagChangeDifferingGeometriesTest.sh
@@ -21,8 +21,10 @@ LOG_LEVEL=--warn
 # not a lot of efficiency will be gained by reducing the matchers.
 echo "Running diff changeset with tags, separate outputs..."
 hoot conflate $LOG_LEVEL -C DifferentialConflation.conf -C NetworkAlgorithm.conf -C Testing.conf \
- -D differential.remove.linear.partial.matches.as.whole=true $INPUT_DIR/Input1.osm $INPUT_DIR/Input2.osm \
- $OUTPUT_DIR/output.osc --differential --include-tags --separate-output
+ -D differential.remove.linear.partial.matches.as.whole=true \
+ -D conflate.differential.include.tags=true \
+ -D conflate.differential.tags.separate.output=true \
+ $INPUT_DIR/Input1.osm $INPUT_DIR/Input2.osm $OUTPUT_DIR/output.osc
 
 # Check tag output
 echo "Checking tag diff"

--- a/test-files/cmd/slow/NetworkConflateCmdRelationEdgeTest.sh
+++ b/test-files/cmd/slow/NetworkConflateCmdRelationEdgeTest.sh
@@ -14,7 +14,7 @@ OUTPUT_DIR=test-output/cmd/slow/NetworkConflateCmdRelationEdgeTest
 rm -rf $OUTPUT_DIR
 mkdir -p $OUTPUT_DIR
 
-hoot conflate --warn -C DifferentialConflation.conf -C NetworkAlgorithm.conf -C Testing.conf \
+hoot conflate --warn -C ReferenceConflation.conf -C NetworkAlgorithm.conf -C Testing.conf \
   -D uuid.helper.repeatable=true -D match.creators="NetworkMatchCreator" \
   -D merger.creators="NetworkMergerCreator" \
   $INPUT_DIR/input1.osm $INPUT_DIR/input2.osm $OUTPUT_DIR/out.osm

--- a/test-files/cmd/slow/RiverDiffConflateTest.sh
+++ b/test-files/cmd/slow/RiverDiffConflateTest.sh
@@ -17,7 +17,7 @@ source scripts/core/ScriptTestUtils.sh
 # remove partial matches partially
 hoot conflate $LOG_LEVEL $CONFIG -D differential.remove.river.partial.matches.as.whole=false \
   $IN_DIR_2/Haiti_CNIGS_Rivers_REF1-cropped-2.osm $IN_DIR_2/Haiti_osm_waterway_ss_REF2-cropped-2.osm \
-  $OUT_DIR/output-partial.osm --differential
+  $OUT_DIR/output-partial.osm
 hoot diff $LOG_LEVEL -C Testing.conf $IN_DIR/output-partial.osm $OUT_DIR/output-partial.osm || \
   diff $IN_DIR/output-partial.osm $OUT_DIR/output-partial.osm
 validateTestOutput $OUT_DIR/output-partial.osm $OUT_DIR/output-partial-validation-report \
@@ -26,7 +26,7 @@ validateTestOutput $OUT_DIR/output-partial.osm $OUT_DIR/output-partial-validatio
 # remove partial matches completely
 hoot conflate $LOG_LEVEL $CONFIG -D differential.remove.river.partial.matches.as.whole=true \
   $IN_DIR_2/Haiti_CNIGS_Rivers_REF1-cropped-2.osm $IN_DIR_2/Haiti_osm_waterway_ss_REF2-cropped-2.osm \
-  $OUT_DIR/output-complete.osm --differential
+  $OUT_DIR/output-complete.osm
 hoot diff $LOG_LEVEL -C Testing.conf $IN_DIR/output-complete.osm $OUT_DIR/output-complete.osm || \
   diff $IN_DIR/output-complete.osm $OUT_DIR/output-complete.osm
 validateTestOutput $OUT_DIR/output-complete.osm $OUT_DIR/output-complete-validation-report \

--- a/test-files/cmd/slow/serial/RailwayDiffConflateTest.sh
+++ b/test-files/cmd/slow/serial/RailwayDiffConflateTest.sh
@@ -17,7 +17,7 @@ source scripts/core/ScriptTestUtils.sh
 hoot conflate $LOG_LEVEL $CONFIG -D differential.remove.linear.partial.matches.as.whole=false \
   -D conflate.pre.ops++=ReplaceTagVisitor -D replace.tag.visitor.match.tag="railway=Other" \
   -D replace.tag.visitor.replace.tag="railway=rail" $IN_DIR_2/RR_Ref1_ManuallyMatched.osm \
-  $IN_DIR_2/RR_Ref2_ManuallyMatched.osm $OUT_DIR/output-partial.osm --differential
+  $IN_DIR_2/RR_Ref2_ManuallyMatched.osm $OUT_DIR/output-partial.osm
 hoot diff $LOG_LEVEL -C Testing.conf $IN_DIR/output-partial.osm $OUT_DIR/output-partial.osm || \
   diff $IN_DIR/output-partial.osm $OUT_DIR/output-partial.osm
 validateTestOutput $OUT_DIR/output-partial.osm $OUT_DIR/output-partial-validation-report \
@@ -27,7 +27,7 @@ validateTestOutput $OUT_DIR/output-partial.osm $OUT_DIR/output-partial-validatio
 hoot conflate $LOG_LEVEL $CONFIG -D differential.remove.linear.partial.matches.as.whole=true \
   -D conflate.pre.ops++=ReplaceTagVisitor -D replace.tag.visitor.match.tag="railway=Other" \
   -D replace.tag.visitor.replace.tag="railway=rail" $IN_DIR_2/RR_Ref1_ManuallyMatched.osm \
-  $IN_DIR_2/RR_Ref2_ManuallyMatched.osm $OUT_DIR/output-complete.osm --differential
+  $IN_DIR_2/RR_Ref2_ManuallyMatched.osm $OUT_DIR/output-complete.osm
 hoot diff $LOG_LEVEL -C Testing.conf $IN_DIR/output-complete.osm $OUT_DIR/output-complete.osm || \
   diff $IN_DIR/output-complete.osm $OUT_DIR/output-complete.osm
 validateTestOutput $OUT_DIR/output-complete.osm $OUT_DIR/output-complete-validation-report \

--- a/test-files/cmd/slow/serial/ServiceDiffRoadSnapTest.sh.off
+++ b/test-files/cmd/slow/serial/ServiceDiffRoadSnapTest.sh.off
@@ -25,12 +25,12 @@ fi
 if [[ "$7" == "false" ]]; then
   INCLUDE_TAGS=
 else
-  INCLUDE_TAGS=--include-tags
+  INCLUDE_TAGS="-D conflate.differential.include.tags=true"
 fi
 if [[ "$8" == "false" ]]; then
   SEPARATE_OUTPUT=
 else
-  SEPARATE_OUTPUT=--separate-output
+  SEPARATE_OUTPUT="-D conflate.differential.tags.separate.output=true"
 fi
 ALG_CONFIG=$9
 # This is a bit of a hack, but just trying to reduce test runtime here.
@@ -128,16 +128,16 @@ if [ "$NUM_STEPS" == "2" ]; then
   echo ""
   echo "Running conflation as part of a two step process..."
   echo ""
-  hoot conflate $LOG_LEVEL $LOG_FILTER $BOUNDS $GENERAL_OPTS $DB_OPTS $CONFLATE_OPTS $CHANGESET_DERIVE_OPTS $REF_INPUT $SEC_INPUT $OUTPUT_DIR/diff.osc.sql --osmApiDatabaseUrl $OSM_API_DB_URL --differential $INCLUDE_TAGS $SEPARATE_OUTPUT --write-bounds
+  hoot conflate $LOG_LEVEL $LOG_FILTER $BOUNDS $GENERAL_OPTS $DB_OPTS $CONFLATE_OPTS $CHANGESET_DERIVE_OPTS $INCLUDE_TAGS $SEPARATE_OUTPUT $REF_INPUT $SEC_INPUT $OUTPUT_DIR/diff.osc.sql --osmApiDatabaseUrl $OSM_API_DB_URL --write-bounds
   if [ "$DEBUG" == "true" ]; then
-    hoot conflate $LOG_LEVEL $LOG_FILTER $BOUNDS $GENERAL_OPTS $DB_OPTS $CONFLATE_OPTS $CHANGESET_DERIVE_OPTS $REF_INPUT $SEC_INPUT $OUTPUT_DIR/diff.osc --differential $INCLUDE_TAGS $SEPARATE_OUTPUT --write-bounds
+    hoot conflate $LOG_LEVEL $LOG_FILTER $BOUNDS $GENERAL_OPTS $DB_OPTS $CONFLATE_OPTS $CHANGESET_DERIVE_OPTS $INCLUDE_TAGS $SEPARATE_OUTPUT $REF_INPUT $SEC_INPUT $OUTPUT_DIR/diff.osc --write-bounds
   fi
 else
   # Run diff conflate to osm w/ road snapping; retain both sets of IDs during conflate
   echo ""
   echo "Running conflation as part of a three step process..."
   echo ""
-  hoot conflate $LOG_LEVEL $LOG_FILTER $BOUNDS $GENERAL_OPTS $DB_OPTS $CONFLATE_OPTS $REF_INPUT $SEC_INPUT $OUTPUT_DIR/diff.osm --differential $INCLUDE_TAGS $SEPARATE_OUTPUT --write-bounds
+  hoot conflate $LOG_LEVEL $LOG_FILTER $BOUNDS $GENERAL_OPTS $DB_OPTS $CONFLATE_OPTS $INCLUDE_TAGS $SEPARATE_OUTPUT $REF_INPUT $SEC_INPUT $OUTPUT_DIR/diff.osm --write-bounds
   # Generate a changeset between the original ref data and the diff calculated in the previous step
   echo ""
   echo "Running changeset derivation as part of a three step process..."


### PR DESCRIPTION
Move differential conflation from a command line argument `--differential`, `--include-tags`, and `--separate-output` to a config options.  Updated `DifferentialConflation.conf` to enable `conflate.differential`.  Updated all affected unit tests.

Closes #5084 