### PR TITLE
Add support for polygon bounds in OsmApiReader

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTest.cpp
@@ -38,7 +38,7 @@
 #include <hoot/core/util/OsmApiUtils.h>
 
 //  Run tests against a local test server
-#define RUN_LOCAL_TEST_SERVER
+//#define RUN_LOCAL_TEST_SERVER
 
 namespace hoot
 {
@@ -46,16 +46,16 @@ namespace hoot
 class OsmApiReaderTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(OsmApiReaderTest);
-#ifdef ENABLE_OSM_API_READER_TEST
+  CPPUNIT_TEST(runLoadBoundsTest);
 
 #ifdef RUN_LOCAL_TEST_SERVER
   CPPUNIT_TEST(runSimpleTest);
   CPPUNIT_TEST(runSplitGeographicTest);
   CPPUNIT_TEST(runSplitElementsTest);
   CPPUNIT_TEST(runFailureTest);
+  CPPUNIT_TEST(runPolygonBoundsTest);
 #endif
 
-#endif
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -67,11 +67,52 @@ public:
   const int PORT_SIMPLE =         9900;
   const int PORT_SPLIT_GEO =      9901;
   const int PORT_SPLIT_ELEMENTS = 9902;
+  const int PORT_POLYGON =        9903;
 
   OsmApiReaderTest()
     : HootTestFixture("test-files/io/OsmApiReaderTest/",
                       "test-output/io/OsmApiReaderTest/")
   {
+  }
+
+  void runLoadBoundsTest()
+  {
+    OsmApiReader reader;
+    Settings s;
+    //  Use a bounding box in `bounds`
+    s.set(ConfigOptions::getBoundsKey(), "38.4902,35.7982,38.6193,35.8536");
+    s.set(ConfigOptions::getBoundsInputFileKey(), "");
+    reader.setConfiguration(s);
+    CPPUNIT_ASSERT(reader._loadBounds());
+    CPPUNIT_ASSERT(!reader._isPolygon);
+
+    //  Use a bounding polygon that is a rectangle in `bounds`
+    s.set(ConfigOptions::getBoundsKey(), "-72.474,18.545;-72.474,18.548;-72.471,18.548;-72.471,18.545;-72.474,18.545");
+    s.set(ConfigOptions::getBoundsInputFileKey(), "");
+    reader.setConfiguration(s);
+    CPPUNIT_ASSERT(reader._loadBounds());
+    CPPUNIT_ASSERT(!reader._isPolygon);
+
+    //  Use a bounding polygon in `bounds`
+    s.set(ConfigOptions::getBoundsKey(), "-72.474,18.545;-72.471,18.548;-72.471,18.545;-72.474,18.545");
+    s.set(ConfigOptions::getBoundsInputFileKey(), "");
+    reader.setConfiguration(s);
+    CPPUNIT_ASSERT(reader._loadBounds());
+    CPPUNIT_ASSERT(reader._isPolygon);
+
+    //  Use a bounding box in `bounds.input.file`
+    s.set(ConfigOptions::getBoundsKey(), "");
+    s.set(ConfigOptions::getBoundsInputFileKey(), _inputPath + "ToyTestBboxBounds.osm");
+    reader.setConfiguration(s);
+    CPPUNIT_ASSERT(reader._loadBounds());
+    CPPUNIT_ASSERT(!reader._isPolygon);
+
+    //  Use a bounding polygon in `bounds.input.file`
+    s.set(ConfigOptions::getBoundsKey(), "");
+    s.set(ConfigOptions::getBoundsInputFileKey(), _inputPath + "ToyTestPolyBounds.osm");
+    reader.setConfiguration(s);
+    CPPUNIT_ASSERT(reader._loadBounds());
+    CPPUNIT_ASSERT(reader._isPolygon);
   }
 
   void runSimpleTest()
@@ -178,6 +219,35 @@ public:
     }
     CPPUNIT_ASSERT(exceptionMsg == "Cannot request areas larger than 1.0000 square degrees.");
 #endif
+  }
+
+  void runPolygonBoundsTest()
+  {
+#ifdef RUN_LOCAL_TEST_SERVER
+    SimpleReaderTestServer server(PORT_POLYGON);
+    server.start();
+
+    OsmMapPtr map = std::make_shared<OsmMap>();
+
+    OsmApiReader reader;
+    Settings s;
+    s.set(ConfigOptions::getReaderHttpBboxThreadCountKey(), 1);
+    s.set(ConfigOptions::getBoundsInputFileKey(), _inputPath + "ToyTestPolyBounds.osm");
+    reader.setConfiguration(s);
+    reader.open(LOCAL_TEST_API_URL.arg(PORT_POLYGON) + OsmApiEndpoints::API_PATH_MAP);
+    reader.read(map);
+
+    server.shutdown();
+
+    QString output = _outputPath + "PolygonBoundsTestOutput.osm";
+
+    OsmXmlWriter writer;
+    writer.write(map, output);
+    writer.close();
+
+    HOOT_FILE_EQUALS(_inputPath + "PolygonBoundsTestExpected.osm", output);
+#endif
+
   }
 };
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "OsmApiReaderTestServer.h"

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #include "HighwayMatchCreator.h"
 
@@ -37,8 +37,8 @@
 #include <hoot/core/criterion/HighwayCriterion.h>
 #include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/schema/TagAncestorDifferencer.h>
-#include <hoot/core/util/ConfPath.h>
 #include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/ConfPath.h>
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/MemoryUsageChecker.h>
 #include <hoot/core/util/StringUtils.h>
@@ -76,38 +76,36 @@ class HighwayMatchVisitor : public ConstElementVisitor
 {
 public:
 
-  HighwayMatchVisitor(
-    const ConstOsmMapPtr& map, vector<ConstMatchPtr>& result,
-    ElementCriterionPtr filter = ElementCriterionPtr()) :
-  _map(map),
-  _result(result),
-  _filter(filter)
+  HighwayMatchVisitor(const ConstOsmMapPtr& map, vector<ConstMatchPtr>& result,
+                      ElementCriterionPtr filter = ElementCriterionPtr())
+  : _map(map),
+    _result(result),
+    _filter(filter)
   {
   }
 
-  HighwayMatchVisitor(
-    const ConstOsmMapPtr& map, vector<ConstMatchPtr>& result,
-    std::shared_ptr<HighwayClassifier> classifier,
-    std::shared_ptr<HighwayClassifier> medianClassifier,
-    std::shared_ptr<SublineStringMatcher> sublineMatcher, ConstMatchThresholdPtr threshold,
-    std::shared_ptr<TagAncestorDifferencer> tagAncestorDiff,
-    ElementCriterionPtr filter = ElementCriterionPtr()):
-  _map(map),
-  _result(result),
-  _classifier(classifier),
-  _medianClassifier(medianClassifier),
-  _sublineMatcher(sublineMatcher),
-  _threshold(threshold),
-  _neighborCountMax(-1),
-  _neighborCountSum(0),
-  _elementsEvaluated(0),
-  _searchRadius(ConfigOptions().getSearchRadiusHighway()),
-  _tagAncestorDiff(tagAncestorDiff),
-  _filter(filter),
-  _numElementsVisited(0),
-  _numMatchCandidatesVisited(0),
-  _taskStatusUpdateInterval(ConfigOptions().getTaskStatusUpdateInterval()),
-  _memoryCheckUpdateInterval(ConfigOptions().getMemoryUsageCheckerInterval())
+  HighwayMatchVisitor(const ConstOsmMapPtr& map, vector<ConstMatchPtr>& result,
+                      std::shared_ptr<HighwayClassifier> classifier,
+                      std::shared_ptr<HighwayClassifier> medianClassifier,
+                      std::shared_ptr<SublineStringMatcher> sublineMatcher, ConstMatchThresholdPtr threshold,
+                      std::shared_ptr<TagAncestorDifferencer> tagAncestorDiff,
+                      ElementCriterionPtr filter = ElementCriterionPtr())
+  : _map(map),
+    _result(result),
+    _classifier(classifier),
+    _medianClassifier(medianClassifier),
+    _sublineMatcher(sublineMatcher),
+    _threshold(threshold),
+    _neighborCountMax(-1),
+    _neighborCountSum(0),
+    _elementsEvaluated(0),
+    _searchRadius(ConfigOptions().getSearchRadiusHighway()),
+    _tagAncestorDiff(tagAncestorDiff),
+    _filter(filter),
+    _numElementsVisited(0),
+    _numMatchCandidatesVisited(0),
+    _taskStatusUpdateInterval(ConfigOptions().getTaskStatusUpdateInterval()),
+    _memoryCheckUpdateInterval(ConfigOptions().getMemoryUsageCheckerInterval())
   {
   }
 
@@ -132,11 +130,11 @@ public:
     int neighborCount = 0;
 
     const bool medianMatchEnabled = _medianClassifier.get();
-    for (set<ElementId>::const_iterator it = neighbors.begin(); it != neighbors.end(); ++it)
+    for (const auto& elementId : neighbors)
     {
-      if (elementBeingMatched != *it)
+      if (elementBeingMatched != elementId)
       {
-        const std::shared_ptr<const Element>& neighbor = _map->getElement(*it);
+        const std::shared_ptr<const Element>& neighbor = _map->getElement(elementId);
 
         std::shared_ptr<HighwayClassifier> classifier;
 
@@ -153,14 +151,10 @@ public:
           medianTagFound = !kvp.isEmpty();
           LOG_VART(medianTagFound);
           if (medianTagFound)
-          {
             classifier = _medianClassifier;
-          }
         }
         if (!medianTagFound)
-        {
           classifier = _classifier;
-        }
 
         // Score each candidate.
         std::shared_ptr<HighwayMatch> match =
@@ -177,10 +171,12 @@ public:
     _neighborCountMax = std::max(_neighborCountMax, neighborCount);
   }
 
-  static std::shared_ptr<HighwayMatch> createMatch(
-    const ConstOsmMapPtr& map, std::shared_ptr<HighwayClassifier> classifier,
-    std::shared_ptr<SublineStringMatcher> sublineMatcher, ConstMatchThresholdPtr threshold,
-    std::shared_ptr<TagAncestorDifferencer> tagAncestorDiff, ConstElementPtr e1, ConstElementPtr e2)
+  static std::shared_ptr<HighwayMatch> createMatch(const ConstOsmMapPtr& map,
+                                                   std::shared_ptr<HighwayClassifier> classifier,
+                                                   std::shared_ptr<SublineStringMatcher> sublineMatcher,
+                                                   ConstMatchThresholdPtr threshold,
+                                                   std::shared_ptr<TagAncestorDifferencer> tagAncestorDiff,
+                                                   ConstElementPtr e1, ConstElementPtr e2)
   {
     std::shared_ptr<HighwayMatch> result;
 
@@ -213,12 +209,9 @@ public:
             classifier, sublineMatcher, map, e1->getElementId(), e2->getElementId(), threshold);
         // if we're confident this is a miss
         if (result->getType() == MatchType::Miss)
-        {
           result.reset();
-        }
       }
     }
