### PR TITLE
Ogr reader updates

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OgrReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OgrReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 // Hoot
@@ -43,192 +43,184 @@ namespace hoot
 
 class OgrReaderTest : public HootTestFixture
 {
-    CPPUNIT_TEST_SUITE(OgrReaderTest);
-    CPPUNIT_TEST(runBasicTest);
-    CPPUNIT_TEST(runBoundingBoxTest);
-    CPPUNIT_TEST(runJavaScriptTranslateTest);
-    CPPUNIT_TEST(runPythonTranslateTest);
-    CPPUNIT_TEST(runStreamHasMoreElementsTest);
-    CPPUNIT_TEST(runStreamReadNextElementTest);
-    CPPUNIT_TEST(runOgrZipTest);
-    CPPUNIT_TEST_SUITE_END();
+  CPPUNIT_TEST_SUITE(OgrReaderTest);
+  CPPUNIT_TEST(runBasicTest);
+  CPPUNIT_TEST(runBoundingBoxTest);
+  CPPUNIT_TEST(runJavaScriptTranslateTest);
+  CPPUNIT_TEST(runPythonTranslateTest);
+  CPPUNIT_TEST(runStreamHasMoreElementsTest);
+  CPPUNIT_TEST(runStreamReadNextElementTest);
+  CPPUNIT_TEST(runOgrZipTest);
+  CPPUNIT_TEST_SUITE_END();
 
 public:
 
-    OgrReaderTest() : HootTestFixture("test-files/", UNUSED_PATH)
+  OgrReaderTest() : HootTestFixture("test-files/", UNUSED_PATH)
+  {
+  }
+
+  void runBasicTest()
+  {
+    OgrReader uut;
+
+    OsmMapPtr map = std::make_shared<OsmMap>();
+    uut.read(_inputPath + "jakarta_raya_coastline.shp", "", map);
+
+    CPPUNIT_ASSERT_EQUAL(604, (int)map->getNodes().size());
+    CPPUNIT_ASSERT_EQUAL(6, (int)map->getWays().size());
+  }
+
+  void runBoundingBoxTest()
+  {
+    OgrReader uut;
+
+    OGREnvelope env;
+    env.MinX = -1;
+    env.MaxX = 1;
+    env.MinY = 85;
+    env.MaxY = 86;
+
+    Coordinate c1(-1, 84);
+    Coordinate c2(1, 84);
+
     {
+      std::shared_ptr<OGRSpatialReference> ortho1 = MapProjector::createOrthographic(env);
+
+      Settings s;
+      // 15512.4m wide at the top
+      // 19381.6m wide at the bottom
+      // 111385.6m tall
+      s.set(ConfigOptions::getBoundsKey(), "-1,85,1,86");
+      s.set(ConfigOptions::getOgrReaderBoundingBoxLatlngKey(), "true");
+      // resulting bounding box is
+      // 19403.28m wide
+      // 111385.6m tall
+      HOOT_STR_EQUALS("Env[-9734.03:9734.03,-55842.4:55911]",
+        uut.getBoundingBoxFromConfig(s, ortho1.get())->toString());
     }
 
-    void runBasicTest()
     {
-      OgrReader uut;
+      Settings s;
+      // 15512.4m wide
+      // 111385.6m tall
+      s.set(ConfigOptions::getBoundsKey(), "-7756.2,-55692.8,7756.2,55692.8");
+      HOOT_STR_EQUALS("Env[-7756.2:7756.2,-55692.8:55692.8]",
+        uut.getBoundingBoxFromConfig(s, 0)->toString());
+    }
+  }
 
-      OsmMapPtr map = std::make_shared<OsmMap>();
-      uut.read(_inputPath + "jakarta_raya_coastline.shp", "", map);
+  void runJavaScriptTranslateTest()
+  {
+    OgrReader uut;
 
-      CPPUNIT_ASSERT_EQUAL(604, (int)map->getNodes().size());
-      CPPUNIT_ASSERT_EQUAL(6, (int)map->getWays().size());
+    OsmMapPtr map = std::make_shared<OsmMap>();
+    uut.setSchemaTranslationScript("translations/cloudmade.js");
+    uut.read(_inputPath + "jakarta_raya_coastline.shp", "", map);
+
+    CPPUNIT_ASSERT_EQUAL(604, (int)map->getNodes().size());
+    CPPUNIT_ASSERT_EQUAL(6, (int)map->getWays().size());
+
+    int shoreline = 0;
+    int water = 0;
+    for (auto it = map->getWays().begin(); it != map->getWays().end(); ++it)
+    {
+      WayPtr w = it->second;
+      if (w->getTags()["natural"] == "shoreline")
+        shoreline++;
+      if (w->getTags()["natural"] == "water")
+        water++;
+    }
+    CPPUNIT_ASSERT_EQUAL(5, shoreline);
+    CPPUNIT_ASSERT_EQUAL(1, water);
+  }
+
+  void runPythonTranslateTest()
+  {
+    OgrReader uut;
+
+    OsmMapPtr map = std::make_shared<OsmMap>();
+    uut.setSchemaTranslationScript("cloudmade");
+    uut.read(_inputPath + "jakarta_raya_coastline.shp", "", map);
+
+    CPPUNIT_ASSERT_EQUAL(604, (int)map->getNodes().size());
+    CPPUNIT_ASSERT_EQUAL(6, (int)map->getWays().size());
+
+    int shoreline = 0;
+    int water = 0;
+    for (auto it = map->getWays().begin(); it != map->getWays().end(); ++it)
+    {
+      WayPtr w = it->second;
+      if (w->getTags()["natural"] == "shoreline")
+        shoreline++;
+      if (w->getTags()["natural"] == "water")
+        water++;
+    }
+    CPPUNIT_ASSERT_EQUAL(5, shoreline);
+    CPPUNIT_ASSERT_EQUAL(1, water);
+  }
+
+  void runStreamHasMoreElementsTest()
+  {
+    OgrReader reader1;
+
+    // If we haven't opened a file, it best not be ready to read.
+    CPPUNIT_ASSERT_EQUAL(reader1.hasMoreElements(), false);
+
+    // Try to open an invalid file.
+    OgrReader reader2(_inputPath + "totalgarbage.osm.pbf");
+    CPPUNIT_ASSERT_EQUAL(reader2.hasMoreElements(), false);
+
+    // Open a valid file.
+    OgrReader reader3(_inputPath + "jakarta_raya_coastline.shp");
+    CPPUNIT_ASSERT_EQUAL(reader3.hasMoreElements(), true);
+
+    // Close the file and check again.
+    reader3.close();
+    CPPUNIT_ASSERT_EQUAL(reader3.hasMoreElements(), false);
+  }
+
+  void runStreamReadNextElementTest()
+  {
+    OgrReader reader(_inputPath + "jakarta_raya_coastline.shp");
+
+    // Iterate through all items.
+    int numberOfElements(0);
+    while (reader.hasMoreElements() == true)
+    {
+      ElementPtr tempElement = reader.readNextElement();
+      numberOfElements++;
+      LOG_VART(tempElement->toString());
     }
 
-    void runBoundingBoxTest()
+    CPPUNIT_ASSERT_EQUAL(610, numberOfElements);
+  }
+
+  void runOgrZipTest()
+  {
+    QStringList files_extensions({".zip", ".tar", ".tar.gz"});
+    QStringList files_prefixes({"/vsizip/", "/vsitar/", "/vsitar/"});
+
+    for (int ext = 0; ext < files_extensions.length(); ++ext)
     {
-      OgrReader uut;
-
-      OGREnvelope env;
-      env.MinX = -1;
-      env.MaxX = 1;
-      env.MinY = 85;
-      env.MaxY = 86;
-
-      Coordinate c1(-1, 84);
-      Coordinate c2(1, 84);
-
-      {
-        std::shared_ptr<OGRSpatialReference> ortho1 = MapProjector::createOrthographic(env);
-
-        Settings s;
-        // 15512.4m wide at the top
-        // 19381.6m wide at the bottom
-        // 111385.6m tall
-        s.set(ConfigOptions::getBoundsKey(), "-1,85,1,86");
-        s.set(ConfigOptions::getOgrReaderBoundingBoxLatlngKey(), "true");
-        // resulting bounding box is
-        // 19403.28m wide
-        // 111385.6m tall
-        HOOT_STR_EQUALS("Env[-9734.03:9734.03,-55842.4:55911]",
-          uut.getBoundingBoxFromConfig(s, ortho1.get())->toString());
-      }
-
-      {
-        Settings s;
-        // 15512.4m wide
-        // 111385.6m tall
-        s.set(ConfigOptions::getBoundsKey(), "-7756.2,-55692.8,7756.2,55692.8");
-        HOOT_STR_EQUALS("Env[-7756.2:7756.2,-55692.8:55692.8]",
-          uut.getBoundingBoxFromConfig(s, 0)->toString());
-      }
+      QString file = _inputPath + "MGCPv3" + files_extensions[ext];
+      QStringList files = OgrUtilities::getInstance().getValidFilesInContainer(file);
+      //  The MGCPv3 container files contain 9 Shapefiles
+      CPPUNIT_ASSERT_EQUAL(9, files.length());
+      //  Make sure all of them begin will the correct prefix
+      for (int f = 0; f < files.length(); ++f)
+        CPPUNIT_ASSERT(files[f].startsWith(files_prefixes[ext]));
+      //  Check the files in alphabetical order
+      CPPUNIT_ASSERT(files[0].endsWith("MGCPv3" + files_extensions[ext] + "/AAL015.shp"));
+      CPPUNIT_ASSERT(files[1].endsWith("MGCPv3" + files_extensions[ext] + "/AAL020.shp"));
+      CPPUNIT_ASSERT(files[2].endsWith("MGCPv3" + files_extensions[ext] + "/LAN010.shp"));
+      CPPUNIT_ASSERT(files[3].endsWith("MGCPv3" + files_extensions[ext] + "/LAP010.shp"));
+      CPPUNIT_ASSERT(files[4].endsWith("MGCPv3" + files_extensions[ext] + "/LAP030.shp"));
+      CPPUNIT_ASSERT(files[5].endsWith("MGCPv3" + files_extensions[ext] + "/LAP050.shp"));
+      CPPUNIT_ASSERT(files[6].endsWith("MGCPv3" + files_extensions[ext] + "/LAQ040.shp"));
+      CPPUNIT_ASSERT(files[7].endsWith("MGCPv3" + files_extensions[ext] + "/LBH140.shp"));
+      CPPUNIT_ASSERT(files[8].endsWith("MGCPv3" + files_extensions[ext] + "/PAL015.shp"));
     }
-
-    void runJavaScriptTranslateTest()
-    {
-      OgrReader uut;
-
-      OsmMapPtr map = std::make_shared<OsmMap>();
-      uut.setSchemaTranslationScript("translations/cloudmade.js");
-      uut.read(_inputPath + "jakarta_raya_coastline.shp", "", map);
-
-      CPPUNIT_ASSERT_EQUAL(604, (int)map->getNodes().size());
-      CPPUNIT_ASSERT_EQUAL(6, (int)map->getWays().size());
-
-      int shoreline = 0;
-      int water = 0;
-      for (WayMap::const_iterator it = map->getWays().begin(); it != map->getWays().end(); ++it)
-      {
-        WayPtr w = it->second;
-        if (w->getTags()["natural"] == "shoreline")
-        {
-          shoreline++;
-        }
-        if (w->getTags()["natural"] == "water")
-        {
-          water++;
-        }
-      }
-      CPPUNIT_ASSERT_EQUAL(5, shoreline);
-      CPPUNIT_ASSERT_EQUAL(1, water);
-    }
-
-    void runPythonTranslateTest()
-    {
-      OgrReader uut;
-
-      OsmMapPtr map = std::make_shared<OsmMap>();
-      uut.setSchemaTranslationScript("cloudmade");
-      uut.read(_inputPath + "jakarta_raya_coastline.shp", "", map);
-
-      CPPUNIT_ASSERT_EQUAL(604, (int)map->getNodes().size());
-      CPPUNIT_ASSERT_EQUAL(6, (int)map->getWays().size());
-
-      int shoreline = 0;
-      int water = 0;
-      for (WayMap::const_iterator it = map->getWays().begin(); it != map->getWays().end(); ++it)
-      {
-        WayPtr w = it->second;
-        if (w->getTags()["natural"] == "shoreline")
-        {
-          shoreline++;
-        }
-        if (w->getTags()["natural"] == "water")
-        {
-          water++;
-        }
-      }
-      CPPUNIT_ASSERT_EQUAL(5, shoreline);
-      CPPUNIT_ASSERT_EQUAL(1, water);
-    }
-
-    void runStreamHasMoreElementsTest()
-    {
-      OgrReader reader1;
-
-      // If we haven't opened a file, it best not be ready to read.
-      CPPUNIT_ASSERT_EQUAL(reader1.hasMoreElements(), false);
-
-      // Try to open an invalid file.
-      OgrReader reader2(_inputPath + "totalgarbage.osm.pbf");
-      CPPUNIT_ASSERT_EQUAL(reader2.hasMoreElements(), false);
-
-      // Open a valid file.
-      OgrReader reader3(_inputPath + "jakarta_raya_coastline.shp");
-      CPPUNIT_ASSERT_EQUAL(reader3.hasMoreElements(), true);
-
-      // Close the file and check again.
-      reader3.close();
-      CPPUNIT_ASSERT_EQUAL(reader3.hasMoreElements(), false);
-    }
-
-    void runStreamReadNextElementTest()
-    {
-      OgrReader reader(_inputPath + "jakarta_raya_coastline.shp");
-
-      // Iterate through all items.
-      int numberOfElements(0);
-      while (reader.hasMoreElements() == true)
-      {
-        ElementPtr tempElement = reader.readNextElement();
-        numberOfElements++;
-        LOG_VART(tempElement->toString());
-      }
-
-      CPPUNIT_ASSERT_EQUAL(610, numberOfElements);
-    }
-
-    void runOgrZipTest()
-    {
-      QStringList files_extensions({".zip", ".tar", ".tar.gz"});
-      QStringList files_prefixes({"/vsizip/", "/vsitar/", "/vsitar/"});
-
-      for (int ext = 0; ext < files_extensions.length(); ++ext)
-      {
-        QString file = _inputPath + "MGCPv3" + files_extensions[ext];
-        QStringList files = OgrUtilities::getInstance().getValidFilesInContainer(file);
-        //  The MGCPv3 container files contain 9 Shapefiles
-        CPPUNIT_ASSERT_EQUAL(9, files.length());
-        //  Make sure all of them begin will the correct prefix
-        for (int f = 0; f < files.length(); ++f)
-          CPPUNIT_ASSERT(files[f].startsWith(files_prefixes[ext]));
-        //  Check the files in alphabetical order
-        CPPUNIT_ASSERT(files[0].endsWith("MGCPv3" + files_extensions[ext] + "/AAL015.shp"));
-        CPPUNIT_ASSERT(files[1].endsWith("MGCPv3" + files_extensions[ext] + "/AAL020.shp"));
-        CPPUNIT_ASSERT(files[2].endsWith("MGCPv3" + files_extensions[ext] + "/LAN010.shp"));
-        CPPUNIT_ASSERT(files[3].endsWith("MGCPv3" + files_extensions[ext] + "/LAP010.shp"));
-        CPPUNIT_ASSERT(files[4].endsWith("MGCPv3" + files_extensions[ext] + "/LAP030.shp"));
-        CPPUNIT_ASSERT(files[5].endsWith("MGCPv3" + files_extensions[ext] + "/LAP050.shp"));
-        CPPUNIT_ASSERT(files[6].endsWith("MGCPv3" + files_extensions[ext] + "/LAQ040.shp"));
-        CPPUNIT_ASSERT(files[7].endsWith("MGCPv3" + files_extensions[ext] + "/LBH140.shp"));
-        CPPUNIT_ASSERT(files[8].endsWith("MGCPv3" + files_extensions[ext] + "/PAL015.shp"));
-      }
-    }
+  }
 };
 
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(OgrReaderTest, "quick");

