### PR TITLE
Come up with a faster algorithm for `DuplicateNodeRemover`

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/LongestCommonNodeString.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/LongestCommonNodeString.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2019, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "LongestCommonNodeString.h"
@@ -47,16 +47,13 @@ int LongestCommonNodeString::apply()
   _i2 = -1;
 
   if (_w1->getNodeCount() == 0 || _w2->getNodeCount() == 0)
-  {
     return 0;
-  }
 
   const vector<long>& str1 = _w1->getNodeIds();
   const vector<long>& str2 = _w2->getNodeIds();
 
-  int* curr = new int[_w2->getNodeCount()];
-  int* prev = new int[_w2->getNodeCount()];
-  int* swap = nullptr;
+  std::vector<int> curr(_w2->getNodeCount());
+  std::vector<int> prev(_w2->getNodeCount());
   int maxSubstr = 0;
 
   for (size_t i = 0; i < str1.size(); ++i)
@@ -64,34 +61,24 @@ int LongestCommonNodeString::apply()
     for (size_t j = 0; j < str2.size(); ++j)
     {
       if (str1[i] != str2[j])
-      {
         curr[j] = 0;
-      }
       else
       {
         if (i == 0 || j == 0)
-        {
           curr[j] = 1;
-        }
         else
-        {
           curr[j] = 1 + prev[j-1];
-        }
+
         if (curr[j] > maxSubstr)
         {
-          _i1 = (int)i - curr[j] + 1;
-          _i2 = (int)j - curr[j] + 1;
+          _i1 = i - curr[j] + 1;
+          _i2 = j - curr[j] + 1;
           maxSubstr = curr[j];
         }
       }
     }
-    swap = curr;
-    curr = prev;
-    prev = swap;
+    curr.swap(prev);
   }
-  delete [] curr;
-  delete [] prev;
-
   return maxSubstr;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/LongestCommonNodeString.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/LongestCommonNodeString.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2019, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef LONGESTCOMMONNODESTRING_H

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/LongestCommonNodeString.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/LongestCommonNodeString.h
@@ -50,17 +50,19 @@ public:
   /**
    * @brief getW1Index returns the start index of the match in w1.
    */
-  int getW1Index() const{ return _i1; }
+  int getW1Index() const{ return static_cast<int>(_i1); }
 
   /**
    * @brief getW2Index returns the start index of the match in w2.
    */
-  int getW2Index() const{ return _i2; }
+  int getW2Index() const{ return static_cast<int>(_i2); }
 
 private:
 
-  std::shared_ptr<Way> _w1, _w2;
-  size_t _i1, _i2;
+  std::shared_ptr<Way> _w1;
+  std::shared_ptr<Way> _w2;
+  size_t _i1;
+  size_t _i2;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/NonIntersectionWayJoiner.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/NonIntersectionWayJoiner.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "NonIntersectionWayJoiner.h"

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/NonIntersectionWayJoiner.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/NonIntersectionWayJoiner.cpp
@@ -61,7 +61,7 @@ void NonIntersectionWayJoiner::_joinAtNode()
   std::shared_ptr<NodeToWayMap> nodeToWayMap = _map->getIndex().getNodeToWayMap();
   HighwayCriterion highway(_map);
   //  Find all ways that have non-intersection endpoints that can be joined
-  for (WayMap::const_iterator it = ways.begin(); it != ways.end(); ++it)
+  for (auto it = ways.begin(); it != ways.end(); ++it)
   {
     WayPtr way = it->second;
     //  Eliminate 0 and 1 node ways (there are some...)
@@ -83,9 +83,9 @@ void NonIntersectionWayJoiner::_joinAtNode()
       ids.insert(last);
   }
   //  Iterate all of the nodes and merge the two ways that join at that node
-  for (unordered_set<long>::iterator it = ids.begin(); it != ids.end(); ++it)
+  for (auto node_id : ids)
   {
-    const set<long>& way_ids = nodeToWayMap->getWaysByNode(*it);
+    const set<long>& way_ids = nodeToWayMap->getWaysByNode(node_id);
     const vector<long> v_way_ids(way_ids.begin(), way_ids.end());
     if (way_ids.size() != 2)
       continue;

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.cpp
@@ -22,14 +22,14 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "ProbabilityOfMatch.h"
 
 // GEOS
-#include <geos/geom/LineString.h>
 #include <geos/geom/GeometryFactory.h>
+#include <geos/geom/LineString.h>
 #include <geos/geom/Point.h>
 
 // Hoot
@@ -60,8 +60,8 @@ ProbabilityOfMatch::ProbabilityOfMatch()
   _parallelExp = ConfigOptions().getMatchParallelExponent();
 }
 
