### PR TITLE
TopologyException in Highway Diff

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/criterion/InBoundsCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/InBoundsCriterion.cpp
@@ -29,6 +29,7 @@
 
 // GEOS
 #include <geos/geom/GeometryFactory.h>
+#include <geos/util/TopologyException.h>
 
 // hoot
 #include <hoot/core/elements/Element.h>
@@ -115,13 +116,27 @@ bool InBoundsCriterion::_nonWayNodeInBounds(const ConstElementPtr& e) const
 
   if (_mustCompletelyContain)
   {
-    LOG_VART(_bounds->contains(geom.get()));
-    return _bounds->contains(geom.get());
+    try
+    {
+      return _bounds->contains(geom.get());
+    }
+    catch (geos::util::TopologyException&)
+    {
+      //  If the contains call fails, use the envelope
+      return _bounds->contains(geom->getEnvelope().get());
+    }
   }
   else
   {
-    LOG_VART(_bounds->intersects(geom.get()));
-    return _bounds->intersects(geom.get());
+    try
+    {
+      return _bounds->intersects(geom.get());
+    }
+    catch (geos::util::TopologyException&)
+    {
+      //  If the intersects call fails, use the envelope
+      return _bounds->intersects(geom->getEnvelope().get());
+    }
   }
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "OsmMap.h"
@@ -136,9 +136,7 @@ void OsmMap::append(const ConstOsmMapPtr& appendFromMap, const bool throwOutDupe
 
   // The append order must be nodes, ways, and then relations. If not, the map indexes won't update
   // properly.
-
-  NodeMap::const_iterator itn = appendFromMap->_nodes.begin();
-  while (itn != appendFromMap->_nodes.end())
+  for (auto itn = appendFromMap->_nodes.begin(); itn != appendFromMap->_nodes.end(); ++itn)
   {
     bool appendElement = true;
     NodePtr node = itn->second;
@@ -173,12 +171,9 @@ void OsmMap::append(const ConstOsmMapPtr& appendFromMap, const bool throwOutDupe
     }
     else
       _numNodesSkippedForAppending++;
-
-    ++itn;
   }
 
-  WayMap::const_iterator it = appendFromMap->_ways.begin();
-  while (it != appendFromMap->_ways.end())
+  for (auto it = appendFromMap->_ways.begin(); it != appendFromMap->_ways.end(); ++it)
   {
     bool appendElement = true;
     WayPtr way = it->second;
@@ -210,8 +205,6 @@ void OsmMap::append(const ConstOsmMapPtr& appendFromMap, const bool throwOutDupe
     }
     else
       _numWaysSkippedForAppending++;
-
-    ++it;
   }
 
   const RelationMap& allRelations = appendFromMap->getRelations();
@@ -504,7 +497,7 @@ void OsmMap::replace(const std::shared_ptr<const Element>& from, const std::shar
 }
 
 void OsmMap::replace(const std::shared_ptr<const Element>& from, const QList<ElementPtr>& to)
-{ 
+{
   const std::shared_ptr<NodeToWayMap>& n2w = getIndex().getNodeToWayMap();
 
   // Do some error checking before we add the new element.
@@ -546,15 +539,15 @@ void OsmMap::replace(const std::shared_ptr<const Element>& from, const QList<Ele
 }
 
 void OsmMap::replaceNode(long oldId, long newId)
-{  
+{
   //  nothing to do
   if (oldId == newId)
     return;
 
   LOG_TRACE("Replacing node: " << oldId << " with: " << newId << "...");
 
-  for (size_t i = 0; i < _listeners.size(); i++)
-    _listeners[i]->replaceNodePre(oldId, newId);
+  for (const auto& listener : _listeners)
+    listener->replaceNodePre(oldId, newId);
 
   const std::shared_ptr<NodeToWayMap>& n2w = getIndex().getNodeToWayMap();
 
@@ -945,7 +938,7 @@ QString OsmMap::getSource() const
 void OsmMap::appendSource(const QString& url)
 {
   QStringList urls = url.split(";");
-  for (const auto& u : urls)
+  for (const auto& u : qAsConst(urls))
   {
     QUrl src(u);
     QString source;

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef OSMMAP_H
 #define OSMMAP_H
@@ -395,39 +395,27 @@ inline NodePtr OsmMap::getNode(long id)
 {
   _tmpNodeMapIt = _nodes.find(id);
   if (_tmpNodeMapIt != _nodes.end())
-  {
     return _tmpNodeMapIt->second;
-  }
   else
-  {
     return _nullNode;
-  }
 }
 
 inline ConstNodePtr OsmMap::getNode(long id) const
 {
   _tmpNodeMapIt = _nodes.find(id);
   if (_tmpNodeMapIt != _nodes.end())
-  {
     return _tmpNodeMapIt->second;
-  }
   else
-  {
     return _constNullNode;
-  }
 }
 
 inline ConstRelationPtr OsmMap::getRelation(long id) const
 {
   RelationMap::iterator it = _relations.find(id);
   if (it != _relations.end())
-  {
     return it->second;
-  }
   else
-  {
     return _nullRelation;
-  }
 }
 
 inline ConstRelationPtr OsmMap::getRelation(ElementId eid) const
@@ -439,26 +427,18 @@ inline RelationPtr OsmMap::getRelation(long id)
 {
   _tmpRelationIt = _relations.find(id);
   if (_tmpRelationIt != _relations.end())
-  {
     return _tmpRelationIt->second;
-  }
   else
-  {
     return _nullRelation;
-  }
 }
 
 inline ConstWayPtr OsmMap::getWay(long id) const
 {
   _tmpWayIt = _ways.find(id);
   if (_tmpWayIt != _ways.end())
-  {
     return _tmpWayIt->second;
-  }
   else
-  {
     return _constNullWay;
-  }
 }
 
 inline ConstWayPtr OsmMap::getWay(ElementId eid) const
@@ -470,13 +450,9 @@ inline WayPtr OsmMap::getWay(long id)
 {
   _tmpWayIt = _ways.find(id);
   if (_tmpWayIt != _ways.end())
-  {
     return _tmpWayIt->second;
-  }
   else
-  {
     return _nullWay;
-  }
 }
 
 inline WayPtr OsmMap::getWay(ElementId eid)


### PR DESCRIPTION
Retry the `Geometry::contains()` or `Geometry::intersects()` functions when a `geos::util::TopologyException` is thrown

Closes #5217 