--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDbSqlStatementFormatter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDbSqlStatementFormatter.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #include "ApiDbSqlStatementFormatter.h"
 
@@ -36,7 +36,7 @@ namespace hoot
 {
 
 ApiDbSqlStatementFormatter::ApiDbSqlStatementFormatter()
-  : _dateString(QDateTime::currentDateTime().toUTC().toString("yyyy-MM-dd hh:mm:ss.zzz")),
+  : _dateString(QDateTime::currentDateTimeUtc().toString("yyyy-MM-dd hh:mm:ss.zzz")),
     _useSourceVersion(ConfigOptions().getApidbBulkInserterUseSourceVersion())
 {
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "OgrReader.h"
@@ -221,16 +221,12 @@ protected:
     _d->readNext(_map);
 
     const NodeMap& nm = _map->getNodes();
-    for (NodeMap::const_iterator it = nm.begin(); it != nm.end(); ++it)
-    {
+    for (auto it = nm.begin(); it != nm.end(); ++it)
       _addElement(_map->getNode(it->first));
-    }
 
     const WayMap& wm = _map->getWays();
-    for (WayMap::const_iterator it = wm.begin(); it != wm.end(); ++it)
-    {
+    for (auto it = wm.begin(); it != wm.end(); ++it)
       _addElement(_map->getWay(it->first));
-    }
   }
 
 private:
@@ -239,32 +235,26 @@ private:
   std::shared_ptr<OgrReaderInternal> _d;
 };
 