-double ProbabilityOfMatch::attributeScore(const ConstOsmMapPtr& map,
-  const ConstWayPtr& w1, const ConstWayPtr& w2) const
+double ProbabilityOfMatch::attributeScore(const ConstOsmMapPtr& map, const ConstWayPtr& w1,
+                                          const ConstWayPtr& w2) const
 {
   double score = 1.0;
 
@@ -69,14 +69,11 @@ double ProbabilityOfMatch::attributeScore(const ConstOsmMapPtr& map,
   OneWayCriterion oneWayCrit;
   if (oneWayCrit.isSatisfied(w1) && oneWayCrit.isSatisfied(w2) &&
       !DirectionFinder::isSimilarDirection(map, w1, w2))
-  {
     score *= .1;
-  }
+
   // if we can't compare the scores, then just give it a 1. Hrmph.
   if (score < 0.0)
-  {
     score = 1.0;
-  }
 
   return score;
 }
@@ -88,7 +85,7 @@ double ProbabilityOfMatch::distanceScore(const ConstOsmMapPtr& map, const ConstW
 }
 
 double ProbabilityOfMatch::distanceScore(const ConstOsmMapPtr& map, const ConstWayPtr& w1,
-  const std::shared_ptr<const LineString>& ls2, Meters circularError)
+                                         const std::shared_ptr<const LineString>& ls2, Meters circularError)
 {
   Meters distanceSum = 0.0;
 
@@ -98,9 +95,9 @@ double ProbabilityOfMatch::distanceScore(const ConstOsmMapPtr& map, const ConstW
 
   _dMax = 0.0;
 
-  for (size_t i = 0; i < v.size(); i++)
+  for (const auto& coord : v)
   {
-    std::shared_ptr<Point> point(GeometryFactory::getDefaultInstance()->createPoint(v[i]));
+    std::shared_ptr<Point> point(GeometryFactory::getDefaultInstance()->createPoint(coord));
     LOG_VART(ls2->distance(point.get()));
     double d = ls2->distance(point.get());
     distanceSum += d;
@@ -109,7 +106,7 @@ double ProbabilityOfMatch::distanceScore(const ConstOsmMapPtr& map, const ConstW
 
   _dMax /= (circularError + w1->getCircularError());
 
-  Meters distanceMean = distanceSum / v.size();
+  Meters distanceMean = distanceSum / static_cast<Meters>(v.size());
 
   // TODO: Make me better.
   // E.g. if s1 = 50 & s2 = 50, then sigma = 70.
@@ -136,7 +133,7 @@ ProbabilityOfMatch& ProbabilityOfMatch::getInstance()
 }
 
 double ProbabilityOfMatch::lengthScore(const ConstOsmMapPtr& map, const ConstWayPtr& w1,
-  const ConstWayPtr &w2) const
+                                       const ConstWayPtr &w2) const
 {
   Meters l1 = ElementToGeometryConverter(map).convertToLineString(w1)->getLength();
   Meters l2 = ElementToGeometryConverter(map).convertToLineString(w2)->getLength();
@@ -178,16 +175,10 @@ double ProbabilityOfMatch::expertProbability(const ConstOsmMapPtr& map, const Co
 double ProbabilityOfMatch::zipperScore(const ConstWayPtr& w1, const ConstWayPtr& w2) const
 {
   double result = 1.0;
-
   if (w1->getNodeId(0) != w2->getNodeId(0))
-  {
     result *= 0.5;
-  }
   if (w1->getLastNodeId() != w2->getLastNodeId())
-  {
     result *= 0.5;
-  }
-
   return result;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/ProbabilityOfMatch.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef PROBABILITYOFMATCH_H
@@ -46,22 +46,17 @@ public:
 
   static ProbabilityOfMatch& getInstance();
 
-  double attributeScore(const ConstOsmMapPtr &map, const ConstWayPtr& w1,
-    const ConstWayPtr &w2) const;
+  double attributeScore(const ConstOsmMapPtr &map, const ConstWayPtr& w1, const ConstWayPtr &w2) const;
 
+  double distanceScore(const ConstOsmMapPtr& map, const ConstWayPtr& w1, const ConstWayPtr& w2);
   double distanceScore(const ConstOsmMapPtr& map, const ConstWayPtr& w1,
-    const ConstWayPtr& w2);
-  double distanceScore(const ConstOsmMapPtr& map, const ConstWayPtr& w1,
-    const std::shared_ptr<const geos::geom::LineString> &ls2, Meters circularError);
+                       const std::shared_ptr<const geos::geom::LineString> &ls2, Meters circularError);
 
-  double lengthScore(const ConstOsmMapPtr& map, const ConstWayPtr& w1,
-    const ConstWayPtr& w2) const;
+  double lengthScore(const ConstOsmMapPtr& map, const ConstWayPtr& w1, const ConstWayPtr& w2) const;
 
-  double parallelScore(const ConstOsmMapPtr& map, const ConstWayPtr& w1,
-    const ConstWayPtr& w2) const;
+  double parallelScore(const ConstOsmMapPtr& map, const ConstWayPtr& w1, const ConstWayPtr& w2) const;
 
-  double expertProbability(const ConstOsmMapPtr &map, const ConstWayPtr& w1,
-    const ConstWayPtr &w2);
+  double expertProbability(const ConstOsmMapPtr &map, const ConstWayPtr& w1, const ConstWayPtr &w2);
 
   double zipperScore(const ConstWayPtr& w1, const ConstWayPtr& w2) const;
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "RdpWayGeneralizer.h"

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.cpp
@@ -44,8 +44,8 @@ using namespace std;
 namespace hoot
 {
 
-RdpWayGeneralizer::RdpWayGeneralizer(double epsilon) :
-_removeNodesSharedByWays(false)
+RdpWayGeneralizer::RdpWayGeneralizer(double epsilon)
+  : _removeNodesSharedByWays(false)
 {
   setEpsilon(epsilon);
 }
@@ -53,9 +53,7 @@ _removeNodesSharedByWays(false)
 void RdpWayGeneralizer::setEpsilon(double epsilon)
 {
   if (epsilon <= 0.0)
-  {
     throw HootException("Invalid epsilon value: " + QString::number(epsilon));
-  }
   _epsilon = epsilon;
   LOG_VART(_epsilon);
 }
@@ -63,9 +61,7 @@ void RdpWayGeneralizer::setEpsilon(double epsilon)
 int RdpWayGeneralizer::generalize(const std::shared_ptr<Way>& way)
 {
   if (!_map)
-  {
     throw IllegalArgumentException("No map passed to way generalizer.");
-  }
 
   LOG_TRACE("Attempting to generalize: " << way->getElementId() << "...");
 
@@ -76,13 +72,10 @@ int RdpWayGeneralizer::generalize(const std::shared_ptr<Way>& way)
   // filter the nodes to be generalized to those in this way and those with no information tags;
   // tried using hoot filters here at first, but it didn't end up making sense
   QList<long> wayNodeIdsAfterFiltering;
-  for (QList<long>::const_iterator it = wayNodeIdsBeforeFiltering.begin();
-       it != wayNodeIdsBeforeFiltering.end(); ++it)
+  for (auto node_id : qAsConst(wayNodeIdsBeforeFiltering))
   {
-    if (_map->getNode(*it)->getTags().getInformationCount() == 0)
-    {
-      wayNodeIdsAfterFiltering.append(*it);
-    }
+    if (_map->getNode(node_id)->getTags().getInformationCount() == 0)
+      wayNodeIdsAfterFiltering.append(node_id);
   }
   LOG_VART(wayNodeIdsAfterFiltering);
 
@@ -100,16 +93,13 @@ int RdpWayGeneralizer::generalize(const std::shared_ptr<Way>& way)
   // If _removeNodesSharedByWays=true, we don't want to remove any nodes shared between ways. So,
   // let's come up with a new removal list that excludes those nodes.
   QSet<long> modifiedNodeIdsToRemove;
-  for (QSet<long>::const_iterator it = nodeIdsToRemove.begin(); it != nodeIdsToRemove.end(); ++it)
+  for (auto node_id : qAsConst(nodeIdsToRemove))
   {
-    const long nodeId = *it;
-    LOG_VART(nodeId);
+    LOG_VART(node_id);
     LOG_VART(_removeNodesSharedByWays);
-    LOG_VART(WayUtils::nodeContainedByMoreThanOneWay(nodeId, _map));
-    if (_removeNodesSharedByWays || !WayUtils::nodeContainedByMoreThanOneWay(nodeId, _map))
-    {
-      modifiedNodeIdsToRemove.insert(nodeId);
-    }
+    LOG_VART(WayUtils::nodeContainedByMoreThanOneWay(node_id, _map));
+    if (_removeNodesSharedByWays || !WayUtils::nodeContainedByMoreThanOneWay(node_id, _map))
+      modifiedNodeIdsToRemove.insert(node_id);
   }
   LOG_VART(modifiedNodeIdsToRemove);
 
@@ -138,16 +128,14 @@ int RdpWayGeneralizer::generalize(const std::shared_ptr<Way>& way)
   // this with SuperfluousNodeRemover, but that might be a little more intrusive)
   int nodesRemoved = 0;
   LOG_VART(originalNodeIdsToRemove);
-  for (QSet<long>::const_iterator it = originalNodeIdsToRemove.begin();
-       it != originalNodeIdsToRemove.end(); ++it)
+  for (auto node_id : qAsConst(originalNodeIdsToRemove))
   {
-    const long nodeId = *it;
-    LOG_VART(nodeId);
+    LOG_VART(node_id);
     LOG_VART(_removeNodesSharedByWays);
-    LOG_VART(nodeIdsNotAllowedToBeRemoved.contains(nodeId));
-    if (_removeNodesSharedByWays || !nodeIdsNotAllowedToBeRemoved.contains(nodeId))
+    LOG_VART(nodeIdsNotAllowedToBeRemoved.contains(node_id));
+    if (_removeNodesSharedByWays || !nodeIdsNotAllowedToBeRemoved.contains(node_id))
     {
-      RemoveNodeByEid::removeNode(_map, nodeId, true);
+      RemoveNodeByEid::removeNode(_map, node_id, true);
       nodesRemoved++;
     }
   }
@@ -156,35 +144,29 @@ int RdpWayGeneralizer::generalize(const std::shared_ptr<Way>& way)
   return nodesRemoved;
 }
 
-QList<long> RdpWayGeneralizer::_getUpdatedWayNodeIdsForThoseNotAllowedToBeRemoved(
-  const QSet<long>& nodeIdsNotAllowedToBeRemoved, const QList<long>& nodeIdsBeforeGeneralization,
-  const QList<long>& generalizedNodeIds) const
+QList<long> RdpWayGeneralizer::_getUpdatedWayNodeIdsForThoseNotAllowedToBeRemoved(const QSet<long>& nodeIdsNotAllowedToBeRemoved,
+                                                                                  const QList<long>& nodeIdsBeforeGeneralization,
+                                                                                  const QList<long>& generalizedNodeIds) const
 {
   LOG_VART(nodeIdsBeforeGeneralization);
   LOG_VART(generalizedNodeIds);
 
   QList<long> newNodeIds = generalizedNodeIds;
 
-  for (QSet<long>::const_iterator it = nodeIdsNotAllowedToBeRemoved.begin();
-       it != nodeIdsNotAllowedToBeRemoved.end(); ++it)
+  for (auto nodeIdToAddBack : qAsConst(nodeIdsNotAllowedToBeRemoved))
   {
-    const long nodeIdToAddBack = *it;
     LOG_VART(nodeIdToAddBack);
     const int originalIndex = nodeIdsBeforeGeneralization.indexOf(nodeIdToAddBack);
     LOG_VART(originalIndex);
 
     QList<long> originalBefore;
     for (int i = 0; i < originalIndex; i++)
-    {
       originalBefore.append(nodeIdsBeforeGeneralization.at(i));
-    }
     LOG_VART(originalBefore);
 
     QList<long> originalAfter;
     for (int i = originalIndex + 1; i < nodeIdsBeforeGeneralization.size(); i++)
-    {
       originalAfter.append(nodeIdsBeforeGeneralization.at(i));
-    }
     LOG_VART(originalAfter);
 
     int closestOriginalBeforeIndex = -1;
@@ -197,9 +179,7 @@ QList<long> RdpWayGeneralizer::_getUpdatedWayNodeIdsForThoseNotAllowedToBeRemove
       }
     }
     if (closestOriginalBeforeIndex == -1)
-    {
       closestOriginalBeforeIndex = 0;
-    }
     LOG_VART(closestOriginalBeforeIndex);
 
     int closestOriginalAfterIndex = -1;
@@ -212,14 +192,9 @@ QList<long> RdpWayGeneralizer::_getUpdatedWayNodeIdsForThoseNotAllowedToBeRemove
       }
     }
     if (closestOriginalAfterIndex == -1)
-    {
       closestOriginalAfterIndex = generalizedNodeIds.size() - 1;
-    }
     LOG_VART(closestOriginalAfterIndex);
 
-    //assert(closestOriginalBeforeIndex != closestOriginalAfterIndex);
-    //assert(closestOriginalBeforeIndex < closestOriginalAfterIndex);
-    //assert((closestOriginalAfterIndex - closestOriginalBeforeIndex) >= 2);
     const int newNodeInsertIndex = closestOriginalBeforeIndex + 1;
     LOG_VART(newNodeInsertIndex);
     newNodeIds.insert(newNodeInsertIndex, nodeIdToAddBack);
@@ -231,19 +206,13 @@ QList<long> RdpWayGeneralizer::_getUpdatedWayNodeIdsForThoseNotAllowedToBeRemove
   return newNodeIds;
 }
 
-QList<std::shared_ptr<const Node>> RdpWayGeneralizer::_getGeneralizedPoints(
-  const QList<std::shared_ptr<const Node>>& wayPoints)
+QList<std::shared_ptr<const Node>> RdpWayGeneralizer::_getGeneralizedPoints(const QList<std::shared_ptr<const Node>>& wayPoints)
 {
-  //LOG_VART(wayPoints.size());
   if (wayPoints.size() < 3)
-  {
     return wayPoints;
-  }
 
   std::shared_ptr<const Node> firstPoint = wayPoints.at(0);
-  //LOG_VART(firstPoint->toString());
   std::shared_ptr<const Node> lastPoint = wayPoints.at(wayPoints.size() - 1);
-  //LOG_VART(lastPoint->toString());
 
   int indexOfLargestPerpendicularDistance = -1;
   double largestPerpendicularDistance = 0;
@@ -258,9 +227,6 @@ QList<std::shared_ptr<const Node>> RdpWayGeneralizer::_getGeneralizedPoints(
       indexOfLargestPerpendicularDistance = i;
     }
   }
-  //LOG_VART(largestPerpendicularDistance);
-  //LOG_VART(indexOfLargestPerpendicularDistance);
-  //LOG_VART(_epsilon);
 
   if (largestPerpendicularDistance > _epsilon)
   {
@@ -291,31 +257,20 @@ QList<std::shared_ptr<const Node>> RdpWayGeneralizer::_getGeneralizedPoints(
   }
 }
 
-double RdpWayGeneralizer::_getPerpendicularDistanceBetweenSplitNodeAndImaginaryLine(
-  const std::shared_ptr<const Node> splitPoint,
-  const std::shared_ptr<const Node> lineToBeReducedStartPoint,
-  const std::shared_ptr<const Node> lineToBeReducedEndPoint) const
+double RdpWayGeneralizer::_getPerpendicularDistanceBetweenSplitNodeAndImaginaryLine(const std::shared_ptr<const Node> splitPoint,
+                                                                                    const std::shared_ptr<const Node> lineToBeReducedStartPoint,
+                                                                                    const std::shared_ptr<const Node> lineToBeReducedEndPoint) const
 {
-  //LOG_VART(lineToBeReducedStartPoint->getX());
-  //LOG_VART(lineToBeReducedEndPoint->getX());
   double perpendicularDistance;
   if (lineToBeReducedStartPoint->getX() == lineToBeReducedEndPoint->getX())
-  {
     perpendicularDistance = abs(splitPoint->getX() - lineToBeReducedStartPoint->getX());
-  }
   else
   {
-    const double slope =
-      (lineToBeReducedEndPoint->getY() - lineToBeReducedStartPoint->getY()) /
-      (lineToBeReducedEndPoint->getX() - lineToBeReducedStartPoint->getX());
-    //LOG_VART(slope);
-    const double intercept =
-      lineToBeReducedStartPoint->getY() - (slope * lineToBeReducedStartPoint->getX());
-    //LOG_VART(intercept);
-    perpendicularDistance =
-      abs(slope * splitPoint->getX() - splitPoint->getY() + intercept) / sqrt(pow(slope, 2) + 1);
+    const double slope = (lineToBeReducedEndPoint->getY() - lineToBeReducedStartPoint->getY()) /
+                         (lineToBeReducedEndPoint->getX() - lineToBeReducedStartPoint->getX());
+    const double intercept = lineToBeReducedStartPoint->getY() - (slope * lineToBeReducedStartPoint->getX());
+    perpendicularDistance = abs(slope * splitPoint->getX() - splitPoint->getY() + intercept) / sqrt(pow(slope, 2) + 1);
   }
-  //LOG_VART(perpendicularDistance);
   return perpendicularDistance;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef RDP_WAY_GENERALIZER_H

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.h
@@ -115,8 +115,7 @@ private:
     @param wayPoints the collection of points to be reduced
     @returns a reduced set of line points
     */
-  QList<std::shared_ptr<const Node>> _getGeneralizedPoints(
-    const QList<std::shared_ptr<const Node>>& wayPoints);
+  QList<std::shared_ptr<const Node>> _getGeneralizedPoints(const QList<std::shared_ptr<const Node>>& wayPoints);
 
   /*
     Finds the perpendicular distance between an imaginary line drawn from the first point on a line
@@ -128,10 +127,9 @@ private:
     @param lineToBeReducedEndPoint end point on the line to be reduced; also the ending
     point for the imaginary line drawn directly from start to end point on the line to be reduced
     */
-  double _getPerpendicularDistanceBetweenSplitNodeAndImaginaryLine(
-    const std::shared_ptr<const Node> splitPoint,
-    const std::shared_ptr<const Node> lineToBeReducedStartPoint,
-    const std::shared_ptr<const Node> lineToBeReducedEndPoint) const;
+  double _getPerpendicularDistanceBetweenSplitNodeAndImaginaryLine(const std::shared_ptr<const Node> splitPoint,
+                                                                   const std::shared_ptr<const Node> lineToBeReducedStartPoint,
+                                                                   const std::shared_ptr<const Node> lineToBeReducedEndPoint) const;
 
   /*
    * Takes in the way node IDs before the way was generalized and after it was generalized and
@@ -140,9 +138,9 @@ private:
    * keep shared nodes into the recursive generalization function, so we run the logic after the
    * generalization instead.
    */
-  QList<long> _getUpdatedWayNodeIdsForThoseNotAllowedToBeRemoved(
-    const QSet<long>& nodeIdsNotAllowedToBeRemoved, const QList<long>& nodeIdsBeforeGeneralization,
-    const QList<long>& generalizedNodeIds) const;
+  QList<long> _getUpdatedWayNodeIdsForThoseNotAllowedToBeRemoved(const QSet<long>& nodeIdsNotAllowedToBeRemoved,
+                                                                 const QList<long>& nodeIdsBeforeGeneralization,
+                                                                 const QList<long>& generalizedNodeIds) const;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoiner.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoiner.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "WayJoiner.h"

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.cpp
@@ -632,7 +632,7 @@ void OsmMap::replaceNodes(const std::map<long, long>& replacements)
     if (updated)
       way->setNodes(nodes);
   }
-  //  Iterate all of the
+  //  Iterate all of the nodes that are being replaced and delete them
   for (auto r = replacements.begin(); r != replacements.end(); ++r)
   {
     _index->removeNode(getNode(r->first));

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMap.h
@@ -63,8 +63,7 @@ class RubberSheet;
  * OsmMap class maintains pointers to OsmData and an OsmIndex where neither directly references the
  * other.
  */
-class OsmMap : public std::enable_shared_from_this<OsmMap>, public ElementProvider,
-  public ElementIterator
+class OsmMap : public std::enable_shared_from_this<OsmMap>, public ElementProvider, public ElementIterator
 {
 public:
 
@@ -169,6 +168,11 @@ public:
    * removed from this OsmMap entirely.
    */
   void replaceNode(long oldId, long newId);
+  /**
+   * Replace all of the nodes in the map<from, to> all at one time, deleting the 'from' nodes after updating
+   * all ways and relations with the new values, used to quickly replace large quantities of nodes
+   */
+  void replaceNodes(const std::map<long, long>& replacements);
 
   long createNextNodeId() const { return _idGen->createNodeId(); }
 

--- a/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.cpp
@@ -127,4 +127,11 @@ int64_t ClosePointHash::_toBin(double x, double y) const
   return (yi << 32) | xi;
 }
 
+void ClosePointHash::reset()
+{
+  _bins.clear();
+  _idTobin.clear();
+  resetIterator();
+}
+
 }

--- a/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.h
+++ b/hoot-core/src/main/cpp/hoot/core/index/ClosePointHash.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef CLOSEPOINTHASH_H
@@ -83,6 +83,11 @@ public:
   void resetIterator();
 
   size_t size() const { return _bins.size(); }
+
+  /**
+   * Empty out the ClosePointHash object
+   */
+  void reset();
 
 private:
 

--- a/test-files/cmd/quick/DuplicateNodeRemoverTest.sh
+++ b/test-files/cmd/quick/DuplicateNodeRemoverTest.sh
@@ -8,3 +8,6 @@ CONFIG="--warn -C Testing.conf"
 
 hoot convert $CONFIG -D convert.ops="DuplicateNodeRemover" $IN_DIR/input.json $OUT_DIR/output.json
 hoot diff $CONFIG $IN_DIR/input.json $OUT_DIR/output.json || diff $IN_DIR/input.json $OUT_DIR/output.json
+
+hoot convert $CONFIG -D convert.ops="DuplicateNodeRemover" $IN_DIR/crossing_test.osm $OUT_DIR/output.osm
+hoot diff $CONFIG $IN_DIR/crossing_input.osm $OUT_DIR/output.osm || diff $IN_DIR/crossing_input.osm $OUT_DIR/output.osm

--- a/test-files/cmd/quick/DuplicateNodeRemoverTest/crossing_input.osm
+++ b/test-files/cmd/quick/DuplicateNodeRemoverTest/crossing_input.osm
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="0.28224074854" minlon="0.35617674624" maxlat="0.28256533117" maxlon="0.3566515199"/>
+    <node visible="true" id="1" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2824564966200000" lon="0.3563072202900000">
+        <tag k="name" v="Upper-left cluster"/>
+    </node>
+    <node visible="true" id="5" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2823251149500000" lon="0.3563058933000000">
+        <tag k="name" v="Lower-left cluster"/>
+    </node>
+    <node visible="true" id="9" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2824531940200000" lon="0.3564721772900000">
+        <tag k="name" v="Upper-right cluster"/>
+    </node>
+    <node visible="true" id="10" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2823204590100000" lon="0.3564767268100000"/>
+    <node visible="true" id="13" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2823893735200000" lon="0.3563890303300000">
+        <tag k="name" v="Middle cluster"/>
+    </node>
+    <node visible="true" id="101" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2825586640700000" lon="0.3566427472900000"/>
+    <node visible="true" id="102" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2822442575400000" lon="0.3561767462400000"/>
+    <node visible="true" id="103" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2822414503400000" lon="0.3566125695100000"/>
+    <node visible="true" id="104" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2825516460700000" lon="0.3562027131600000"/>
+    <node visible="true" id="105" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2822414503400000" lon="0.3564778222200000"/>
+    <node visible="true" id="106" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2825653311700000" lon="0.3564620315200000"/>
+    <node visible="true" id="107" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2822407485400000" lon="0.3563044754400000"/>
+    <node visible="true" id="108" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2825628748700000" lon="0.3563058790600000"/>
+    <node visible="true" id="109" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2823172447700000" lon="0.3566515199000000"/>
+    <node visible="true" id="110" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2823277717800000" lon="0.3561806061800000"/>
+    <node visible="true" id="111" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2824502359300000" lon="0.3566504671900000"/>
+    <node visible="true" id="112" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2824569030300000" lon="0.3561851679400000"/>
+    <way visible="true" id="1" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="102"/>
+        <nd ref="5"/>
+        <nd ref="13"/>
+        <nd ref="9"/>
+        <nd ref="101"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="way-1"/>
+    </way>
+    <way visible="true" id="2" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="104"/>
+        <nd ref="1"/>
+        <nd ref="13"/>
+        <nd ref="10"/>
+        <nd ref="103"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="way-2"/>
+    </way>
+    <way visible="true" id="3" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="106"/>
+        <nd ref="9"/>
+        <nd ref="10"/>
+        <nd ref="105"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="way-3"/>
+    </way>
+    <way visible="true" id="4" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="108"/>
+        <nd ref="1"/>
+        <nd ref="5"/>
+        <nd ref="107"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="way-4"/>
+    </way>
+    <way visible="true" id="5" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="110"/>
+        <nd ref="5"/>
+        <nd ref="10"/>
+        <nd ref="109"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="way-5"/>
+    </way>
+    <way visible="true" id="6" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="112"/>
+        <nd ref="1"/>
+        <nd ref="9"/>
+        <nd ref="111"/>
+        <tag k="highway" v="primary"/>
+        <tag k="name" v="way-6"/>
+    </way>
+</osm>

--- a/test-files/cmd/quick/DuplicateNodeRemoverTest/crossing_test.osm
+++ b/test-files/cmd/quick/DuplicateNodeRemoverTest/crossing_test.osm
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hootenanny" srs="+epsg:4326">
+    <bounds minlat="0.28224074854" minlon="0.35617674624" maxlat="0.28256533117" maxlon="0.3566515199"/>
+    <!-- Upper-left cluster tests the first node having tags -->
+    <node visible="true" id="1" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2824564966200000" lon="0.3563072202900000">
+        <tag k="name" v="Upper-left cluster"/>
+    </node>
+    <node visible="true" id="2" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2824564775300000" lon="0.3563072460100000"/>
+    <node visible="true" id="3" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2824564767300000" lon="0.3563072092900000"/>
+    <!-- Lower-left cluster tests the middle node having tags -->
+    <node visible="true" id="4" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2823251186500000" lon="0.3563058736900000"/>
+    <node visible="true" id="5" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2823251149500000" lon="0.3563058933000000">
+        <tag k="name" v="Lower-left cluster"/>
+    </node>
+    <node visible="true" id="6" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2823251020800000" lon="0.3563058763500000"/>
+    <!-- Upper-right cluster tests the last node having tags -->
+    <node visible="true" id="7" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2824531642800000" lon="0.3564721883700000"/>
+    <node visible="true" id="8" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2824531715200000" lon="0.3564722121500000"/>
+    <node visible="true" id="9" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2824531940200000" lon="0.3564721772900000">
+        <tag k="name" v="Upper-right cluster"/>
+    </node>
+    <!-- Lower-right cluster tests all nodes with no tags -->
+    <node visible="true" id="10" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2823204590100000" lon="0.3564767268100000"/>
+    <node visible="true" id="11" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2823204491600000" lon="0.3564767361100000"/>
+    <node visible="true" id="12" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2823204465300000" lon="0.3564767226400000"/>
+    <!-- Middle cluster tests both nodes having tags -->
+    <node visible="true" id="13" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2823893735200000" lon="0.3563890303300000">
+        <tag k="name" v="Middle cluster"/>
+    </node>
+    <node visible="true" id="14" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2823893715400000" lon="0.3563890935200000">
+        <tag k="name" v="Middle cluster"/>
+    </node>
+    <node visible="true" id="101" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2825586640700000" lon="0.3566427472900000"/>
+    <node visible="true" id="102" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2822442575400000" lon="0.3561767462400000"/>
+    <node visible="true" id="103" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2822414503400000" lon="0.3566125695100000"/>
+    <node visible="true" id="104" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2825516460700000" lon="0.3562027131600000"/>
+    <node visible="true" id="105" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2822414503400000" lon="0.3564778222200000"/>
+    <node visible="true" id="106" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2825653311700000" lon="0.3564620315200000"/>
+    <node visible="true" id="107" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2822407485400000" lon="0.3563044754400000"/>
+    <node visible="true" id="108" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2825628748700000" lon="0.3563058790600000"/>
+    <node visible="true" id="109" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2823172447700000" lon="0.3566515199000000"/>
+    <node visible="true" id="110" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2823277717800000" lon="0.3561806061800000"/>
+    <node visible="true" id="111" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2824502359300000" lon="0.3566504671900000"/>
+    <node visible="true" id="112" timestamp="1970-01-01T00:00:00Z" version="1" lat="0.2824569030300000" lon="0.3561851679400000"/>
+    <way visible="true" id="1" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="102"/>
+        <nd ref="4"/>
+        <nd ref="13"/>
+        <nd ref="9"/>
+        <nd ref="101"/>
+        <tag k="name" v="way-1"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="2" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="104"/>
+        <nd ref="3"/>
+        <nd ref="14"/>
+        <nd ref="12"/>
+        <nd ref="103"/>
+        <tag k="name" v="way-2"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="3" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="106"/>
+        <nd ref="8"/>
+        <nd ref="11"/>
+        <nd ref="105"/>
+        <tag k="name" v="way-3"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="4" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="108"/>
+        <nd ref="2"/>
+        <nd ref="5"/>
+        <nd ref="107"/>
+        <tag k="name" v="way-4"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="5" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="110"/>
+        <nd ref="6"/>
+        <nd ref="10"/>
+        <nd ref="109"/>
+        <tag k="name" v="way-5"/>
+        <tag k="highway" v="primary"/>
+    </way>
+    <way visible="true" id="6" timestamp="1970-01-01T00:00:00Z" version="1">
+        <nd ref="112"/>
+        <nd ref="1"/>
+        <nd ref="7"/>
+        <nd ref="111"/>
+        <tag k="name" v="way-6"/>
+        <tag k="highway" v="primary"/>
+    </way>
+</osm>

--- a/test-files/cmd/slow/SplitLongWaysTest.sh
+++ b/test-files/cmd/slow/SplitLongWaysTest.sh
@@ -8,7 +8,7 @@ export OUTPUT_DIR=$HOOT_HOME/test-output/cmd/slow/SplitLongWaysTest
 export DATA_DIR=$HOOT_HOME/test-files/cmd/slow/SplitLongWaysTest
 export INPUTS=$DATA_DIR/SplitLongWaysTest.shp
 export KNOWN_GOOD_OUTPUT=$DATA_DIR/SplitLongWaysTestResults.osm.pbf
-export TEST_OUTPUT=$OUTPUT_DIR/SplitLongWaysTest.osm.pbf
+export TEST_OUTPUT=$OUTPUT_DIR/SplitLongWaysTest.osm #.pbf
 
 # Wipe out output dir so we don't get stale data and false pass
 rm -rf $OUTPUT_DIR


### PR DESCRIPTION
The real slow down wasn't in the use of the `ClosePointHash` but in the way that we replaced nodes, one at a time searching all relations and ways for that node, replacing it and reindexing the `OsmMapIndex`.  Here we iterate the relations, ways, and nodes only once looking for all replacements and doing all of them in one fell swoop.

Closes #3710 