-
     return result;
   }
 
@@ -226,13 +219,9 @@ public:
   {
     Meters searchRadius;
     if (_searchRadius >= 0)
-    {
       searchRadius = _searchRadius;
-    }
     else
-    {
       searchRadius = e->getCircularError();
-    }
     LOG_VART(searchRadius);
     return searchRadius;
   }
@@ -242,7 +231,6 @@ public:
     if (e->getStatus() == Status::Unknown1 && isMatchCandidate(e))
     {
       checkForMatch(e);
-
       _numMatchCandidatesVisited++;
       if (_numMatchCandidatesVisited % (_taskStatusUpdateInterval * 10) == 0)
       {
@@ -253,7 +241,6 @@ public:
           " elements.");
       }
     }
-
     _numElementsVisited++;
     if (_numElementsVisited % _taskStatusUpdateInterval == 0)
     {
@@ -263,9 +250,7 @@ public:
         " elements.");
     }
     if (_numElementsVisited % _memoryCheckUpdateInterval == 0)
-    {
       MemoryUsageChecker::getInstance().check();
-    }
   }
 
   bool isMatchCandidate(ConstElementPtr element) const
@@ -346,13 +331,13 @@ private:
   int _memoryCheckUpdateInterval;
 };
 
-HighwayMatchCreator::HighwayMatchCreator() :
-_classifier(
-  Factory::getInstance().constructObject<HighwayClassifier>(
-    ConfigOptions().getConflateMatchHighwayClassifier())),
-_sublineMatcher(
-  SublineStringMatcherFactory::getMatcher(CreatorDescription::BaseFeatureType::Highway)),
-_tagAncestorDiff(std::make_shared<TagAncestorDifferencer>("highway"))
+HighwayMatchCreator::HighwayMatchCreator()
+  : _classifier(
+      Factory::getInstance().constructObject<HighwayClassifier>(
+        ConfigOptions().getConflateMatchHighwayClassifier())),
+    _sublineMatcher(
+      SublineStringMatcherFactory::getMatcher(CreatorDescription::BaseFeatureType::Highway)),
+    _tagAncestorDiff(std::make_shared<TagAncestorDifferencer>("highway"))
 {
   // Enable/disable road median matching and validate associated configuration options.
   setRunMedianMatching(
@@ -361,8 +346,8 @@ _tagAncestorDiff(std::make_shared<TagAncestorDifferencer>("highway"))
     ConfigOptions().getHighwayMedianToDualHighwayTransferKeys());
 }
 