-OgrReader::OgrReader() :
-_d(std::make_shared<OgrReaderInternal>())
+OgrReader::OgrReader()
+  : _d(std::make_shared<OgrReaderInternal>())
 {
 }
 
-OgrReader::OgrReader(const QString& path) :
-_d(std::make_shared<OgrReaderInternal>())
+OgrReader::OgrReader(const QString& path)
+  : _d(std::make_shared<OgrReaderInternal>())
 {
   if (isSupported(path) == true)
-  {
     _d->open(path, QString(""));
-  }
 }
 
 void OgrReader::setProgress(const Progress& progress)
 {
   if (!_d)
-  {
-    throw IllegalArgumentException(
-      "Internal reader must be initialized before setting progress on OgrReader.");
-  }
+    throw IllegalArgumentException("Internal reader must be initialized before setting progress on OgrReader.");
   _d->setProgress(progress);
 }
 
-std::shared_ptr<ElementIterator> OgrReader::createIterator(
-  const QString& path, const QString& layer) const
+std::shared_ptr<ElementIterator> OgrReader::createIterator(const QString& path, const QString& layer) const
 {
   std::shared_ptr<OgrReaderInternal> d = std::make_shared<OgrReaderInternal>();
   d->setDefaultCircularError(_d->getDefaultCircularError());
@@ -275,8 +265,7 @@ std::shared_ptr<ElementIterator> OgrReader::createIterator(
   return std::make_shared<OgrElementIterator>(d);
 }
 
-std::shared_ptr<OGRSpatialReference> OgrReaderInternal::_fixProjection(
-  std::shared_ptr<OGRSpatialReference> srs)
+std::shared_ptr<OGRSpatialReference> OgrReaderInternal::_fixProjection(std::shared_ptr<OGRSpatialReference> srs)
 {
   std::shared_ptr<OGRSpatialReference> result;
   int epsgOverride = ConfigOptions().getOgrReaderEpsgOverride();
@@ -285,9 +274,7 @@ std::shared_ptr<OGRSpatialReference> OgrReaderInternal::_fixProjection(
     result.reset(new OGRSpatialReference());
     result->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     if (result->importFromEPSG(epsgOverride) != OGRERR_NONE)
-    {
       throw HootException(QString("Error creating EPSG:%1 projection.").arg(epsgOverride));
-    }
     return result;
   }
 
@@ -337,8 +324,7 @@ std::shared_ptr<OGRSpatialReference> OgrReaderInternal::_fixProjection(
   //  TODO: Fix the crash when using NAD83/Maryland i.e. EPSG:2248
   if (srs->GetEPSGGeogCS() == 4269 && MapProjector::toWkt(srs).contains("NAD83 / Maryland"))
   {
-    LOG_WARN(
-      "Overriding input projection NAD83 / Maryland with WGS84")
+    LOG_WARN("Overriding input projection NAD83 / Maryland with WGS84")
     return MapProjector::createWgs84Projection();
   }
 
@@ -346,8 +332,7 @@ std::shared_ptr<OGRSpatialReference> OgrReaderInternal::_fixProjection(
   return result;
 }
 
-std::shared_ptr<Envelope> OgrReader::getBoundingBoxFromConfig(
-  const Settings& s, const OGRSpatialReference* srs)
+std::shared_ptr<Envelope> OgrReader::getBoundingBoxFromConfig(const Settings& s, const OGRSpatialReference* srs)
 {
   return _d->getBoundingBoxFromConfig(s, srs);
 }
@@ -365,12 +350,10 @@ QStringList OgrReader::getFilteredLayerNames(const QString& path) const
   QStringList allLayers = _d->getLayersWithGeometry(path);
   LOG_VART(allLayers);
 
-  for (int i = 0; i < allLayers.size(); i++)
+  for (const auto& layer : qAsConst(allLayers))
   {
-    if (allLayers[i].contains(filterStr))
-    {
-      result.append(allLayers[i]);
-    }
+    if (layer.contains(filterStr))
+      result.append(layer);
   }
 
   // Make the results consistent.
@@ -386,8 +369,7 @@ long OgrReader::getFeatureCount(const QString& path, const QString& layer) const
   return _d->getFeatureCount();
 }
 
-std::vector<float> OgrReader::_getInputProgressWeights(
-  const QString& input, const QStringList& layers) const
+std::vector<float> OgrReader::_getInputProgressWeights(const QString& input, const QStringList& layers) const
 {
   std::vector<float> progressWeights;
   LOG_VART(layers.size());
@@ -395,11 +377,11 @@ std::vector<float> OgrReader::_getInputProgressWeights(
   // process the completion status report information first
   long featureCountTotal = 0;
   int undefinedCounts = 0;
-  for (int i = 0; i < layers.size(); i++)
+  for (const auto& layer : qAsConst(layers))
   {
-    LOG_VART(layers[i]);
+    LOG_VART(layer);
     // simply open the file, get the meta feature count value, and close
-    long featuresPerLayer = getFeatureCount(input, layers[i]);
+    long featuresPerLayer = getFeatureCount(input, layer);
     LOG_VART(featuresPerLayer);
     progressWeights.push_back((float)featuresPerLayer);
     // cover the case where no feature count available efficiently; Despite the documentation
@@ -419,24 +401,28 @@ std::vector<float> OgrReader::_getInputProgressWeights(
   // determine weights for 3 possible cases
   if (undefinedCounts == layers.size())
   {
-    for (int i = 0; i < layers.size(); i++) progressWeights[i] = 1. / (float)layers.size();
+    for (int i = 0; i < layers.size(); i++)
+      progressWeights[i] = 1.0f / static_cast<float>(layers.size());
   }
   else if (definedCounts == layers.size())
   {
-    for (int i = 0; i < layers.size(); i++) progressWeights[i] /= (float)featureCountTotal;
+    for (int i = 0; i < layers.size(); i++)
+      progressWeights[i] /= static_cast<float>(featureCountTotal);
   }
   else
   {
-    for (int i = 0; i<layers.size(); i++)
+    for (int i = 0; i < layers.size(); i++)
+    {
       if (progressWeights[i] == -1)
-      {
-        progressWeights[i] = (1. / (float)definedCounts) * featureCountTotal;
-      }
+        progressWeights[i] = (1.0f / static_cast<float>(definedCounts)) * static_cast<float>(featureCountTotal);
+    }
     // reset featurecount total and recalculate
     featureCountTotal = 0;
-    for (int i = 0; i < layers.size(); i++) featureCountTotal += progressWeights[i];
+    for (int i = 0; i < layers.size(); i++)
+      featureCountTotal += static_cast<long>(progressWeights[i]);
     LOG_VART(progressWeights);
-    for (int i = 0; i < layers.size(); i++) progressWeights[i] /= (float)featureCountTotal;
+    for (int i = 0; i < layers.size(); i++)
+      progressWeights[i] /= (float)featureCountTotal;
   }
 
   LOG_VART(progressWeights);
@@ -478,9 +464,8 @@ QStringList OgrReader::_getLayersFromPath(QString& input) const
   return layers;
 }
 
-void OgrReader::read(
-  const QString& path, const QString& layer, const OsmMapPtr& map, const QString& jobSource,
-  const int numTasks)
+void OgrReader::read(const QString& path, const QString& layer, const OsmMapPtr& map, const QString& jobSource,
+                     const int numTasks)
 {
   LOG_VARD(path);
   LOG_VARD(layer);
@@ -572,17 +557,14 @@ bool OgrReader::isSupported(const QString& url) const
   LOG_VART(url);
 
   if (url.endsWith(".osc") || url.endsWith(".osc.sql"))
-  {
     return false;
-  }
 
   QString justPath = url;
   IoUtils::ogrPathAndLayerToPath(justPath); // in case the layer syntax is in use
   LOG_VART(OgrUtilities::getInstance().isReasonableUrl(justPath));
   LOG_VART(IoUtils::isSupportedOgrFormat(url, true));
-  return
-    OgrUtilities::getInstance().isReasonableUrl(justPath) ||
-    IoUtils::isSupportedOgrFormat(url, true);
+  return OgrUtilities::getInstance().isReasonableUrl(justPath) ||
+         IoUtils::isSupportedOgrFormat(url, true);
 }
 
 void OgrReader::setUseDataSourceIds(bool useDataSourceIds)
@@ -611,17 +593,17 @@ std::shared_ptr<OGRSpatialReference> OgrReader::getProjection() const
 
 int OgrReaderInternal::logWarnCount = 0;
 
-OgrReaderInternal::OgrReaderInternal() :
-_defaultCircularError(ConfigOptions().getCircularErrorDefaultValue()),
-_circularErrorTagKeys(ConfigOptions().getCircularErrorTagKeys()),
-_status(Status::Invalid),
-_map(std::make_shared<OsmMap>()),
-_layer(nullptr),
-_limit(-1),
-_featureCount(0),
-_transform(nullptr),
-_addSourceDateTime(ConfigOptions().getReaderAddSourceDatetime()),
-_nodeIdFieldName(ConfigOptions().getOgrReaderNodeIdFieldName())
+OgrReaderInternal::OgrReaderInternal()
+  : _defaultCircularError(ConfigOptions().getCircularErrorDefaultValue()),
+    _circularErrorTagKeys(ConfigOptions().getCircularErrorTagKeys()),
+    _status(Status::Invalid),
+    _map(std::make_shared<OsmMap>()),
+    _layer(nullptr),
+    _limit(-1),
+    _featureCount(0),
+    _transform(nullptr),
+    _addSourceDateTime(ConfigOptions().getReaderAddSourceDatetime()),
+    _nodeIdFieldName(ConfigOptions().getOgrReaderNodeIdFieldName())
 {
   _nodesItr = _map->getNodes().begin();
   _waysItr =  _map->getWays().begin();
@@ -633,9 +615,7 @@ OgrReaderInternal::~OgrReaderInternal()
   close();
 
   if (_transform != nullptr)
-  {
     OGRCoordinateTransformation::DestroyCT(_transform);
-  }
 }
 
 QStringList OgrReaderInternal::getLayersWithGeometry(const QString& path) const
@@ -668,11 +648,10 @@ QRegExp OgrReaderInternal::getNameFilter()
   _initTranslate();
   // Check the commandline / environment var.
   QString rawFilter = ConfigOptions().getOgrImportFilter();
+  // Try the translation file. This function will return "." by default.
   if (rawFilter == "")
-  {
-    // Try the translation file. This function will return "." by default.
     rawFilter = _translator->getLayerNameFilter();
-  }
+
   return QRegExp(rawFilter);
 }
 
@@ -687,16 +666,13 @@ void OgrReaderInternal::_addFeature(OGRFeature* f)
     QString value;
 
     // This skips NULL fields.
-    if (! f->IsFieldSet(i)) continue;
+    if (! f->IsFieldSet(i))
+      continue;
 
     if (f->GetDefnRef()->GetFieldDefn(i)->GetType() == OFTReal)
-    {
       value = QString::number(f->GetFieldAsDouble(i), 'g', 17);
-    }
     else
-    {
       value = QString::fromUtf8(f->GetFieldAsString(i));
-    }
 
     // Make sure the tag is only added if its value is non-null.
     if ( value.length() == 0 )
@@ -716,13 +692,11 @@ void OgrReaderInternal::_addFeature(OGRFeature* f)
   {
     // Add an ingest datetime tag
     t.appendValue(MetadataTags::SourceIngestDateTime(),
-                  QDateTime::currentDateTime().toUTC().toString("yyyy-MM-ddThh:mm:ss.zzzZ"));
+                  QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddThh:mm:ss.zzzZ"));
   }
 
   if (!t.empty())
-  {
     _addGeometry(f->GetGeometryRef(), t);
-  }
 }
 
 void OgrReaderInternal::_addGeometry(OGRGeometry* g, Tags& t)
@@ -733,39 +707,36 @@ void OgrReaderInternal::_addGeometry(OGRGeometry* g, Tags& t)
     {
       switch (wkbFlatten(g->getGeometryType()))
       {
-        case wkbLineString:
-          LOG_TRACE("Adding line string: " << _toWkt(g).left(100));
-          _addLineString((OGRLineString*)g, t);
-          break;
-        case wkbPoint:
-          LOG_TRACE("Adding point: " << _toWkt(g).left(100));
-          _addPoint((OGRPoint*)g, t);
-          break;
-        case wkbPolygon:
-          LOG_TRACE("Adding polygon: " << _toWkt(g).left(100));
-          _addPolygon((OGRPolygon*)g, t);
-          break;
-        case wkbMultiPolygon:
-          LOG_TRACE("Adding multi-polygon: " << _toWkt(g).left(100));
-          _addMultiPolygon((OGRMultiPolygon*)g, t);
-          break;
-        case wkbMultiPoint:
-        case wkbMultiLineString:
-        case wkbGeometryCollection:
-        {
-          LOG_TRACE(
-            "Adding geometry collection (multipoint, multiline, etc.): " <<
-            _toWkt(g).left(100));
-          OGRGeometryCollection* gc = dynamic_cast<OGRGeometryCollection*>(g);
-          int nParts = gc->getNumGeometries();
-          for (int i = 0; i < nParts; i++)
-          {
-            _addGeometry(gc->getGeometryRef(i), t);
-          }
-          break;
-        }
-        default:
-          throw HootException("Unsupported geometry type.");
+      case wkbLineString:
+        LOG_TRACE("Adding line string: " << _toWkt(g).left(100));
+        _addLineString((OGRLineString*)g, t);
+        break;
+      case wkbPoint:
+        LOG_TRACE("Adding point: " << _toWkt(g).left(100));
+        _addPoint((OGRPoint*)g, t);
+        break;
+      case wkbPolygon:
+        LOG_TRACE("Adding polygon: " << _toWkt(g).left(100));
+        _addPolygon((OGRPolygon*)g, t);
+        break;
+      case wkbMultiPolygon:
+        LOG_TRACE("Adding multi-polygon: " << _toWkt(g).left(100));
+        _addMultiPolygon((OGRMultiPolygon*)g, t);
+        break;
+      case wkbMultiPoint:
+      case wkbMultiLineString:
+      case wkbGeometryCollection:
+      {
+        LOG_TRACE("Adding geometry collection (multipoint, multiline, etc.): " <<
+                  _toWkt(g).left(100));
+        OGRGeometryCollection* gc = dynamic_cast<OGRGeometryCollection*>(g);
+        int nParts = gc->getNumGeometries();
+        for (int i = 0; i < nParts; i++)
+          _addGeometry(gc->getGeometryRef(i), t);
+        break;
+      }
+      default:
+        throw HootException("Unsupported geometry type.");
       }
     }
     catch (const IllegalArgumentException& e)
@@ -801,9 +772,7 @@ void OgrReaderInternal::_addMultiPolygon(OGRMultiPolygon* mp, Tags& t)
 
   int nParts = mp->getNumGeometries();
   if (nParts == 1)
-  {
     _addPolygon((OGRPolygon*)mp->getGeometryRef(0), t);
-  }
   else
   {
     RelationPtr r =
@@ -812,9 +781,7 @@ void OgrReaderInternal::_addMultiPolygon(OGRMultiPolygon* mp, Tags& t)
     r->setTags(t);
 
     for (int i = 0; i < nParts; i++)
-    {
       _addPolygon((OGRPolygon*)mp->getGeometryRef(i), r, circularError);
-    }
 
     _map->addRelation(r);
   }
@@ -829,17 +796,13 @@ void OgrReaderInternal::_addPoint(const OGRPoint* p, Tags& t)
   _reproject(x, y);
   long id;
   if (_nodeIdFieldName.isEmpty())
-  {
     id = _map->createNextNodeId();
-  }
   else
   {
     bool ok = false;
     id = t.get(_nodeIdFieldName).toLong(&ok);
     if (!ok)
-    {
       throw HootException("Unable to parse node ID from field: " + _nodeIdFieldName);
-    }
   }
   NodePtr node(Node::newSp(_status, id, x, y, circularError));
 
@@ -859,9 +822,7 @@ void OgrReaderInternal::_addPolygon(OGRPolygon* p, Tags& t)
     {
       WayPtr outer = _createWay(p->getExteriorRing(), circularError);
       if (areaCrit.isSatisfied(t, ElementType::Way) == false)
-      {
         t.setArea(true);
-      }
       outer->setTags(t);
       _map->addWay(outer);
     }
@@ -886,9 +847,7 @@ void OgrReaderInternal::_addPolygon(OGRPolygon* p, Tags& t)
       std::make_shared<Relation>(
         _status, _map->createNextRelationId(), circularError, MetadataTags::RelationMultiPolygon());
     if (areaCrit.isSatisfied(t, ElementType::Relation) == false)
-    {
       t.setArea(true);
-    }
     r->setTags(t);
     _addPolygon(p, r, circularError);
     _map->addRelation(r);
@@ -900,7 +859,7 @@ QString OgrReaderInternal::_toWkt(const OGRGeometry* geom)
   char* buffer;
   geom->exportToWkt(&buffer);
   QString result = QString::fromUtf8(buffer);
-  delete buffer;
+  CPLFree(buffer);
   return result;
 }
 
@@ -921,15 +880,11 @@ void OgrReaderInternal::_addPolygon(OGRPolygon* p, RelationPtr r, Meters circula
 void OgrReaderInternal::close()
 {
   // No need to finalize the translation here. We may need it again.
-
   _useFileId = false;
-
   if (_dataSource != nullptr)
   {
     if (_layer != nullptr)
-    {
       _layer->Dereference();
-    }
     _dataSource.reset();
     _layer = nullptr;
     _pendingLayers.clear();
@@ -964,59 +919,41 @@ void OgrReaderInternal::_finalizeTranslate()
   _translator.reset();
 }
 
-std::shared_ptr<Envelope> OgrReaderInternal::getBoundingBoxFromConfig(
-  const Settings& s, const OGRSpatialReference* srs) const
+std::shared_ptr<Envelope> OgrReaderInternal::getBoundingBoxFromConfig(const Settings& s, const OGRSpatialReference* srs) const
 {
   ConfigOptions co(s);
   std::shared_ptr<Envelope> result;
   const QString bboxStrRaw = co.getBounds();
   if (!bboxStrRaw.trimmed().isEmpty() && !GeometryUtils::isEnvelopeString(bboxStrRaw))
-  {
     throw IllegalArgumentException("OGR reader only supports rectangular convert bounds.");
-  }
+
   const bool asWgs84 = co.getOgrReaderBoundingBoxLatlng();
   QString bboxStr;
-  QString key;
 
   if (bboxStrRaw.isEmpty())
-  {
     return result;
-  }
   else if (bboxStrRaw.isEmpty() == false)
-  {
     bboxStr = bboxStrRaw;
-  }
 
   if (!asWgs84)
-  {
     result = std::make_shared<Envelope>(GeometryUtils::envelopeFromString(bboxStr));
-  }
   else
   {
     if (!srs)
-    {
-      throw HootException("A valid projection must be available when using a lat/lng bounding "
-        "box.");
-    }
+      throw HootException("A valid projection must be available when using a lat/lng bounding box.");
 
     QStringList bbox = bboxStr.split(",");
 
     if (bbox.size() != 4)
-    {
-      throw HootException(
-        QString("Error parsing %1 (%2)").arg(ConfigOptions::getBoundsKey()).arg(bboxStr));
-    }
+      throw HootException(QString("Error parsing %1 (%2)").arg(ConfigOptions::getBoundsKey(), bboxStr));
 
     bool ok;
     vector<double> bboxValues(4);
-    for (size_t i = 0; i < 4; i++)
+    for (int i = 0; i < 4; i++)
     {
       bboxValues[i] = bbox[i].toDouble(&ok);
       if (!ok)
-      {
-        throw HootException(
-          QString("Error parsing %1 (%2)").arg(ConfigOptions::getBoundsKey()).arg(bboxStr));
-      }
+        throw HootException(QString("Error parsing %1 (%2)").arg(ConfigOptions::getBoundsKey(), bboxStr));
     }
 
     result = std::make_shared<Envelope>();
@@ -1031,14 +968,11 @@ std::shared_ptr<Envelope> OgrReaderInternal::getBoundingBoxFromConfig(
       {
         double ty = bboxValues[1] + yi * (bboxValues[3] - bboxValues[1]) / (double)steps;
         double tx = x;
-
         transform->Transform(1, &tx, &ty);
-
         result->expandToInclude(tx, ty);
       }
     }
   }
-
   return result;
 }
 
@@ -1051,9 +985,7 @@ void OgrReaderInternal::_initTranslate()
   {
     _translator = ScriptSchemaTranslatorFactory::getInstance().createTranslator(_translatePath);
     if (_translator.get() == nullptr)
-    {
       throw HootException("Unable to find a valid translation format for: " + _translatePath);
-    }
   }
 }
 
@@ -1065,13 +997,9 @@ void OgrReaderInternal::open(const QString& path, const QString& layer)
   LOG_TRACE("Opening data source for layer: " << layer);
   _dataSource = OgrUtilities::getInstance().openDataSource(path, true);
   if (layer.isEmpty() == false)
-  {
     _pendingLayers.append(layer);
-  }
   else
-  {
     _pendingLayers = getLayersWithGeometry(path);
-  }
   LOG_VARD(_pendingLayers);
 }
 
@@ -1080,18 +1008,12 @@ void OgrReaderInternal::_openLayer(const QString& path, const QString& layer)
   _path = path;
   _layerName = layer;
   if (layer == "")
-  {
     throw HootException("Please specify a layer to open.");
-  }
   else
-  {
     _layer = _dataSource->GetLayerByName(layer.toUtf8());
-  }
 
   if (_layer == nullptr)
-  {
     throw HootException("Failed to identify source layer from data source.");
-  }
 
   std::shared_ptr<OGRSpatialReference> sourceSrs;
 
@@ -1109,9 +1031,7 @@ void OgrReaderInternal::_openLayer(const QString& path, const QString& layer)
     _transform = OGRCreateCoordinateTransformation(sourceSrs.get(), _wgs84.get());
 
     if (_transform == nullptr)
-    {
       throw HootException(QString("Error creating transformation object: ") + CPLGetLastErrorMsg());
-    }
   }
 
   std::shared_ptr<Envelope> filter = getBoundingBoxFromConfig(conf(), sourceSrs.get());
@@ -1170,12 +1090,9 @@ Meters OgrReaderInternal::_parseCircularError(Tags& t) const
       // may want to unify their behavior. Removing 'error:circular' seems ok, since its a hoot
       // specific key. Not as sure about 'accuracy', though, as that may be OSM specific.
       if (ceKey == MetadataTags::ErrorCircular() || ceKey == MetadataTags::Accuracy())
-      {
         t.remove(ceKey);
-      }
     }
   }
