### PR TITLE
OGR streaming discards translation

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.cpp
@@ -96,6 +96,10 @@ void ElementStreamer::stream(const QStringList& inputs, const QString& out, cons
     if ((ogrReader || ogrWriter) && _translationScript.isEmpty())
       throw IllegalArgumentException("No translation script specified.");
 
+    //  Set the translation script for OGR readers
+    if (ogrReader && !ogrWriter)
+      ogrReader->setSchemaTranslationScript(_translationScript);
+
     // Need to run separate logic for streaming from an OGR source with layers in order to support
     // the layer syntax.
     if (ogrReader && input.contains(";"))

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrReader.cpp
@@ -175,7 +175,7 @@ private:
    * Use some hard coded rules to convert from projections that PROJ4 doesn't handle to projections
    * that it will handle.
    */
-  std::shared_ptr<OGRSpatialReference> _fixProjection(std::shared_ptr<OGRSpatialReference> srs);
+  std::shared_ptr<OGRSpatialReference> _fixProjection(std::shared_ptr<OGRSpatialReference> srs) const;
 
   void _initTranslate();
   void _finalizeTranslate();
@@ -265,7 +265,7 @@ std::shared_ptr<ElementIterator> OgrReader::createIterator(const QString& path, 
   return std::make_shared<OgrElementIterator>(d);
 }
 
-std::shared_ptr<OGRSpatialReference> OgrReaderInternal::_fixProjection(std::shared_ptr<OGRSpatialReference> srs)
+std::shared_ptr<OGRSpatialReference> OgrReaderInternal::_fixProjection(std::shared_ptr<OGRSpatialReference> srs) const
 {
   std::shared_ptr<OGRSpatialReference> result;
   int epsgOverride = ConfigOptions().getOgrReaderEpsgOverride();
@@ -422,7 +422,7 @@ std::vector<float> OgrReader::_getInputProgressWeights(const QString& input, con
       featureCountTotal += static_cast<long>(progressWeights[i]);
     LOG_VART(progressWeights);
     for (int i = 0; i < layers.size(); i++)
-      progressWeights[i] /= (float)featureCountTotal;
+      progressWeights[i] /= static_cast<float>(featureCountTotal);
   }
 
   LOG_VART(progressWeights);


### PR DESCRIPTION
Streaming input from an OGR source needs translation script set.

Closes #5238 