### PR TITLE
Hoot api db crash

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDb.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDb.h
@@ -86,6 +86,8 @@ public:
 
   static const Status DEFAULT_ELEMENT_STATUS;
 
+  static QString className() { return "ApiDb"; }
+
   ApiDb();
 
   virtual ~ApiDb();
@@ -145,8 +147,7 @@ public:
    * dealing with very large record sets
    * @return a result iterator to the elements
    */
-  virtual std::shared_ptr<QSqlQuery> selectElements(
-    const ElementType& elementType, const long minId = 0);
+  virtual std::shared_ptr<QSqlQuery> selectElements(const ElementType& elementType, const long minId = 0);
 
   /**
    * Returns a vector with all the OSM node ID's for a given way
@@ -228,8 +229,7 @@ public:
    * @param tableType the type of database table to query
    * @return a SQL results iterator
    */
-  std::shared_ptr<QSqlQuery> selectElementsByElementIdList(
-    const QSet<QString>& elementIds, const TableType& tableType);
+  std::shared_ptr<QSqlQuery> selectElementsByElementIdList(const QSet<QString>& elementIds, const TableType& tableType);
 
   /**
    * Returns all the IDs of all nodes owned by the input way IDs
@@ -246,8 +246,7 @@ public:
    * @param memberElementType the element type of the associated relation member
    * @return a SQL results iterator
    */
-  std::shared_ptr<QSqlQuery> selectRelationIdsByMemberIds(
-    const QSet<QString>& memberIds, const ElementType& memberElementType);
+  std::shared_ptr<QSqlQuery> selectRelationIdsByMemberIds(const QSet<QString>& memberIds, const ElementType& memberElementType);
 
   virtual QString tableTypeToTableName(const TableType& tableType) const = 0;
 
@@ -426,15 +425,18 @@ protected:
 
   long _maxElementsPerPartialMap;
 
-  QSqlQuery _exec(
-    const QString& sql, QVariant v1 = QVariant(), QVariant v2 = QVariant(),
-    QVariant v3 = QVariant()) const;
+  QSqlQuery _exec(const QString& sql, QVariant v1 = QVariant(), QVariant v2 = QVariant(),
+                  QVariant v3 = QVariant()) const;
 
   static void _unescapeString(QString& s);
 
   virtual void _resetQueries();
 
+  std::vector<RelationData::Entry> _selectRelationMembers(const std::shared_ptr<QSqlQuery>& relation_query) const;
+
 private:
+
+  static int logWarnCount;
 
   std::shared_ptr<QSqlQuery> _selectNodesByBounds;
   std::shared_ptr<QSqlQuery> _selectWayIdsByWayNodeIds;

--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDb.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDb.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef APIDB_H
 #define APIDB_H

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #include "HootApiDb.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
@@ -22,15 +22,15 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef HOOTAPIDB_H
 #define HOOTAPIDB_H
 
 // hoot
-#include <hoot/core/io/ApiDb.h>
 #include <hoot/core/elements/Node.h>
 #include <hoot/core/elements/Way.h>
+#include <hoot/core/io/ApiDb.h>
 #include <hoot/core/io/BulkDelete.h>
 #include <hoot/core/io/BulkInsert.h>
 
@@ -178,10 +178,8 @@ public:
    */
   long insertMap(QString mapName);
 
-  bool insertNode(
-    const double lat, const double lon, const Tags &tags, long& assignedId, long version = 0);
-  bool insertNode(
-    const long id, const double lat, const double lon, const Tags &tags, long version = 0);
+  bool insertNode(const double lat, const double lon, const Tags &tags, long& assignedId, long version = 0);
+  bool insertNode(const long id, const double lat, const double lon, const Tags &tags, long version = 0);
 
   bool insertWay(const Tags& tags, long& assignedId, long version = 0);
   bool insertWay( const long wayId, const Tags& tags, long version = 0);
@@ -201,9 +199,8 @@ public:
    * @param sequenceId Sequence for the relation
    * @return True if success, else false
    */
-  bool insertRelationMember(
-    const long relationId, const ElementType& type, const long elementId, const QString& role,
-    const int sequenceId);
+  bool insertRelationMember(const long relationId, const ElementType& type, const long elementId, const QString& role,
+                            const int sequenceId);
 
   void insertRelationTag(long relationId, const QString& k, const QString& v);
 