-
   return circularError;
 }
 
@@ -1187,10 +1104,7 @@ void OgrReaderInternal::read(const OsmMapPtr& map)
   _openNextLayer();
 
   if (_layer == nullptr)
-  {
-    throw HootException("Error reading from input. No valid layers. Did you forget to set the "
-      "layer name?");
-  }
+    throw HootException("Error reading from input. No valid layers. Did you forget to set the layer name?");
 
   LOG_STATUS("Reading: " << _layerName.toLatin1().data() << "...");
 
@@ -1226,19 +1140,13 @@ void OgrReaderInternal::readNext(const OsmMapPtr& map)
 
   while (!done)
   {
-    // if the current layer is empty
+    // if the current layer is empty open the next layer
     if (_layer == nullptr)
-    {
-      // open the next layer
       _openNextLayer();
-    }
 
-    // if there are no more layers
+    // if there are no more layers we're done
     if (_layer == nullptr)
-    {
-      // we're done
       done = true;
-    }
     // if this is a valid layer
     else
     {
@@ -1253,12 +1161,8 @@ void OgrReaderInternal::readNext(const OsmMapPtr& map)
         // we're done
         done = true;
       }
-      // if there wasn't a next feature
-      else
-      {
-        // this layer is now empty set it to null so we'll load the next layer
+      else  // if there wasn't a next feature this layer is now empty set it to null so we'll load the next layer
         _layer = nullptr;
-      }
     }
   }
 }