-void HighwayMatchCreator::setRunMedianMatching(
-  const bool runMatching, const QStringList& identifyingTags, const QStringList& transferKeys)
+void HighwayMatchCreator::setRunMedianMatching(const bool runMatching, const QStringList& identifyingTags,
+                                               const QStringList& transferKeys)
 {
   if (runMatching)
   {
@@ -406,8 +391,8 @@ MatchPtr HighwayMatchCreator::createMatch(const ConstOsmMapPtr& map, ElementId e
       map->getElement(eid1), map->getElement(eid2));
 }
 
-void HighwayMatchCreator::createMatches(
-  const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& matches, ConstMatchThresholdPtr threshold)
+void HighwayMatchCreator::createMatches(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& matches,
+                                        ConstMatchThresholdPtr threshold)
 {
   QElapsedTimer timer;
   timer.start();
@@ -418,24 +403,19 @@ void HighwayMatchCreator::createMatches(
   QString searchRadiusStr;
   const double searchRadius = ConfigOptions().getSearchRadiusHighway();
   if (searchRadius < 0)
-  {
     searchRadiusStr = "within a feature dependent search radius";
-  }
   else
-  {
-    searchRadiusStr =
-      "within a search radius of " + QString::number(searchRadius, 'g', 2) + " meters";
-  }
+    searchRadiusStr = "within a search radius of " + QString::number(searchRadius, 'g', 2) + " meters";
+
   LOG_INFO("Looking for matches with: " << className() << " " << searchRadiusStr << "...");
   LOG_VARD(*threshold);
-  const int matchesSizeBefore = matches.size();
+  const int matchesSizeBefore = static_cast<int>(matches.size());
 
-  HighwayMatchVisitor v(
-    map, matches, _classifier, _medianClassifier, _sublineMatcher, threshold, _tagAncestorDiff,
-    _filter);
+  HighwayMatchVisitor v(map, matches, _classifier, _medianClassifier, _sublineMatcher, threshold,
+                        _tagAncestorDiff, _filter);
   map->visitWaysRo(v);
   map->visitRelationsRo(v);
-  const int matchesSizeAfter = matches.size();
+  const int matchesSizeAfter = static_cast<int>(matches.size());
 
   LOG_STATUS(
     "\tFound " << StringUtils::formatLargeNumber(v.getNumMatchCandidatesFound()) <<
@@ -467,7 +447,8 @@ std::shared_ptr<MatchThreshold> HighwayMatchCreator::getMatchThreshold()
   {
     _matchThreshold =
       std::make_shared<MatchThreshold>(
-        ConfigOptions().getHighwayMatchThreshold(), ConfigOptions().getHighwayMissThreshold(),
+        ConfigOptions().getHighwayMatchThreshold(),
+        ConfigOptions().getHighwayMissThreshold(),
         ConfigOptions().getHighwayReviewThreshold());
   }
   return _matchThreshold;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/highway/HighwayMatchCreator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef HIGHWAYMATCHCREATOR_H
 #define HIGHWAYMATCHCREATOR_H
@@ -55,9 +55,8 @@ public:
   /**
    * Search the provided map for highway matches and add the matches to the matches vector.
    */
-  void createMatches(
-    const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& matches,
-    ConstMatchThresholdPtr threshold) override;
+  void createMatches(const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& matches,
+                     ConstMatchThresholdPtr threshold) override;
 
   std::vector<CreatorDescription> getAllCreators() const override;
 
@@ -87,8 +86,7 @@ public:
    * @param transferKeys tag keys transferred from matching secondary road median features to
    * reference road median features
    */
-  void setRunMedianMatching(
-    const bool runMatching, const QStringList& identifyingTags, const QStringList& transferKeys);
+  void setRunMedianMatching(const bool runMatching, const QStringList& identifyingTags, const QStringList& transferKeys);
 
 private:
 
@@ -96,13 +94,10 @@ private:
   std::shared_ptr<HighwayClassifier> _classifier;
   // classifier used for the road median to divided road tag transfer workflow
   std::shared_ptr<HighwayClassifier> _medianClassifier;
-
   // geometry matcher
   std::shared_ptr<SublineStringMatcher> _sublineMatcher;
-
   // threshold controlling the determined match classification
   std::shared_ptr<MatchThreshold> _matchThreshold;
-
   // used to prevent roads of widely different types from matching
   std::shared_ptr<TagAncestorDifferencer> _tagAncestorDiff;
 };

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.cpp
@@ -36,14 +36,14 @@
 namespace hoot
 {
 
-MatchCreator::MatchCreator() :
-_boundsAddedToFilter(false)
+MatchCreator::MatchCreator()
+  : _boundsAddedToFilter(false)
 {
 }
 
-void MatchCreator::createMatches(
-  const ConstOsmMapPtr& map, std::vector<ConstMatchPtr>& /*matches*/,
-  ConstMatchThresholdPtr /*threshold*/)
+void MatchCreator::createMatches(const ConstOsmMapPtr& map,
+                                 std::vector<ConstMatchPtr>& /*matches*/,
+                                 ConstMatchThresholdPtr /*threshold*/)
 {    
   if (_filter)
   {
@@ -52,9 +52,7 @@ void MatchCreator::createMatches(
     std::shared_ptr<ConstOsmMapConsumer> mapConsumer =
       std::dynamic_pointer_cast<ConstOsmMapConsumer>(_filter);
     if (mapConsumer)
-    {
       mapConsumer->setOsmMap(map.get());
-    }
   }
 
   if (!_boundsAddedToFilter && ConfigUtils::boundsOptionEnabled())
@@ -79,9 +77,7 @@ void MatchCreator::createMatches(
 
     ElementCriterionPtr boundsFilter = ConfigUtils::getBoundsFilter(map);
     if (!_filter)
-    {
       _filter = boundsFilter;
-    }
     else
     {
       ElementCriterionPtr existingFilter = _filter->clone();

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "MatchCreator.h"

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/MatchCreator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef MATCHCREATOR_H
 #define MATCHCREATOR_H
@@ -30,9 +30,9 @@
 // Hoot
 #include <hoot/core/conflate/matching/Match.h>
 #include <hoot/core/conflate/matching/MatchThreshold.h>
-#include <hoot/core/info/CreatorDescription.h>
 #include <hoot/core/criterion/ElementCriterion.h>
 #include <hoot/core/criterion/FilteredByGeometryTypeCriteria.h>
+#include <hoot/core/info/CreatorDescription.h>
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/criterion/InBoundsCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/InBoundsCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "InBoundsCriterion.h"
@@ -31,27 +31,27 @@
 #include <geos/geom/GeometryFactory.h>
 
 // hoot
-#include <hoot/core/util/Factory.h>
 #include <hoot/core/elements/Element.h>
-#include <hoot/core/util/ConfigOptions.h>
-#include <hoot/core/geometry/GeometryUtils.h>
 #include <hoot/core/elements/WayUtils.h>
+#include <hoot/core/geometry/GeometryUtils.h>
+#include <hoot/core/util/ConfigOptions.h>
+#include <hoot/core/util/Factory.h>
 
 namespace hoot
 {
 
 HOOT_FACTORY_REGISTER(ElementCriterion, InBoundsCriterion)
 
-InBoundsCriterion::InBoundsCriterion() :
-_mustCompletelyContain(true),
-_treatWayNodesAsPartOfWays(true)
+InBoundsCriterion::InBoundsCriterion()
+  : _mustCompletelyContain(true),
+    _treatWayNodesAsPartOfWays(true)
 {
   setConfiguration(conf());
 }
 
-InBoundsCriterion::InBoundsCriterion(const bool mustCompletelyContain) :
-_mustCompletelyContain(mustCompletelyContain),
-_treatWayNodesAsPartOfWays(true)
+InBoundsCriterion::InBoundsCriterion(const bool mustCompletelyContain)
+  : _mustCompletelyContain(mustCompletelyContain),
+    _treatWayNodesAsPartOfWays(true)
 {
 }
 
@@ -79,51 +79,29 @@ void InBoundsCriterion::setOsmMap(const OsmMap* map)
 bool InBoundsCriterion::isSatisfied(const ConstElementPtr& e) const
 {
   if (!_map)
-  {
     throw IllegalArgumentException("No map passed to InBoundsCriterion.");
-  }
   if (!_bounds)
-  {
     throw IllegalArgumentException("No bounds passed to InBoundsCriterion.");
-  }
   if (!_elementConverter)
-  {
     throw IllegalArgumentException("No map set on InBoundsCriterion.");
-  }
   if (!_wayNodeCrit)
-  {
     throw IllegalArgumentException("No way node criterion set on InBoundsCriterion.");
-  }
   if (!e)
-  {
     return false;
-  }
   LOG_VART(e->getElementId());
 
   const bool isWayNode = _wayNodeCrit->isSatisfied(e);
   LOG_VART(isWayNode);
   if (!isWayNode || (isWayNode && !_treatWayNodesAsPartOfWays))
-  {
     return _nonWayNodeInBounds(e);
-  }
   else
   {
-    std::vector<ConstWayPtr> containingWays =
-      WayUtils::getContainingWaysConst(e->getElementId().getId(), _map);
+    std::vector<ConstWayPtr> containingWays = WayUtils::getContainingWaysConst(e->getElementId().getId(), _map);
     LOG_VART(containingWays.size());
-    for (std::vector<ConstWayPtr>::const_iterator containingWaysItr = containingWays.begin();
-         containingWaysItr != containingWays.end(); ++containingWaysItr)
+    for (const auto& containingWay : containingWays)
     {
-      ConstWayPtr containingWay = *containingWaysItr;
-      if (containingWay)
-      {
-        LOG_VART(containingWay->getElementId());
-        const bool inBounds = _nonWayNodeInBounds(containingWay);
-        if (inBounds)
-        {
+      if (containingWay && _nonWayNodeInBounds(containingWay))
           return true;
-        }
-      }
     }
     return false;
   }
@@ -133,9 +111,8 @@ bool InBoundsCriterion::_nonWayNodeInBounds(const ConstElementPtr& e) const
 {
   std::shared_ptr<geos::geom::Geometry> geom = _elementConverter->convertToGeometry(e);
   if (!geom || geom->isEmpty())
-  {
     return false;
-  }
+
   if (_mustCompletelyContain)
   {
     LOG_VART(_bounds->contains(geom.get()));

--- a/hoot-core/src/main/cpp/hoot/core/criterion/InBoundsCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/InBoundsCriterion.h
@@ -22,20 +22,20 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef IN_BOUNDS_CRITERION_H
 #define IN_BOUNDS_CRITERION_H
 
 // hoot
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/criterion/ElementCriterion.h>
-#include <hoot/core/util/Boundable.h>
-#include <hoot/core/elements/ConstOsmMapConsumer.h>
-#include <hoot/core/geometry/ElementToGeometryConverter.h>
-#include <hoot/core/util/Configurable.h>
 #include <hoot/core/criterion/WayNodeCriterion.h>
+#include <hoot/core/elements/ConstOsmMapConsumer.h>
+#include <hoot/core/elements/OsmMap.h>
+#include <hoot/core/geometry/ElementToGeometryConverter.h>
+#include <hoot/core/util/Boundable.h>
+#include <hoot/core/util/Configurable.h>
 
 // GEOS
 #include <geos/geom/Geometry.h>

--- a/hoot-core/src/main/cpp/hoot/core/elements/MapProjector.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/MapProjector.cpp
@@ -126,9 +126,9 @@ Radians MapProjector::_calculateAngle(Coordinate p1, Coordinate p2, Coordinate p
   return theta1 - theta2;
 }
 
-std::shared_ptr<OGRSpatialReference> MapProjector::createAeacProjection(const OGREnvelope& env)
+OGRSpatialReferencePtr MapProjector::createAeacProjection(const OGREnvelope& env)
 {
-  std::shared_ptr<OGRSpatialReference> srs(new OGRSpatialReference());
+  OGRSpatialReferencePtr srs(new OGRSpatialReference());
   srs->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
   double height = env.MaxY - env.MinY;
   double stdP1 = env.MinY + height * .25;
@@ -137,21 +137,17 @@ std::shared_ptr<OGRSpatialReference> MapProjector::createAeacProjection(const OG
   double y = (env.MinY + env.MaxY) / 2.0;
 
   if (env.MinX == env.MaxX || env.MinY == env.MaxY)
-  {
     throw HootException("Min and max bounds values cannot be the same.");
-  }
 
   if (srs->SetACEA(stdP1, stdP2, y, x, 0, 0) != OGRERR_NONE)
-  {
     throw HootException("Error creating Albers equal area conic projection.");
-  }
+
   return srs;
 }
 
-vector<std::shared_ptr<OGRSpatialReference>> MapProjector::createAllPlanarProjections(
-  const OGREnvelope& env) const
+vector<OGRSpatialReferencePtr> MapProjector::createAllPlanarProjections(const OGREnvelope& env) const
 {
-  vector<std::shared_ptr<OGRSpatialReference>> result;
+  vector<OGRSpatialReferencePtr> result;
 
   double centerLat = (env.MaxY + env.MinY) / 2.0;
   double centerLon = (env.MaxX + env.MinX) / 2.0;
@@ -166,79 +162,79 @@ vector<std::shared_ptr<OGRSpatialReference>> MapProjector::createAllPlanarProjec
     try { result.push_back(createAeacProjection(env)); } catch (const HootException&) { }
     try { result.push_back(createSinusoidalProjection(env)); } catch (const HootException&) { }
 
-    std::shared_ptr<OGRSpatialReference> mollweide(new OGRSpatialReference());
+    OGRSpatialReferencePtr mollweide(new OGRSpatialReference());
     mollweide->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     if (mollweide->SetFromUserInput("ESRI:54009") == OGRERR_NONE)
       result.push_back(mollweide);
 
-    std::shared_ptr<OGRSpatialReference> eckertVI(new OGRSpatialReference());
+    OGRSpatialReferencePtr eckertVI(new OGRSpatialReference());
     eckertVI->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     if (eckertVI->SetFromUserInput("ESRI:53010") == OGRERR_NONE)
       result.push_back(eckertVI);
 
-    std::shared_ptr<OGRSpatialReference> sphereBonne(new OGRSpatialReference());
+    OGRSpatialReferencePtr sphereBonne(new OGRSpatialReference());
     sphereBonne->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     if (sphereBonne->SetFromUserInput("ESRI:53024") == OGRERR_NONE)
       result.push_back(sphereBonne);
 
-    std::shared_ptr<OGRSpatialReference> customMercator(new OGRSpatialReference());
+    OGRSpatialReferencePtr customMercator(new OGRSpatialReference());
     customMercator->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     if (customMercator->SetMercator(centerLat, centerLon, 1.0, 0.0, 0.0) == OGRERR_NONE)
       result.push_back(customMercator);
 
-    std::shared_ptr<OGRSpatialReference> customBonne(new OGRSpatialReference());
+    OGRSpatialReferencePtr customBonne(new OGRSpatialReference());
     customBonne->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     if (customBonne->SetBonne(M_PI_2, centerLon, 0.0, 0.0) == OGRERR_NONE)
       result.push_back(customBonne);
 
     // Lambert azimuthal equal-area projection
-    std::shared_ptr<OGRSpatialReference> customLaea(new OGRSpatialReference());
+    OGRSpatialReferencePtr customLaea(new OGRSpatialReference());
     customLaea->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     if (customLaea->SetLAEA(centerLat, centerLon, 0.0, 0.0) == OGRERR_NONE)
       result.push_back(customLaea);
 
-    std::shared_ptr<OGRSpatialReference> customLcc1sp(new OGRSpatialReference());
+    OGRSpatialReferencePtr customLcc1sp(new OGRSpatialReference());
     customLcc1sp->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     if (customLcc1sp->SetLCC1SP(centerLat, centerLon, 1.0, 0.0, 0.0) == OGRERR_NONE)
       result.push_back(customLcc1sp);
 
-    std::shared_ptr<OGRSpatialReference> customRobinson(new OGRSpatialReference());
+    OGRSpatialReferencePtr customRobinson(new OGRSpatialReference());
     customRobinson->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     if (customRobinson->SetRobinson(centerLon, 0.0, 0.0) == OGRERR_NONE)
       result.push_back(customRobinson);
 
     // custom transverse mercator
-    std::shared_ptr<OGRSpatialReference> customTm(new OGRSpatialReference());
+    OGRSpatialReferencePtr customTm(new OGRSpatialReference());
     customTm->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     if (customTm->SetTM(centerLat, centerLon, 1.0, 0.0, 0.0) == OGRERR_NONE)
       result.push_back(customTm);
 
     // Polyconic
-    std::shared_ptr<OGRSpatialReference> customPolyconic(new OGRSpatialReference());
+    OGRSpatialReferencePtr customPolyconic(new OGRSpatialReference());
     customPolyconic->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     if (customPolyconic->SetPolyconic(centerLat, centerLon, 0.0, 0.0) == OGRERR_NONE)
       result.push_back(customPolyconic);
 
     // Two Point Equidistant
-    std::shared_ptr<OGRSpatialReference> customTped(new OGRSpatialReference());
+    OGRSpatialReferencePtr customTped(new OGRSpatialReference());
     customTped->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     if (customTped->SetTPED(stdP1, centerLon, stdP2, centerLon, 0.0, 0.0) == OGRERR_NONE)
       result.push_back(customTped);
 
     // Equidistant Conic
-    std::shared_ptr<OGRSpatialReference> customEc(new OGRSpatialReference());
+    OGRSpatialReferencePtr customEc(new OGRSpatialReference());
     customEc->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     if (customEc->SetEC(stdP1, stdP2, centerLat, centerLon, 0.0, 0.0) == OGRERR_NONE)
       result.push_back(customEc);
 
     // Azimuthal Equidistant
-    std::shared_ptr<OGRSpatialReference> customAe(new OGRSpatialReference());
+    OGRSpatialReferencePtr customAe(new OGRSpatialReference());
     customAe->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     if (customAe->SetAE(centerLat, centerLon, 0.0, 0.0) == OGRERR_NONE)
       result.push_back(customAe);
 
     // Lambert Convformal Conic
-    std::shared_ptr<OGRSpatialReference> customLcc(new OGRSpatialReference());
+    OGRSpatialReferencePtr customLcc(new OGRSpatialReference());
     customLcc->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     if (customLcc->SetLCC(stdP1, stdP2, centerLat, centerLon, 0.0, 0.0) == OGRERR_NONE)
       result.push_back(customLcc);
@@ -247,27 +243,25 @@ vector<std::shared_ptr<OGRSpatialReference>> MapProjector::createAllPlanarProjec
   return result;
 }
 
-std::shared_ptr<OGRSpatialReference> MapProjector::createOrthographic(const OGREnvelope& env)
+OGRSpatialReferencePtr MapProjector::createOrthographic(const OGREnvelope& env)
 {
   double x = (env.MinX + env.MaxX) / 2.0;
   double y = (env.MinY + env.MaxY) / 2.0;
   return createOrthographic(x, y);
 }
 
-std::shared_ptr<OGRSpatialReference> MapProjector::createOrthographic(double x, double y)
+OGRSpatialReferencePtr MapProjector::createOrthographic(double x, double y)
 {
-  std::shared_ptr<OGRSpatialReference> srs(new OGRSpatialReference());
+  OGRSpatialReferencePtr srs(new OGRSpatialReference());
   srs->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
   if (srs->SetOrthographic(y, x, 0, 0) != OGRERR_NONE)
-  {
     throw HootException("Error creating orthographic projection.");
-  }
   return srs;
 }
 
-std::shared_ptr<OGRSpatialReference> MapProjector::createPlanarProjection(
-  const OGREnvelope& env, Radians maxAngleError, Meters maxDistanceError, Meters testDistance,
-  bool warnOnFail) const
+OGRSpatialReferencePtr MapProjector::createPlanarProjection(const OGREnvelope& env, Radians maxAngleError,
+                                                            Meters maxDistanceError, Meters testDistance,
+                                                            bool warnOnFail) const
 {
   LOG_TRACE("Selecting best planar projection...");
 
@@ -279,33 +273,30 @@ std::shared_ptr<OGRSpatialReference> MapProjector::createPlanarProjection(
   if (env.MaxX == env.MinX || env.MaxY == env.MinY)
     return createOrthographic(env);
 
-  vector<std::shared_ptr<OGRSpatialReference>> projs = createAllPlanarProjections(env);
+  vector<OGRSpatialReferencePtr> projs = createAllPlanarProjections(env);
   LOG_VART(projs.size());
 
-  QString deg = QChar(0x00B0);
+  const QString deg = QChar(0x00B0);
 
   if (projs.empty())
-  {
     throw HootException("No candidate planar projections are available.");
-  }
 
   vector<PlanarTestResult> testResults;
   vector<PlanarTestResult> passingResults;
 
-  for (size_t i = 0; i < projs.size(); ++i)
+  size_t index = 0;
+  for (const auto& projection : projs)
   {
     PlanarTestResult tr;
-    tr.i = i;
-    if (_evaluateProjection(env, projs[i], testDistance, tr.distanceError, tr.angleError))
+    tr.i = index;
+    if (_evaluateProjection(env, projection, testDistance, tr.distanceError, tr.angleError))
     {
       // create a score that is weighted by the user's threshold values.
       tr.score = tr.distanceError / maxDistanceError + tr.angleError / maxAngleError;
       LOG_VART(tr.score);
       testResults.push_back(tr);
       if (tr.distanceError <= maxDistanceError && tr.angleError <= maxAngleError)
-      {
         passingResults.push_back(tr);
-      }
     }
     else
     {
@@ -315,6 +306,7 @@ std::shared_ptr<OGRSpatialReference> MapProjector::createPlanarProjection(
       testResults.push_back(tr);
     }
     LOG_TRACE("dis: " << tr.distanceError << "m angle: " << toDegrees(tr.angleError) << deg);
+    index++;
   }
 
   //  |<---                       80 cols                                         -->|
@@ -329,18 +321,16 @@ std::shared_ptr<OGRSpatialReference> MapProjector::createPlanarProjection(
   LOG_VART(testResults.size());
   if (!passingResults.empty())
   {
-    bestIndex = _findBestScore(passingResults);
+    bestIndex = static_cast<int>(_findBestScore(passingResults));
     LOG_VART(bestIndex);
     LOG_VART(toWkt(projs[bestIndex]));
   }
   else if (warnOnFail == false)
-  {
     level = Log::Warn;
-  }
   else if (!testResults.empty())
   {
     LOG_WARN(errorMessage);
-    bestIndex = _findBestScore(testResults);
+    bestIndex = static_cast<int>(_findBestScore(testResults));
     LOG_VART(bestIndex);
     level = Log::Info;
   }
@@ -353,19 +343,16 @@ std::shared_ptr<OGRSpatialReference> MapProjector::createPlanarProjection(
   LOG_LEVEL(level, "Projection: " << toWkt(projs[bestIndex]));
 
   if (bestIndex == -1)
-  {
     throw HootException(errorMessage);
-  }
 
   LOG_VART(toWkt(projs[bestIndex].get()));
   return projs[bestIndex];
 }
 
-std::shared_ptr<OGRSpatialReference> MapProjector::createSinusoidalProjection(
-const OGREnvelope& env)
+OGRSpatialReferencePtr MapProjector::createSinusoidalProjection(const OGREnvelope& env)
 {
   double centerLon = (env.MaxX + env.MinX) / 2.0;
-  std::shared_ptr<OGRSpatialReference> srs(new OGRSpatialReference());
+  OGRSpatialReferencePtr srs(new OGRSpatialReference());
   srs->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
   if (srs->SetSinusoidal(centerLon, 0.0, 0.0) != OGRERR_NONE)
   {
@@ -374,37 +361,30 @@ const OGREnvelope& env)
   return srs;
 }
 
-std::shared_ptr<OGRSpatialReference> MapProjector::createWgs84Projection()
+OGRSpatialReferencePtr MapProjector::createWgs84Projection()
 {
-  std::shared_ptr<OGRSpatialReference> srs(new OGRSpatialReference());
+  OGRSpatialReferencePtr srs(new OGRSpatialReference());
   srs->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
   if (srs->importFromEPSG(4326) != OGRERR_NONE)
-  {
     throw HootException("Error creating EPSG:4326 projection.");
-  }
   return srs;
 }
 
-bool MapProjector::_evaluateProjection(
-  const OGREnvelope& env, const std::shared_ptr<OGRSpatialReference>& srs, Meters testDistance,
-  Meters& maxDistanceError, Radians& maxAngleError) const
+bool MapProjector::_evaluateProjection(const OGREnvelope& env, const OGRSpatialReferencePtr& srs,
+                                       Meters testDistance, Meters& maxDistanceError,
+                                       Radians& maxAngleError) const
 {
   // Disable CPL error messages. They will be re-enabled when the DisableCplErrors object is
   // destructed.
   DisableCplErrors disableErrors;
-  std::shared_ptr<OGRSpatialReference> wgs84 = MapProjector::createWgs84Projection();
+  OGRSpatialReferencePtr wgs84 = MapProjector::createWgs84Projection();
 
-  std::shared_ptr<OGRCoordinateTransformation> t(
-    OGRCreateCoordinateTransformation(wgs84.get(), srs.get()));
+  std::shared_ptr<OGRCoordinateTransformation> t(OGRCreateCoordinateTransformation(wgs84.get(), srs.get()));
   if (t.get() == nullptr)
-  {
     return false;
-  }
 
   if (env.MaxX == env.MinX || env.MaxY == env.MinY)
-  {
     throw HootException("Cannot evaluate a projection with an envelope of zero area.");
-  }
 
   double width = env.MaxX - env.MinX;
   double height = env.MaxY - env.MinY;
@@ -426,20 +406,20 @@ bool MapProjector::_evaluateProjection(
     {
       Coordinate c1(x, y);
       Coordinate p1 = c1;
-      success &= t->Transform(1, &p1.x, &p1.y);
+      success = t->Transform(1, &p1.x, &p1.y) && success;
 
       if (!success)
         return false;
 
       Coordinate upc = GeometryUtils::calculateDestination(c1, 0.0, testDistance);
       Coordinate up = upc;
-      success &= t->Transform(1, &up.x, &up.y);
+      success = t->Transform(1, &up.x, &up.y) && success;
 
       for (double bearing = 0.0; bearing < 360.0; bearing += 20.0)
       {
         Coordinate c2 = GeometryUtils::calculateDestination(c1, bearing, testDistance);
         Coordinate p2 = c2;
-        success &= t->Transform(1, &p2.x, &p2.y);
+        success = t->Transform(1, &p2.x, &p2.y) && success;
 
         if (e->contains(c2))
         {
@@ -465,7 +445,7 @@ bool MapProjector::_evaluateProjection(
 }
 
 bool MapProjector::_distanceLessThan(const MapProjector::PlanarTestResult& p1,
-  const MapProjector::PlanarTestResult& p2)
+                                     const MapProjector::PlanarTestResult& p2)
 {
   return p1.distanceError < p2.distanceError;
 }
@@ -483,15 +463,13 @@ bool MapProjector::isGeographic(const ConstElementProviderPtr& provider)
 }
 
 Coordinate MapProjector::project(const Coordinate& c,
-                                 const std::shared_ptr<OGRSpatialReference>& srs1,
-                                 const std::shared_ptr<OGRSpatialReference>& srs2)
+                                 const OGRSpatialReferencePtr& srs1,
+                                 const OGRSpatialReferencePtr& srs2)
 {
   OGRCoordinateTransformation* t(OGRCreateCoordinateTransformation(srs1.get(), srs2.get()));
 
   if (t == nullptr)
-  {
     throw HootException(QString("Error creating transformation object: ") + CPLGetLastErrorMsg());
-  }
 
   LOG_TRACE("Reprojecting map from: " << toWkt(srs1) << " to " << toWkt(srs2) << "...");
 
@@ -506,23 +484,21 @@ Coordinate MapProjector::project(const Coordinate& c,
 }
 
 void MapProjector::project(const std::shared_ptr<OsmMap>& map,
-                           const std::shared_ptr<OGRSpatialReference>& ref)
+                           const OGRSpatialReferencePtr& ref)
 {
   LOG_TRACE("Reprojecting map to: " << toWkt(ref) << "...");
 
-  std::shared_ptr<OGRSpatialReference> sourceSrs = map->getProjection();
+  OGRSpatialReferencePtr sourceSrs = map->getProjection();
   OGRCoordinateTransformation* t(OGRCreateCoordinateTransformation(sourceSrs.get(), ref.get()));
 
   if (t == nullptr)
-  {
     throw HootException(QString("Error creating transformation object: ") + CPLGetLastErrorMsg());
-  }
 
   ReprojectCoordinateFilter rcf(t);
 
   int count = 0;
   const NodeMap& nodes = map->getNodes();
-  for (NodeMap::const_iterator it = nodes.begin(); it != nodes.end(); ++it)
+  for (auto it = nodes.begin(); it != nodes.end(); ++it)
   {
     Node* n = it->second.get();
     Coordinate c = n->toCoordinate();
@@ -563,28 +539,27 @@ void MapProjector::project(const std::shared_ptr<OsmMap>& map,
 }
 
 void MapProjector::project(const std::shared_ptr<Geometry>& g,
-  const std::shared_ptr<OGRSpatialReference>& srs1,
-  const std::shared_ptr<OGRSpatialReference>& srs2)
+                           const OGRSpatialReferencePtr& srs1,
+                           const OGRSpatialReferencePtr& srs2)
 {
   OGRCoordinateTransformation* t(OGRCreateCoordinateTransformation(srs1.get(), srs2.get()));
 
   if (t == nullptr)
-  {
     throw HootException(QString("Error creating transformation object: ") + CPLGetLastErrorMsg());
-  }
 
   LOG_TRACE("Reprojecting map from: " << toWkt(srs1) << " to " << toWkt(srs1) << "...");
 
   ReprojectCoordinateFilter filter(t);
   g->apply_rw(&filter);
+  //  NOTE: It is very important that the geometry is marked as changed after if it reprojected
+  g->geometryChanged();
 
   OGRCoordinateTransformation::DestroyCT(t);
 }
 
 void MapProjector::projectToAeac(const std::shared_ptr<OsmMap>& map)
 {
-  std::shared_ptr<OGRSpatialReference> srs = getInstance().createAeacProjection(
-    CalculateMapBoundsVisitor::getBounds(map));
+  OGRSpatialReferencePtr srs = getInstance().createAeacProjection(CalculateMapBoundsVisitor::getBounds(map));
   project(map, srs);
 }
 
@@ -598,14 +573,12 @@ void MapProjector::projectToOrthographic(const std::shared_ptr<OsmMap>& map, con
 {
   LOG_TRACE("Projecting to orthographic...");
   MapProjector proj;
-  std::shared_ptr<OGRSpatialReference> srs(new OGRSpatialReference());
+  OGRSpatialReferencePtr srs(new OGRSpatialReference());
   srs->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
   double x = (env.MinX + env.MaxX) / 2.0;
   double y = (env.MinY + env.MaxY) / 2.0;
   if (srs->SetOrthographic(y, x, 0, 0) != OGRERR_NONE)
-  {
     throw HootException("Error creating orthographic projection.");
-  }
   proj.project(map, srs);
 }
 
@@ -633,13 +606,13 @@ void MapProjector::projectToWgs84(const std::shared_ptr<OsmMap>& map)
   if (isGeographic(map) == false)
   {
     MapProjector proj;
-    std::shared_ptr<OGRSpatialReference> srs = MapProjector::createWgs84Projection();
+    OGRSpatialReferencePtr srs = MapProjector::createWgs84Projection();
     proj.project(map, srs);
   }
 }
 
 bool MapProjector::_scoreLessThan(const MapProjector::PlanarTestResult& p1,
-  const MapProjector::PlanarTestResult& p2)
+                                  const MapProjector::PlanarTestResult& p2)
 {
   return p1.score < p2.score;
 }

--- a/hoot-core/src/main/cpp/hoot/core/elements/MapProjector.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/MapProjector.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "MapProjector.h"

--- a/hoot-core/src/main/cpp/hoot/core/elements/MapProjector.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/MapProjector.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef __MAP_PROJECTOR_H__
 #define __MAP_PROJECTOR_H__
@@ -43,6 +43,8 @@ namespace hoot
 
 class OsmMap;
 
+using OGRSpatialReferencePtr = std::shared_ptr<OGRSpatialReference>;
+
 /**
  * (Singleton)
  *
@@ -60,30 +62,29 @@ public:
    * Given a bounding box in WGS84, create a reasonable planar projection for that region. The
    * units are in meters.
    */
-  static std::shared_ptr<OGRSpatialReference> createAeacProjection(const OGREnvelope& env);
+  static OGRSpatialReferencePtr createAeacProjection(const OGREnvelope& env);
 
   /**
    * Create an orthographic projection centered around env.
    */
-  static std::shared_ptr<OGRSpatialReference> createOrthographic(const OGREnvelope& env);
-  static std::shared_ptr<OGRSpatialReference> createOrthographic(double x, double y);
+  static OGRSpatialReferencePtr createOrthographic(const OGREnvelope& env);
+  static OGRSpatialReferencePtr createOrthographic(double x, double y);
 
   /**
    * Given a bounding box in WGS84, create a reasonable planar projection for that region. The
    * units are in meters.
    */
-  static std::shared_ptr<OGRSpatialReference> createSinusoidalProjection(const OGREnvelope& env);
+  static OGRSpatialReferencePtr createSinusoidalProjection(const OGREnvelope& env);
 
-  static std::shared_ptr<OGRSpatialReference> createWgs84Projection();
+  static OGRSpatialReferencePtr createWgs84Projection();
 
   static void project(const std::shared_ptr<OsmMap>& map,
-                      const std::shared_ptr<OGRSpatialReference>& ref);
+                      const OGRSpatialReferencePtr& ref);
 
   /**
    * Returns a vector of all candidate planar projections for a given envelope.
    */
-  std::vector<std::shared_ptr<OGRSpatialReference>> createAllPlanarProjections(
-    const OGREnvelope& env) const;
+  std::vector<OGRSpatialReferencePtr> createAllPlanarProjections(const OGREnvelope& env) const;
 
   /**
    * Using a predefined set of projections this method evaluates each one of them for both distance
@@ -94,9 +95,9 @@ public:
    *
    * Best is an internal heuristic that is subject to change.
    */
-  std::shared_ptr<OGRSpatialReference> createPlanarProjection(const OGREnvelope& env,
-    Radians maxAngleError = toRadians(2.0), Meters maxDistanceError = 10.0,
-    Meters testDistance = 1000.0, bool warnOnFail = true) const;
+  OGRSpatialReferencePtr createPlanarProjection(const OGREnvelope& env, Radians maxAngleError = toRadians(2.0),
+                                                Meters maxDistanceError = 10.0, Meters testDistance = 1000.0,
+                                                bool warnOnFail = true) const;
 
   static MapProjector& getInstance();
 
@@ -113,8 +114,8 @@ public:
    * nothing else will be modified.
    */
   static void project(const std::shared_ptr<geos::geom::Geometry>& g,
-                      const std::shared_ptr<OGRSpatialReference>& srs1,
-                      const std::shared_ptr<OGRSpatialReference>& srs2);
+                      const OGRSpatialReferencePtr& srs1,
+                      const OGRSpatialReferencePtr& srs2);
 
   static void projectToAeac(const std::shared_ptr<OsmMap>& map);
 
@@ -142,17 +143,17 @@ public:
    * Very slow convenience function.
    */
   static geos::geom::Coordinate project(const geos::geom::Coordinate& c,
-                                        const std::shared_ptr<OGRSpatialReference>& srs1,
-                                        const std::shared_ptr<OGRSpatialReference>& srs2);
+                                        const OGRSpatialReferencePtr& srs1,
+                                        const OGRSpatialReferencePtr& srs2);
 
-  static QString toWkt(const std::shared_ptr<OGRSpatialReference>& srs) { return toWkt(srs.get()); }
+  static QString toWkt(const OGRSpatialReferencePtr& srs) { return toWkt(srs.get()); }
   static QString toWkt(const OGRSpatialReference* srs);
 
 private:
 
   struct PlanarTestResult
   {
-    size_t i;
+    long i;
     Meters distanceError;
     Radians angleError;
     double score;
@@ -189,9 +190,8 @@ private:
 
   static bool _distanceLessThan(const PlanarTestResult& p1, const PlanarTestResult& p2);
 
-  bool _evaluateProjection(
-    const OGREnvelope& env, const std::shared_ptr<OGRSpatialReference>& srs, Meters testDistance,
-    Meters& maxDistanceError, Radians& maxAngleError) const;
+  bool _evaluateProjection(const OGREnvelope& env, const OGRSpatialReferencePtr& srs, Meters testDistance,
+                           Meters& maxDistanceError, Radians& maxAngleError) const;
 
   size_t _findBestScore(const std::vector<PlanarTestResult>& results) const;
 

--- a/hoot-core/src/main/cpp/hoot/core/geometry/GeometryUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/GeometryUtils.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef GEOMETRYUTILS_H
@@ -63,8 +63,7 @@ public:
    *
    * Taken from http://www.movable-type.co.uk/scripts/latlong.html
    */
-  static geos::geom::Coordinate calculateDestination(
-    const geos::geom::Coordinate& start, Degrees bearing, Meters distance);
+  static geos::geom::Coordinate calculateDestination(const geos::geom::Coordinate& start, Degrees bearing, Meters distance);
 
   /**
    * Returns the distance between two coordinates using the haversine formula and a mean earth
@@ -155,10 +154,12 @@ public:
    * support other geometries if needed.
    *
    * @param str the string to parse
+   * @param isEnvelope (output) true for envelope bounds string, false for polygon
    * @return a valid polygon if the input string is a valid envelope or polygon string; a null
    * object otherwise
    */
   static std::shared_ptr<geos::geom::Polygon> boundsFromString(const QString& str);
+  static std::shared_ptr<geos::geom::Polygon> boundsFromString(const QString& str, bool& isEnvelope);
 
   /**
    * Converts a polygon string to an envelope string
@@ -205,8 +206,7 @@ public:
    * @param boundsCollection a collection of bounding boxes keyed by ID
    * @return a bounding box map
    */
-  static OsmMapPtr createMapFromBoundsCollection(
-    const QMap<int, geos::geom::Envelope>& boundsCollection);
+  static OsmMapPtr createMapFromBoundsCollection(const QMap<int, geos::geom::Envelope>& boundsCollection);
 
   /**
    * Creates a bounding rectangle within the specified map
@@ -251,6 +251,7 @@ public:
    * @return an envelope representing the bounds of the file
    */
   static std::shared_ptr<geos::geom::Geometry> readBoundsFromFile(const QString& input);
+  static std::shared_ptr<geos::geom::Geometry> readBoundsFromFile(const QString& input, bool& isEnvelope);
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "OsmApiReader.h"

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
@@ -28,6 +28,8 @@
 #include "OsmApiReader.h"
 
 // Hoot
+#include <hoot/core/criterion/ChildElementCriterion.h>
+#include <hoot/core/criterion/InBoundsCriterion.h>
 #include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/geometry/GeometryUtils.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
@@ -36,6 +38,7 @@
 #include <hoot/core/util/Factory.h>
 #include <hoot/core/util/OsmApiUtils.h>
 #include <hoot/core/util/StringUtils.h>
+#include <hoot/core/visitors/RemoveElementsVisitor.h>
 #include <hoot/core/visitors/ReportMissingElementsVisitor.h>
 
 // Qt
@@ -47,6 +50,7 @@ namespace hoot
 HOOT_FACTORY_REGISTER(OsmMapReader, OsmApiReader)
 
 OsmApiReader::OsmApiReader()
+  : _isPolygon(false)
 {
   setConfiguration(conf());
   //  When reading in from the OSM API there won't be duplicates unless we are
@@ -113,20 +117,11 @@ void OsmApiReader::read(const OsmMapPtr& map)
   LOG_VART(_preserveAllTags);
 
   //  Set the bounds once we begin the read if setBounds() hasn't already been called
-  if (_bounds == nullptr)
-    setBounds(_getBoundsEnvelope());
+  if (_bounds == nullptr && _loadBounds())
+    setBounds(_boundingPoly);
 
-  // If a non-rectangular bounds was passed in from the config, we'll catch it here. If it is passed
-  // in from setBounds, we'll silently disregard by using the envelope of the bounds only.
-  if (!_boundsString.trimmed().isEmpty() && !GeometryUtils::isEnvelopeString(_boundsString))
-  {
-    throw IllegalArgumentException(
-      "OsmApiReader does not support a non-rectangular bounds: " + _boundsString);
-  }
-  else if (_bounds == nullptr)
-  {
+  if (_bounds == nullptr)
     throw IllegalArgumentException("OsmApiReader requires rectangular bounds");
-  }
 
   //  Reusing the reader for multiple reads has two options, the first is the
   //  default where the reader is reset and duplicates error out.  The second
@@ -165,9 +160,7 @@ void OsmApiReader::read(const OsmMapPtr& map)
       //  Do the actual parsing
       QXmlInputSource xmlInputSource(&buffer);
       if (reader.parse(xmlInputSource) == false)
-      {
         throw HootException(_errorString);
-      }
     }
     else
       _sleep();
@@ -183,27 +176,61 @@ void OsmApiReader::read(const OsmMapPtr& map)
   _map->visitRw(visitor);
   LOG_DEBUG("\t" << visitor.getCompletedStatusMessage());
 
+  //  Filter the map based on the polygon
+  if (_isPolygon)
+  {
+    size_t element_count = _map->getElementCount();
+    std::shared_ptr<InBoundsCriterion> crit = std::make_shared<InBoundsCriterion>(false);
+    crit->setBounds(_boundingPoly);
+    //  Remove any elements that don't meet the criterion
+    RemoveElementsVisitor v(true);
+    v.addCriterion(crit);
+    v.setRecursive(true);
+    v.setOsmMap(_map.get());
+    _map->visitRw(v);
+    size_t elements_filtered = element_count - _map->getElementCount();
+    if (elements_filtered > 0)
+      LOG_STATUS("Filtered " << elements_filtered << " out of bounds elements from OSM API.");
+ }
   _map.reset();
 }
 
 void OsmApiReader::close()
 {
   finalizePartial();
-
   _map.reset();
 }
 
-std::shared_ptr<geos::geom::Geometry> OsmApiReader::_getBoundsEnvelope() const
+void OsmApiReader::setBounds(std::shared_ptr<geos::geom::Geometry> bounds)
 {
+  _isPolygon = (bounds ? !bounds->isRectangle() : false);
+  _bounds = bounds;
+}
+
+void OsmApiReader::setBounds(const geos::geom::Envelope& bounds)
+{
+  _isPolygon = false;
+  setBounds(GeometryUtils::envelopeToPolygon(bounds));
+}
+
+bool OsmApiReader::_loadBounds()
+{
+  bool isEnvelope = false;
   //  Try to read the bounds from the `bounds` string
   if (_boundsString != ConfigOptions::getBoundsDefaultValue())
-    return GeometryUtils::boundsFromString(_boundsString);
+  {
+    _boundingPoly =  GeometryUtils::boundsFromString(_boundsString, isEnvelope);
+    _isPolygon = !isEnvelope;
+    return true;
+  }
   //  Try to read the bounds from the `bounds.input.file` file
   else if (_boundsFilename != ConfigOptions::getBoundsInputFileDefaultValue())
-    return GeometryUtils::readBoundsFromFile(_boundsFilename);
-  //  Neither exist return a NULL pointer
-  else
-    return nullptr;
+  {
+    _boundingPoly = GeometryUtils::readBoundsFromFile(_boundsFilename, isEnvelope);
+    _isPolygon = !isEnvelope;
+    return true;
+  }
+  return false;
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef OSM_API_READER_H
 #define OSM_API_READER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.h
@@ -37,7 +37,9 @@ namespace hoot
 {
 
 /**
- * Reads OSM XML output from an OSM API map call by bounding box.  Reading will fail without a bounding box
+ * Reads OSM XML output from an OSM API map call by bounding box or bounding polygon.  Reading will fail without
+ * bounds.  When using a bounding polygon, the bounding box for the polygon will be used in API calls and then
+ * subsequently filter the resulting map on the polygon afterwards
  * https://wiki.openstreetmap.org/wiki/API_v0.6#Retrieving_map_data_by_bounding_box:_GET_.2Fapi.2F0.6.2Fmap
  */
 class OsmApiReader : public OsmXmlReader, private ParallelBoundedApiReader
@@ -79,20 +81,30 @@ public:
    * @param conf Updated configuration
    */
   void setConfiguration(const Settings& conf) override;
+  /**
+   * See `Boundable` class
+   */
+  void setBounds(std::shared_ptr<geos::geom::Geometry> bounds) override;
+  void setBounds(const geos::geom::Envelope& bounds) override;
 
 private:
-
   /**
-   * @brief _getBoundsEnvelope - Get either the `bounds` parameter value
+   * @brief _loadBounds - Get either the `bounds` parameter value
    *  or the bounds of a file listed in `bounds.file` parameter
-   * @return The bounds for the read
+   * @return true if the bounds were parsed correctly
    */
-  std::shared_ptr<geos::geom::Geometry> _getBoundsEnvelope() const;
+  bool _loadBounds();
 
   /** Value of the bounds envelope string */
   QString _boundsString;
   /** Value of the bounds filename string */
   QString _boundsFilename;
+  /** Is the bounds a polygon */
+  bool _isPolygon;
+  /** Value of the bounding box or polygon */
+  std::shared_ptr<geos::geom::Geometry> _boundingPoly;
+  /** For testing */
+  friend class OsmApiReaderTest;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
@@ -379,9 +379,9 @@ void OsmXmlReader::read(const OsmMapPtr& map)
   // bounds is already smaller than _bounds, this will have no effect. Also, We don't support
   // cropping during streaming, and there is a check in IoUtils::isStreamableIo to make
   // sure nothing tries to stream with this reader when a bounds has been set.
-  LOG_VARD(_bounds.get());
   if (_bounds.get())
   {
+    LOG_VARD(_bounds->toString());
     IoUtils::cropToBounds(_map, _bounds, _keepImmediatelyConnectedWaysOutsideBounds);
     LOG_VARD(StringUtils::formatLargeNumber(_map->getElementCount()));
   }

--- a/hoot-core/src/main/cpp/hoot/core/util/ConfigUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/ConfigUtils.h
@@ -22,16 +22,16 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef CONFIGUTILS_H
 #define CONFIGUTILS_H
 
 // Hoot
-#include <hoot/core/geometry/GeometryUtils.h>
-#include <hoot/core/geometry/GeometricRelationship.h>
 #include <hoot/core/criterion/InBoundsCriterion.h>
+#include <hoot/core/geometry/GeometricRelationship.h>
+#include <hoot/core/geometry/GeometryUtils.h>
 
 namespace hoot
 {

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #include "RemoveElementsVisitor.h"
 
@@ -39,10 +39,10 @@ namespace hoot
 
 HOOT_FACTORY_REGISTER(ElementVisitor, RemoveElementsVisitor)
 
-RemoveElementsVisitor::RemoveElementsVisitor(bool negateCriteria) :
-_recursive(false),
-_recursiveRemoveRefsFromParents(false),
-_startElementCount(0)
+RemoveElementsVisitor::RemoveElementsVisitor(bool negateCriteria)
+  : _recursive(false),
+    _recursiveRemoveRefsFromParents(false),
+    _startElementCount(0)
 {
   _negateCriteria = negateCriteria;
   _chainCriteria = false;
@@ -66,15 +66,11 @@ void RemoveElementsVisitor::setConfiguration(const Settings& conf)
   LOG_VARD(_configureChildren);
   if (_configureChildren)
   {
-    for (std::vector<ElementCriterionPtr>::const_iterator it = _criteria.begin();
-         it != _criteria.end(); ++it)
+    for (const auto& crit : _criteria)
     {
-      ElementCriterionPtr crit = *it;
       Configurable* c = dynamic_cast<Configurable*>(crit.get());
       if (c != nullptr)
-      {
         c->setConfiguration(conf);
-      }
     }
   }
 
@@ -86,10 +82,8 @@ void RemoveElementsVisitor::setOsmMap(OsmMap* map)
   _map = map;
   _startElementCount = _map->getElementCount();
 
-  for (std::vector<ElementCriterionPtr>::const_iterator it = _criteria.begin();
-       it != _criteria.end(); ++it)
+  for (const auto& crit : _criteria)
   {
-    ElementCriterionPtr crit = *it;
     OsmMapConsumer* consumer = dynamic_cast<OsmMapConsumer*>(crit.get());
     if (consumer != nullptr)
       consumer->setOsmMap(map);
@@ -99,14 +93,10 @@ void RemoveElementsVisitor::setOsmMap(OsmMap* map)
 void RemoveElementsVisitor::visit(const ElementPtr& e)
 {
   if (!e)
-  {
     return;
-  }
 
   if (_criteria.empty())
-  {
     throw IllegalArgumentException("No criteria specified for RemoveElementsVisitor.");
-  }
 
   LOG_VART(e->getElementId());
 
@@ -136,8 +126,7 @@ void RemoveElementsVisitor::visit(const ElementPtr& e)
   _numProcessed++;
 }
 
-void RemoveElementsVisitor::removeWays(
-  const std::shared_ptr<OsmMap>& pMap, const std::shared_ptr<ElementCriterion>& pCrit)
+void RemoveElementsVisitor::removeWays(const std::shared_ptr<OsmMap>& pMap, const std::shared_ptr<ElementCriterion>& pCrit)
 {
   RemoveElementsVisitor v;
   v.addCriterion(pCrit);

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.h
@@ -22,16 +22,16 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef REMOVEELEMENTSVISITOR_H
 #define REMOVEELEMENTSVISITOR_H
 
 // hoot
 #include <hoot/core/elements/OsmMapConsumer.h>
-#include <hoot/core/visitors/MultipleCriterionConsumerVisitor.h>
 #include <hoot/core/util/Configurable.h>
 #include <hoot/core/util/StringUtils.h>
+#include <hoot/core/visitors/MultipleCriterionConsumerVisitor.h>
 
 namespace hoot
 {

--- a/test-files/cmd/slow/serial/ServiceDiffRoadSnapTest.sh.off
+++ b/test-files/cmd/slow/serial/ServiceDiffRoadSnapTest.sh.off
@@ -50,6 +50,8 @@ NUM_STEPS=${10}
 WAY_SNAP_TOLERANCE=${11}
 CONFLATE_FROM_FILE=${12}
 UNIFYING_RUBBERSHEET=${13} # This ignored if the Network alg is used.
+# Default to debug=false or take parameter 11
+DEBUG=${14-false}
 
 rm -rf $OUTPUT_DIR
 mkdir -p $OUTPUT_DIR
@@ -83,7 +85,6 @@ DB_OPTS="-D api.db.email=$HOOT_EMAIL -D hootapi.db.writer.create.user=true -D ho
 CONFLATE_OPTS="-D debug.maps.filename=$OUTPUT_DIR/conflate.osm -D writer.include.conflate.score.tags=true $MATCHERS $MERGERS -D conflate.use.data.source.ids.1=true -D conflate.use.data.source.ids.2=false -D differential.snap.unconnected.features=true -D snap.unconnected.ways.snap.criteria=HighwayCriterion -D snap.unconnected.ways.snap.tolerance=$WAY_SNAP_TOLERANCE -D snap.unconnected.ways.mark.snapped.nodes=true -D snap.unconnected.ways.mark.snapped.ways=true -D bounds.output.file=$OUTPUT_DIR/$TEST_NAME-bounds-conflate.osm"
 CHANGESET_DERIVE_OPTS="-D debug.maps.filename=$OUTPUT_DIR/derive.osm -D changeset.user.id=1 -D bounds.output.file=$OUTPUT_DIR/$TEST_NAME-bounds-changeset.osm"
 
-DEBUG=false
 if [ "$DEBUG" == "true" ]; then
   GENERAL_OPTS=$GENERAL_OPTS" -D debug.maps.write=true -D debug.maps.write.detailed=true -D debug.maps.class.include.filter=UnconnectedWaySnapper;DiffConflator "
   LOG_LEVEL="--trace"
@@ -103,7 +104,7 @@ echo "Writing ref data..."
 echo ""
 hoot convert $LOG_LEVEL $LOG_FILTER -D debug.maps.filename=$OUTPUT_DIR/ref-load.osm -D reader.use.data.source.ids=true $GENERAL_OPTS $DB_OPTS $REF_INPUT $OSM_API_DB_URL
 if [ "$DEBUG" == "true" ]; then
-  hoot convert --warn -D debug.maps.filename=$OUTPUT_DIR/ref-load.osm -D reader.use.data.source.ids=true $GENERAL_OPTS $DB_OPTS $OSM_API_DB_URL $OUTPUT_DIR/ref-original.osm
+  hoot convert $LOG_LEVEL -D debug.maps.filename=$OUTPUT_DIR/ref-load.osm -D reader.use.data.source.ids=true $GENERAL_OPTS $DB_OPTS $OSM_API_DB_URL $OUTPUT_DIR/ref-original.osm
 fi
 
 if [ "$CONFLATE_FROM_FILE" == "false" ]; then

--- a/test-files/io/OsmApiReaderTest/PolygonBoundsTestExpected.osm
+++ b/test-files/io/OsmApiReaderTest/PolygonBoundsTestExpected.osm
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="38.85324242720166" minlon="-104.9024316099691" maxlat="38.85496143739888" maxlon="-104.8961823052624"/>
+    <node visible="true" id="-1669793" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549321261880536" lon="-104.8979050333482093"/>
+    <node visible="true" id="-1669791" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549524185660573" lon="-104.8987388916486054"/>
+    <node visible="true" id="-1669789" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8540541370891077" lon="-104.9024316099691276"/>
+    <node visible="true" id="-1669787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541298962059614" lon="-104.9023065312240703"/>
+    <node visible="true" id="-1669785" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8543319201230304" lon="-104.9017876860593788"/>
+    <node visible="true" id="-1669783" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548207434768855" lon="-104.9008079025564655"/>
+    <node visible="true" id="-1669781" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549289695954272" lon="-104.9005253172435630"/>
+    <node visible="true" id="-1669777" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549073243849037" lon="-104.8961823052623856"/>
+    <node visible="true" id="-1669775" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549019130812496" lon="-104.8964394115716487"/>
+    <node visible="true" id="-1669773" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8548604264061623" lon="-104.8968586569948798"/>
+    <node visible="true" id="-1669771" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8547197322843374" lon="-104.8973219116062410"/>
+    <node visible="true" id="-1669769" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8546042907457476" lon="-104.8977759011253141"/>
+    <node visible="true" id="-1669767" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8544293243065937" lon="-104.8980654352573794"/>
+    <node visible="true" id="-1669765" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542327120211866" lon="-104.8983109602013855"/>
+    <node visible="true" id="-1669763" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541767946664436" lon="-104.8987070428940598"/>
+    <node visible="true" id="-1669761" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541335037809361" lon="-104.8988900284655159"/>
+    <node visible="true" id="-1669759" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539585361836473" lon="-104.8989155074691695"/>
+    <node visible="true" id="-1669757" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8537204352567329" lon="-104.8987232568054679"/>
+    <node visible="true" id="-1669755" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536194225014810" lon="-104.8987070428940598"/>
+    <node visible="true" id="-1669753" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535508780501431" lon="-104.8988321216391171"/>
+    <node visible="true" id="-1669751" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535689160700528" lon="-104.8990568001256065"/>
+    <node visible="true" id="-1669749" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8535166057996975" lon="-104.8992698972467963"/>
+    <node visible="true" id="-1669747" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533470481072030" lon="-104.8993671807151884"/>
+    <node visible="true" id="-1669745" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8533001490996028" lon="-104.8994528828182951"/>
+    <node visible="true" id="-1669743" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532424272016641" lon="-104.8996868263970015"/>
+    <node visible="true" id="-1669741" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8532583477841484" lon="-104.8997542928851772"/>
+    <node visible="true" id="-1669739" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8536248456666229" lon="-104.8996934957527998"/>
+    <node visible="true" id="-1669737" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8539525522998730" lon="-104.8996840393162842"/>
+    <node visible="true" id="-1669735" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8542618470630714" lon="-104.8997171368440888"/>
+    <node visible="true" id="-1669733" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8545785045938388" lon="-104.8997171368440888"/>
+    <node visible="true" id="-1669731" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8549614373988845" lon="-104.8997124086258452"/>
+    <node visible="true" id="-1669723" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8541670018907581" lon="-104.8997069874790355"/>
+    <way visible="true" id="-1669801" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1669731"/>
+        <nd ref="-1669791"/>
+        <nd ref="-1669793"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="1"/>
+    </way>
+    <way visible="true" id="-1669797" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="-1669789"/>
+        <nd ref="-1669787"/>
+        <nd ref="-1669785"/>
+        <nd ref="-1669783"/>
+        <nd ref="-1669781"/>
+        <nd ref="-1669731"/>
+        <nd ref="-1669733"/>
+        <nd ref="-1669735"/>
+        <nd ref="-1669723"/>
+        <nd ref="-1669737"/>
+        <nd ref="-1669739"/>
+        <nd ref="-1669741"/>
+        <nd ref="-1669743"/>
+        <nd ref="-1669745"/>
+        <nd ref="-1669747"/>
+        <nd ref="-1669749"/>
+        <nd ref="-1669751"/>
+        <nd ref="-1669753"/>
+        <nd ref="-1669755"/>
+        <nd ref="-1669757"/>
+        <nd ref="-1669759"/>
+        <nd ref="-1669761"/>
+        <nd ref="-1669763"/>
+        <nd ref="-1669765"/>
+        <nd ref="-1669767"/>
+        <nd ref="-1669769"/>
+        <nd ref="-1669771"/>
+        <nd ref="-1669773"/>
+        <nd ref="-1669775"/>
+        <nd ref="-1669777"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="highway" v="road"/>
+        <tag k="note" v="0"/>
+    </way>
+</osm>

--- a/test-files/io/OsmApiReaderTest/ToyTestBboxBounds.osm
+++ b/test-files/io/OsmApiReaderTest/ToyTestBboxBounds.osm
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="38.85292901852" minlon="-104.90285854516" maxlat="38.85547896322" maxlon="-104.8959223334"/>
+    <node visible="true" id="1" version="1" lat="38.85292901852" lon="-104.90285854516"/>
+    <node visible="true" id="2" version="1" lat="38.85292901852" lon="-104.8959223334"/>
+    <node visible="true" id="3" version="1" lat="38.85547896322" lon="-104.8959223334"/>
+    <node visible="true" id="4" version="1" lat="38.85547896322" lon="-104.90285854516"/>
+    <way visible="true" id="1" version="1">
+        <nd ref="1"/>
+        <nd ref="2"/>
+        <nd ref="3"/>
+        <nd ref="4"/>
+        <nd ref="1"/>
+    </way>
+</osm>

--- a/test-files/io/OsmApiReaderTest/ToyTestPolyBounds.osm
+++ b/test-files/io/OsmApiReaderTest/ToyTestPolyBounds.osm
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="38.85292901852" minlon="-104.90285854516" maxlat="38.85547896322" maxlon="-104.8959223334"/>
+    <node visible="true" id="1" version="1" lat="38.8553583054300020" lon="-104.9009940831700050"/>
+    <node visible="true" id="2" version="1" lat="38.8553904808600024" lon="-104.8999404813900043"/>
+    <node visible="true" id="3" version="1" lat="38.8554789632200013" lon="-104.8980243722599965"/>
+    <node visible="true" id="4" version="1" lat="38.8553542834999988" lon="-104.8966608875900022"/>
+    <node visible="true" id="5" version="1" lat="38.8548877381199986" lon="-104.8959223333999944"/>
+    <node visible="true" id="6" version="1" lat="38.8539747482199971" lon="-104.8965782521599976"/>
+    <node visible="true" id="7" version="1" lat="38.8529290185200011" lon="-104.8999869638199982"/>
+    <node visible="true" id="8" version="1" lat="38.8539586601900027" lon="-104.8999921285300019"/>
+    <node visible="true" id="9" version="1" lat="38.8543286840199968" lon="-104.8994291746400052"/>
+    <node visible="true" id="10" version="1" lat="38.8544815193899993" lon="-104.9002038818299951"/>
+    <node visible="true" id="11" version="1" lat="38.8550526381299974" lon="-104.9002348701200020"/>
+    <node visible="true" id="12" version="1" lat="38.8551009014800002" lon="-104.9006996944399930"/>
+    <node visible="true" id="13" version="1" lat="38.8547590354099981" lon="-104.9007100238700048"/>
+    <node visible="true" id="14" version="1" lat="38.8536690749700000" lon="-104.9022181205399988"/>
+    <node visible="true" id="15" version="1" lat="38.8541718263300027" lon="-104.9028585451600009"/>
+    <way visible="true" id="1" version="1">
+        <nd ref="1"/>
+        <nd ref="15"/>
+        <nd ref="14"/>
+        <nd ref="13"/>
+        <nd ref="12"/>
+        <nd ref="11"/>
+        <nd ref="10"/>
+        <nd ref="9"/>
+        <nd ref="8"/>
+        <nd ref="7"/>
+        <nd ref="6"/>
+        <nd ref="5"/>
+        <nd ref="4"/>
+        <nd ref="3"/>
+        <nd ref="2"/>
+        <nd ref="1"/>
+    </way>
+</osm>


### PR DESCRIPTION
Anywhere that `bounds` or `bounds.input.filename` are used they can now be converted into a polygon `Geometry` to be used for cropping, etc.

Closes #5207