@@ -244,8 +241,7 @@ public:
    */
   QStringList selectMapNamesAvailableToCurrentUser();
 
-  void updateNode(
-    const long id, const double lat, const double lon, const long version, const Tags& tags);
+  void updateNode(const long id, const double lat, const double lon, const long version, const Tags& tags);
 
   void updateWay(const long id, const long version, const Tags& tags);
 
@@ -377,8 +373,7 @@ public:
    * @param accessTokenSecret private OAuth access token for the user
    * @return an HTTP session ID or an empty string if no session ID was found for the given input
    */
-  QString getSessionIdByAccessTokens(
-    const QString& userName, const QString& accessToken, const QString& accessTokenSecret);
+  QString getSessionIdByAccessTokens(const QString& userName, const QString& accessToken, const QString& accessTokenSecret);
 
   /**
    * Determines whether a set of access tokens are valid for a user
@@ -389,8 +384,7 @@ public:
    * @return true if the access tokens passed in are associated with the specified user; false
    * otherwise
    */
-  bool accessTokensAreValid(
-    const QString& userName, const QString& accessToken, const QString& accessTokenSecret);
+  bool accessTokensAreValid(const QString& userName, const QString& accessToken, const QString& accessTokenSecret);
 
   /**
    * Returns the HTTP session ID associated with a user
@@ -431,8 +425,7 @@ public:
    * @param accessToken OAuth public access token
    * @param accessTokenSecret OAuth private access token
    */
-  void updateUserAccessTokens(
-    const long userId, const QString& accessToken, const QString& accessTokenSecret);
+  void updateUserAccessTokens(const long userId, const QString& accessToken, const QString& accessTokenSecret);
 
   /**
    * Determines whether a user has permission to access a map
@@ -457,8 +450,7 @@ public:
    * @param isPublic folder visibility
    * @returns ID of the created folder
    */