@@ -1322,9 +1226,7 @@ void OgrReaderInternal::_translate(Tags& t)
     _translator->translateToOsm(t, _layer->GetLayerDefn()->GetName(), geomType);
   }
   else
-  {
     t[MetadataTags::HootLayername()] = _layer->GetLayerDefn()->GetName();
-  }
 }
 
 void OgrReaderInternal::initializePartial()
@@ -1346,9 +1248,7 @@ bool OgrReaderInternal::hasMoreElements()
 {
   // If we're not open, definitely no more elements.
   if (isOpen() == false)
-  {
     return false;
-  }
 
   // Do we have data already in map from previous reads?
   if ((_nodesItr != _map->getNodes().end()) || (_waysItr != _map->getWays().end()) ||
@@ -1361,9 +1261,8 @@ bool OgrReaderInternal::hasMoreElements()
   // empty.
   populateElementMap();
 
-  return
-    ((_nodesItr != _map->getNodes().end()) || (_waysItr != _map->getWays().end())
-     || (_relationsItr != _map->getRelations().end()));
+  return ((_nodesItr != _map->getNodes().end()) || (_waysItr != _map->getWays().end()) ||
+         (_relationsItr != _map->getRelations().end()));
 }
 
 ElementPtr OgrReaderInternal::readNextElement()
@@ -1417,7 +1316,7 @@ QString OgrReaderInternal::_toWkt(const OGRSpatialReference* srs)
   char* buffer;
   srs->exportToWkt(&buffer);
   QString result = QString::fromUtf8(buffer);
-  delete buffer;
+  CPLFree(buffer);
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
@@ -1109,8 +1109,8 @@ void OgrReaderInternal::read(const OsmMapPtr& map)
   LOG_STATUS("Reading: " << _layerName.toLatin1().data() << "...");
 
   const int statusUpdateInterval = ConfigOptions().getTaskStatusUpdateInterval();
-  OGRFeature* f;
-  while ((f = _layer->GetNextFeature()) != nullptr && (_limit == -1 || _count < _limit))
+  OGRFeature* f = _layer->GetNextFeature();
+  while (f != nullptr && (_limit == -1 || _count < _limit))
   {
     _addFeature(f);
     OGRFeature::DestroyFeature(f);
@@ -1130,6 +1130,8 @@ void OgrReaderInternal::read(const OsmMapPtr& map)
         StringUtils::formatLargeNumber(_featureCount) + " features from layer: " +
         _layerName.toLatin1().data(), true);
     }
+
+    f = _layer->GetNextFeature();
   }
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrReader.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef __OGR_READER_H__
@@ -79,9 +79,8 @@ public:
    * @param jobSource optional job name for status reporting
    * @param numTasks optional number of job tasks being performed for status reporting
    */
-  void read(
-    const QString& path, const QString& layer, const OsmMapPtr& map, const QString& jobSource = "",
-    const int numTasks = -1);
+  void read(const QString& path, const QString& layer, const OsmMapPtr& map, const QString& jobSource = "",
+            const int numTasks = -1);
 
   /**
    * Returns true if this appears to be a reasonable path without actually attempting to open the
@@ -100,8 +99,7 @@ public:
    * Returns the bounding box for the specified projection and configuration settings. This is
    * likely only useful in unit tests.
    */
-  virtual std::shared_ptr<geos::geom::Envelope> getBoundingBoxFromConfig(
-    const Settings& s, const OGRSpatialReference* srs);
+  virtual std::shared_ptr<geos::geom::Envelope> getBoundingBoxFromConfig(const Settings& s, const OGRSpatialReference* srs);
 
   std::shared_ptr<OGRSpatialReference> getProjection() const override;
 
@@ -132,8 +130,7 @@ private:
    * feature size. If the feature size hasn't already been calculated for each layer, then a even
    * distribution of weighting between layers is returned.
    */