-  long insertFolder(
-    const QString& displayName, const long parentId, const long userId, const bool isPublic);
+  long insertFolder(const QString& displayName, const long parentId, const long userId, const bool isPublic);
 
   /**
    * Creates a mapping between a map and a data folder

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDb.h
@@ -532,8 +532,6 @@ protected:
 
 private:
 
-  static int logWarnCount;
-
   friend class ServiceHootApiDbReaderTest;
   friend class ServiceHootApiDbWriterTest;
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
@@ -191,8 +191,8 @@ private:
 
   void populateElementMap();
 
-  QString _toWkt(const OGRSpatialReference* srs);
-  QString _toWkt(const OGRGeometry* geom);
+  QString _toWkt(const OGRSpatialReference* srs) const;
+  QString _toWkt(const OGRGeometry* geom) const;
 };
 
 class OgrElementIterator : public ElementIterator
@@ -895,7 +895,7 @@ void OgrReaderInternal::_addPolygon(OGRPolygon* p, Tags& t)
   }
 }
 
-QString OgrReaderInternal::_toWkt(const OGRGeometry* geom)
+QString OgrReaderInternal::_toWkt(const OGRGeometry* geom) const
 {
   char* buffer;
   geom->exportToWkt(&buffer);
@@ -1412,7 +1412,7 @@ std::shared_ptr<OGRSpatialReference> OgrReaderInternal::getProjection() const
   return MapProjector::createWgs84Projection();
 }
 
-QString OgrReaderInternal::_toWkt(const OGRSpatialReference* srs)
+QString OgrReaderInternal::_toWkt(const OGRSpatialReference* srs) const
 {
   char* buffer;
   srs->exportToWkt(&buffer);

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "OgrReader.h"

--- a/hoot-core/src/main/cpp/hoot/core/ops/DuplicateNodeRemover.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/DuplicateNodeRemover.cpp
@@ -163,7 +163,7 @@ void DuplicateNodeRemover::apply(std::shared_ptr<OsmMap>& map)
                   "Skipping processing of " << n1->getElementId() << " and " <<
                   n2->getElementId() << " at least one of them cannot be conflated by any " <<
                   "actively configured conflate matcher...");
-                continue;
+                replace = false;
               }
 
               Tags tags1 = n1->getTags();
@@ -174,8 +174,8 @@ void DuplicateNodeRemover::apply(std::shared_ptr<OsmMap>& map)
               if ((tags1.empty() && tags2.empty()) ||
                   (!tags1.empty() && tags2.empty()))
               {
-                //  When both sets of tags are empty or the first set is and the second set isn't
-                //  continue on because `replace` is already set
+                //  When both sets of tags are empty or the first set is and the second set isn't, replace
+                replace = true;
               }
               else if (tags1.empty() && !tags2.empty())
               {
@@ -183,7 +183,7 @@ void DuplicateNodeRemover::apply(std::shared_ptr<OsmMap>& map)
                 //  because a later iteration of the loop with merge the two nodes in the correct order
                 replace = false;
               }
-              else if (tagDiff.diff(map, n1, n2) != 0.0)
+              else if (replace && tagDiff.diff(map, n1, n2) != 0.0)
               {
                 //  Both sets of tags aren't empty and the tag differencer score is non-zero they can't be merged
                 LOG_VART(tagDiff.diff(map, n1, n2));

--- a/hoot-core/src/main/cpp/hoot/core/ops/DuplicateNodeRemover.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/DuplicateNodeRemover.cpp
@@ -73,8 +73,7 @@ DuplicateNodeRemover::DuplicateNodeRemover(Meters distanceThreshold)
     if (_distance <= 0.0)
     {
       throw IllegalArgumentException(
-        "Nearby node merging distance must be greater than zero. Distance specified: " +
-        QString::number(_distance));
+        QString("Nearby node merging distance must be greater than zero. Distance specified: %1").arg(QString::number(_distance)));
     }
   }
 }
@@ -136,7 +135,7 @@ void DuplicateNodeRemover::apply(std::shared_ptr<OsmMap>& map)
 
       for (auto matchIdJ : v)
       {
-        bool replace = false;
+        bool replace = true;
         double calcdDistanceSquared = -1.0;
 
         if (matchIdI != matchIdJ && map->containsNode(matchIdJ))
@@ -164,27 +163,29 @@ void DuplicateNodeRemover::apply(std::shared_ptr<OsmMap>& map)
                   "Skipping processing of " << n1->getElementId() << " and " <<
                   n2->getElementId() << " at least one of them cannot be conflated by any " <<
                   "actively configured conflate matcher...");
-                replace = false;
+                continue;
               }
-              else
-              {
-                replace = true;
-              }
-              LOG_VART(replace);
 
               Tags tags1 = n1->getTags();
               tags1.removeMetadata();
               Tags tags2 = n2->getTags();
               tags2.removeMetadata();
-              if (tags1.empty() || tags2.empty()) //  An empty node should always merge
+              //  Check the tags
+              if ((tags1.empty() && tags2.empty()) ||
+                  (!tags1.empty() && tags2.empty()))
               {
-                //  Keep the node that has tags, if any
-                if (!tags2.empty())
-                  std::swap(n1, n2);
-                replace = true;
+                //  When both sets of tags are empty or the first set is and the second set isn't
+                //  continue on because `replace` is already set
               }
-              else if (replace && tagDiff.diff(map, n1, n2) != 0.0)
+              else if (tags1.empty() && !tags2.empty())
               {
+                //  When the first set of tags is empty but the second set isn't, don't replace the node
+                //  because a later iteration of the loop with merge the two nodes in the correct order
+                replace = false;
+              }
+              else if (tagDiff.diff(map, n1, n2) != 0.0)
+              {
+                //  Both sets of tags aren't empty and the tag differencer score is non-zero they can't be merged
                 LOG_VART(tagDiff.diff(map, n1, n2));
                 LOG_TRACE(
                   "Skipping merge for " << n1->getElementId() << " and " << n2->getElementId() <<
@@ -262,6 +263,9 @@ void DuplicateNodeRemover::_logMergeResult(const long nodeId1, const long nodeId
                                            const OsmMapPtr& map, const bool replaced,
                                            const double distance, const double calcdDistance) const
 {
+  //  Since all log messages below are TRACE level messages, if the log level is above trace, exit
+  if (Log::getInstance().getLevel() > Log::Trace)
+    return;
   if (_passesLogMergeFilter(nodeId1, nodeId2, map))
   {
     QString msg = "merging nodes: ";

--- a/hoot-core/src/main/cpp/hoot/core/ops/DuplicateNodeRemover.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/DuplicateNodeRemover.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "DuplicateNodeRemover.h"


### PR DESCRIPTION
The `DuplicateNodeRemover` would hit a corner case in certain inputs where some nodes would be deleted but not all parent ways would be updated.