-  std::vector<float> _getInputProgressWeights(
-    const QString& input, const QStringList& layers) const;
+  std::vector<float> _getInputProgressWeights(const QString& input, const QStringList& layers) const;
   /*
    * Determines the list of layers in an OGR input. The reader must already have been initialized.
    */

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -469,11 +469,6 @@ void OgrWriter::writePartial(const ConstRelationPtr& newRelation)
 
       switch (member_type)
       {
-      default:
-        //  Node and Way members throw if we don't force the skip
-        if (!_forceSkipFailedRelations)
-          throw HootException(msg);
-        break;
       case ElementType::Relation:
         //  Relation members throw that fail and aren't forced
         if (_failOnSkipRelation && !_forceSkipFailedRelations)
@@ -488,6 +483,11 @@ void OgrWriter::writePartial(const ConstRelationPtr& newRelation)
           return;
         }
         break;
+      default:
+        //  Node and Way members throw if we don't force the skip
+        if (!_forceSkipFailedRelations)
+          throw HootException(msg);
+        break;
       }
       //  Add this member to the list to remove for OGR files
       removeEntries.insert(member);
@@ -496,9 +496,8 @@ void OgrWriter::writePartial(const ConstRelationPtr& newRelation)
 
   ConstElementPtr constRelation(newRelation);
   //  Update the element to remove any non-existing members
-  if (removeEntries.size() > 0)
+  if (!removeEntries.empty())
   {
-
     std::vector<RelationData::Entry> newMembers;
     for (const auto& member : newRelation->getMembers())
     {

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxXmlWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxXmlWriter.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #include "OsmGbdxXmlWriter.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxXmlWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGbdxXmlWriter.cpp
@@ -58,11 +58,11 @@ int OsmGbdxXmlWriter::logWarnCount = 0;
 
 HOOT_FACTORY_REGISTER(OsmMapWriter, OsmGbdxXmlWriter)
 
-OsmGbdxXmlWriter::OsmGbdxXmlWriter() :
-_formatXml(ConfigOptions().getWriterXmlFormat()),
-_precision(ConfigOptions().getWriterPrecision()),
-_encodingErrorCount(0),
-_fileNumber(0)
+OsmGbdxXmlWriter::OsmGbdxXmlWriter()
+  : _formatXml(ConfigOptions().getWriterXmlFormat()),
+    _precision(ConfigOptions().getWriterPrecision()),
+    _encodingErrorCount(0),
+    _fileNumber(0)
 {
 }
 
@@ -79,18 +79,14 @@ QString OsmGbdxXmlWriter::removeInvalidCharacters(const QString& s)
   result.reserve(s.size());
 
   bool foundError = false;
-  for (int i = 0; i < s.size(); i++)
+  for (const auto& c : s)//int i = 0; i < s.size(); i++)
   {
-    QChar c = s[i];
+//    QChar c = s[i];
     // See http://stackoverflow.com/questions/730133/invalid-characters-in-xml
     if (c < 0x20 && c != 0x9 && c != 0xA && c != 0xD)
-    {
       foundError = true;
-    }
     else
-    {
       result.append(c);
-    }
   }
 
   if (foundError)
@@ -118,20 +114,16 @@ void OsmGbdxXmlWriter::open(const QString& url)
   _outputFileName = fi.baseName();
 
   if (_outputDir.exists() == false && FileUtils::makeDir(_outputDir.path()) == false)
-  {
     throw HootException("Error creating directory for writing.");
-  }
+
   _bounds.init();
 }
 
 void OsmGbdxXmlWriter::_newOutputFile()
 {
-  // Close the old file and open a new one
+  // Close the old file and open a new one Calling this so that the XML elements & document get closed
   if (_fp.get())
-  {
-    // Calling this so that the XML elements & document get closed
     close();
-  }
 
   // The output has had a few changes.....
   QString url = _outputDir.filePath(QString("%1_00_%2.xml").arg(_outputFileName).arg(_fileNumber++));
@@ -155,17 +147,13 @@ void OsmGbdxXmlWriter::_newOutputFile()
   std::dynamic_pointer_cast<QFile>(_fp)->setFileName(url);
 
   if (!_fp->open(QIODevice::WriteOnly | QIODevice::Text))
-  {
     throw HootException(QObject::tr("Error opening %1 for writing").arg(url));
-  }
 
   _writer = std::make_shared<QXmlStreamWriter>(_fp.get());
   _writer->setCodec("UTF-8");
 
   if (_formatXml)
-  {
     _writer->setAutoFormatting(true);
-  }
 
   _writer->writeStartDocument();
   _writer->writeStartElement("metadata");
@@ -181,9 +169,7 @@ void OsmGbdxXmlWriter::close()
   }
 
   if (_fp.get())
-  {
     _fp->close();
-  }
 }
 
 QString OsmGbdxXmlWriter::toString(const ConstOsmMapPtr& map, const bool formatXml)
@@ -194,11 +180,10 @@ QString OsmGbdxXmlWriter::toString(const ConstOsmMapPtr& map, const bool formatX
   std::shared_ptr<QBuffer> buf = std::make_shared<QBuffer>();
   writer._fp = buf;
   if (!writer._fp->open(QIODevice::WriteOnly | QIODevice::Text))
-  {
     throw InternalErrorException(QObject::tr("Error opening QBuffer for writing. Odd."));
-  }
+
   writer.write(map);
-  return QString::fromUtf8(buf->data(), buf->size());
+  return QString::fromUtf8(buf->data(), static_cast<int>(buf->size()));
 }
 
 QString OsmGbdxXmlWriter::_typeName(ElementType e)
@@ -233,22 +218,22 @@ void OsmGbdxXmlWriter::write(const ConstOsmMapPtr& map)
 
 void OsmGbdxXmlWriter::_writeTags(const ConstElementPtr& element)
 {
-
   // GBDX XML format:
   //   <M_Lang>English</M_Lang>
-
   const Tags& tags = element->getTags();
 
-  for (Tags::const_iterator it = tags.constBegin(); it != tags.constEnd(); ++it)
+  for (auto it = tags.constBegin(); it != tags.constEnd(); ++it)
   {
     const QString key = it.key();
     const QString val = it.value().trimmed();
 
     // Skip the empty stuff
-    if (val.isEmpty()) continue;
+    if (val.isEmpty())
+      continue;
 
     // Skip the Detection ID. This goes in the geometery area
-    if (key == "Det_id") continue;
+    if (key == "Det_id")
+      continue;
 
     // Dump the raw GBDX attributes into a CDATA block
     if (key == "raw_gbdx")
@@ -264,10 +249,10 @@ void OsmGbdxXmlWriter::_writeTags(const ConstElementPtr& element)
     {
       _writer->writeStartElement(key);
       QStringList l = val.split(";");
-      for (int i = 0; i < l.size(); ++i)
+      for (const auto& keyword : qAsConst(l))
       {
         _writer->writeStartElement("value");
-        _writer->writeCharacters(removeInvalidCharacters(l[i]));
+        _writer->writeCharacters(removeInvalidCharacters(keyword));
         _writer->writeEndElement();
       }
       _writer->writeEndElement();
@@ -286,7 +271,7 @@ void OsmGbdxXmlWriter::_writeNodes(ConstOsmMapPtr map)
   NoInformationCriterion crit;
   QList<long> nids;
   const NodeMap& nodes = map->getNodes();
-  for (NodeMap::const_iterator it = nodes.begin(); it != nodes.end(); ++it)
+  for (auto it = nodes.begin(); it != nodes.end(); ++it)
   {
     if (!crit.isSatisfied(map->getNode(it->first)))
         nids.append(it->first);
@@ -294,10 +279,10 @@ void OsmGbdxXmlWriter::_writeNodes(ConstOsmMapPtr map)
 
   // sort the values to give consistent results.
   qSort(nids.begin(), nids.end(), qLess<long>());
-  for (int i = 0; i < nids.size(); i++)
+  for (auto node_id : qAsConst(nids))
   {
     _newOutputFile();
-    writePartial(map->getNode(nids[i]));
+    writePartial(map->getNode(node_id));
   }
 }
 
@@ -305,7 +290,7 @@ void OsmGbdxXmlWriter::_writeWays(ConstOsmMapPtr map)
 {
   const WayMap& ways = map->getWays();
 
-  for (WayMap::const_iterator it = ways.begin(); it != ways.end(); ++it)
+  for (auto it = ways.begin(); it != ways.end(); ++it)
   {
     ConstWayPtr w = it->second;
 
@@ -323,9 +308,9 @@ void OsmGbdxXmlWriter::_writeWays(ConstOsmMapPtr map)
     bool valid = true;
     if (AreaCriterion().isSatisfied(w))
     {
-      for (vector<long>::const_iterator nodeIt = nodes.begin(); nodeIt != nodes.end(); ++nodeIt)
+      for (auto node_id : nodes)
       {
-        ConstNodePtr node = map->getNode(*nodeIt);
+        ConstNodePtr node = map->getNode(node_id);
         if (node.get() == nullptr)
         {
           valid = false;
@@ -341,9 +326,9 @@ void OsmGbdxXmlWriter::_writeWays(ConstOsmMapPtr map)
     }
     else
     {
-      for (vector<long>::const_iterator nodeIt = nodes.begin(); nodeIt != nodes.end(); ++nodeIt)
+      for (auto node_id : nodes)
       {
-        ConstNodePtr node = map->getNode(*nodeIt);
+        ConstNodePtr node = map->getNode(node_id);
         if (node.get() != nullptr)
         {
           LOG_INFO("Writing Nodes XXX");
@@ -360,17 +345,15 @@ void OsmGbdxXmlWriter::_writeRelations(ConstOsmMapPtr map)
 {
   QList<long> rids;
   const RelationMap& relations = map->getRelations();
-  for (RelationMap::const_iterator it = relations.begin(); it != relations.end(); ++it)
-  {
+  for (auto it = relations.begin(); it != relations.end(); ++it)
     rids.append(it->first);
-  }
 
   // sort the values to give consistent results.
   qSort(rids.begin(), rids.end(), qLess<long>());
-  for (int i = 0; i < rids.size(); i++)
+  for (auto relation_id : qAsConst(rids))
   {
     _newOutputFile();
-    _writeRelationWithPoints(map->getRelation(rids[i]),map);
+    _writeRelationWithPoints(map->getRelation(relation_id),map);
   }
 }
 
@@ -392,7 +375,7 @@ void OsmGbdxXmlWriter::writePartial(const ConstNodePtr& n)
   //  POINT (30 10)
 
   _writer->writeStartElement("Location");
-  _writer->writeCharacters(QString("POINT (%1 %2)").arg(QString::number(n->getX(), 'f', _precision)).arg(QString::number(n->getY(), 'f', _precision)));
+  _writer->writeCharacters(QString("POINT (%1 %2)").arg(QString::number(n->getX(), 'f', _precision), QString::number(n->getY(), 'f', _precision)));
   _writer->writeEndElement();
 
   _writeTags(n);
@@ -450,9 +433,9 @@ void OsmGbdxXmlWriter::_writeWayWithPoints(const ConstWayPtr& w, ConstOsmMapPtr 
     else
       _writer->writeCharacters(QString(", "));
 
-    const long nid = w->getNodeId(j);
+    const long nid = w->getNodeId(static_cast<int>(j));
     ConstNodePtr n = map->getNode(nid);
-    _writer->writeCharacters(QString("%1 %2").arg(QString::number(n->getX(), 'f', _precision)).arg(QString::number(n->getY(), 'f', _precision)));
+    _writer->writeCharacters(QString("%1 %2").arg(QString::number(n->getX(), 'f', _precision), QString::number(n->getY(), 'f', _precision)));
   }
   _writer->writeCharacters(endBracket);
 
@@ -483,7 +466,7 @@ void OsmGbdxXmlWriter::writePartial(const ConstWayPtr& w)
   for (size_t j = 0; j < w->getNodeCount(); j++)
   {
     _writer->writeStartElement("nd");
-    _writer->writeAttribute("ref", QString::number(w->getNodeId(j)));
+    _writer->writeAttribute("ref", QString::number(w->getNodeId(static_cast<int>(j))));
     _writer->writeEndElement();
   }
 
@@ -502,9 +485,8 @@ void OsmGbdxXmlWriter::writePartial(const ConstRelationPtr& r)
   _writer->writeAttribute("type", r->getType());
 
   const vector<RelationData::Entry>& members = r->getMembers();
-  for (size_t j = 0; j < members.size(); j++)
+  for (const auto& e : members)
   {
-    const RelationData::Entry& e = members[j];
     _writer->writeStartElement("member");
     _writer->writeAttribute("type", _typeName(e.getElementId().getType()));
     _writer->writeAttribute("ref", QString::number(e.getElementId().getId()));
@@ -566,9 +548,9 @@ void OsmGbdxXmlWriter::_writeRelationWithPoints(const ConstRelationPtr& r,  Cons
 
   bool firstRel = true;
   const vector<RelationData::Entry>& members = r->getMembers();
-  for (vector<RelationData::Entry>::const_iterator it = members.begin(); it != members.end(); ++it)
+  for (const auto& member : members)
   {
-    ConstElementPtr elm = map->getElement(it->getElementId());
+    ConstElementPtr elm = map->getElement(member.getElementId());
     if (elm.get() == nullptr)
       continue;
 
@@ -591,9 +573,9 @@ void OsmGbdxXmlWriter::_writeRelationWithPoints(const ConstRelationPtr& r,  Cons
         else
           _writer->writeCharacters(QString(", "));
 
-        const long nid = w->getNodeId(j);
+        const long nid = w->getNodeId(static_cast<int>(j));
         ConstNodePtr n = map->getNode(nid);
-        _writer->writeCharacters(QString("%1 %2").arg(QString::number(n->getX(), 'f', _precision)).arg(QString::number(n->getY(), 'f', _precision)));
+        _writer->writeCharacters(QString("%1 %2").arg(QString::number(n->getX(), 'f', _precision), QString::number(n->getY(), 'f', _precision)));
       }
       _writer->writeCharacters(endBracket);
     } // End way

--- a/hoot-core/src/main/cpp/hoot/core/util/DateTimeUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/DateTimeUtils.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "DateTimeUtils.h"
@@ -48,10 +48,9 @@ quint64 DateTimeUtils::fromTimeString(QString timestamp)
   //2016-05-04T22:07:19Z
   static QRegularExpression timestampRegex("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z*",
                                            QRegularExpression::OptimizeOnFirstUsageOption);
+
   if (!timestampRegex.match(timestamp).hasMatch())
-  {
     throw IllegalArgumentException("Invalid timestamp string: " + timestamp);
-  }
 
   struct tm t;
   strptime(timestamp.toStdString().c_str(), "%Y-%m-%dT%H:%M:%SZ", &t);


### PR DESCRIPTION
`OgrReader` used `delete` to free GDAL created objects in memory instead of using `CPLFree()`.  It was also reformatted and all sonar findings removed.

`QDateTime::currentDateTime().toUTC()` is deprecated in favor of `QDateTime::currentDateTimeUtc()`.  All instances were updated.