### PR TITLE
See if distance weighting helps other linear script conflators

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -2903,6 +2903,15 @@ details. The "best" value varies depending on the input data as well as how the 
 Absolute path to the directory where the libpostal library, used for address parsing, stores its
 data.
 
+=== linear.matcher.distance.weight.coefficient
+
+* Data Type: double
+* Default Value: `0.01`
+
+A weighting coefficient value, in the range [0.0, 1.0], for the applying distance weighting to linear
+script matches. This will favor feature that are closer together. The higher the coefficient value,
+the higher the weighting applied. A value of 0.0 will disable distance weighting.
+
 === log.class.exclude.filter
 
 * Data Type: list
@@ -4474,7 +4483,7 @@ sheet tie point distances.
 === power.line.matcher.distance.weight.coefficient
 
 * Data Type: double
-* Default Value: `0.01`
+* Default Value: `${linear.matcher.distance.weight.coefficient}`
 
 A weighting coefficient value, in the range [0.0, 1.0], for the applying distance weighting to power
 line matches. This will favor feature that are closer together. The higher the coefficient value,
@@ -4524,6 +4533,15 @@ honored by all progress logging.
 
 Distance, in meters, used for sampling railway data during angle histogram extraction with
 `SampledAngleHistogramExtractor`.
+
+=== railway.matcher.distance.weight.coefficient
+
+* Data Type: double
+* Default Value: `${linear.matcher.distance.weight.coefficient}`
+
+A weighting coefficient value, in the range [0.0, 1.0], for the applying distance weighting to railway
+matches. This will favor feature that are closer together. The higher the coefficient value,
+the higher the weighting applied. A value of 0.0 will disable distance weighting.
 
 === railway.matcher.heading.delta
 
@@ -4999,6 +5017,15 @@ Distance, in meters, used for sampling river data during angle histogram extract
 
 Automatically calculates the search radius to be used during conflation of rivers using rubber
 sheet tie point distances.
+
+=== river.matcher.distance.weight.coefficient
+
+* Data Type: double
+* Default Value: `${linear.matcher.distance.weight.coefficient}`
+
+A weighting coefficient value, in the range [0.0, 1.0], for the applying distance weighting to river
+matches. This will favor feature that are closer together. The higher the coefficient value,
+the higher the weighting applied. A value of 0.0 will disable distance weighting.
 
 === river.matcher.heading.delta
 

--- a/rules/Railway.js
+++ b/rules/Railway.js
@@ -86,6 +86,9 @@ var oneToManyMatches = {};
 // This maps secondary element IDs to their matched ref elements (could be combined with
 // oneToManyMatches eventually).
 var oneToManyMatchIds = {};
+// used for distance weighting
+var distanceWeightCoeff = parseFloat(hoot.get("railway.matcher.distance.weight.coefficient")) * -1.0;
+var distanceScoreExtractor = new hoot.DistanceScoreExtractor();
 
 /**
  * Returns true if e is a candidate for a match. Implementing this method is
@@ -302,8 +305,16 @@ exports.matchScore = function(map, e1, e2)
     // conflate workflow doesn't require that currently.
   }
 
-  hoot.trace("Match: " + e1.getElementId()  + ", " + e2.getElementId());
-  result = { match: 1.0, explain: "match" };
+  // Use distance weighting to slightly favor features that are closer together.
+  var distanceScoreValue = distanceScoreExtractor.extract(map, e1, e2);
+  var delta = (1.0 - distanceScoreValue) * distanceWeightCoeff;
+  result.match = 1.0 + delta;
+  hoot.trace(result.match);
+  result.miss = 0.0 - delta;
+  hoot.trace(result.miss);
+
+//  result = { match: 1.0, explain: "match" };
+
   return result;
 };
 

--- a/rules/River.js
+++ b/rules/River.js
@@ -45,6 +45,10 @@ var nameExtractor = new hoot.NameExtractor(
     { "translate.string.distance.tokenize": "false" },
     new hoot.LevenshteinDistance( { "levenshtein.distance.alpha": 1.15 } )));
 
+// used for distance weighting
+var distanceWeightCoeff = parseFloat(hoot.get("river.matcher.distance.weight.coefficient")) * -1.0;
+var distanceScoreExtractor = new hoot.DistanceScoreExtractor();
+
 /**
  * Runs before match creation occurs and provides an opportunity to perform custom initialization.
  */
@@ -218,6 +222,14 @@ exports.matchScore = function(map, e1, e2)
   {
     return result;
   }
+
+  // Use distance weighting to slightly favor features that are closer together.
+  var distanceScoreValue = distanceScoreExtractor.extract(map, e1, e2);
+  var delta = (1.0 - distanceScoreValue) * distanceWeightCoeff;
+  result.match = 1.0 + delta;
+  hoot.trace(result.match);
+  result.miss = 0.0 - delta;
+  hoot.trace(result.miss);
 
   result = { match: 1.0, miss: 0.0, review: 0.0 };
   return result;

--- a/test-files/cmd/slow/serial/RailwayAttributeConflateTest/output.osm
+++ b/test-files/cmd/slow/serial/RailwayAttributeConflateTest/output.osm
@@ -1123,7 +1123,7 @@
     <node visible="true" id="-3" timestamp="2018-02-15T20:56:52Z" version="1" lat="39.6318742999999927" lon="125.8983422000000161"/>
     <node visible="true" id="-2" timestamp="2018-02-15T20:56:52Z" version="1" lat="39.6350596000000053" lon="125.9030146000000059"/>
     <node visible="true" id="-1" timestamp="2018-02-15T20:56:52Z" version="1" lat="39.6350844000000038" lon="125.9030951000000016"/>
-    <way visible="true" id="-1716" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-1721" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="-38"/>
         <nd ref="-39"/>
         <tag k="FCSubtype" v="0"/>
@@ -1151,7 +1151,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{7aa51969-242a-424c-9049-46da45bbd6d8};{2d02ea64-a2b9-44f9-bc2b-f456ccd1c7df}"/>
     </way>
-    <way visible="true" id="-1713" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-1718" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="-123"/>
         <nd ref="-163"/>
         <tag k="FCSubtype" v="0"/>
@@ -1178,7 +1178,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{f8b23bcb-cfb7-4c74-b2fa-97cb5b929382};{21bb637b-e73a-4421-80a6-222d6365cc54}"/>
     </way>
-    <way visible="true" id="-1710" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-1715" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="-12"/>
         <nd ref="-467"/>
         <tag k="FCSubtype" v="0"/>
@@ -1209,6 +1209,38 @@
         <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.884Z"/>
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{a4915a46-b9a3-44e1-8e2c-7d29f0a2080c};{08af4d1f-dfbe-4c33-90f7-dc88ca6e5807}"/>
+    </way>
+    <way visible="true" id="-1710" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-58"/>
+        <nd ref="-59"/>
+        <tag k="FCSubtype" v="0"/>
+        <tag k="GFID" v="5DF182A2-EF20-4760-A3E8-0A8B2C173301"/>
+        <tag k="REF1" v="000018"/>
+        <tag k="REF2" v="000058;000018;000025"/>
+        <tag k="SHAPE_Leng" v="0.010270162404400001"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="condition" v="functional"/>
+        <tag k="electrified" v="contact_line"/>
+        <tag k="gauge" v="144"/>
+        <tag k="gauge:type" v="standard"/>
+        <tag k="gndb_id" v="6183466"/>
+        <tag k="gndb_id:2" v="6171468"/>
+        <tag k="lanes" v="1"/>
+        <tag k="layer" v="1"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="location" v="surface"/>
+        <tag k="name" v="Manp'o-son"/>
+        <tag k="note" v="Single"/>
+        <tag k="railway" v="rail"/>
+        <tag k="railway:in_road" v="separated"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source" v="osm"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="source:datetime" v="2018-02-16T13:57:43Z;2012-09-05T16:27:14.000Z"/>
+        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.900Z"/>
+        <tag k="usage" v="high_speed_rail"/>
+        <tag k="uuid" v="{f178421d-fd17-4a0b-9043-066a392886cf};{e1733ad4-367f-4dea-b384-ec858455ea17}"/>
     </way>
     <way visible="true" id="-1707" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="-141"/>
@@ -2021,43 +2053,15 @@
     </way>
     <way visible="true" id="-117" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="-153"/>
-        <nd ref="-826"/>
-        <nd ref="-160"/>
-        <nd ref="-827"/>
-        <nd ref="-828"/>
-        <nd ref="-829"/>
-        <nd ref="-830"/>
-        <nd ref="-831"/>
-        <nd ref="-832"/>
-        <nd ref="-833"/>
-        <nd ref="-834"/>
-        <nd ref="-835"/>
-        <nd ref="-836"/>
-        <nd ref="-837"/>
-        <nd ref="-838"/>
-        <nd ref="-839"/>
-        <nd ref="-840"/>
-        <nd ref="-841"/>
-        <nd ref="-842"/>
-        <nd ref="-843"/>
-        <nd ref="-844"/>
-        <nd ref="-845"/>
-        <nd ref="-846"/>
-        <nd ref="-847"/>
-        <nd ref="-848"/>
-        <nd ref="-849"/>
-        <nd ref="-850"/>
-        <nd ref="-851"/>
-        <nd ref="-852"/>
-        <nd ref="-853"/>
-        <nd ref="-854"/>
-        <nd ref="-855"/>
-        <nd ref="-856"/>
-        <nd ref="-857"/>
-        <nd ref="-806"/>
+        <nd ref="-154"/>
+        <nd ref="-155"/>
+        <nd ref="-156"/>
+        <nd ref="-157"/>
+        <nd ref="-158"/>
+        <nd ref="-159"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="F77EA7D0-7840-4273-B57B-C52AB69B7E85"/>
-        <tag k="REF1" v="000082"/>
+        <tag k="REF1" v="000029"/>
         <tag k="REF2" v="todo"/>
         <tag k="SHAPE_Leng" v="0.018886577265199999"/>
         <tag k="attribution" v="osm"/>
@@ -2073,10 +2077,10 @@
         <tag k="railway:in_road" v="separated"/>
         <tag k="source" v="osm"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2018-02-16T13:57:43Z;2013-09-15T15:31:46.000Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.960Z;2018-02-13T20:09:15.961Z"/>
+        <tag k="source:datetime" v="2018-02-16T13:57:43Z;2013-09-15T15:07:03.000Z"/>
+        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.960Z"/>
         <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{2154ca17-2a83-4a8a-b425-07cff4f5c4b2};{076ee02e-1d1b-4063-b045-a01b58cf07f1};{5f08faf6-1221-46e6-a257-d834e0a8986f};{2284fda4-0857-40fa-848b-ef90534f57df}"/>
+        <tag k="uuid" v="{2154ca17-2a83-4a8a-b425-07cff4f5c4b2};{f5512778-c63c-457b-999d-dbe6d1000f3e}"/>
     </way>
     <way visible="true" id="-116" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="-822"/>
@@ -3144,47 +3148,6 @@
         <tag k="source:datetime" v="2014-01-20T23:08:42.000Z"/>
         <tag k="uuid" v="{fde8d3ba-d034-493e-a62f-b333e4d1a7c4}"/>
     </way>
-    <way visible="true" id="-38" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-200"/>
-        <nd ref="-201"/>
-        <nd ref="-202"/>
-        <nd ref="-203"/>
-        <nd ref="-204"/>
-        <nd ref="-205"/>
-        <nd ref="-206"/>
-        <nd ref="-207"/>
-        <nd ref="-208"/>
-        <nd ref="-209"/>
-        <nd ref="-210"/>
-        <nd ref="-211"/>
-        <nd ref="-212"/>
-        <nd ref="-213"/>
-        <nd ref="-214"/>
-        <nd ref="-215"/>
-        <nd ref="-216"/>
-        <tag k="FCSubtype" v="0"/>
-        <tag k="GFID" v="E3E3EDD8-51AF-4116-BC2E-2D4B6B55A85C"/>
-        <tag k="REF1" v="000033"/>
-        <tag k="REF2" v="todo"/>
-        <tag k="SHAPE_Leng" v="0.021471177499199998"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="condition" v="functional"/>
-        <tag k="electrified" v="contact_line"/>
-        <tag k="gauge" v="144"/>
-        <tag k="gauge:type" v="standard"/>
-        <tag k="lanes" v="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="location" v="surface"/>
-        <tag k="note" v="Single"/>
-        <tag k="railway" v="rail"/>
-        <tag k="railway:in_road" v="separated"/>
-        <tag k="source" v="osm"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2018-02-16T13:57:43Z;2014-01-20T23:08:45.000Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.863Z;2018-02-13T20:09:15.864Z"/>
-        <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{b317dc80-dba7-4c16-aa17-6edcf958302c};{015c9439-e28a-439f-acfc-c1d26fdf26f9};{351c058a-f98f-419e-9cbf-1ab85c9adbf3};{79162455-a391-4f2e-b5d3-dfc27c89e9cb}"/>
-    </way>
     <way visible="true" id="-36" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="-192"/>
         <nd ref="-193"/>
@@ -3197,6 +3160,21 @@
         <tag k="source" v="osm"/>
         <tag k="source:datetime" v="2012-09-06T19:20:31.000Z"/>
         <tag k="uuid" v="{56d6592b-7fed-4622-a7ed-56b4699c2a47}"/>
+    </way>
+    <way visible="true" id="-35" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-30"/>
+        <nd ref="-187"/>
+        <nd ref="-188"/>
+        <nd ref="-189"/>
+        <nd ref="-190"/>
+        <nd ref="-191"/>
+        <tag k="REF1" v="000030"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="railway" v="rail"/>
+        <tag k="source" v="osm"/>
+        <tag k="source:datetime" v="2014-01-20T23:08:42.000Z"/>
+        <tag k="uuid" v="{befe487d-56b2-4178-85fc-464c2ff9e984}"/>
     </way>
     <way visible="true" id="-34" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="-185"/>
@@ -3244,44 +3222,13 @@
         <nd ref="-161"/>
         <nd ref="-162"/>
         <nd ref="-155"/>
-        <tag k="FCSubtype" v="0"/>
-        <tag k="GFID" v="F77EA7D0-7840-4273-B57B-C52AB69B7E85"/>
-        <tag k="REF1" v="000082;00002a"/>
-        <tag k="REF2" v="todo"/>
-        <tag k="SHAPE_Leng" v="0.018886577265199999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="condition" v="functional"/>
-        <tag k="electrified" v="contact_line"/>
-        <tag k="gauge" v="144"/>
-        <tag k="gauge:type" v="standard"/>
-        <tag k="lanes" v="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="location" v="surface"/>
-        <tag k="note" v="Single"/>
-        <tag k="railway" v="rail"/>
-        <tag k="railway:in_road" v="separated"/>
-        <tag k="source" v="osm"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2018-02-16T13:57:43Z;2013-09-15T15:31:46.000Z;2013-09-15T15:07:03.000Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.960Z"/>
-        <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{2154ca17-2a83-4a8a-b425-07cff4f5c4b2};{076ee02e-1d1b-4063-b045-a01b58cf07f1};{8d9d9138-2716-449f-9921-5e46cecd2dc0}"/>
-    </way>
-    <way visible="true" id="-28" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-153"/>
-        <nd ref="-154"/>
-        <nd ref="-155"/>
-        <nd ref="-156"/>
-        <nd ref="-157"/>
-        <nd ref="-158"/>
-        <nd ref="-159"/>
-        <tag k="REF1" v="000029"/>
+        <tag k="REF1" v="00002a"/>
         <tag k="attribution" v="osm"/>
         <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
         <tag k="railway" v="rail"/>
         <tag k="source" v="osm"/>
         <tag k="source:datetime" v="2013-09-15T15:07:03.000Z"/>
-        <tag k="uuid" v="{f5512778-c63c-457b-999d-dbe6d1000f3e}"/>
+        <tag k="uuid" v="{8d9d9138-2716-449f-9921-5e46cecd2dc0}"/>
     </way>
     <way visible="true" id="-25" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="-145"/>
@@ -3295,6 +3242,18 @@
         <tag k="source" v="osm"/>
         <tag k="source:datetime" v="2012-09-05T16:27:13.000Z"/>
         <tag k="uuid" v="{90d716a1-dee9-45e7-af22-f318f59c374f}"/>
+    </way>
+    <way visible="true" id="-24" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-143"/>
+        <nd ref="-144"/>
+        <nd ref="-58"/>
+        <tag k="REF1" v="000025"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="railway" v="rail"/>
+        <tag k="source" v="osm"/>
+        <tag k="source:datetime" v="2012-09-05T16:27:13.000Z"/>
+        <tag k="uuid" v="{5e63fd09-7f9a-4d5e-b026-65d6a869f751}"/>
     </way>
     <way visible="true" id="-22" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="-136"/>
@@ -3342,21 +3301,6 @@
         <tag k="source" v="osm"/>
         <tag k="source:datetime" v="2013-09-15T14:40:19.000Z"/>
         <tag k="uuid" v="{10ab6160-a146-4209-ae87-5624cc103e63}"/>
-    </way>
-    <way visible="true" id="-19" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-31"/>
-        <nd ref="-124"/>
-        <nd ref="-125"/>
-        <nd ref="-126"/>
-        <nd ref="-127"/>
-        <nd ref="-24"/>
-        <tag k="REF1" v="000020"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="railway" v="rail"/>
-        <tag k="source" v="osm"/>
-        <tag k="source:datetime" v="2014-01-20T23:08:54.000Z"/>
-        <tag k="uuid" v="{1d32d041-3d06-47fe-ade7-9d54e45210bc}"/>
     </way>
     <way visible="true" id="-18" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="-57"/>
@@ -3431,30 +3375,6 @@
         <tag k="source" v="osm"/>
         <tag k="source:datetime" v="2013-09-15T14:40:19.000Z"/>
         <tag k="uuid" v="{a0b62896-d47e-46f9-aeeb-959106aaedf1}"/>
-    </way>
-    <way visible="true" id="-12" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-60"/>
-        <nd ref="-61"/>
-        <tag k="REF1" v="000019"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="railway" v="rail"/>
-        <tag k="source" v="osm"/>
-        <tag k="source:datetime" v="2012-09-05T16:27:14.000Z"/>
-        <tag k="uuid" v="{20d00780-d8be-49a2-a063-dd58e3b3e775}"/>
-    </way>
-    <way visible="true" id="-11" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-58"/>
-        <nd ref="-59"/>
-        <tag k="REF1" v="000018"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="layer" v="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="railway" v="rail"/>
-        <tag k="source" v="osm"/>
-        <tag k="source:datetime" v="2012-09-05T16:27:14.000Z"/>
-        <tag k="uuid" v="{e1733ad4-367f-4dea-b384-ec858455ea17}"/>
     </way>
     <way visible="true" id="-9" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="-34"/>
@@ -3682,6 +3602,65 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{9ceb959a-707c-466d-afd2-d46ca5c0c42b};{27d8ee7d-db24-4cda-8190-35dea3214570}"/>
     </way>
+    <way visible="true" id="13" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-153"/>
+        <nd ref="-826"/>
+        <nd ref="-160"/>
+        <nd ref="-827"/>
+        <nd ref="-828"/>
+        <nd ref="-829"/>
+        <nd ref="-830"/>
+        <nd ref="-831"/>
+        <nd ref="-832"/>
+        <nd ref="-833"/>
+        <nd ref="-834"/>
+        <nd ref="-835"/>
+        <nd ref="-836"/>
+        <nd ref="-837"/>
+        <nd ref="-838"/>
+        <nd ref="-839"/>
+        <nd ref="-840"/>
+        <nd ref="-841"/>
+        <nd ref="-842"/>
+        <nd ref="-843"/>
+        <nd ref="-844"/>
+        <nd ref="-845"/>
+        <nd ref="-846"/>
+        <nd ref="-847"/>
+        <nd ref="-848"/>
+        <nd ref="-849"/>
+        <nd ref="-850"/>
+        <nd ref="-851"/>
+        <nd ref="-852"/>
+        <nd ref="-853"/>
+        <nd ref="-854"/>
+        <nd ref="-855"/>
+        <nd ref="-856"/>
+        <nd ref="-857"/>
+        <nd ref="-806"/>
+        <tag k="FCSubtype" v="0"/>
+        <tag k="GFID" v="F77EA7D0-7840-4273-B57B-C52AB69B7E85"/>
+        <tag k="REF1" v="000029;000082"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="SHAPE_Leng" v="0.018886577265199999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="condition" v="functional"/>
+        <tag k="electrified" v="contact_line"/>
+        <tag k="gauge" v="144"/>
+        <tag k="gauge:type" v="standard"/>
+        <tag k="lanes" v="1"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="location" v="surface"/>
+        <tag k="note" v="Single"/>
+        <tag k="railway" v="rail"/>
+        <tag k="railway:in_road" v="separated"/>
+        <tag k="source" v="osm"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="source:datetime" v="2018-02-16T13:57:43Z;2013-09-15T15:07:03.000Z;2013-09-15T15:31:46.000Z"/>
+        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.960Z;2018-02-13T20:09:15.961Z"/>
+        <tag k="usage" v="high_speed_rail"/>
+        <tag k="uuid" v="{2154ca17-2a83-4a8a-b425-07cff4f5c4b2};{f5512778-c63c-457b-999d-dbe6d1000f3e};{076ee02e-1d1b-4063-b045-a01b58cf07f1};{5f08faf6-1221-46e6-a257-d834e0a8986f};{2284fda4-0857-40fa-848b-ef90534f57df}"/>
+    </way>
     <way visible="true" id="14" timestamp="2018-02-15T20:56:52Z" version="1" changeset="17283">
         <nd ref="-59"/>
         <nd ref="-532"/>
@@ -3845,47 +3824,16 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{41b58113-3b96-4bf2-bc2a-1660e4dd781a};{36cac6df-ad16-49b7-8cee-25981197046e}"/>
     </way>
-    <way visible="true" id="26" timestamp="2018-02-15T20:56:52Z" version="1" changeset="17283">
-        <nd ref="-143"/>
-        <nd ref="-144"/>
-        <nd ref="-58"/>
-        <tag k="FCSubtype" v="0"/>
-        <tag k="GFID" v="5DF182A2-EF20-4760-A3E8-0A8B2C173301"/>
-        <tag k="REF1" v="000025"/>
-        <tag k="REF2" v="000058;000018;000025"/>
-        <tag k="SHAPE_Leng" v="0.010270162404400001"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="condition" v="functional"/>
-        <tag k="electrified" v="contact_line"/>
-        <tag k="gauge" v="144"/>
-        <tag k="gauge:type" v="standard"/>
-        <tag k="gndb_id" v="6183466"/>
-        <tag k="gndb_id:2" v="6171468"/>
-        <tag k="lanes" v="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="location" v="surface"/>
-        <tag k="name" v="Manp'o-son"/>
-        <tag k="note" v="Single"/>
-        <tag k="railway" v="rail"/>
-        <tag k="railway:in_road" v="separated"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source" v="osm"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2018-02-16T13:57:43Z;2012-09-05T16:27:13.000Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.900Z"/>
-        <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{f178421d-fd17-4a0b-9043-066a392886cf};{5e63fd09-7f9a-4d5e-b026-65d6a869f751}"/>
-    </way>
     <way visible="true" id="27" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-30"/>
-        <nd ref="-187"/>
-        <nd ref="-188"/>
-        <nd ref="-189"/>
-        <nd ref="-190"/>
-        <nd ref="-191"/>
+        <nd ref="-31"/>
+        <nd ref="-124"/>
+        <nd ref="-125"/>
+        <nd ref="-126"/>
+        <nd ref="-127"/>
+        <nd ref="-24"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="CF55958D-3815-42C9-B9C4-D5AC9E191181"/>
-        <tag k="REF1" v="000030"/>
+        <tag k="REF1" v="000020"/>
         <tag k="REF2" v="000012"/>
         <tag k="SHAPE_Leng" v="0.0060340641372099999"/>
         <tag k="attribution" v="osm"/>
@@ -3905,10 +3853,10 @@
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source" v="osm"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2018-02-16T13:57:43Z;2014-01-20T23:08:42.000Z"/>
+        <tag k="source:datetime" v="2018-02-16T13:57:43Z;2014-01-20T23:08:54.000Z"/>
         <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.899Z"/>
         <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{940cac72-480e-472b-82fe-964e9bcf5b40};{befe487d-56b2-4178-85fc-464c2ff9e984}"/>
+        <tag k="uuid" v="{940cac72-480e-472b-82fe-964e9bcf5b40};{1d32d041-3d06-47fe-ade7-9d54e45210bc}"/>
     </way>
     <way visible="true" id="28" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="-15"/>
@@ -3933,7 +3881,7 @@
         <nd ref="-34"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="F2DEFC5B-8994-4012-889B-FF758DEF4D9B"/>
-        <tag k="REF1" v="000012;000030"/>
+        <tag k="REF1" v="000012;000020"/>
         <tag k="REF2" v="000012"/>
         <tag k="SHAPE_Leng" v="0.0066267351563999996"/>
         <tag k="attribution" v="osm"/>
@@ -3953,10 +3901,10 @@
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source" v="osm"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2018-02-16T13:57:43Z;2014-01-20T23:08:54.000Z;2014-01-20T23:08:42.000Z"/>
+        <tag k="source:datetime" v="2018-02-16T13:57:43Z;2014-01-20T23:08:54.000Z"/>
         <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.899Z;2018-02-13T20:09:15.861Z"/>
         <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{7c06f254-3eaa-44c2-9741-b5b9c31060e0};{53cf273b-d06f-4b51-967c-6f5b88c0972c};{940cac72-480e-472b-82fe-964e9bcf5b40};{befe487d-56b2-4178-85fc-464c2ff9e984};{a8d38519-d61b-49fb-a81e-968ea09d544c}"/>
+        <tag k="uuid" v="{7c06f254-3eaa-44c2-9741-b5b9c31060e0};{53cf273b-d06f-4b51-967c-6f5b88c0972c};{940cac72-480e-472b-82fe-964e9bcf5b40};{1d32d041-3d06-47fe-ade7-9d54e45210bc};{a8d38519-d61b-49fb-a81e-968ea09d544c}"/>
     </way>
     <way visible="true" id="33" timestamp="2018-02-15T20:56:52Z" version="1" changeset="17283">
         <nd ref="-163"/>
@@ -4493,13 +4441,13 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{ff0c59c7-db65-458d-8068-187454099763};{db8eed00-1bbe-4f17-ac5b-20a089a79a5b};{72eb22d9-3194-4a6f-a2d2-064702ae8cfb};{6d42371e-5e0e-48d3-82cc-764afbc2de6c};{a07c3e64-6348-4ee6-86a6-ad7b2efbf7e9}"/>
     </way>
-    <way visible="true" id="111" timestamp="2018-02-15T20:56:52Z" version="1" changeset="17283">
+    <way visible="true" id="110" timestamp="2018-02-15T20:56:52Z" version="1" changeset="17283">
+        <nd ref="-60"/>
         <nd ref="-61"/>
-        <nd ref="-220"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="7D8E1290-064A-4F4F-9CEA-7D5CA4BEFDC3"/>
-        <tag k="REF1" v="000035"/>
-        <tag k="REF2" v="000019;000035"/>
+        <tag k="REF1" v="000019"/>
+        <tag k="REF2" v="000019"/>
         <tag k="SHAPE_Leng" v="0.0079749628093000006"/>
         <tag k="attribution" v="osm"/>
         <tag k="condition" v="functional"/>
@@ -4517,12 +4465,83 @@
         <tag k="railway:in_road" v="separated"/>
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source" v="osm"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate;approximate"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="source:datetime" v="2018-02-16T13:57:43Z;2012-09-05T16:27:14.000Z"/>
+        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.864Z"/>
+        <tag k="usage" v="high_speed_rail"/>
+        <tag k="uuid" v="{85468d1e-a7f9-43fe-8435-c1cd61c0df26};{20d00780-d8be-49a2-a063-dd58e3b3e775}"/>
+    </way>
+    <way visible="true" id="111" timestamp="2018-02-15T20:56:52Z" version="1" changeset="17283">
+        <nd ref="-61"/>
+        <nd ref="-220"/>
+        <tag k="FCSubtype" v="0"/>
+        <tag k="GFID" v="0A11475C-00BF-4BA3-ADEA-53BE1C77951F"/>
+        <tag k="REF1" v="000035"/>
+        <tag k="REF2" v="000035"/>
+        <tag k="SHAPE_Leng" v="0.0014113828813999999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="condition" v="functional"/>
+        <tag k="electrified" v="contact_line"/>
+        <tag k="gauge" v="144"/>
+        <tag k="gauge:type" v="standard"/>
+        <tag k="gndb_id" v="6282826"/>
+        <tag k="gndb_id:2" v="6253325"/>
+        <tag k="lanes" v="1"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="location" v="underground"/>
+        <tag k="name" v="Kaech'on-son"/>
+        <tag k="note" v="Single"/>
+        <tag k="railway" v="rail"/>
+        <tag k="railway:in_road" v="separated"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source" v="osm"/>
+        <tag k="source:accuracy:horizontal:category" v="approximate"/>
         <tag k="source:datetime" v="2018-02-16T13:57:43Z;2012-09-04T17:44:15.000Z"/>
         <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.864Z"/>
         <tag k="tunnel" v="yes"/>
         <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{85468d1e-a7f9-43fe-8435-c1cd61c0df26};{31355d65-50f8-45a7-87f2-d0d13295ffac};{89c4a35b-cbe9-4de9-83a9-1ce0d4ee3394}"/>
+        <tag k="uuid" v="{31355d65-50f8-45a7-87f2-d0d13295ffac};{89c4a35b-cbe9-4de9-83a9-1ce0d4ee3394}"/>
+    </way>
+    <way visible="true" id="113" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-200"/>
+        <nd ref="-201"/>
+        <nd ref="-202"/>
+        <nd ref="-203"/>
+        <nd ref="-204"/>
+        <nd ref="-205"/>
+        <nd ref="-206"/>
+        <nd ref="-207"/>
+        <nd ref="-208"/>
+        <nd ref="-209"/>
+        <nd ref="-210"/>
+        <nd ref="-211"/>
+        <nd ref="-212"/>
+        <nd ref="-213"/>
+        <nd ref="-214"/>
+        <nd ref="-215"/>
+        <nd ref="-216"/>
+        <tag k="FCSubtype" v="0"/>
+        <tag k="GFID" v="E3E3EDD8-51AF-4116-BC2E-2D4B6B55A85C"/>
+        <tag k="REF1" v="000033"/>
+        <tag k="REF2" v="todo"/>
+        <tag k="SHAPE_Leng" v="0.021471177499199998"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="condition" v="functional"/>
+        <tag k="electrified" v="contact_line"/>
+        <tag k="gauge" v="144"/>
+        <tag k="gauge:type" v="standard"/>
+        <tag k="lanes" v="1"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="location" v="surface"/>
+        <tag k="note" v="Single"/>
+        <tag k="railway" v="rail"/>
+        <tag k="railway:in_road" v="separated"/>
+        <tag k="source" v="osm"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="source:datetime" v="2018-02-16T13:57:43Z;2014-01-20T23:08:45.000Z"/>
+        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.863Z;2018-02-13T20:09:15.864Z"/>
+        <tag k="usage" v="high_speed_rail"/>
+        <tag k="uuid" v="{b317dc80-dba7-4c16-aa17-6edcf958302c};{79162455-a391-4f2e-b5d3-dfc27c89e9cb};{015c9439-e28a-439f-acfc-c1d26fdf26f9};{351c058a-f98f-419e-9cbf-1ab85c9adbf3}"/>
     </way>
     <way visible="true" id="115" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="-282"/>

--- a/test-files/cmd/slow/serial/RailwayConflateTest/output.osm
+++ b/test-files/cmd/slow/serial/RailwayConflateTest/output.osm
@@ -1,71 +1,69 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="39.5693406" minlon="125.780683" maxlat="39.7527495" maxlon="126.079206"/>
-    <node visible="true" id="-7170" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5951828549631060" lon="125.8694362226237331"/>
-    <node visible="true" id="-7159" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5838896462872398" lon="125.9744789395166151"/>
-    <node visible="true" id="-7154" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5838257233908308" lon="125.9744856375280904"/>
-    <node visible="true" id="-7149" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5702042444130839" lon="125.9787912466176749"/>
-    <node visible="true" id="-7148" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5760381683648248" lon="125.9760880189643046"/>
-    <node visible="true" id="-7144" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6010899460928201" lon="125.9863054402750464"/>
-    <node visible="true" id="-7143" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6012562818723239" lon="125.9865267896511227"/>
-    <node visible="true" id="-7140" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6453259043829505" lon="125.9142424240284868"/>
-    <node visible="true" id="-7135" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6918786140282549" lon="125.8892398919631006"/>
-    <node visible="true" id="-7130" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6936245544094604" lon="125.8903901341671627"/>
-    <node visible="true" id="-7129" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6928126811097073" lon="125.8899907927087440"/>
-    <node visible="true" id="-7126" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6816957042826601" lon="125.8401928480796386"/>
-    <node visible="true" id="-7121" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6759331127309878" lon="125.8069534073614761"/>
-    <node visible="true" id="-7112" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6759320686090931" lon="125.8070646772459185"/>
-    <node visible="true" id="-7103" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6817437859467148" lon="125.8403171215274341"/>
-    <node visible="true" id="-7094" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6715799956218333" lon="125.7912288969076258"/>
-    <node visible="true" id="-7029" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6770416820542593" lon="125.8202297419073261"/>
-    <node visible="true" id="-7028" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6767768192382704" lon="125.8189840323825877"/>
-    <node visible="true" id="-6963" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6875357427417867" lon="125.8690290356367711"/>
-    <node visible="true" id="-6962" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6874995754306070" lon="125.8688215784158757"/>
-    <node visible="true" id="-6929" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6707529444768099" lon="125.7893144279544657"/>
-    <node visible="true" id="-6928" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6706934357517085" lon="125.7891766809517549"/>
-    <node visible="true" id="-6911" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6841588519002428" lon="125.8501766716767492"/>
-    <node visible="true" id="-6910" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6841393065652497" lon="125.8500324877060308"/>
-    <node visible="true" id="-6901" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6668022323600624" lon="125.7826980974773079"/>
-    <node visible="true" id="-6900" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6667050826447891" lon="125.7826528610784038"/>
-    <node visible="true" id="-6896" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6932806030152179" lon="125.8941110570823838"/>
-    <node visible="true" id="-6891" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6940973402555386" lon="125.8930314940675004"/>
-    <node visible="true" id="-6890" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6942223454534471" lon="125.8928671139630353"/>
-    <node visible="true" id="-6882" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6516362906550768" lon="125.9068189350816169"/>
-    <node visible="true" id="-6873" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6500413419027851" lon="125.9057245826444529"/>
-    <node visible="true" id="-6864" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6501196594083751" lon="125.9057320670957267"/>
-    <node visible="true" id="-6863" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6507291386506111" lon="125.9059132556393763"/>
-    <node visible="true" id="-6852" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6477768287868528" lon="125.9073243869141265"/>
-    <node visible="true" id="-6851" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6478532125104834" lon="125.9071956142393418"/>
-    <node visible="true" id="-6847" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6507240677772472" lon="125.9053825628443519"/>
-    <node visible="true" id="-6842" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6767488862311097" lon="125.9298335130612827"/>
-    <node visible="true" id="-6840" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6766996505645366" lon="125.9299619518878330"/>
-    <node visible="true" id="-6835" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6793267851407947" lon="125.9166402829227565"/>
-    <node visible="true" id="-6834" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6793445064261334" lon="125.9164766412670673"/>
-    <node visible="true" id="-6828" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6678774475464451" lon="125.9550857792686003"/>
-    <node visible="true" id="-6827" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6679008057832050" lon="125.9547601072710705"/>
-    <node visible="true" id="-6823" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6895522875918374" lon="125.8814421966636274"/>
-    <node visible="true" id="-6820" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7228933887601485" lon="125.8961182856489671"/>
-    <node visible="true" id="-6813" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5833447329407448" lon="125.8637281216041259"/>
-    <node visible="true" id="-6811" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5832789712938009" lon="125.8637631440387281"/>
-    <node visible="true" id="-6807" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5768915620675088" lon="125.8607032528908718"/>
-    <node visible="true" id="-6803" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6810216848362174" lon="125.9999974953169755"/>
-    <node visible="true" id="-6800" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7202348729857775" lon="125.8718055477644100"/>
-    <node visible="true" id="-6791" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7317931816679675" lon="125.8650279350267596"/>
-    <node visible="true" id="-6782" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7318940136731484" lon="125.8649570810400462"/>
-    <node visible="true" id="-6773" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7470101476177220" lon="125.8570484539636141"/>
-    <node visible="true" id="-6764" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7224444796906226" lon="125.8698753023678023"/>
-    <node visible="true" id="-6763" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7203325217312795" lon="125.8717103350007562"/>
-    <node visible="true" id="-6753" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6990854713866170" lon="125.8888478348063700"/>
-    <node visible="true" id="-6748" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7407689329675193" lon="125.8596346416124163"/>
-    <node visible="true" id="-6747" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7406858602307977" lon="125.8596681405573037"/>
-    <node visible="true" id="-6742" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6829534747214865" lon="125.9066208390902659"/>
-    <node visible="true" id="-6739" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6971827026909949" lon="125.8905083544732264"/>
-    <node visible="true" id="-6738" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6970015573979467" lon="125.8907431281922982"/>
-    <node visible="true" id="-6734" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7001714864019206" lon="125.8882726085418255"/>
-    <node visible="true" id="-6723" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6988735644553969" lon="126.0229206962003872"/>
-    <node visible="true" id="-6720" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6988029228915593" lon="126.0227910578535102"/>
-    <node visible="true" id="-6715" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7097186053212994" lon="126.0621845844701596"/>
-    <node visible="true" id="-6709" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6002278511633961" lon="125.8642144054825138"/>
+    <node visible="true" id="-7157" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5951828549631060" lon="125.8694362226237331"/>
+    <node visible="true" id="-7146" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5838896462872398" lon="125.9744789395166151"/>
+    <node visible="true" id="-7141" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5838257233908308" lon="125.9744856375280904"/>
+    <node visible="true" id="-7136" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5702042444130839" lon="125.9787912466176749"/>
+    <node visible="true" id="-7135" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5760381683648248" lon="125.9760880189643046"/>
+    <node visible="true" id="-7131" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6010899460928201" lon="125.9863054402750464"/>
+    <node visible="true" id="-7130" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6012562818723239" lon="125.9865267896511227"/>
+    <node visible="true" id="-7127" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6453259043829505" lon="125.9142424240284868"/>
+    <node visible="true" id="-7122" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6918786140282549" lon="125.8892398919631006"/>
+    <node visible="true" id="-7117" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6936245544094604" lon="125.8903901341671627"/>
+    <node visible="true" id="-7116" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6928126811097073" lon="125.8899907927087440"/>
+    <node visible="true" id="-7113" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6816957042826601" lon="125.8401928480796386"/>
+    <node visible="true" id="-7108" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6759331127309878" lon="125.8069534073614761"/>
+    <node visible="true" id="-7099" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6759320686090931" lon="125.8070646772459185"/>
+    <node visible="true" id="-7090" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6817437859467148" lon="125.8403171215274341"/>
+    <node visible="true" id="-7081" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6715799956218333" lon="125.7912288969076258"/>
+    <node visible="true" id="-7016" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6770416820542593" lon="125.8202297419073261"/>
+    <node visible="true" id="-7015" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6767768192382704" lon="125.8189840323825877"/>
+    <node visible="true" id="-6950" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6875357427417867" lon="125.8690290356367711"/>
+    <node visible="true" id="-6949" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6874995754306070" lon="125.8688215784158757"/>
+    <node visible="true" id="-6916" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6707529444768099" lon="125.7893144279544657"/>
+    <node visible="true" id="-6915" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6706934357517085" lon="125.7891766809517549"/>
+    <node visible="true" id="-6898" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6841588519002428" lon="125.8501766716767492"/>
+    <node visible="true" id="-6897" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6841393065652497" lon="125.8500324877060308"/>
+    <node visible="true" id="-6888" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6668022323600624" lon="125.7826980974773079"/>
+    <node visible="true" id="-6887" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6667050826447891" lon="125.7826528610784038"/>
+    <node visible="true" id="-6883" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6932806030152179" lon="125.8941110570823838"/>
+    <node visible="true" id="-6878" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6940973402555386" lon="125.8930314940675004"/>
+    <node visible="true" id="-6877" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6942223454534471" lon="125.8928671139630353"/>
+    <node visible="true" id="-6870" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6500413419027851" lon="125.9057245826444529"/>
+    <node visible="true" id="-6861" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6501196594083751" lon="125.9057320670957267"/>
+    <node visible="true" id="-6860" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6507291386506111" lon="125.9059132556393763"/>
+    <node visible="true" id="-6849" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6477768287868528" lon="125.9073243869141265"/>
+    <node visible="true" id="-6848" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6478532125104834" lon="125.9071956142393418"/>
+    <node visible="true" id="-6844" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6507240677772472" lon="125.9053825628443519"/>
+    <node visible="true" id="-6839" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6767488862311097" lon="125.9298335130612827"/>
+    <node visible="true" id="-6837" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6766996505645366" lon="125.9299619518878330"/>
+    <node visible="true" id="-6832" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6793267851407947" lon="125.9166402829227565"/>
+    <node visible="true" id="-6831" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6793445064261334" lon="125.9164766412670673"/>
+    <node visible="true" id="-6825" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6678774475464451" lon="125.9550857792686003"/>
+    <node visible="true" id="-6824" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6679008057832050" lon="125.9547601072710705"/>
+    <node visible="true" id="-6820" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6895522875918374" lon="125.8814421966636274"/>
+    <node visible="true" id="-6817" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7228933887601485" lon="125.8961182856489671"/>
+    <node visible="true" id="-6812" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5768915620675088" lon="125.8607032528908718"/>
+    <node visible="true" id="-6805" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5833447329407448" lon="125.8637281216041259"/>
+    <node visible="true" id="-6801" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6810216848362174" lon="125.9999974953169755"/>
+    <node visible="true" id="-6798" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7202348729857775" lon="125.8718055477644100"/>
+    <node visible="true" id="-6789" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7317931816679675" lon="125.8650279350267596"/>
+    <node visible="true" id="-6780" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7318940136731484" lon="125.8649570810400462"/>
+    <node visible="true" id="-6771" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7470101476177220" lon="125.8570484539636141"/>
+    <node visible="true" id="-6762" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7224444796906226" lon="125.8698753023678023"/>
+    <node visible="true" id="-6761" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7203325217312795" lon="125.8717103350007562"/>
+    <node visible="true" id="-6751" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6990854713866170" lon="125.8888478348063700"/>
+    <node visible="true" id="-6746" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7407689329675193" lon="125.8596346416124163"/>
+    <node visible="true" id="-6745" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7406858602307977" lon="125.8596681405573037"/>
+    <node visible="true" id="-6740" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6829534747214865" lon="125.9066208390902659"/>
+    <node visible="true" id="-6737" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6971827026909949" lon="125.8905083544732264"/>
+    <node visible="true" id="-6736" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6970015573979467" lon="125.8907431281922982"/>
+    <node visible="true" id="-6732" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7001714864019206" lon="125.8882726085418255"/>
+    <node visible="true" id="-6721" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6002278511633961" lon="125.8642144054825138"/>
+    <node visible="true" id="-6719" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6988735644553969" lon="126.0229206962003872"/>
+    <node visible="true" id="-6716" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6988029228915593" lon="126.0227910578535102"/>
+    <node visible="true" id="-6712" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7097186053212994" lon="126.0621845844701596"/>
     <node visible="true" id="-2092" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.7505546020000011" lon="125.9132189900000185"/>
     <node visible="true" id="-2091" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.7510661150000075" lon="125.9134548340000066"/>
     <node visible="true" id="-2090" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.7517626699999980" lon="125.9137486890000162"/>
@@ -279,10 +277,13 @@
     <node visible="true" id="-265" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.7067920900000004" lon="125.8849474879999804"/>
     <node visible="true" id="-252" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.7113348889999926" lon="125.8846627770000168"/>
     <node visible="true" id="-251" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.7112885640000002" lon="125.8846360269999991"/>
+    <node visible="true" id="-249" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5828855700000091" lon="125.8636050490000002"/>
+    <node visible="true" id="-248" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5823673570000025" lon="125.8634375529999971"/>
+    <node visible="true" id="-247" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5818343259999992" lon="125.8632409650000028"/>
+    <node visible="true" id="-246" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5812207809999990" lon="125.8630137189999942"/>
+    <node visible="true" id="-245" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5807077710000073" lon="125.8628162300000071"/>
     <node visible="true" id="-230" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5833158630000028" lon="125.8637377639999926"/>
-    <node visible="true" id="-210" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6927077250000053" lon="126.0115137829999981"/>
-    <node visible="true" id="-209" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6930153930000031" lon="126.0120774180000183"/>
-    <node visible="true" id="-208" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6932974200000004" lon="126.0125991209999938"/>
+    <node visible="true" id="-229" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5832858950000102" lon="125.8637276539999874"/>
     <node visible="true" id="-110" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6988167089999990" lon="126.0228760349999959"/>
     <node visible="true" id="-108" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6883166819999929" lon="126.0073696410000110"/>
     <node visible="true" id="-107" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6884632270000068" lon="126.0074137769999965"/>
@@ -1429,7 +1430,7 @@
     <node visible="true" id="1009" timestamp="2018-02-15T20:56:52Z" version="1" changeset="17283" lat="39.5786780000000036" lon="125.8569717999999966"/>
     <node visible="true" id="1010" timestamp="2018-02-15T20:56:52Z" version="1" changeset="17283" lat="39.7015076000000064" lon="125.8852477000000079"/>
     <node visible="true" id="1011" timestamp="2018-02-15T20:56:52Z" version="1" changeset="17283" lat="39.7008407999999946" lon="125.8865820999999983"/>
-    <way visible="true" id="-8476" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8467" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="917"/>
         <nd ref="992"/>
         <nd ref="993"/>
@@ -1467,8 +1468,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{6fb0d35c-1703-4e1d-a883-24bc9c1146fe};{969c0372-5ec6-4758-9b81-01ca8fb53d42}"/>
     </way>
-    <way visible="true" id="-8474" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-6709"/>
+    <way visible="true" id="-8465" timestamp="2018-02-16T13:57:43Z" version="1">
+        <nd ref="-6721"/>
         <nd ref="975"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="06CDEA93-8387-4E74-8BA3-D516CDFF35ED"/>
@@ -1497,7 +1498,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{8bea8c4a-389e-4858-8aa1-80c944fece58}"/>
     </way>
-    <way visible="true" id="-8472" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8463" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="975"/>
         <nd ref="976"/>
         <nd ref="977"/>
@@ -1505,7 +1506,7 @@
         <nd ref="979"/>
         <nd ref="980"/>
         <nd ref="981"/>
-        <nd ref="-7170"/>
+        <nd ref="-7157"/>
         <nd ref="982"/>
         <nd ref="983"/>
         <nd ref="984"/>
@@ -1538,7 +1539,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{5894d6b1-749a-4d31-a98e-4a2406eca280};{8bea8c4a-389e-4858-8aa1-80c944fece58};{7c1f2ac9-78fe-4037-8f5b-d879f6f7c846}"/>
     </way>
-    <way visible="true" id="-8465" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8456" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="821"/>
         <nd ref="281"/>
         <tag k="FCSubtype" v="0"/>
@@ -1571,7 +1572,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{04da109f-9c58-4372-b621-222405a9861e};{7c1f2ac9-78fe-4037-8f5b-d879f6f7c846}"/>
     </way>
-    <way visible="true" id="-8459" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8450" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="920"/>
         <nd ref="821"/>
         <tag k="FCSubtype" v="0"/>
@@ -1604,7 +1605,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{ff459033-3209-49f5-970e-451a705a9e0e};{7c1f2ac9-78fe-4037-8f5b-d879f6f7c846}"/>
     </way>
-    <way visible="true" id="-8456" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8447" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="817"/>
         <nd ref="927"/>
         <nd ref="928"/>
@@ -1651,7 +1652,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{173d9690-9566-4863-96f9-4639b97a6662};{92cb72af-9207-4072-830d-6bfbbbc2ce28}"/>
     </way>
-    <way visible="true" id="-8452" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8443" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="893"/>
         <nd ref="1004"/>
         <nd ref="1005"/>
@@ -1686,7 +1687,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{4f7b875f-46c5-40b5-b11a-8b9178ed413b};{92cb72af-9207-4072-830d-6bfbbbc2ce28}"/>
     </way>
-    <way visible="true" id="-8447" timestamp="2018-02-16T13:57:43Z" version="1">
+    <way visible="true" id="-8438" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="783"/>
         <nd ref="-1641"/>
         <nd ref="784"/>
@@ -1717,7 +1718,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{92cb72af-9207-4072-830d-6bfbbbc2ce28}"/>
     </way>
-    <way visible="true" id="-8445" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8436" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="193"/>
         <nd ref="783"/>
         <tag k="FCSubtype" v="0"/>
@@ -1748,7 +1749,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{33cfe72a-2b95-45cf-8534-24725b02af14};{92cb72af-9207-4072-830d-6bfbbbc2ce28}"/>
     </way>
-    <way visible="true" id="-8438" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8429" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="784"/>
         <nd ref="918"/>
         <nd ref="919"/>
@@ -1781,7 +1782,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{9f46118b-d921-410d-be34-98d56a67af43};{92cb72af-9207-4072-830d-6bfbbbc2ce28}"/>
     </way>
-    <way visible="true" id="-8430" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8421" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="892"/>
         <nd ref="893"/>
         <tag k="FCSubtype" v="0"/>
@@ -1814,7 +1815,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{140d45f3-8040-40f2-bdb1-87ede657812d};{92cb72af-9207-4072-830d-6bfbbbc2ce28}"/>
     </way>
-    <way visible="true" id="-8424" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8415" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="816"/>
         <nd ref="817"/>
         <tag k="FCSubtype" v="0"/>
@@ -1847,7 +1848,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{5d6eaf32-1bcb-44b3-88a4-affd416c3882};{92cb72af-9207-4072-830d-6bfbbbc2ce28}"/>
     </way>
-    <way visible="true" id="-8421" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8412" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="792"/>
         <nd ref="793"/>
         <tag k="FCSubtype" v="0"/>
@@ -1877,7 +1878,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{6b6b2225-4a1b-4f37-817e-50d70a903a60};{e1d70a4b-bd24-4ca8-91b4-2ea57d57b5e2}"/>
     </way>
-    <way visible="true" id="-8418" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8409" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="777"/>
         <nd ref="697"/>
         <tag k="FCSubtype" v="0"/>
@@ -1907,7 +1908,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{238a441e-98a8-4383-b2a4-8f83d9ad3797};{7e6ab770-8e64-47b2-ba39-e698de655fb8}"/>
     </way>
-    <way visible="true" id="-8415" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8406" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="718"/>
         <nd ref="785"/>
         <tag k="FCSubtype" v="0"/>
@@ -1939,7 +1940,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{ec1f8089-9b4f-4d65-a0f2-fa646679d9e2};{7eaf829c-4b09-4bef-b3b5-40c9f6b4b358}"/>
     </way>
-    <way visible="true" id="-8412" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8403" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="720"/>
         <nd ref="777"/>
         <tag k="FCSubtype" v="0"/>
@@ -1967,7 +1968,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{385a7bd8-2d9b-44e3-ac51-cc5606cc89c7};{5dd77fc1-c610-402e-95eb-ce3ec61c37b4}"/>
     </way>
-    <way visible="true" id="-8409" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8400" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="719"/>
         <nd ref="720"/>
         <tag k="FCSubtype" v="0"/>
@@ -1997,7 +1998,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{823b9844-de80-4b95-973e-f572f8784c16};{c4580f50-6ce7-4580-8e5f-ee924ecff7e8}"/>
     </way>
-    <way visible="true" id="-8406" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8397" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="697"/>
         <nd ref="698"/>
         <nd ref="699"/>
@@ -2045,7 +2046,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{e08e4cf7-9b41-4154-8348-4c2574b0f8e8};{9cef9f05-7f6a-48d6-a41f-cf139dd6df67}"/>
     </way>
-    <way visible="true" id="-8404" timestamp="2018-02-16T13:57:43Z" version="1">
+    <way visible="true" id="-8395" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="542"/>
         <nd ref="-338"/>
         <tag k="FCSubtype" v="0"/>
@@ -2075,7 +2076,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{41b58113-3b96-4bf2-bc2a-1660e4dd781a}"/>
     </way>
-    <way visible="true" id="-8402" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8393" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="542"/>
         <nd ref="689"/>
         <nd ref="690"/>
@@ -2113,7 +2114,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{36cac6df-ad16-49b7-8cee-25981197046e};{41b58113-3b96-4bf2-bc2a-1660e4dd781a}"/>
     </way>
-    <way visible="true" id="-8399" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8390" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="290"/>
         <nd ref="5"/>
         <tag k="FCSubtype" v="0"/>
@@ -2146,8 +2147,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{0d2f2625-15c4-47cf-b2d4-d1b1498684e7};{0e7b66c7-c9a3-4848-9049-14616c584ff5}"/>
     </way>
-    <way visible="true" id="-8395" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-7144"/>
+    <way visible="true" id="-8386" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-7131"/>
         <nd ref="634"/>
         <nd ref="635"/>
         <nd ref="636"/>
@@ -2173,8 +2174,8 @@
         <nd ref="656"/>
         <nd ref="657"/>
         <nd ref="658"/>
-        <nd ref="-7159"/>
-        <nd ref="-7154"/>
+        <nd ref="-7146"/>
+        <nd ref="-7141"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="3E33EC85-4844-4100-9C1D-E50067DF84E2"/>
         <tag k="REF1" v="000065"/>
@@ -2201,8 +2202,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{89b88164-623a-4a0a-bd3e-04419acc5ab3};{b9195bf6-44e8-4914-8eb2-92b23d30d171}"/>
     </way>
-    <way visible="true" id="-8388" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-7154"/>
+    <way visible="true" id="-8379" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-7141"/>
         <nd ref="659"/>
         <nd ref="660"/>
         <nd ref="661"/>
@@ -2210,7 +2211,7 @@
         <nd ref="663"/>
         <nd ref="664"/>
         <nd ref="665"/>
-        <nd ref="-7148"/>
+        <nd ref="-7135"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="BED13379-DD35-4BAE-93CC-F423B1B1ED30"/>
         <tag k="REF1" v="000065"/>
@@ -2237,15 +2238,15 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{89b88164-623a-4a0a-bd3e-04419acc5ab3};{2499fb65-02dc-442c-801b-c06d88b26ea0}"/>
     </way>
-    <way visible="true" id="-8380" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-7148"/>
+    <way visible="true" id="-8371" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-7135"/>
         <nd ref="666"/>
         <nd ref="667"/>
         <nd ref="668"/>
         <nd ref="669"/>
         <nd ref="670"/>
         <nd ref="671"/>
-        <nd ref="-7149"/>
+        <nd ref="-7136"/>
         <nd ref="672"/>
         <nd ref="673"/>
         <tag k="FCSubtype" v="0"/>
@@ -2274,7 +2275,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{89b88164-623a-4a0a-bd3e-04419acc5ab3};{0d7ee6a6-788e-44a6-935b-d63b586172e1}"/>
     </way>
-    <way visible="true" id="-8378" timestamp="2018-02-16T13:57:43Z" version="1">
+    <way visible="true" id="-8369" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="-2070"/>
         <nd ref="631"/>
         <tag k="FCSubtype" v="0"/>
@@ -2301,11 +2302,11 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{7496465e-e9d7-4184-a426-c9b738781922}"/>
     </way>
-    <way visible="true" id="-8376" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8367" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="631"/>
         <nd ref="632"/>
         <nd ref="633"/>
-        <nd ref="-7143"/>
+        <nd ref="-7130"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="21B95A9E-52CF-409B-883B-35A9D1660021"/>
         <tag k="REF1" v="000065"/>
@@ -2332,7 +2333,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{89b88164-623a-4a0a-bd3e-04419acc5ab3};{7496465e-e9d7-4184-a426-c9b738781922}"/>
     </way>
-    <way visible="true" id="-8365" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8356" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="484"/>
         <nd ref="15"/>
         <tag k="FCSubtype" v="0"/>
@@ -2365,7 +2366,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{cd3bd5b1-d7fe-4a3c-b9ec-07e93e17a8ed};{d86b419c-cfc1-4bca-8af1-eb8ebd4d5de1}"/>
     </way>
-    <way visible="true" id="-8362" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8353" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="453"/>
         <nd ref="60"/>
         <tag k="FCSubtype" v="0"/>
@@ -2398,7 +2399,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{a6667db0-47ed-49a4-a7b6-a547ce7f4947};{7156dd33-941b-44bf-9220-07415b1de2dc}"/>
     </way>
-    <way visible="true" id="-8359" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8350" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="531"/>
         <nd ref="272"/>
         <tag k="FCSubtype" v="0"/>
@@ -2426,7 +2427,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{8681b06c-91ee-46e2-b417-8c31ebb3831d};{88e1f975-2d23-4d22-8835-9d2674006aa0}"/>
     </way>
-    <way visible="true" id="-8344" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8335" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="142"/>
         <nd ref="471"/>
         <nd ref="472"/>
@@ -2472,7 +2473,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{d32e7dfd-dc31-49e1-8aef-e0a6f22a85c7};{8b6d80e3-57b7-47f6-9240-db34de739a2f}"/>
     </way>
-    <way visible="true" id="-8341" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8332" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="12"/>
         <nd ref="467"/>
         <tag k="FCSubtype" v="0"/>
@@ -2505,7 +2506,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{08af4d1f-dfbe-4c33-90f7-dc88ca6e5807};{a4915a46-b9a3-44e1-8e2c-7d29f0a2080c}"/>
     </way>
-    <way visible="true" id="-8333" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8324" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="220"/>
         <nd ref="454"/>
         <nd ref="455"/>
@@ -2513,7 +2514,7 @@
         <nd ref="457"/>
         <nd ref="458"/>
         <nd ref="459"/>
-        <nd ref="-7135"/>
+        <nd ref="-7122"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="2808A595-6E71-4522-B748-091D5572EA4D"/>
         <tag k="REF1" v="00004e"/>
@@ -2542,8 +2543,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{f66a5171-9e14-4042-93f2-ec035b9b99bf};{b5c0ed93-dc45-412b-94e9-eae90f89488c}"/>
     </way>
-    <way visible="true" id="-8330" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-7130"/>
+    <way visible="true" id="-8321" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-7117"/>
         <nd ref="462"/>
         <nd ref="463"/>
         <nd ref="464"/>
@@ -2578,10 +2579,10 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{f66a5171-9e14-4042-93f2-ec035b9b99bf};{e2f59a17-0cd0-4123-95c2-314e94cf8527}"/>
     </way>
-    <way visible="true" id="-8323" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-7135"/>
+    <way visible="true" id="-8314" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-7122"/>
         <nd ref="460"/>
-        <nd ref="-7129"/>
+        <nd ref="-7116"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="668FE6C9-4ADD-463F-BC97-89AD0658898F"/>
         <tag k="REF1" v="00004e"/>
@@ -2610,14 +2611,14 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{f66a5171-9e14-4042-93f2-ec035b9b99bf};{8c5b0acd-920c-498a-ad0f-4f8b9e830b99}"/>
     </way>
-    <way visible="true" id="-8311" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-7029"/>
+    <way visible="true" id="-8302" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-7016"/>
         <nd ref="440"/>
         <nd ref="441"/>
         <nd ref="442"/>
         <nd ref="443"/>
-        <nd ref="-7126"/>
-        <nd ref="-7103"/>
+        <nd ref="-7113"/>
+        <nd ref="-7090"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="68C7E585-48AE-41ED-A9CC-7E4120780B2A"/>
         <tag k="REF1" v="00004d"/>
@@ -2646,14 +2647,14 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{9cd7f19e-d6bf-4365-9124-8a9c2ecca25e};{243552b1-f552-4893-93c2-92c90baa2e18}"/>
     </way>
-    <way visible="true" id="-8305" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6911"/>
+    <way visible="true" id="-8296" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6898"/>
         <nd ref="447"/>
         <nd ref="448"/>
         <nd ref="449"/>
         <nd ref="450"/>
         <nd ref="451"/>
-        <nd ref="-6962"/>
+        <nd ref="-6949"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="086CA38F-2330-42CD-8EE7-0276BA37DD65"/>
         <tag k="REF1" v="00004d"/>
@@ -2682,8 +2683,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{9cd7f19e-d6bf-4365-9124-8a9c2ecca25e};{8b17653d-9d6e-441b-8d1e-2d2c8a903d61}"/>
     </way>
-    <way visible="true" id="-8294" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-7094"/>
+    <way visible="true" id="-8285" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-7081"/>
         <nd ref="425"/>
         <nd ref="426"/>
         <nd ref="427"/>
@@ -2692,8 +2693,8 @@
         <nd ref="430"/>
         <nd ref="431"/>
         <nd ref="432"/>
-        <nd ref="-7121"/>
-        <nd ref="-7112"/>
+        <nd ref="-7108"/>
+        <nd ref="-7099"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="CE45E966-F7D0-4A7A-BD04-52839A146E25"/>
         <tag k="REF1" v="00004d"/>
@@ -2722,15 +2723,15 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{9cd7f19e-d6bf-4365-9124-8a9c2ecca25e};{8f3a4881-f4a9-46f6-9256-0dc8c8b74c2e}"/>
     </way>
-    <way visible="true" id="-8283" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-7112"/>
+    <way visible="true" id="-8274" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-7099"/>
         <nd ref="433"/>
         <nd ref="434"/>
         <nd ref="435"/>
         <nd ref="436"/>
         <nd ref="437"/>
         <nd ref="438"/>
-        <nd ref="-7028"/>
+        <nd ref="-7015"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="3AF9899D-D0A7-4C9F-A2C3-CC88A67E5F12"/>
         <tag k="REF1" v="00004d"/>
@@ -2759,12 +2760,12 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{9cd7f19e-d6bf-4365-9124-8a9c2ecca25e};{4fb09a16-7747-4d2e-a509-3dd8e3b5d7ee}"/>
     </way>
-    <way visible="true" id="-8271" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-7103"/>
+    <way visible="true" id="-8262" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-7090"/>
         <nd ref="444"/>
         <nd ref="445"/>
         <nd ref="446"/>
-        <nd ref="-6910"/>
+        <nd ref="-6897"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="203A9846-39CD-4291-B322-4D6AF88A3FF3"/>
         <tag k="REF1" v="00004d"/>
@@ -2793,8 +2794,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{9cd7f19e-d6bf-4365-9124-8a9c2ecca25e};{b8edee3e-65cb-445a-a644-5f85015a56f2}"/>
     </way>
-    <way visible="true" id="-8261" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6901"/>
+    <way visible="true" id="-8252" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6888"/>
         <nd ref="418"/>
         <nd ref="419"/>
         <nd ref="420"/>
@@ -2802,7 +2803,7 @@
         <nd ref="422"/>
         <nd ref="423"/>
         <nd ref="424"/>
-        <nd ref="-6928"/>
+        <nd ref="-6915"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="B75A63E4-ED0D-4FA9-B63B-8FDCF8C3522F"/>
         <tag k="REF1" v="00004d"/>
@@ -2831,11 +2832,11 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{9cd7f19e-d6bf-4365-9124-8a9c2ecca25e};{87126459-e815-4abf-a2c6-f1b5025a33c0}"/>
     </way>
-    <way visible="true" id="-8243" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-8234" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="415"/>
         <nd ref="416"/>
         <nd ref="417"/>
-        <nd ref="-6900"/>
+        <nd ref="-6887"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="AF3A8758-486B-48B3-BE02-69015CF7A287"/>
         <tag k="REF1" v="00004d"/>
@@ -2864,8 +2865,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{9cd7f19e-d6bf-4365-9124-8a9c2ecca25e};{64504ef6-b7e6-4628-89a7-d2741ac8acc2}"/>
     </way>
-    <way visible="true" id="-8209" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6963"/>
+    <way visible="true" id="-8200" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6950"/>
         <nd ref="452"/>
         <nd ref="453"/>
         <tag k="FCSubtype" v="0"/>
@@ -2896,9 +2897,9 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{9cd7f19e-d6bf-4365-9124-8a9c2ecca25e};{cbbd8953-651f-487f-9dc3-d4192d884c83}"/>
     </way>
-    <way visible="true" id="-8142" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6929"/>
-        <nd ref="-7094"/>
+    <way visible="true" id="-8133" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6916"/>
+        <nd ref="-7081"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="31E928F8-A27B-428D-917C-B913ED9ADAD3"/>
         <tag k="REF1" v="00004d"/>
@@ -2927,10 +2928,10 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{9cd7f19e-d6bf-4365-9124-8a9c2ecca25e};{85becdb8-887a-4ea9-a858-6e87523f7efd}"/>
     </way>
-    <way visible="true" id="-8074" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-7028"/>
+    <way visible="true" id="-8065" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-7015"/>
         <nd ref="439"/>
-        <nd ref="-7029"/>
+        <nd ref="-7016"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="32DF8E14-8B71-4728-9FB3-2E958D05B8AF"/>
         <tag k="REF1" v="00004d"/>
@@ -2959,9 +2960,9 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{9cd7f19e-d6bf-4365-9124-8a9c2ecca25e};{6ef668d1-6f4f-43f1-9ad1-c1afcbc29c32}"/>
     </way>
-    <way visible="true" id="-8038" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6962"/>
-        <nd ref="-6963"/>
+    <way visible="true" id="-8029" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6949"/>
+        <nd ref="-6950"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="8F5C3A3F-9B7F-4F72-BCA2-CD5DD581FEFE"/>
         <tag k="REF1" v="00004d"/>
@@ -2990,9 +2991,9 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{9cd7f19e-d6bf-4365-9124-8a9c2ecca25e};{83a29304-7d95-4182-a637-d579c71926d1}"/>
     </way>
-    <way visible="true" id="-8018" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6928"/>
-        <nd ref="-6929"/>
+    <way visible="true" id="-8009" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6915"/>
+        <nd ref="-6916"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="4DBA6AF3-1387-4786-92A2-746868981D01"/>
         <tag k="REF1" v="00004d"/>
@@ -3021,9 +3022,9 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{9cd7f19e-d6bf-4365-9124-8a9c2ecca25e};{beec903a-fd90-4e1d-ba00-9826d1675d8b}"/>
     </way>
-    <way visible="true" id="-8006" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6910"/>
-        <nd ref="-6911"/>
+    <way visible="true" id="-7997" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6897"/>
+        <nd ref="-6898"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="75282547-0B13-4997-8B5F-072DFDB42F68"/>
         <tag k="REF1" v="00004d"/>
@@ -3052,15 +3053,14 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{9cd7f19e-d6bf-4365-9124-8a9c2ecca25e};{51ca29f3-8063-4767-b429-5358bc14ad07}"/>
     </way>
-    <way visible="true" id="-7995" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="327"/>
-        <nd ref="328"/>
+    <way visible="true" id="-7986" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="394"/>
+        <nd ref="283"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="25DBE2D9-CB86-4DD5-835B-E0F6262C8497"/>
-        <tag k="REF1" v="00003c"/>
-        <tag k="REF2" v="000085;00003c"/>
+        <tag k="REF1" v="000085"/>
+        <tag k="REF2" v="000085"/>
         <tag k="SHAPE_Leng" v="0.00027842719605599998"/>
-        <tag k="alt_name" v="Kaech'on-son"/>
         <tag k="attribution" v="osm"/>
         <tag k="bridge" v="yes"/>
         <tag k="condition" v="functional"/>
@@ -3081,12 +3081,45 @@
         <tag k="security:classification" v="UNCLASSIFIED"/>
         <tag k="source" v="osm;mgcp:railrdl_rail"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2012-09-06T20:46:11.000Z;2018-02-16T13:57:43Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.870Z;2018-02-13T20:09:15.866Z"/>
+        <tag k="source:datetime" v="2012-09-06T20:46:15.000Z;2018-02-16T13:57:43Z"/>
+        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.870Z"/>
         <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{33c630e0-ba67-4efd-96a1-fd7e98ce3e11};{92e1c92c-4846-469f-b408-c32bc00c5bf1};{b38f1856-cc10-45a8-be85-f16fc7f99abe}"/>
+        <tag k="uuid" v="{b911fb54-f7aa-45ca-ad97-851c90344b7f};{92e1c92c-4846-469f-b408-c32bc00c5bf1}"/>
     </way>
-    <way visible="true" id="-7990" timestamp="2018-02-16T13:57:43Z" version="1">
+    <way visible="true" id="-7983" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="327"/>
+        <nd ref="328"/>
+        <tag k="FCSubtype" v="0"/>
+        <tag k="GFID" v="4723E439-0AF3-414B-A982-AC8F2F5D02EE"/>
+        <tag k="REF1" v="00003c"/>
+        <tag k="REF2" v="00003c"/>
+        <tag k="SHAPE_Leng" v="0.00026790124595799997"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="bridge" v="yes"/>
+        <tag k="condition" v="functional"/>
+        <tag k="electrified" v="contact_line"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="gauge" v="144"/>
+        <tag k="gauge:type" v="standard"/>
+        <tag k="gndb_id" v="6282826"/>
+        <tag k="gndb_id:2" v="6253325"/>
+        <tag k="lanes" v="1"/>
+        <tag k="layer" v="1"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="location" v="overground"/>
+        <tag k="name" v="Kaech'on-son"/>
+        <tag k="note" v="Single"/>
+        <tag k="railway" v="rail"/>
+        <tag k="railway:in_road" v="separated"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source" v="osm;mgcp:railrdl_rail"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="source:datetime" v="2012-09-06T20:46:11.000Z;2018-02-16T13:57:43Z"/>
+        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.866Z"/>
+        <tag k="usage" v="high_speed_rail"/>
+        <tag k="uuid" v="{33c630e0-ba67-4efd-96a1-fd7e98ce3e11};{b38f1856-cc10-45a8-be85-f16fc7f99abe}"/>
+    </way>
+    <way visible="true" id="-7981" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="294"/>
         <nd ref="-712"/>
         <nd ref="-711"/>
@@ -3115,7 +3148,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{a4bf38ac-0b13-44b5-ba07-350e188239b1}"/>
     </way>
-    <way visible="true" id="-7988" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7979" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="294"/>
         <nd ref="295"/>
         <nd ref="296"/>
@@ -3180,8 +3213,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{35c40728-7e1c-4b2c-9d82-8e991d5afb77};{a4bf38ac-0b13-44b5-ba07-350e188239b1}"/>
     </way>
-    <way visible="true" id="-7985" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6896"/>
+    <way visible="true" id="-7976" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6883"/>
         <nd ref="289"/>
         <nd ref="290"/>
         <tag k="FCSubtype" v="0"/>
@@ -3212,13 +3245,13 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{a07c3e64-6348-4ee6-86a6-ad7b2efbf7e9};{ff0c59c7-db65-458d-8068-187454099763}"/>
     </way>
-    <way visible="true" id="-7982" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7973" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="283"/>
         <nd ref="284"/>
         <nd ref="285"/>
         <nd ref="286"/>
         <nd ref="287"/>
-        <nd ref="-6890"/>
+        <nd ref="-6877"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="917456E0-181F-43E3-B507-57CBB45F6560"/>
         <tag k="REF1" v="000039"/>
@@ -3247,9 +3280,9 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{a07c3e64-6348-4ee6-86a6-ad7b2efbf7e9};{db8eed00-1bbe-4f17-ac5b-20a089a79a5b}"/>
     </way>
-    <way visible="true" id="-7975" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6891"/>
-        <nd ref="-6896"/>
+    <way visible="true" id="-7966" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6878"/>
+        <nd ref="-6883"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="28C8CFE2-E2E4-4C42-A9CB-AFFB1F5BF99D"/>
         <tag k="REF1" v="000039"/>
@@ -3278,7 +3311,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{a07c3e64-6348-4ee6-86a6-ad7b2efbf7e9};{72eb22d9-3194-4a6f-a2d2-064702ae8cfb}"/>
     </way>
-    <way visible="true" id="-7965" timestamp="2018-02-16T13:57:43Z" version="1">
+    <way visible="true" id="-7956" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="-1568"/>
         <nd ref="273"/>
         <tag k="FCSubtype" v="0"/>
@@ -3308,7 +3341,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{cec91cec-05c3-49b7-93c6-0b284ff78e05}"/>
     </way>
-    <way visible="true" id="-7963" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7954" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="273"/>
         <nd ref="274"/>
         <nd ref="275"/>
@@ -3345,8 +3378,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{82ed14c3-8515-4df7-8064-72751e9471ff};{cec91cec-05c3-49b7-93c6-0b284ff78e05}"/>
     </way>
-    <way visible="true" id="-7956" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-6734"/>
+    <way visible="true" id="-7947" timestamp="2018-02-16T13:57:43Z" version="1">
+        <nd ref="-6732"/>
         <nd ref="-286"/>
         <nd ref="-285"/>
         <nd ref="-284"/>
@@ -3397,7 +3430,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{cb84b01d-3161-44be-8ee6-db1604553333}"/>
     </way>
-    <way visible="true" id="-7951" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7942" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="123"/>
         <nd ref="163"/>
         <tag k="FCSubtype" v="0"/>
@@ -3425,7 +3458,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{21bb637b-e73a-4421-80a6-222d6365cc54};{f8b23bcb-cfb7-4c74-b2fa-97cb5b929382}"/>
     </way>
-    <way visible="true" id="-7949" timestamp="2018-02-16T13:57:43Z" version="1">
+    <way visible="true" id="-7940" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="146"/>
         <nd ref="-252"/>
         <tag k="FCSubtype" v="0"/>
@@ -3455,7 +3488,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{9a240920-fd44-43bd-9403-edb08c6b18a5}"/>
     </way>
-    <way visible="true" id="-7947" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7938" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="146"/>
         <nd ref="147"/>
         <nd ref="145"/>
@@ -3487,8 +3520,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{2341dfae-b484-4d3d-835e-604b34610430};{9a240920-fd44-43bd-9403-edb08c6b18a5}"/>
     </way>
-    <way visible="true" id="-7944" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6852"/>
+    <way visible="true" id="-7935" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6849"/>
         <nd ref="351"/>
         <nd ref="352"/>
         <nd ref="353"/>
@@ -3519,42 +3552,14 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{44fbda29-276c-41ed-a150-faa9ad7d70b8};{72f3379a-c5fc-4f57-a6c0-11c04d32c6fa}"/>
     </way>
-    <way visible="true" id="-7935" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-6882"/>
-        <nd ref="124"/>
-        <tag k="FCSubtype" v="0"/>
-        <tag k="GFID" v="FFF2A7E6-4C5E-458B-A0F4-C97E93EED43E"/>
-        <tag k="REF2" v="00003f"/>
-        <tag k="SHAPE_Leng" v="0.0056383737048400001"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="condition" v="functional"/>
-        <tag k="electrified" v="contact_line"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="gauge" v="144"/>
-        <tag k="gauge:type" v="standard"/>
-        <tag k="lanes" v="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="location" v="surface"/>
-        <tag k="note" v="Single"/>
-        <tag k="railway" v="rail"/>
-        <tag k="railway:in_road" v="separated"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source" v="mgcp:railrdl_rail;osm"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2018-02-16T13:57:43Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.899Z"/>
-        <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{b2554eac-ebfe-415a-b0f7-c317a25c83e5}"/>
-    </way>
-    <way visible="true" id="-7920" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7917" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="337"/>
         <nd ref="338"/>
         <nd ref="339"/>
         <nd ref="340"/>
-        <nd ref="-6882"/>
         <nd ref="341"/>
         <nd ref="342"/>
-        <nd ref="-6863"/>
+        <nd ref="-6860"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="FFF2A7E6-4C5E-458B-A0F4-C97E93EED43E"/>
         <tag k="REF1" v="00003f"/>
@@ -3580,16 +3585,16 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{44fbda29-276c-41ed-a150-faa9ad7d70b8};{b2554eac-ebfe-415a-b0f7-c317a25c83e5}"/>
     </way>
-    <way visible="true" id="-7916" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6864"/>
-        <nd ref="-6873"/>
+    <way visible="true" id="-7913" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6861"/>
+        <nd ref="-6870"/>
         <nd ref="345"/>
         <nd ref="346"/>
         <nd ref="347"/>
         <nd ref="348"/>
         <nd ref="349"/>
         <nd ref="350"/>
-        <nd ref="-6851"/>
+        <nd ref="-6848"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="D5A945C6-3B0E-4AED-BFAE-34BA4AA0F305"/>
         <tag k="REF1" v="00003f"/>
@@ -3615,11 +3620,11 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{44fbda29-276c-41ed-a150-faa9ad7d70b8};{39b82504-21e2-470c-ab57-7e6d2095634f}"/>
     </way>
-    <way visible="true" id="-7903" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6863"/>
+    <way visible="true" id="-7900" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6860"/>
         <nd ref="343"/>
         <nd ref="344"/>
-        <nd ref="-6864"/>
+        <nd ref="-6861"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="8868443E-97CD-4397-8F10-E8581A883522"/>
         <tag k="REF1" v="00003f"/>
@@ -3645,35 +3650,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{44fbda29-276c-41ed-a150-faa9ad7d70b8};{5d8c34d9-225f-4069-8577-6502e21dd255}"/>
     </way>
-    <way visible="true" id="-7895" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="339"/>
-        <nd ref="124"/>
-        <tag k="FCSubtype" v="0"/>
-        <tag k="GFID" v="FFF2A7E6-4C5E-458B-A0F4-C97E93EED43E"/>
-        <tag k="REF1" v="000047"/>
-        <tag k="REF2" v="00003f"/>
-        <tag k="SHAPE_Leng" v="0.0056383737048400001"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="condition" v="functional"/>
-        <tag k="electrified" v="contact_line"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="gauge" v="144"/>
-        <tag k="gauge:type" v="standard"/>
-        <tag k="lanes" v="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="location" v="surface"/>
-        <tag k="note" v="Single"/>
-        <tag k="railway" v="rail"/>
-        <tag k="railway:in_road" v="separated"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source" v="osm;mgcp:railrdl_rail"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2014-01-20T23:08:41.000Z;2018-02-16T13:57:43Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.899Z"/>
-        <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{5cfde9e9-4998-4e3d-bbec-a0c6cdb17dca};{b2554eac-ebfe-415a-b0f7-c317a25c83e5}"/>
-    </way>
-    <way visible="true" id="-7887" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7884" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="467"/>
         <nd ref="535"/>
         <nd ref="536"/>
@@ -3707,7 +3684,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{edf39c62-e7a6-4679-ada6-5c3cebce1865};{5fb8b74b-703e-4e3a-abc2-576225a869c8}"/>
     </way>
-    <way visible="true" id="-7884" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7881" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="141"/>
         <nd ref="142"/>
         <tag k="FCSubtype" v="0"/>
@@ -3740,7 +3717,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{7ee8145a-25c3-4dcb-bf9f-465ee7d86ae5};{88e2319e-e3c4-4d97-91fb-39835b024283}"/>
     </way>
-    <way visible="true" id="-7882" timestamp="2018-02-16T13:57:43Z" version="1">
+    <way visible="true" id="-7879" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="30"/>
         <nd ref="-405"/>
         <nd ref="-404"/>
@@ -3774,7 +3751,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{940cac72-480e-472b-82fe-964e9bcf5b40}"/>
     </way>
-    <way visible="true" id="-7868" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7865" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="24"/>
         <nd ref="25"/>
         <nd ref="26"/>
@@ -3784,7 +3761,7 @@
         <nd ref="30"/>
         <nd ref="31"/>
         <nd ref="32"/>
-        <nd ref="-6847"/>
+        <nd ref="-6844"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="CF55958D-3815-42C9-B9C4-D5AC9E191181"/>
         <tag k="REF1" v="000012"/>
@@ -3813,7 +3790,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{53cf273b-d06f-4b51-967c-6f5b88c0972c};{940cac72-480e-472b-82fe-964e9bcf5b40}"/>
     </way>
-    <way visible="true" id="-7862" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7859" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="31"/>
         <nd ref="124"/>
         <nd ref="125"/>
@@ -3848,15 +3825,15 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{1d32d041-3d06-47fe-ade7-9d54e45210bc};{940cac72-480e-472b-82fe-964e9bcf5b40}"/>
     </way>
-    <way visible="true" id="-7858" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6835"/>
+    <way visible="true" id="-7855" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6832"/>
         <nd ref="113"/>
         <nd ref="114"/>
         <nd ref="115"/>
         <nd ref="116"/>
         <nd ref="117"/>
-        <nd ref="-6842"/>
-        <nd ref="-6840"/>
+        <nd ref="-6839"/>
+        <nd ref="-6837"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="8D813221-7A7C-4F40-9544-78AE6AE8FBA5"/>
         <tag k="REF1" v="00001e"/>
@@ -3881,7 +3858,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{02e059f1-4039-432f-be8f-a029e40fe710};{fa86a0bd-ab90-4068-a8f4-6aa7c544866f}"/>
     </way>
-    <way visible="true" id="-7855" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7852" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="105"/>
         <nd ref="106"/>
         <nd ref="107"/>
@@ -3890,7 +3867,7 @@
         <nd ref="110"/>
         <nd ref="111"/>
         <nd ref="112"/>
-        <nd ref="-6834"/>
+        <nd ref="-6831"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="1D21A073-3577-4286-A0C7-C9F994AEEBCE"/>
         <tag k="REF1" v="00001e"/>
@@ -3915,8 +3892,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{02e059f1-4039-432f-be8f-a029e40fe710};{4442f8b4-0abc-4fbc-ba25-cdbef77006f3}"/>
     </way>
-    <way visible="true" id="-7848" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6840"/>
+    <way visible="true" id="-7845" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6837"/>
         <nd ref="118"/>
         <nd ref="119"/>
         <nd ref="120"/>
@@ -3947,7 +3924,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{02e059f1-4039-432f-be8f-a029e40fe710};{27514f7a-3614-4044-929f-ae6784dea699}"/>
     </way>
-    <way visible="true" id="-7833" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7830" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="84"/>
         <nd ref="85"/>
         <nd ref="86"/>
@@ -3995,8 +3972,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{b5ca2dc4-7049-413b-a42d-701a300ed78f};{bb0cb652-a8f9-4e0a-822e-7378c442dfe1}"/>
     </way>
-    <way visible="true" id="-7829" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6828"/>
+    <way visible="true" id="-7826" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6825"/>
         <nd ref="175"/>
         <nd ref="176"/>
         <nd ref="177"/>
@@ -4026,7 +4003,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{2d11ee7e-27dd-4c7e-92cb-08db5d5958a7};{917489ae-1607-4604-a1d1-21e13bf02249}"/>
     </way>
-    <way visible="true" id="-7826" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7823" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="163"/>
         <nd ref="164"/>
         <nd ref="165"/>
@@ -4039,7 +4016,7 @@
         <nd ref="172"/>
         <nd ref="173"/>
         <nd ref="174"/>
-        <nd ref="-6827"/>
+        <nd ref="-6824"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="65A91BE8-7B6E-44EC-82D9-251D7942CC1F"/>
         <tag k="REF1" v="00002c"/>
@@ -4064,7 +4041,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{2d11ee7e-27dd-4c7e-92cb-08db5d5958a7};{749c8a0b-3001-42e3-97e1-372771aa3586}"/>
     </way>
-    <way visible="true" id="-7820" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7817" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="83"/>
         <nd ref="148"/>
         <nd ref="149"/>
@@ -4096,7 +4073,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{137c1380-1cde-493b-a1a9-37ffaa6f3a45};{917489ae-1607-4604-a1d1-21e13bf02249}"/>
     </way>
-    <way visible="true" id="-7814" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7811" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="77"/>
         <nd ref="78"/>
         <nd ref="79"/>
@@ -4128,7 +4105,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{36530fe9-fa34-4b70-8d62-26efa0726a24};{917489ae-1607-4604-a1d1-21e13bf02249}"/>
     </way>
-    <way visible="true" id="-7806" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7803" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="55"/>
         <nd ref="63"/>
         <nd ref="64"/>
@@ -4172,7 +4149,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{e5a98462-f846-45a3-b3af-e28e99b6a850};{233dbb9c-5072-4b13-afe3-ef4a41c3bcf3}"/>
     </way>
-    <way visible="true" id="-7803" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7800" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="60"/>
         <nd ref="61"/>
         <tag k="FCSubtype" v="0"/>
@@ -4203,7 +4180,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{20d00780-d8be-49a2-a063-dd58e3b3e775};{85468d1e-a7f9-43fe-8435-c1cd61c0df26}"/>
     </way>
-    <way visible="true" id="-7793" timestamp="2018-02-16T13:57:43Z" version="1">
+    <way visible="true" id="-7790" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="143"/>
         <nd ref="-312"/>
         <tag k="FCSubtype" v="0"/>
@@ -4233,7 +4210,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{f178421d-fd17-4a0b-9043-066a392886cf}"/>
     </way>
-    <way visible="true" id="-7791" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7788" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="143"/>
         <nd ref="144"/>
         <nd ref="58"/>
@@ -4265,10 +4242,10 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{5e63fd09-7f9a-4d5e-b026-65d6a869f751};{f178421d-fd17-4a0b-9043-066a392886cf}"/>
     </way>
-    <way visible="true" id="-7788" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7785" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="59"/>
         <nd ref="532"/>
-        <nd ref="-6820"/>
+        <nd ref="-6817"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="5DF182A2-EF20-4760-A3E8-0A8B2C173301"/>
         <tag k="REF1" v="000058"/>
@@ -4297,7 +4274,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{1e58a387-2ad6-47f4-86ce-f59386839d45};{f178421d-fd17-4a0b-9043-066a392886cf}"/>
     </way>
-    <way visible="true" id="-7778" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7775" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="58"/>
         <nd ref="59"/>
         <tag k="FCSubtype" v="0"/>
@@ -4330,94 +4307,18 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{e1733ad4-367f-4dea-b384-ec858455ea17};{f178421d-fd17-4a0b-9043-066a392886cf}"/>
     </way>
-    <way visible="true" id="-7776" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="199"/>
-        <nd ref="-1942"/>
-        <nd ref="198"/>
-        <tag k="FCSubtype" v="0"/>
-        <tag k="GFID" v="7E3486F2-DFB6-4DB4-B7EF-C382DEF1D95E"/>
-        <tag k="REF2" v="000088"/>
-        <tag k="SHAPE_Leng" v="0.00799775686823"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="condition" v="functional"/>
-        <tag k="electrified" v="contact_line"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="gauge" v="144"/>
-        <tag k="gauge:type" v="standard"/>
-        <tag k="gndb_id" v="6183466"/>
-        <tag k="gndb_id:2" v="6171468"/>
-        <tag k="lanes" v="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="location" v="surface"/>
-        <tag k="name" v="Manp'o-son"/>
-        <tag k="note" v="Single"/>
-        <tag k="railway" v="rail"/>
-        <tag k="railway:in_road" v="separated"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source" v="mgcp:railrdl_rail;osm"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2018-02-16T13:57:43Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.862Z"/>
-        <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{aa909189-e138-49c5-bca8-8e34db155572}"/>
-    </way>
-    <way visible="true" id="-7775" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-1963"/>
-        <nd ref="282"/>
-        <tag k="FCSubtype" v="0"/>
-        <tag k="GFID" v="7E3486F2-DFB6-4DB4-B7EF-C382DEF1D95E"/>
-        <tag k="REF2" v="000088"/>
-        <tag k="SHAPE_Leng" v="0.00799775686823"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="condition" v="functional"/>
-        <tag k="electrified" v="contact_line"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="gauge" v="144"/>
-        <tag k="gauge:type" v="standard"/>
-        <tag k="gndb_id" v="6183466"/>
-        <tag k="gndb_id:2" v="6171468"/>
-        <tag k="lanes" v="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="location" v="surface"/>
-        <tag k="name" v="Manp'o-son"/>
-        <tag k="note" v="Single"/>
-        <tag k="railway" v="rail"/>
-        <tag k="railway:in_road" v="separated"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source" v="mgcp:railrdl_rail;osm"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2018-02-16T13:57:43Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.862Z"/>
-        <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{aa909189-e138-49c5-bca8-8e34db155572}"/>
-    </way>
-    <way visible="true" id="-7773" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="282"/>
-        <nd ref="876"/>
-        <nd ref="877"/>
-        <nd ref="878"/>
-        <nd ref="879"/>
-        <nd ref="880"/>
-        <nd ref="881"/>
-        <nd ref="882"/>
-        <nd ref="883"/>
-        <nd ref="884"/>
-        <nd ref="199"/>
-        <nd ref="-6811"/>
-        <nd ref="885"/>
+    <way visible="true" id="-7772" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="194"/>
         <nd ref="886"/>
         <nd ref="887"/>
         <nd ref="888"/>
         <nd ref="889"/>
-        <nd ref="-6807"/>
-        <nd ref="890"/>
-        <nd ref="891"/>
+        <nd ref="-6812"/>
         <tag k="FCSubtype" v="0"/>
-        <tag k="GFID" v="7E3486F2-DFB6-4DB4-B7EF-C382DEF1D95E"/>
+        <tag k="GFID" v="37F03C01-6C64-49CC-BE79-D603D0BC0821"/>
         <tag k="REF1" v="000088"/>
-        <tag k="REF2" v="000088;none"/>
-        <tag k="SHAPE_Leng" v="0.00799775686823"/>
+        <tag k="REF2" v="000088"/>
+        <tag k="SHAPE_Leng" v="0.0071384093354699999"/>
         <tag k="attribution" v="osm"/>
         <tag k="condition" v="functional"/>
         <tag k="electrified" v="contact_line"/>
@@ -4437,11 +4338,11 @@
         <tag k="source" v="osm;mgcp:railrdl_rail"/>
         <tag k="source:accuracy:horizontal:category" v="accurate"/>
         <tag k="source:datetime" v="2012-09-06T19:20:34.000Z;2018-02-16T13:57:43Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.862Z;2018-02-13T20:09:15.903Z;2018-02-13T20:09:15.882Z"/>
+        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.903Z"/>
         <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{7f076ab0-1a37-451c-a22b-e5672d5f2a55};{aa909189-e138-49c5-bca8-8e34db155572};{256fdcaf-8ea5-45b2-b654-8dbfcd079d8f};{a26f95b0-df1a-4003-85c8-6b17d3cfed2b}"/>
+        <tag k="uuid" v="{7f076ab0-1a37-451c-a22b-e5672d5f2a55};{256fdcaf-8ea5-45b2-b654-8dbfcd079d8f}"/>
     </way>
-    <way visible="true" id="-7758" timestamp="2018-02-16T13:57:43Z" version="1">
+    <way visible="true" id="-7769" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="-4"/>
         <nd ref="-1251"/>
         <nd ref="-1250"/>
@@ -4485,7 +4386,181 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{a26f95b0-df1a-4003-85c8-6b17d3cfed2b}"/>
     </way>
-    <way visible="true" id="-7752" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7763" timestamp="2018-02-16T13:57:43Z" version="1">
+        <nd ref="-229"/>
+        <nd ref="-249"/>
+        <nd ref="-248"/>
+        <nd ref="-247"/>
+        <nd ref="-246"/>
+        <nd ref="-245"/>
+        <nd ref="195"/>
+        <tag k="FCSubtype" v="0"/>
+        <tag k="GFID" v="37F03C01-6C64-49CC-BE79-D603D0BC0821"/>
+        <tag k="REF2" v="000088"/>
+        <tag k="SHAPE_Leng" v="0.0071384093354699999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="condition" v="functional"/>
+        <tag k="electrified" v="contact_line"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="gauge" v="144"/>
+        <tag k="gauge:type" v="standard"/>
+        <tag k="gndb_id" v="6183466"/>
+        <tag k="gndb_id:2" v="6171468"/>
+        <tag k="lanes" v="1"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="location" v="surface"/>
+        <tag k="name" v="Manp'o-son"/>
+        <tag k="note" v="Single"/>
+        <tag k="railway" v="rail"/>
+        <tag k="railway:in_road" v="separated"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source" v="mgcp:railrdl_rail;osm"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="source:datetime" v="2018-02-16T13:57:43Z"/>
+        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.903Z"/>
+        <tag k="usage" v="high_speed_rail"/>
+        <tag k="uuid" v="{256fdcaf-8ea5-45b2-b654-8dbfcd079d8f}"/>
+    </way>
+    <way visible="true" id="-7761" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="194"/>
+        <nd ref="195"/>
+        <nd ref="196"/>
+        <nd ref="197"/>
+        <nd ref="-6805"/>
+        <nd ref="198"/>
+        <nd ref="199"/>
+        <tag k="FCSubtype" v="0"/>
+        <tag k="GFID" v="37F03C01-6C64-49CC-BE79-D603D0BC0821"/>
+        <tag k="REF1" v="000032"/>
+        <tag k="REF2" v="000088"/>
+        <tag k="SHAPE_Leng" v="0.0071384093354699999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="condition" v="functional"/>
+        <tag k="electrified" v="contact_line"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="gauge" v="144"/>
+        <tag k="gauge:type" v="standard"/>
+        <tag k="gndb_id" v="6183466"/>
+        <tag k="gndb_id:2" v="6171468"/>
+        <tag k="lanes" v="1"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="location" v="surface"/>
+        <tag k="name" v="Manp'o-son"/>
+        <tag k="note" v="Single"/>
+        <tag k="railway" v="rail"/>
+        <tag k="railway:in_road" v="separated"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source" v="osm;mgcp:railrdl_rail"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="source:datetime" v="2012-09-06T19:20:31.000Z;2018-02-16T13:57:43Z"/>
+        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.903Z;2018-02-13T20:09:15.862Z"/>
+        <tag k="usage" v="high_speed_rail"/>
+        <tag k="uuid" v="{45d5f386-2c92-4950-849e-3f2e059a468f};{256fdcaf-8ea5-45b2-b654-8dbfcd079d8f};{aa909189-e138-49c5-bca8-8e34db155572}"/>
+    </way>
+    <way visible="true" id="-7759" timestamp="2018-02-16T13:57:43Z" version="1">
+        <nd ref="199"/>
+        <nd ref="-1942"/>
+        <nd ref="198"/>
+        <tag k="FCSubtype" v="0"/>
+        <tag k="GFID" v="7E3486F2-DFB6-4DB4-B7EF-C382DEF1D95E"/>
+        <tag k="REF2" v="000088"/>
+        <tag k="SHAPE_Leng" v="0.00799775686823"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="condition" v="functional"/>
+        <tag k="electrified" v="contact_line"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="gauge" v="144"/>
+        <tag k="gauge:type" v="standard"/>
+        <tag k="gndb_id" v="6183466"/>
+        <tag k="gndb_id:2" v="6171468"/>
+        <tag k="lanes" v="1"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="location" v="surface"/>
+        <tag k="name" v="Manp'o-son"/>
+        <tag k="note" v="Single"/>
+        <tag k="railway" v="rail"/>
+        <tag k="railway:in_road" v="separated"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source" v="mgcp:railrdl_rail;osm"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="source:datetime" v="2018-02-16T13:57:43Z"/>
+        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.862Z"/>
+        <tag k="usage" v="high_speed_rail"/>
+        <tag k="uuid" v="{aa909189-e138-49c5-bca8-8e34db155572}"/>
+    </way>
+    <way visible="true" id="-7758" timestamp="2018-02-16T13:57:43Z" version="1">
+        <nd ref="-1963"/>
+        <nd ref="282"/>
+        <tag k="FCSubtype" v="0"/>
+        <tag k="GFID" v="7E3486F2-DFB6-4DB4-B7EF-C382DEF1D95E"/>
+        <tag k="REF2" v="000088"/>
+        <tag k="SHAPE_Leng" v="0.00799775686823"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="condition" v="functional"/>
+        <tag k="electrified" v="contact_line"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="gauge" v="144"/>
+        <tag k="gauge:type" v="standard"/>
+        <tag k="gndb_id" v="6183466"/>
+        <tag k="gndb_id:2" v="6171468"/>
+        <tag k="lanes" v="1"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="location" v="surface"/>
+        <tag k="name" v="Manp'o-son"/>
+        <tag k="note" v="Single"/>
+        <tag k="railway" v="rail"/>
+        <tag k="railway:in_road" v="separated"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source" v="mgcp:railrdl_rail;osm"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="source:datetime" v="2018-02-16T13:57:43Z"/>
+        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.862Z"/>
+        <tag k="usage" v="high_speed_rail"/>
+        <tag k="uuid" v="{aa909189-e138-49c5-bca8-8e34db155572}"/>
+    </way>
+    <way visible="true" id="-7756" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="282"/>
+        <nd ref="876"/>
+        <nd ref="877"/>
+        <nd ref="878"/>
+        <nd ref="879"/>
+        <nd ref="880"/>
+        <nd ref="881"/>
+        <nd ref="882"/>
+        <nd ref="883"/>
+        <nd ref="884"/>
+        <nd ref="199"/>
+        <nd ref="885"/>
+        <nd ref="194"/>
+        <tag k="FCSubtype" v="0"/>
+        <tag k="GFID" v="7E3486F2-DFB6-4DB4-B7EF-C382DEF1D95E"/>
+        <tag k="REF1" v="000088"/>
+        <tag k="REF2" v="000088"/>
+        <tag k="SHAPE_Leng" v="0.00799775686823"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="condition" v="functional"/>
+        <tag k="electrified" v="contact_line"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="gauge" v="144"/>
+        <tag k="gauge:type" v="standard"/>
+        <tag k="gndb_id" v="6183466"/>
+        <tag k="gndb_id:2" v="6171468"/>
+        <tag k="lanes" v="1"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="location" v="surface"/>
+        <tag k="name" v="Manp'o-son"/>
+        <tag k="note" v="Single"/>
+        <tag k="railway" v="rail"/>
+        <tag k="railway:in_road" v="separated"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source" v="osm;mgcp:railrdl_rail"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="source:datetime" v="2012-09-06T19:20:34.000Z;2018-02-16T13:57:43Z"/>
+        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.862Z"/>
+        <tag k="usage" v="high_speed_rail"/>
+        <tag k="uuid" v="{7f076ab0-1a37-451c-a22b-e5672d5f2a55};{aa909189-e138-49c5-bca8-8e34db155572}"/>
+    </way>
+    <way visible="true" id="-7748" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="39"/>
         <nd ref="56"/>
         <nd ref="57"/>
@@ -4513,7 +4588,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{29d637eb-94db-4b04-b593-52dc5b7cbb21};{ef563ce8-f181-4d85-bc46-ed6caffe780f}"/>
     </way>
-    <way visible="true" id="-7746" timestamp="2018-02-16T13:57:43Z" version="1">
+    <way visible="true" id="-7742" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="807"/>
         <nd ref="-51"/>
         <nd ref="-6"/>
@@ -4540,7 +4615,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{d7d4ba79-5452-4ceb-9869-336b33a55595}"/>
     </way>
-    <way visible="true" id="-7743" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7739" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="807"/>
         <nd ref="721"/>
         <nd ref="808"/>
@@ -4572,7 +4647,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{ec1f595f-ed98-482c-a259-30e7107143ea};{d7d4ba79-5452-4ceb-9869-336b33a55595}"/>
     </way>
-    <way visible="true" id="-7734" timestamp="2018-02-16T13:57:43Z" version="1">
+    <way visible="true" id="-7730" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="593"/>
         <nd ref="-1930"/>
         <nd ref="-1929"/>
@@ -4622,7 +4697,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{0cf4ea9f-d066-4a91-a5f0-8fffac7776b2}"/>
     </way>
-    <way visible="true" id="-7731" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7727" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="539"/>
         <nd ref="943"/>
         <nd ref="944"/>
@@ -4631,8 +4706,8 @@
         <nd ref="947"/>
         <nd ref="948"/>
         <nd ref="949"/>
-        <nd ref="-6800"/>
-        <nd ref="-6763"/>
+        <nd ref="-6798"/>
+        <nd ref="-6761"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="45FA327E-47D7-4C7B-BFB2-BD377EF95E9F"/>
         <tag k="REF1" v="000091"/>
@@ -4659,8 +4734,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{1a85ce13-0bae-4497-8267-55a9fc7f723b};{0cf4ea9f-d066-4a91-a5f0-8fffac7776b2}"/>
     </way>
-    <way visible="true" id="-7720" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6764"/>
+    <way visible="true" id="-7716" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6762"/>
         <nd ref="952"/>
         <nd ref="953"/>
         <nd ref="954"/>
@@ -4668,8 +4743,8 @@
         <nd ref="956"/>
         <nd ref="957"/>
         <nd ref="958"/>
-        <nd ref="-6791"/>
-        <nd ref="-6782"/>
+        <nd ref="-6789"/>
+        <nd ref="-6780"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="A761203F-9B8C-4B45-B2B5-2A81408A30ED"/>
         <tag k="REF1" v="000091"/>
@@ -4695,15 +4770,15 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{1a85ce13-0bae-4497-8267-55a9fc7f723b};{b176f957-ac67-4cf8-b2d2-74b383b33812}"/>
     </way>
-    <way visible="true" id="-7708" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6782"/>
+    <way visible="true" id="-7704" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6780"/>
         <nd ref="959"/>
         <nd ref="960"/>
         <nd ref="961"/>
         <nd ref="962"/>
         <nd ref="963"/>
         <nd ref="964"/>
-        <nd ref="-6747"/>
+        <nd ref="-6745"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="6E8515E8-59A1-462F-A9B3-23D7375E5FEF"/>
         <tag k="REF1" v="000091"/>
@@ -4729,12 +4804,12 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{1a85ce13-0bae-4497-8267-55a9fc7f723b};{7865f11c-074f-46bd-9f8f-2908f82bde67}"/>
     </way>
-    <way visible="true" id="-7697" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6748"/>
+    <way visible="true" id="-7693" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6746"/>
         <nd ref="965"/>
         <nd ref="966"/>
         <nd ref="967"/>
-        <nd ref="-6773"/>
+        <nd ref="-6771"/>
         <nd ref="968"/>
         <nd ref="969"/>
         <nd ref="970"/>
@@ -4767,11 +4842,11 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{1a85ce13-0bae-4497-8267-55a9fc7f723b};{15271cd5-1eb7-4d36-af39-d7dd46c2e9bd}"/>
     </way>
-    <way visible="true" id="-7685" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6763"/>
+    <way visible="true" id="-7681" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6761"/>
         <nd ref="950"/>
         <nd ref="951"/>
-        <nd ref="-6764"/>
+        <nd ref="-6762"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="4D9FF680-1303-4556-8A31-BB4FB39BCE5A"/>
         <tag k="REF1" v="000091"/>
@@ -4797,10 +4872,10 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{1a85ce13-0bae-4497-8267-55a9fc7f723b};{5fec1144-cc0d-46b3-b0d5-54cc06835bba}"/>
     </way>
-    <way visible="true" id="-7673" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7669" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="328"/>
         <nd ref="384"/>
-        <nd ref="-6753"/>
+        <nd ref="-6751"/>
         <nd ref="216"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="45FA327E-47D7-4C7B-BFB2-BD377EF95E9F"/>
@@ -4827,7 +4902,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{7e85f1a7-d71d-43b8-9ea8-b2f07d1cf622};{0cf4ea9f-d066-4a91-a5f0-8fffac7776b2}"/>
     </way>
-    <way visible="true" id="-7667" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7663" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="590"/>
         <nd ref="591"/>
         <nd ref="592"/>
@@ -4873,14 +4948,14 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{8015f547-07f9-46b7-ac11-61331a765797};{0cf4ea9f-d066-4a91-a5f0-8fffac7776b2}"/>
     </way>
-    <way visible="true" id="-7659" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7655" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="206"/>
         <nd ref="207"/>
         <nd ref="208"/>
         <nd ref="209"/>
         <nd ref="210"/>
         <nd ref="211"/>
-        <nd ref="-6738"/>
+        <nd ref="-6736"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="E3E3EDD8-51AF-4116-BC2E-2D4B6B55A85C"/>
         <tag k="REF1" v="000033"/>
@@ -4905,11 +4980,11 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{79162455-a391-4f2e-b5d3-dfc27c89e9cb};{b317dc80-dba7-4c16-aa17-6edcf958302c}"/>
     </way>
-    <way visible="true" id="-7657" timestamp="2018-02-16T13:57:43Z" version="1">
+    <way visible="true" id="-7653" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="216"/>
         <nd ref="-1792"/>
         <nd ref="-1791"/>
-        <nd ref="-6734"/>
+        <nd ref="-6732"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="81024870-B195-4EA2-840B-54CD57811A41"/>
         <tag k="REF2" v="todo"/>
@@ -4933,8 +5008,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{015c9439-e28a-439f-acfc-c1d26fdf26f9}"/>
     </way>
-    <way visible="true" id="-7655" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6739"/>
+    <way visible="true" id="-7651" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6737"/>
         <nd ref="212"/>
         <nd ref="213"/>
         <nd ref="214"/>
@@ -4964,7 +5039,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{79162455-a391-4f2e-b5d3-dfc27c89e9cb};{015c9439-e28a-439f-acfc-c1d26fdf26f9}"/>
     </way>
-    <way visible="true" id="-7640" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7636" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="200"/>
         <nd ref="105"/>
         <tag k="FCSubtype" v="0"/>
@@ -4993,7 +5068,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{0cdd9599-c436-4a14-a1b9-b80bd1478bab};{a19ddfeb-f921-4174-8da1-171369ca9d7f}"/>
     </way>
-    <way visible="true" id="-7633" timestamp="2018-02-16T13:57:43Z" version="1">
+    <way visible="true" id="-7629" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="384"/>
         <nd ref="-293"/>
         <nd ref="-292"/>
@@ -5026,7 +5101,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{cb84b01d-3161-44be-8ee6-db1604553333}"/>
     </way>
-    <way visible="true" id="-7626" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7622" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="384"/>
         <nd ref="394"/>
         <tag k="FCSubtype" v="0"/>
@@ -5057,7 +5132,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{819d21c1-f32d-4fa2-bbc2-b9100ab19b68};{cb84b01d-3161-44be-8ee6-db1604553333}"/>
     </way>
-    <way visible="true" id="-7623" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7619" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="38"/>
         <nd ref="39"/>
         <tag k="FCSubtype" v="0"/>
@@ -5086,7 +5161,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{2d02ea64-a2b9-44f9-bc2b-f456ccd1c7df};{7aa51969-242a-424c-9049-46da45bbd6d8}"/>
     </way>
-    <way visible="true" id="-7620" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7616" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="15"/>
         <nd ref="16"/>
         <nd ref="17"/>
@@ -5125,7 +5200,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{53cf273b-d06f-4b51-967c-6f5b88c0972c};{7c06f254-3eaa-44c2-9741-b5b9c31060e0}"/>
     </way>
-    <way visible="true" id="-7617" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7613" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="5"/>
         <nd ref="6"/>
         <nd ref="7"/>
@@ -5162,7 +5237,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{af406b13-1520-4ecb-bb30-6e88fab68407};{ed273594-c643-43ac-806b-09c65f880254}"/>
     </way>
-    <way visible="true" id="-7610" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7606" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="785"/>
         <nd ref="786"/>
         <nd ref="787"/>
@@ -5197,7 +5272,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{27d8ee7d-db24-4cda-8190-35dea3214570};{9ceb959a-707c-466d-afd2-d46ca5c0c42b}"/>
     </way>
-    <way visible="true" id="-7606" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7602" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="14"/>
         <nd ref="365"/>
         <nd ref="366"/>
@@ -5237,7 +5312,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{60845bf7-2192-4433-b78c-11f68b62136a};{93f3e200-8a80-48c6-8295-52655354fea7}"/>
     </way>
-    <way visible="true" id="-7602" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7598" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="2"/>
         <nd ref="131"/>
         <nd ref="132"/>
@@ -5273,7 +5348,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{79936be5-985c-4692-a3d6-d18c62137b07};{93f3e200-8a80-48c6-8295-52655354fea7}"/>
     </way>
-    <way visible="true" id="-7595" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7591" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="4"/>
         <nd ref="866"/>
         <nd ref="867"/>
@@ -5308,7 +5383,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{fe033ac2-0ce5-4d82-ae33-ecf7a55dc26d};{93f3e200-8a80-48c6-8295-52655354fea7}"/>
     </way>
-    <way visible="true" id="-7588" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7584" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="136"/>
         <nd ref="137"/>
         <nd ref="138"/>
@@ -5343,7 +5418,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{563b234e-b91f-40f7-a8da-61ffd0e1d34c};{93f3e200-8a80-48c6-8295-52655354fea7}"/>
     </way>
-    <way visible="true" id="-7580" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7576" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="3"/>
         <nd ref="4"/>
         <tag k="FCSubtype" v="0"/>
@@ -5376,7 +5451,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{7bb5177e-2b1c-4d85-85eb-3ec07f389e3e};{93f3e200-8a80-48c6-8295-52655354fea7}"/>
     </way>
-    <way visible="true" id="-7574" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7570" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="13"/>
         <nd ref="14"/>
         <tag k="FCSubtype" v="0"/>
@@ -5409,9 +5484,9 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{9204712e-abcd-4951-98a4-f2a80cc619db};{93f3e200-8a80-48c6-8295-52655354fea7}"/>
     </way>
-    <way visible="true" id="-7571" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6720"/>
-        <nd ref="-6723"/>
+    <way visible="true" id="-7563" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6716"/>
+        <nd ref="-6719"/>
         <nd ref="828"/>
         <nd ref="829"/>
         <nd ref="830"/>
@@ -5467,9 +5542,9 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{076ee02e-1d1b-4063-b045-a01b58cf07f1};{5f08faf6-1221-46e6-a257-d834e0a8986f}"/>
     </way>
-    <way visible="true" id="-7562" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-6715"/>
-        <nd ref="-6715"/>
+    <way visible="true" id="-7555" timestamp="2018-02-16T13:57:43Z" version="1">
+        <nd ref="-6712"/>
+        <nd ref="-6712"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="865454EB-A4C8-47D1-B727-2A75C8FDFBAB"/>
         <tag k="REF2" v="todo"/>
@@ -5493,7 +5568,7 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{5f08faf6-1221-46e6-a257-d834e0a8986f}"/>
     </way>
-    <way visible="true" id="-7552" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7545" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="178"/>
         <nd ref="179"/>
         <nd ref="180"/>
@@ -5526,40 +5601,12 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{79e69860-2ce5-456e-be2f-7a239f944a46};{2154ca17-2a83-4a8a-b425-07cff4f5c4b2}"/>
     </way>
-    <way visible="true" id="-7546" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="155"/>
-        <nd ref="-210"/>
-        <nd ref="-209"/>
-        <nd ref="-208"/>
-        <nd ref="826"/>
-        <tag k="FCSubtype" v="0"/>
-        <tag k="GFID" v="F77EA7D0-7840-4273-B57B-C52AB69B7E85"/>
-        <tag k="REF2" v="todo"/>
-        <tag k="SHAPE_Leng" v="0.018886577265199999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="condition" v="functional"/>
-        <tag k="electrified" v="contact_line"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="gauge" v="144"/>
-        <tag k="gauge:type" v="standard"/>
-        <tag k="lanes" v="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="location" v="surface"/>
-        <tag k="note" v="Single"/>
-        <tag k="railway" v="rail"/>
-        <tag k="railway:in_road" v="separated"/>
-        <tag k="source" v="mgcp:railrdl_rail;osm"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2018-02-16T13:57:43Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.960Z"/>
-        <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{2154ca17-2a83-4a8a-b425-07cff4f5c4b2}"/>
-    </way>
-    <way visible="true" id="-7544" timestamp="2018-02-15T20:56:52Z" version="1">
+    <way visible="true" id="-7540" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="153"/>
         <nd ref="826"/>
         <nd ref="160"/>
         <nd ref="827"/>
-        <nd ref="-6720"/>
+        <nd ref="-6716"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="F77EA7D0-7840-4273-B57B-C52AB69B7E85"/>
         <tag k="REF1" v="000082"/>
@@ -5584,42 +5631,10 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{076ee02e-1d1b-4063-b045-a01b58cf07f1};{2154ca17-2a83-4a8a-b425-07cff4f5c4b2}"/>
     </way>
-    <way visible="true" id="-7538" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="153"/>
-        <nd ref="154"/>
-        <nd ref="155"/>
-        <nd ref="156"/>
-        <nd ref="157"/>
-        <nd ref="158"/>
-        <nd ref="159"/>
-        <tag k="FCSubtype" v="0"/>
-        <tag k="GFID" v="F77EA7D0-7840-4273-B57B-C52AB69B7E85"/>
-        <tag k="REF1" v="000029"/>
-        <tag k="REF2" v="todo"/>
-        <tag k="SHAPE_Leng" v="0.018886577265199999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="condition" v="functional"/>
-        <tag k="electrified" v="contact_line"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="gauge" v="144"/>
-        <tag k="gauge:type" v="standard"/>
-        <tag k="lanes" v="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="location" v="surface"/>
-        <tag k="note" v="Single"/>
-        <tag k="railway" v="rail"/>
-        <tag k="railway:in_road" v="separated"/>
-        <tag k="source" v="osm;mgcp:railrdl_rail"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2013-09-15T15:07:03.000Z;2018-02-16T13:57:43Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.960Z"/>
-        <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{f5512778-c63c-457b-999d-dbe6d1000f3e};{2154ca17-2a83-4a8a-b425-07cff4f5c4b2}"/>
-    </way>
     <way visible="true" id="-176" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-7129"/>
+        <nd ref="-7116"/>
         <nd ref="461"/>
-        <nd ref="-7130"/>
+        <nd ref="-7117"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="E10FBBB0-B15D-4D90-89B6-828CCA72A5E0"/>
         <tag k="REF1" v="00004e"/>
@@ -5649,8 +5664,8 @@
         <tag k="uuid" v="{f66a5171-9e14-4042-93f2-ec035b9b99bf};{1ccdb093-b10f-4592-ac54-f01fecabc492}"/>
     </way>
     <way visible="true" id="-172" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6851"/>
-        <nd ref="-6852"/>
+        <nd ref="-6848"/>
+        <nd ref="-6849"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="A2058D86-20C0-4943-AA5D-42E687856F58"/>
         <tag k="REF1" v="00003f"/>
@@ -5677,7 +5692,7 @@
     </way>
     <way visible="true" id="-161" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="216"/>
-        <nd ref="-6734"/>
+        <nd ref="-6732"/>
         <nd ref="385"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="874803D2-9CB4-4461-9A4A-D3A85DA354F8"/>
@@ -5708,8 +5723,8 @@
         <tag k="uuid" v="{7e85f1a7-d71d-43b8-9ea8-b2f07d1cf622};{cb84b01d-3161-44be-8ee6-db1604553333}"/>
     </way>
     <way visible="true" id="-160" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6738"/>
-        <nd ref="-6739"/>
+        <nd ref="-6736"/>
+        <nd ref="-6737"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="B042D580-B39F-4E05-B2B1-0FB78F268713"/>
         <tag k="REF1" v="000033"/>
@@ -5734,8 +5749,40 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{79162455-a391-4f2e-b5d3-dfc27c89e9cb};{351c058a-f98f-419e-9cbf-1ab85c9adbf3}"/>
     </way>
+    <way visible="true" id="-155" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="-6812"/>
+        <nd ref="890"/>
+        <nd ref="891"/>
+        <tag k="FCSubtype" v="0"/>
+        <tag k="GFID" v="D339C2B4-E595-4354-97BF-3B9A181DCBBA"/>
+        <tag k="REF1" v="000088"/>
+        <tag k="REF2" v="none"/>
+        <tag k="SHAPE_Leng" v="0.0153244490001"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="condition" v="functional"/>
+        <tag k="electrified" v="contact_line"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="gauge" v="144"/>
+        <tag k="gauge:type" v="standard"/>
+        <tag k="gndb_id" v="6183466"/>
+        <tag k="gndb_id:2" v="6171468"/>
+        <tag k="lanes" v="1"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="location" v="surface"/>
+        <tag k="name" v="Manp'o-son"/>
+        <tag k="note" v="Single"/>
+        <tag k="railway" v="rail"/>
+        <tag k="railway:in_road" v="separated"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source" v="osm;mgcp:railrdl_rail"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="source:datetime" v="2012-09-06T19:20:34.000Z;2018-02-16T13:57:43Z"/>
+        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.882Z"/>
+        <tag k="usage" v="high_speed_rail"/>
+        <tag k="uuid" v="{7f076ab0-1a37-451c-a22b-e5672d5f2a55};{a26f95b0-df1a-4003-85c8-6b17d3cfed2b}"/>
+    </way>
     <way visible="true" id="-138" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6847"/>
+        <nd ref="-6844"/>
         <nd ref="33"/>
         <nd ref="34"/>
         <tag k="FCSubtype" v="0"/>
@@ -6126,10 +6173,10 @@
         <tag k="uuid" v="{cec4601b-9e40-4cc7-911a-4ea83cba0868}"/>
     </way>
     <way visible="true" id="-89" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-7112"/>
+        <nd ref="-7099"/>
         <nd ref="-1516"/>
         <nd ref="-1515"/>
-        <nd ref="-7121"/>
+        <nd ref="-7108"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="D9008066-0A34-4B54-98BF-BB32471F37C8"/>
         <tag k="REF2" v="00004d"/>
@@ -6158,9 +6205,9 @@
         <tag k="uuid" v="{22de9c4f-db4c-4500-8e7e-c6a71cd1d403}"/>
     </way>
     <way visible="true" id="-86" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-6782"/>
+        <nd ref="-6780"/>
         <nd ref="-1431"/>
-        <nd ref="-6791"/>
+        <nd ref="-6789"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="8C3A65D0-2ACB-4924-AA98-FE7BD12B6771"/>
         <tag k="REF2" v="todo"/>
@@ -6185,9 +6232,9 @@
         <tag k="uuid" v="{f2c02b61-b7e5-48b6-ab9e-0e8e57c7b254}"/>
     </way>
     <way visible="true" id="-84" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-6763"/>
+        <nd ref="-6761"/>
         <nd ref="-1406"/>
-        <nd ref="-6800"/>
+        <nd ref="-6798"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="BCA6385F-C991-4F95-8475-A4BC62D776CA"/>
         <tag k="REF2" v="todo"/>
@@ -6354,10 +6401,10 @@
         <tag k="uuid" v="{fd59eccb-9c1b-4584-9b67-7d48463ebbf7}"/>
     </way>
     <way visible="true" id="-64" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-7103"/>
+        <nd ref="-7090"/>
         <nd ref="-1140"/>
         <nd ref="-1139"/>
-        <nd ref="-7126"/>
+        <nd ref="-7113"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="1E2C957E-5DD6-472D-B668-682615845B31"/>
         <tag k="REF2" v="00004d"/>
@@ -6386,9 +6433,9 @@
         <tag k="uuid" v="{ffc14593-6129-49d6-8a09-9212229c562b}"/>
     </way>
     <way visible="true" id="-59" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-7159"/>
+        <nd ref="-7146"/>
         <nd ref="-983"/>
-        <nd ref="-7154"/>
+        <nd ref="-7141"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="16A9ECED-DE72-464D-9495-C64EA5BB5E5C"/>
         <tag k="REF2" v="todo"/>
@@ -6440,9 +6487,9 @@
         <tag k="uuid" v="{0fbb41d3-a379-487b-8421-4d19ca48abf5}"/>
     </way>
     <way visible="true" id="-54" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-6864"/>
+        <nd ref="-6861"/>
         <nd ref="-944"/>
-        <nd ref="-6873"/>
+        <nd ref="-6870"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="571DA482-E2BC-49DA-8E50-F4EF24ABA284"/>
         <tag k="REF2" v="00003f"/>
@@ -6470,7 +6517,7 @@
     <way visible="true" id="-50" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="355"/>
         <nd ref="-910"/>
-        <nd ref="-7140"/>
+        <nd ref="-7127"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="2B123040-22DD-4D89-9434-8F62B7E81F90"/>
         <tag k="REF2" v="todo"/>
@@ -6521,9 +6568,9 @@
         <tag k="uuid" v="{0f9ca7f2-b724-45ab-8375-76ce6f874231}"/>
     </way>
     <way visible="true" id="-40" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-6842"/>
+        <nd ref="-6839"/>
         <nd ref="-676"/>
-        <nd ref="-6840"/>
+        <nd ref="-6837"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="EC56FAEF-334D-4ACC-8B4E-A84CB30F2A00"/>
         <tag k="REF2" v="todo"/>
@@ -6752,9 +6799,9 @@
         <tag k="uuid" v="{ff1b7309-ef57-4c16-beb9-03e3a5897027}"/>
     </way>
     <way visible="true" id="-15" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-6813"/>
+        <nd ref="-6805"/>
         <nd ref="-230"/>
-        <nd ref="-6811"/>
+        <nd ref="-229"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="0477D1FA-1E7F-4529-BE77-2ACAAE71E56C"/>
         <tag k="REF2" v="000088"/>
@@ -6783,9 +6830,9 @@
         <tag k="uuid" v="{d2ba0fac-6640-4003-82ae-86a533d56d0e}"/>
     </way>
     <way visible="true" id="-11" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-6720"/>
+        <nd ref="-6716"/>
         <nd ref="-110"/>
-        <nd ref="-6723"/>
+        <nd ref="-6719"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="E7E913A1-F1E8-4B32-98D6-D16B79A1A7A3"/>
         <tag k="REF2" v="todo"/>
@@ -6874,7 +6921,7 @@
         <nd ref="44"/>
         <nd ref="45"/>
         <nd ref="46"/>
-        <nd ref="-6803"/>
+        <nd ref="-6801"/>
         <nd ref="47"/>
         <nd ref="48"/>
         <nd ref="49"/>
@@ -6935,8 +6982,8 @@
         <tag k="uuid" v="{a0b62896-d47e-46f9-aeeb-959106aaedf1}"/>
     </way>
     <way visible="true" id="17" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6834"/>
-        <nd ref="-6835"/>
+        <nd ref="-6831"/>
+        <nd ref="-6832"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="740C7188-E877-4CC4-AC57-756C0004312E"/>
         <tag k="REF1" v="00001e"/>
@@ -7007,6 +7054,23 @@
         <tag k="source:datetime" v="2012-09-05T16:27:13.000Z"/>
         <tag k="uuid" v="{90d716a1-dee9-45e7-af22-f318f59c374f}"/>
     </way>
+    <way visible="true" id="28" timestamp="2018-02-15T20:56:52Z" version="1">
+        <nd ref="153"/>
+        <nd ref="154"/>
+        <nd ref="155"/>
+        <nd ref="156"/>
+        <nd ref="157"/>
+        <nd ref="158"/>
+        <nd ref="159"/>
+        <tag k="REF1" v="000029"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="railway" v="rail"/>
+        <tag k="source" v="osm"/>
+        <tag k="source:datetime" v="2013-09-15T15:07:03.000Z"/>
+        <tag k="uuid" v="{f5512778-c63c-457b-999d-dbe6d1000f3e}"/>
+    </way>
     <way visible="true" id="29" timestamp="2018-02-15T20:56:52Z" version="1" changeset="17283">
         <nd ref="160"/>
         <nd ref="161"/>
@@ -7022,8 +7086,8 @@
         <tag k="uuid" v="{8d9d9138-2716-449f-9921-5e46cecd2dc0}"/>
     </way>
     <way visible="true" id="31" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6827"/>
-        <nd ref="-6828"/>
+        <nd ref="-6824"/>
+        <nd ref="-6825"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="9C73D923-4A4B-444E-92A4-9DB058F5FE6E"/>
         <tag k="REF1" v="00002c"/>
@@ -7104,45 +7168,9 @@
         <tag k="source:datetime" v="2012-09-06T19:20:31.000Z"/>
         <tag k="uuid" v="{56d6592b-7fed-4622-a7ed-56b4699c2a47}"/>
     </way>
-    <way visible="true" id="37" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="194"/>
-        <nd ref="195"/>
-        <nd ref="196"/>
-        <nd ref="197"/>
-        <nd ref="-6813"/>
-        <nd ref="198"/>
-        <nd ref="199"/>
-        <tag k="FCSubtype" v="0"/>
-        <tag k="GFID" v="7E3486F2-DFB6-4DB4-B7EF-C382DEF1D95E"/>
-        <tag k="REF1" v="000032"/>
-        <tag k="REF2" v="000088"/>
-        <tag k="SHAPE_Leng" v="0.00799775686823"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="condition" v="functional"/>
-        <tag k="electrified" v="contact_line"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="gauge" v="144"/>
-        <tag k="gauge:type" v="standard"/>
-        <tag k="gndb_id" v="6183466"/>
-        <tag k="gndb_id:2" v="6171468"/>
-        <tag k="lanes" v="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="location" v="surface"/>
-        <tag k="name" v="Manp'o-son"/>
-        <tag k="note" v="Single"/>
-        <tag k="railway" v="rail"/>
-        <tag k="railway:in_road" v="separated"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source" v="osm;mgcp:railrdl_rail"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2012-09-06T19:20:31.000Z;2018-02-16T13:57:43Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.862Z"/>
-        <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{45d5f386-2c92-4950-849e-3f2e059a468f};{aa909189-e138-49c5-bca8-8e34db155572}"/>
-    </way>
     <way visible="true" id="38" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="200"/>
-        <nd ref="-6742"/>
+        <nd ref="-6740"/>
         <nd ref="201"/>
         <nd ref="202"/>
         <nd ref="203"/>
@@ -7189,7 +7217,7 @@
     </way>
     <way visible="true" id="40" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="61"/>
-        <nd ref="-6823"/>
+        <nd ref="-6820"/>
         <nd ref="220"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="0A11475C-00BF-4BA3-ADEA-53BE1C77951F"/>
@@ -7315,9 +7343,9 @@
         <tag k="uuid" v="{befd5aa7-889e-4bfc-a898-818bdc36a454}"/>
     </way>
     <way visible="true" id="44" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6890"/>
+        <nd ref="-6877"/>
         <nd ref="288"/>
-        <nd ref="-6891"/>
+        <nd ref="-6878"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="44925887-9BBC-417F-891A-4727FBB1828E"/>
         <tag k="REF1" v="000039"/>
@@ -7461,6 +7489,18 @@
         <tag k="source:datetime" v="2012-09-06T18:57:24.000Z"/>
         <tag k="uuid" v="{61207963-d1dc-4649-b20c-18cb0d322e7c}"/>
     </way>
+    <way visible="true" id="58" timestamp="2018-02-15T20:56:52Z" version="1" changeset="17283">
+        <nd ref="339"/>
+        <nd ref="124"/>
+        <tag k="REF1" v="000047"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="railway" v="rail"/>
+        <tag k="source" v="osm"/>
+        <tag k="source:datetime" v="2014-01-20T23:08:41.000Z"/>
+        <tag k="uuid" v="{5cfde9e9-4998-4e3d-bbec-a0c6cdb17dca}"/>
+    </way>
     <way visible="true" id="59" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="386"/>
         <nd ref="387"/>
@@ -7535,8 +7575,8 @@
         <tag k="uuid" v="{727c4652-d7fa-4c42-8d50-bcec78cbc976}"/>
     </way>
     <way visible="true" id="64" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6900"/>
-        <nd ref="-6901"/>
+        <nd ref="-6887"/>
+        <nd ref="-6888"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="79E6B0C4-769D-4C4B-A361-946C637A53EB"/>
         <tag k="REF1" v="00004d"/>
@@ -7676,7 +7716,7 @@
     </way>
     <way visible="true" id="74" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="468"/>
-        <nd ref="-7140"/>
+        <nd ref="-7127"/>
         <nd ref="519"/>
         <nd ref="520"/>
         <nd ref="521"/>
@@ -7716,7 +7756,7 @@
         <tag k="uuid" v="{421f44a6-7134-4ca1-8af0-81d7a2cf2a4a};{b390c590-3526-451d-a85a-6b71777610f5}"/>
     </way>
     <way visible="true" id="75" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6820"/>
+        <nd ref="-6817"/>
         <nd ref="533"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="B44E01E4-FEC5-4868-A33E-7F1F88F29077"/>
@@ -7941,8 +7981,8 @@
         <tag k="uuid" v="{4d320147-1ef7-4a84-9f30-5d257e8de0ce}"/>
     </way>
     <way visible="true" id="88" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-7143"/>
-        <nd ref="-7144"/>
+        <nd ref="-7130"/>
+        <nd ref="-7131"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="BAA15724-518D-4D8F-B8AF-E3DEAA25E884"/>
         <tag k="REF1" v="000065"/>
@@ -8182,7 +8222,7 @@
         <nd ref="800"/>
         <nd ref="801"/>
         <nd ref="802"/>
-        <nd ref="-6715"/>
+        <nd ref="-6712"/>
         <nd ref="803"/>
         <nd ref="804"/>
         <nd ref="805"/>
@@ -8289,18 +8329,6 @@
         <tag k="source:datetime" v="2013-09-15T15:05:25.000Z"/>
         <tag k="uuid" v="{c3027b55-96d8-4258-91eb-58d3c95486d0}"/>
     </way>
-    <way visible="true" id="117" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="153"/>
-        <nd ref="826"/>
-        <tag k="REF1" v="000082"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="railway" v="rail"/>
-        <tag k="source" v="osm"/>
-        <tag k="source:datetime" v="2013-09-15T15:31:46.000Z"/>
-        <tag k="uuid" v="{076ee02e-1d1b-4063-b045-a01b58cf07f1}"/>
-    </way>
     <way visible="true" id="118" timestamp="2018-02-15T20:56:52Z" version="1" changeset="17283">
         <nd ref="198"/>
         <nd ref="858"/>
@@ -8331,20 +8359,6 @@
         <tag k="source" v="osm"/>
         <tag k="source:datetime" v="2014-01-20T23:08:38.000Z"/>
         <tag k="uuid" v="{1aa311af-c909-4a60-8f55-a1715d70320c}"/>
-    </way>
-    <way visible="true" id="120" timestamp="2018-02-15T20:56:52Z" version="1" changeset="17283">
-        <nd ref="394"/>
-        <nd ref="283"/>
-        <tag k="REF1" v="000085"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="bridge" v="yes"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="layer" v="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="railway" v="rail"/>
-        <tag k="source" v="osm"/>
-        <tag k="source:datetime" v="2012-09-06T20:46:15.000Z"/>
-        <tag k="uuid" v="{b911fb54-f7aa-45ca-ad97-851c90344b7f}"/>
     </way>
     <way visible="true" id="122" timestamp="2018-02-15T20:56:52Z" version="1" changeset="17283">
         <nd ref="137"/>
@@ -8445,8 +8459,8 @@
         <tag k="uuid" v="{9b0143d4-a0b8-4359-a589-a690b657be77}"/>
     </way>
     <way visible="true" id="132" timestamp="2018-02-15T20:56:52Z" version="1">
-        <nd ref="-6747"/>
-        <nd ref="-6748"/>
+        <nd ref="-6745"/>
+        <nd ref="-6746"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="A02107AE-A566-4D5C-BF51-83F92CC9015A"/>
         <tag k="REF1" v="000091"/>
@@ -8506,7 +8520,7 @@
     <way visible="true" id="137" timestamp="2018-02-15T20:56:52Z" version="1">
         <nd ref="280"/>
         <nd ref="999"/>
-        <nd ref="-6709"/>
+        <nd ref="-6721"/>
         <nd ref="975"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="FD493389-9894-4C0F-A5AD-359382D74881"/>
@@ -8595,8 +8609,19 @@
         <tag k="uuid" v="{5d4d6d8d-906e-4c53-b48e-83c8c1a98989}"/>
     </way>
     <relation visible="true" id="-844" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-7655" role="reviewee"/>
-        <member type="way" ref="-7633" role="reviewee"/>
+        <member type="way" ref="-7651" role="reviewee"/>
+        <member type="way" ref="-7629" role="reviewee"/>
+        <tag k="hoot:review:members" v="2"/>
+        <tag k="hoot:review:needs" v="yes"/>
+        <tag k="hoot:review:note" v="Crossing railways"/>
+        <tag k="hoot:review:score" v="1"/>
+        <tag k="hoot:review:sort_order" v="0"/>
+        <tag k="hoot:review:type" v="crossing_railways"/>
+        <tag k="type" v="review"/>
+    </relation>
+    <relation visible="true" id="-843" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="way" ref="72" role="reviewee"/>
+        <member type="way" ref="-7730" role="reviewee"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:note" v="Crossing railways"/>
@@ -8605,36 +8630,14 @@
         <tag k="hoot:review:type" v="crossing_railways"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-843" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="78" role="reviewee"/>
-        <member type="way" ref="-7956" role="reviewee"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:note" v="Crossing railways"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:sort_order" v="3"/>
-        <tag k="hoot:review:type" v="crossing_railways"/>
-        <tag k="type" v="review"/>
-    </relation>
     <relation visible="true" id="-842" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="72" role="reviewee"/>
-        <member type="way" ref="-7734" role="reviewee"/>
+        <member type="way" ref="-7947" role="reviewee"/>
+        <member type="way" ref="78" role="reviewee"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:note" v="Crossing railways"/>
         <tag k="hoot:review:score" v="1"/>
         <tag k="hoot:review:sort_order" v="2"/>
-        <tag k="hoot:review:type" v="crossing_railways"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-841" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="-7546" role="reviewee"/>
-        <member type="way" ref="117" role="reviewee"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:note" v="Crossing railways"/>
-        <tag k="hoot:review:score" v="1"/>
-        <tag k="hoot:review:sort_order" v="0"/>
         <tag k="hoot:review:type" v="crossing_railways"/>
         <tag k="type" v="review"/>
     </relation>

--- a/test-files/cmd/slow/serial/RailwayDiffConflateTest/output-partial.osm
+++ b/test-files/cmd/slow/serial/RailwayDiffConflateTest/output-partial.osm
@@ -1,37 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="39.569728" minlon="125.780683" maxlat="39.75273500000001" maxlon="126.079206"/>
-    <node visible="true" id="-4211" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6002022233422366" lon="125.8642861978360372"/>
-    <node visible="true" id="-4206" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6220347585461639" lon="125.8941776411788425"/>
-    <node visible="true" id="-4205" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6219849945947260" lon="125.8941130594038640"/>
-    <node visible="true" id="-4204" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6101069574638487" lon="125.8751599429818953"/>
-    <node visible="true" id="-4200" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7239372873752927" lon="125.8972495899472648"/>
-    <node visible="true" id="-4193" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6025854473928192" lon="125.9879182838872964"/>
-    <node visible="true" id="-4175" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6715943259999975" lon="125.7912185310000126"/>
-    <node visible="true" id="-4168" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6668074649999980" lon="125.7826792830000073"/>
-    <node visible="true" id="-4151" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6146811685940463" lon="125.9645338243991688"/>
-    <node visible="true" id="-4144" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6062186523853939" lon="125.8681657191718699"/>
-    <node visible="true" id="-4142" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7069006624283816" lon="125.8848913856198521"/>
-    <node visible="true" id="-4141" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7115006846315737" lon="125.8847665650248189"/>
-    <node visible="true" id="-4129" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6753215044886716" lon="125.9107856106588770"/>
-    <node visible="true" id="-4127" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6519750045330639" lon="125.9070334940444127"/>
-    <node visible="true" id="-4122" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6517054981941683" lon="125.9067318594896108"/>
-    <node visible="true" id="-4105" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7156892551352811" lon="125.8888748229620234"/>
-    <node visible="true" id="-4100" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5840263581996652" lon="125.8639738151986052"/>
-    <node visible="true" id="-4099" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5892002922154589" lon="125.8687295313154237"/>
-    <node visible="true" id="-4098" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5835673982505156" lon="125.8638177106951019"/>
-    <node visible="true" id="-4093" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5760188147746277" lon="125.8601184929684393"/>
-    <node visible="true" id="-4091" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7300808034633803" lon="126.0787565628532008"/>
-    <node visible="true" id="-4086" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6992609188214445" lon="125.8888476350337982"/>
-    <node visible="true" id="-4078" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7070738247108252" lon="125.8847576372468922"/>
-    <node visible="true" id="-4063" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6999423734368548" lon="125.8883673580242117"/>
-    <node visible="true" id="-4058" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6350962604673995" lon="125.9030895613158236"/>
-    <node visible="true" id="-4057" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6350722610326756" lon="125.9030078320884627"/>
-    <node visible="true" id="-4055" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6317800714951005" lon="125.8982282009924205"/>
-    <node visible="true" id="-4050" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7097185550000020" lon="126.0621820330000133"/>
-    <node visible="true" id="-4046" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6943288591571957" lon="126.0145299608137606"/>
-    <node visible="true" id="-4045" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6936160373209717" lon="126.0131855605725093"/>
-    <node visible="true" id="-4044" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6924363784685568" lon="126.0110057352741251"/>
+    <node visible="true" id="-4209" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6002022233422366" lon="125.8642861978360372"/>
+    <node visible="true" id="-4204" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6220347585461639" lon="125.8941776411788425"/>
+    <node visible="true" id="-4203" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6219849945947260" lon="125.8941130594038640"/>
+    <node visible="true" id="-4202" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6101069574638487" lon="125.8751599429818953"/>
+    <node visible="true" id="-4198" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7239372873752927" lon="125.8972495899472648"/>
+    <node visible="true" id="-4191" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6025854473928192" lon="125.9879182838872964"/>
+    <node visible="true" id="-4173" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6715943259999975" lon="125.7912185310000126"/>
+    <node visible="true" id="-4166" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6668074649999980" lon="125.7826792830000073"/>
+    <node visible="true" id="-4149" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6146811685940463" lon="125.9645338243991688"/>
+    <node visible="true" id="-4142" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6062186523853939" lon="125.8681657191718699"/>
+    <node visible="true" id="-4140" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7069006624283816" lon="125.8848913856198521"/>
+    <node visible="true" id="-4139" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7115006846315737" lon="125.8847665650248189"/>
+    <node visible="true" id="-4128" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6519750045330639" lon="125.9070334940444127"/>
+    <node visible="true" id="-4123" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6517054981941683" lon="125.9067318594896108"/>
+    <node visible="true" id="-4106" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7156892551352811" lon="125.8888748229620234"/>
+    <node visible="true" id="-4100" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5760188147746277" lon="125.8601184929684393"/>
+    <node visible="true" id="-4097" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5804427968956816" lon="125.8627060952961614"/>
+    <node visible="true" id="-4096" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5840263581996652" lon="125.8639738151986052"/>
+    <node visible="true" id="-4095" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5892002922154589" lon="125.8687295313154237"/>
+    <node visible="true" id="-4094" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.5835673982505156" lon="125.8638177106951019"/>
+    <node visible="true" id="-4092" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7300808034633803" lon="126.0787565628532008"/>
+    <node visible="true" id="-4087" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6992609188214445" lon="125.8888476350337982"/>
+    <node visible="true" id="-4079" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7070738247108252" lon="125.8847576372468922"/>
+    <node visible="true" id="-4064" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6999423734368548" lon="125.8883673580242117"/>
+    <node visible="true" id="-4059" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6350962604673995" lon="125.9030895613158236"/>
+    <node visible="true" id="-4058" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6350722610326756" lon="125.9030078320884627"/>
+    <node visible="true" id="-4056" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.6317800714951005" lon="125.8982282009924205"/>
+    <node visible="true" id="-4049" timestamp="1970-01-01T00:00:00Z" version="1" lat="39.7097185550000020" lon="126.0621820330000133"/>
     <node visible="true" id="-2092" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.7505546020000011" lon="125.9132189900000185"/>
     <node visible="true" id="-2091" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.7510661150000075" lon="125.9134548340000066"/>
     <node visible="true" id="-2090" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.7517626699999980" lon="125.9137486890000162"/>
@@ -221,21 +218,6 @@
     <node visible="true" id="-1240" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5750423049999966" lon="125.8598139159999789"/>
     <node visible="true" id="-1239" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5753733830000058" lon="125.8598854300000056"/>
     <node visible="true" id="-1238" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5758160549999971" lon="125.8600236720000112"/>
-    <node visible="true" id="-1159" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6798588340000009" lon="125.9087805700000189"/>
-    <node visible="true" id="-1158" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6796376799999990" lon="125.9089130859999983"/>
-    <node visible="true" id="-1157" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6793452770000030" lon="125.9090615820000210"/>
-    <node visible="true" id="-1156" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6789859159999949" lon="125.9092510960000055"/>
-    <node visible="true" id="-1155" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6786043139999975" lon="125.9094514709999970"/>
-    <node visible="true" id="-1154" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6782366990000099" lon="125.9096336390000062"/>
-    <node visible="true" id="-1153" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6779272679999977" lon="125.9097992049999988"/>
-    <node visible="true" id="-1152" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6776152300000007" lon="125.9099616679999940"/>
-    <node visible="true" id="-1151" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6773136519999952" lon="125.9101216459999932"/>
-    <node visible="true" id="-1150" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6769796150000005" lon="125.9102865389999977"/>
-    <node visible="true" id="-1149" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6766537150000076" lon="125.9104225199999973"/>
-    <node visible="true" id="-1148" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6763651190000033" lon="125.9105319650000041"/>
-    <node visible="true" id="-1147" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6760944769999995" lon="125.9106055140000109"/>
-    <node visible="true" id="-1146" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6757787539999995" lon="125.9106813909999829"/>
-    <node visible="true" id="-1145" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6755162050000010" lon="125.9107409239999953"/>
     <node visible="true" id="-1141" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6817392299999980" lon="125.8403200740000045"/>
     <node visible="true" id="-1140" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6817303870000018" lon="125.8402982970000039"/>
     <node visible="true" id="-1139" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6817155040000031" lon="125.8402616459999876"/>
@@ -323,30 +305,15 @@
     <node visible="true" id="-252" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.7113348889999926" lon="125.8846627770000168"/>
     <node visible="true" id="-251" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.7112885640000002" lon="125.8846360269999991"/>
     <node visible="true" id="-250" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.7111990060000011" lon="125.8845843120000154"/>
+    <node visible="true" id="-249" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5828855700000091" lon="125.8636050490000002"/>
+    <node visible="true" id="-248" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5823673570000025" lon="125.8634375529999971"/>
+    <node visible="true" id="-247" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5818343259999992" lon="125.8632409650000028"/>
+    <node visible="true" id="-246" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5812207809999990" lon="125.8630137189999942"/>
+    <node visible="true" id="-245" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5807077710000073" lon="125.8628162300000071"/>
     <node visible="true" id="-231" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5833401189999989" lon="125.8637469359999983"/>
     <node visible="true" id="-230" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5833158630000028" lon="125.8637377639999926"/>
     <node visible="true" id="-229" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.5832858950000102" lon="125.8637276539999874"/>
     <node visible="true" id="-228" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.7237282069999935" lon="125.8970103590000065"/>
-    <node visible="true" id="-210" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6927077250000053" lon="126.0115137829999981"/>
-    <node visible="true" id="-209" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6930153930000031" lon="126.0120774180000183"/>
-    <node visible="true" id="-208" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6932974200000004" lon="126.0125991209999938"/>
-    <node visible="true" id="-204" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6944373520000084" lon="126.0147378340000159"/>
-    <node visible="true" id="-203" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6947572870000087" lon="126.0153362640000125"/>
-    <node visible="true" id="-202" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6950191500000074" lon="126.0158288689999893"/>
-    <node visible="true" id="-201" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6952435509999901" lon="126.0162276389999931"/>
-    <node visible="true" id="-200" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6955341250000018" lon="126.0167633180000024"/>
-    <node visible="true" id="-199" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6958016840000099" lon="126.0172753180000171"/>
-    <node visible="true" id="-198" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6959923300000099" lon="126.0176312950000010"/>
-    <node visible="true" id="-197" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6962971450000026" lon="126.0182003460000004"/>
-    <node visible="true" id="-196" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6964723829999997" lon="126.0185235819999860"/>
-    <node visible="true" id="-195" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6966105119999995" lon="126.0187833709999978"/>
-    <node visible="true" id="-194" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6968861780000069" lon="126.0192962320000021"/>
-    <node visible="true" id="-193" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6971765349999970" lon="126.0198253540000053"/>
-    <node visible="true" id="-192" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6976058240000071" lon="126.0206134730000116"/>
-    <node visible="true" id="-191" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6979719980000070" lon="126.0212960489999858"/>
-    <node visible="true" id="-190" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6984061019999999" lon="126.0221075510000190"/>
-    <node visible="true" id="-189" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6986379800000009" lon="126.0225377400000184"/>
-    <node visible="true" id="-111" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6987830139999929" lon="126.0228092380000078"/>
     <node visible="true" id="-108" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6883166819999929" lon="126.0073696410000110"/>
     <node visible="true" id="-107" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6884632270000068" lon="126.0074137769999965"/>
     <node visible="true" id="-106" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.6885319960000089" lon="126.0074526759999998"/>
@@ -361,7 +328,7 @@
     <node visible="true" id="-1" timestamp="2018-02-16T13:57:43Z" version="1" lat="39.7527350000000084" lon="125.9141793350100045"/>
     <way visible="true" id="-4525" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="-1049"/>
-        <nd ref="-4211"/>
+        <nd ref="-4209"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="06CDEA93-8387-4E74-8BA3-D516CDFF35ED"/>
         <tag k="SHAPE_Leng" v="0.0074347424660099999"/>
@@ -389,9 +356,9 @@
         <tag k="uuid" v="{8bea8c4a-389e-4858-8aa1-80c944fece58}"/>
     </way>
     <way visible="true" id="-4515" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4206"/>
+        <nd ref="-4204"/>
         <nd ref="-1641"/>
-        <nd ref="-4205"/>
+        <nd ref="-4203"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="E321083D-F887-4B88-A6B3-D426D856EFA4"/>
         <tag k="SHAPE_Leng" v="0.0331224642794"/>
@@ -419,7 +386,7 @@
         <tag k="uuid" v="{92cb72af-9207-4072-830d-6bfbbbc2ce28}"/>
     </way>
     <way visible="true" id="-4507" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4204"/>
+        <nd ref="-4202"/>
         <nd ref="-1586"/>
         <nd ref="-1585"/>
         <nd ref="-1584"/>
@@ -464,7 +431,7 @@
         <tag k="uuid" v="{92cb72af-9207-4072-830d-6bfbbbc2ce28}"/>
     </way>
     <way visible="true" id="-4491" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4200"/>
+        <nd ref="-4198"/>
         <nd ref="-338"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="0A463DAA-BD74-4BD5-8652-362B7F51A59E"/>
@@ -494,7 +461,7 @@
     </way>
     <way visible="true" id="-4481" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="-2070"/>
-        <nd ref="-4193"/>
+        <nd ref="-4191"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="21B95A9E-52CF-409B-883B-35A9D1660021"/>
         <tag k="SHAPE_Leng" v="0.0024139442267300001"/>
@@ -519,7 +486,7 @@
         <tag k="uuid" v="{7496465e-e9d7-4184-a426-c9b738781922}"/>
     </way>
     <way visible="true" id="-4448" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4175"/>
+        <nd ref="-4173"/>
         <nd ref="-1369"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="CE45E966-F7D0-4A7A-BD04-52839A146E25"/>
@@ -548,7 +515,7 @@
         <tag k="uuid" v="{8f3a4881-f4a9-46f6-9256-0dc8c8b74c2e}"/>
     </way>
     <way visible="true" id="-4442" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4168"/>
+        <nd ref="-4166"/>
         <nd ref="-680"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="B75A63E4-ED0D-4FA9-B63B-8FDCF8C3522F"/>
@@ -577,7 +544,7 @@
         <tag k="uuid" v="{87126459-e815-4abf-a2c6-f1b5025a33c0}"/>
     </way>
     <way visible="true" id="-4428" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4151"/>
+        <nd ref="-4149"/>
         <nd ref="-712"/>
         <nd ref="-711"/>
         <nd ref="-710"/>
@@ -606,7 +573,7 @@
     </way>
     <way visible="true" id="-4418" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="-1568"/>
-        <nd ref="-4144"/>
+        <nd ref="-4142"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="E88AC4FD-9ECB-46E1-8422-D0CD37FF7CE9"/>
         <tag k="SHAPE_Leng" v="0.0066840824949699999"/>
@@ -657,7 +624,7 @@
         <nd ref="-267"/>
         <nd ref="-266"/>
         <nd ref="-265"/>
-        <nd ref="-4142"/>
+        <nd ref="-4140"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="874803D2-9CB4-4461-9A4A-D3A85DA354F8"/>
         <tag k="SHAPE_Leng" v="0.0155755425742"/>
@@ -685,7 +652,7 @@
         <tag k="uuid" v="{cb84b01d-3161-44be-8ee6-db1604553333}"/>
     </way>
     <way visible="true" id="-4409" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4141"/>
+        <nd ref="-4139"/>
         <nd ref="-252"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="71193742-965D-4F34-9FBA-20F883D11FF2"/>
@@ -714,55 +681,12 @@
         <tag k="uuid" v="{9a240920-fd44-43bd-9403-edb08c6b18a5}"/>
     </way>
     <way visible="true" id="-4389" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-1159"/>
-        <nd ref="-1158"/>
-        <nd ref="-1157"/>
-        <nd ref="-1156"/>
-        <nd ref="-1155"/>
-        <nd ref="-1154"/>
-        <nd ref="-1153"/>
-        <nd ref="-1152"/>
-        <nd ref="-1151"/>
-        <nd ref="-1150"/>
-        <nd ref="-1149"/>
-        <nd ref="-1148"/>
-        <nd ref="-1147"/>
-        <nd ref="-1146"/>
-        <nd ref="-1145"/>
-        <nd ref="-4129"/>
-        <tag k="FCSubtype" v="0"/>
-        <tag k="GFID" v="2C0AA698-F5A4-4C52-A502-63B9672C5CE9"/>
-        <tag k="SHAPE_Leng" v="0.0050289045246600002"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="condition" v="functional"/>
-        <tag k="electrified" v="contact_line"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="gauge" v="144"/>
-        <tag k="gauge:type" v="standard"/>
-        <tag k="gndb_id" v="6183466"/>
-        <tag k="gndb_id:2" v="6171468"/>
-        <tag k="lanes" v="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="location" v="surface"/>
-        <tag k="name" v="Manp'o-son"/>
-        <tag k="note" v="Single"/>
-        <tag k="railway" v="rail"/>
-        <tag k="railway:in_road" v="separated"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source" v="mgcp:railrdl_rail;osm"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2018-02-16T13:57:43Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.884Z"/>
-        <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{5fb8b74b-703e-4e3a-abc2-576225a869c8}"/>
-    </way>
-    <way visible="true" id="-4386" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4127"/>
+        <nd ref="-4128"/>
         <nd ref="-405"/>
         <nd ref="-404"/>
         <nd ref="-403"/>
         <nd ref="-402"/>
-        <nd ref="-4122"/>
+        <nd ref="-4123"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="CF55958D-3815-42C9-B9C4-D5AC9E191181"/>
         <tag k="SHAPE_Leng" v="0.0060340641372099999"/>
@@ -789,8 +713,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{940cac72-480e-472b-82fe-964e9bcf5b40}"/>
     </way>
-    <way visible="true" id="-4343" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4105"/>
+    <way visible="true" id="-4346" timestamp="2018-02-16T13:57:43Z" version="1">
+        <nd ref="-4106"/>
         <nd ref="-312"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="5DF182A2-EF20-4760-A3E8-0A8B2C173301"/>
@@ -819,65 +743,6 @@
         <tag k="uuid" v="{f178421d-fd17-4a0b-9043-066a392886cf}"/>
     </way>
     <way visible="true" id="-4332" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4100"/>
-        <nd ref="-1942"/>
-        <nd ref="-4098"/>
-        <tag k="FCSubtype" v="0"/>
-        <tag k="GFID" v="7E3486F2-DFB6-4DB4-B7EF-C382DEF1D95E"/>
-        <tag k="SHAPE_Leng" v="0.00799775686823"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="condition" v="functional"/>
-        <tag k="electrified" v="contact_line"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="gauge" v="144"/>
-        <tag k="gauge:type" v="standard"/>
-        <tag k="gndb_id" v="6183466"/>
-        <tag k="gndb_id:2" v="6171468"/>
-        <tag k="lanes" v="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="location" v="surface"/>
-        <tag k="name" v="Manp'o-son"/>
-        <tag k="note" v="Single"/>
-        <tag k="railway" v="rail"/>
-        <tag k="railway:in_road" v="separated"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source" v="mgcp:railrdl_rail;osm"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2018-02-16T13:57:43Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.862Z"/>
-        <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{aa909189-e138-49c5-bca8-8e34db155572}"/>
-    </way>
-    <way visible="true" id="-4329" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-1963"/>
-        <nd ref="-4099"/>
-        <tag k="FCSubtype" v="0"/>
-        <tag k="GFID" v="7E3486F2-DFB6-4DB4-B7EF-C382DEF1D95E"/>
-        <tag k="SHAPE_Leng" v="0.00799775686823"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="condition" v="functional"/>
-        <tag k="electrified" v="contact_line"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="gauge" v="144"/>
-        <tag k="gauge:type" v="standard"/>
-        <tag k="gndb_id" v="6183466"/>
-        <tag k="gndb_id:2" v="6171468"/>
-        <tag k="lanes" v="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="location" v="surface"/>
-        <tag k="name" v="Manp'o-son"/>
-        <tag k="note" v="Single"/>
-        <tag k="railway" v="rail"/>
-        <tag k="railway:in_road" v="separated"/>
-        <tag k="security:classification" v="UNCLASSIFIED"/>
-        <tag k="source" v="mgcp:railrdl_rail;osm"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2018-02-16T13:57:43Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.862Z"/>
-        <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{aa909189-e138-49c5-bca8-8e34db155572}"/>
-    </way>
-    <way visible="true" id="-4316" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="-4"/>
         <nd ref="-1251"/>
         <nd ref="-1250"/>
@@ -893,7 +758,7 @@
         <nd ref="-1240"/>
         <nd ref="-1239"/>
         <nd ref="-1238"/>
-        <nd ref="-4093"/>
+        <nd ref="-4100"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="D339C2B4-E595-4354-97BF-3B9A181DCBBA"/>
         <tag k="SHAPE_Leng" v="0.0153244490001"/>
@@ -920,8 +785,101 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{a26f95b0-df1a-4003-85c8-6b17d3cfed2b}"/>
     </way>
-    <way visible="true" id="-4312" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4091"/>
+    <way visible="true" id="-4327" timestamp="2018-02-16T13:57:43Z" version="1">
+        <nd ref="-229"/>
+        <nd ref="-249"/>
+        <nd ref="-248"/>
+        <nd ref="-247"/>
+        <nd ref="-246"/>
+        <nd ref="-245"/>
+        <nd ref="-4097"/>
+        <tag k="FCSubtype" v="0"/>
+        <tag k="GFID" v="37F03C01-6C64-49CC-BE79-D603D0BC0821"/>
+        <tag k="SHAPE_Leng" v="0.0071384093354699999"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="condition" v="functional"/>
+        <tag k="electrified" v="contact_line"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="gauge" v="144"/>
+        <tag k="gauge:type" v="standard"/>
+        <tag k="gndb_id" v="6183466"/>
+        <tag k="gndb_id:2" v="6171468"/>
+        <tag k="lanes" v="1"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="location" v="surface"/>
+        <tag k="name" v="Manp'o-son"/>
+        <tag k="note" v="Single"/>
+        <tag k="railway" v="rail"/>
+        <tag k="railway:in_road" v="separated"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source" v="mgcp:railrdl_rail;osm"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="source:datetime" v="2018-02-16T13:57:43Z"/>
+        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.903Z"/>
+        <tag k="usage" v="high_speed_rail"/>
+        <tag k="uuid" v="{256fdcaf-8ea5-45b2-b654-8dbfcd079d8f}"/>
+    </way>
+    <way visible="true" id="-4325" timestamp="2018-02-16T13:57:43Z" version="1">
+        <nd ref="-4096"/>
+        <nd ref="-1942"/>
+        <nd ref="-4094"/>
+        <tag k="FCSubtype" v="0"/>
+        <tag k="GFID" v="7E3486F2-DFB6-4DB4-B7EF-C382DEF1D95E"/>
+        <tag k="SHAPE_Leng" v="0.00799775686823"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="condition" v="functional"/>
+        <tag k="electrified" v="contact_line"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="gauge" v="144"/>
+        <tag k="gauge:type" v="standard"/>
+        <tag k="gndb_id" v="6183466"/>
+        <tag k="gndb_id:2" v="6171468"/>
+        <tag k="lanes" v="1"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="location" v="surface"/>
+        <tag k="name" v="Manp'o-son"/>
+        <tag k="note" v="Single"/>
+        <tag k="railway" v="rail"/>
+        <tag k="railway:in_road" v="separated"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source" v="mgcp:railrdl_rail;osm"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="source:datetime" v="2018-02-16T13:57:43Z"/>
+        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.862Z"/>
+        <tag k="usage" v="high_speed_rail"/>
+        <tag k="uuid" v="{aa909189-e138-49c5-bca8-8e34db155572}"/>
+    </way>
+    <way visible="true" id="-4322" timestamp="2018-02-16T13:57:43Z" version="1">
+        <nd ref="-1963"/>
+        <nd ref="-4095"/>
+        <tag k="FCSubtype" v="0"/>
+        <tag k="GFID" v="7E3486F2-DFB6-4DB4-B7EF-C382DEF1D95E"/>
+        <tag k="SHAPE_Leng" v="0.00799775686823"/>
+        <tag k="attribution" v="osm"/>
+        <tag k="condition" v="functional"/>
+        <tag k="electrified" v="contact_line"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="gauge" v="144"/>
+        <tag k="gauge:type" v="standard"/>
+        <tag k="gndb_id" v="6183466"/>
+        <tag k="gndb_id:2" v="6171468"/>
+        <tag k="lanes" v="1"/>
+        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
+        <tag k="location" v="surface"/>
+        <tag k="name" v="Manp'o-son"/>
+        <tag k="note" v="Single"/>
+        <tag k="railway" v="rail"/>
+        <tag k="railway:in_road" v="separated"/>
+        <tag k="security:classification" v="UNCLASSIFIED"/>
+        <tag k="source" v="mgcp:railrdl_rail;osm"/>
+        <tag k="source:accuracy:horizontal:category" v="accurate"/>
+        <tag k="source:datetime" v="2018-02-16T13:57:43Z"/>
+        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.862Z"/>
+        <tag k="usage" v="high_speed_rail"/>
+        <tag k="uuid" v="{aa909189-e138-49c5-bca8-8e34db155572}"/>
+    </way>
+    <way visible="true" id="-4314" timestamp="2018-02-16T13:57:43Z" version="1">
+        <nd ref="-4092"/>
         <nd ref="-51"/>
         <nd ref="-6"/>
         <tag k="FCSubtype" v="0"/>
@@ -946,8 +904,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{d7d4ba79-5452-4ceb-9869-336b33a55595}"/>
     </way>
-    <way visible="true" id="-4304" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4086"/>
+    <way visible="true" id="-4306" timestamp="2018-02-16T13:57:43Z" version="1">
+        <nd ref="-4087"/>
         <nd ref="-1792"/>
         <nd ref="-1791"/>
         <nd ref="-287"/>
@@ -973,8 +931,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{015c9439-e28a-439f-acfc-c1d26fdf26f9}"/>
     </way>
-    <way visible="true" id="-4288" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4063"/>
+    <way visible="true" id="-4290" timestamp="2018-02-16T13:57:43Z" version="1">
+        <nd ref="-4064"/>
         <nd ref="-1930"/>
         <nd ref="-1929"/>
         <nd ref="-1928"/>
@@ -998,7 +956,7 @@
         <nd ref="-1910"/>
         <nd ref="-1909"/>
         <nd ref="-1908"/>
-        <nd ref="-4078"/>
+        <nd ref="-4079"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="45FA327E-47D7-4C7B-BFB2-BD377EF95E9F"/>
         <tag k="SHAPE_Leng" v="0.029715494970199999"/>
@@ -1022,10 +980,10 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{0cf4ea9f-d066-4a91-a5f0-8fffac7776b2}"/>
     </way>
-    <way visible="true" id="-4253" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4058"/>
+    <way visible="true" id="-4255" timestamp="2018-02-16T13:57:43Z" version="1">
+        <nd ref="-4059"/>
         <nd ref="-1693"/>
-        <nd ref="-4057"/>
+        <nd ref="-4058"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="CE15A63D-8BB5-42E7-BB13-462DBB77FB44"/>
         <tag k="SHAPE_Leng" v="0.022989659365000002"/>
@@ -1052,8 +1010,8 @@
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{93f3e200-8a80-48c6-8295-52655354fea7}"/>
     </way>
-    <way visible="true" id="-4240" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4055"/>
+    <way visible="true" id="-4242" timestamp="2018-02-16T13:57:43Z" version="1">
+        <nd ref="-4056"/>
         <nd ref="-1677"/>
         <nd ref="-1676"/>
         <nd ref="-1675"/>
@@ -1094,7 +1052,7 @@
         <tag k="uuid" v="{93f3e200-8a80-48c6-8295-52655354fea7}"/>
     </way>
     <way visible="true" id="-4229" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4050"/>
+        <nd ref="-4049"/>
         <nd ref="-22"/>
         <tag k="FCSubtype" v="0"/>
         <tag k="GFID" v="865454EB-A4C8-47D1-B727-2A75C8FDFBAB"/>
@@ -1117,75 +1075,6 @@
         <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.960Z"/>
         <tag k="usage" v="high_speed_rail"/>
         <tag k="uuid" v="{5f08faf6-1221-46e6-a257-d834e0a8986f}"/>
-    </way>
-    <way visible="true" id="-4222" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4046"/>
-        <nd ref="-204"/>
-        <nd ref="-203"/>
-        <nd ref="-202"/>
-        <nd ref="-201"/>
-        <nd ref="-200"/>
-        <nd ref="-199"/>
-        <nd ref="-198"/>
-        <nd ref="-197"/>
-        <nd ref="-196"/>
-        <nd ref="-195"/>
-        <nd ref="-194"/>
-        <nd ref="-193"/>
-        <nd ref="-192"/>
-        <nd ref="-191"/>
-        <nd ref="-190"/>
-        <nd ref="-189"/>
-        <nd ref="-111"/>
-        <tag k="FCSubtype" v="0"/>
-        <tag k="GFID" v="F77EA7D0-7840-4273-B57B-C52AB69B7E85"/>
-        <tag k="SHAPE_Leng" v="0.018886577265199999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="condition" v="functional"/>
-        <tag k="electrified" v="contact_line"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="gauge" v="144"/>
-        <tag k="gauge:type" v="standard"/>
-        <tag k="lanes" v="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="location" v="surface"/>
-        <tag k="note" v="Single"/>
-        <tag k="railway" v="rail"/>
-        <tag k="railway:in_road" v="separated"/>
-        <tag k="source" v="mgcp:railrdl_rail;osm"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2018-02-16T13:57:43Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.960Z"/>
-        <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{2154ca17-2a83-4a8a-b425-07cff4f5c4b2}"/>
-    </way>
-    <way visible="true" id="-4219" timestamp="2018-02-16T13:57:43Z" version="1">
-        <nd ref="-4044"/>
-        <nd ref="-210"/>
-        <nd ref="-209"/>
-        <nd ref="-208"/>
-        <nd ref="-4045"/>
-        <tag k="FCSubtype" v="0"/>
-        <tag k="GFID" v="F77EA7D0-7840-4273-B57B-C52AB69B7E85"/>
-        <tag k="SHAPE_Leng" v="0.018886577265199999"/>
-        <tag k="attribution" v="osm"/>
-        <tag k="condition" v="functional"/>
-        <tag k="electrified" v="contact_line"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="gauge" v="144"/>
-        <tag k="gauge:type" v="standard"/>
-        <tag k="lanes" v="1"/>
-        <tag k="license" v="This data is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/."/>
-        <tag k="location" v="surface"/>
-        <tag k="note" v="Single"/>
-        <tag k="railway" v="rail"/>
-        <tag k="railway:in_road" v="separated"/>
-        <tag k="source" v="mgcp:railrdl_rail;osm"/>
-        <tag k="source:accuracy:horizontal:category" v="accurate"/>
-        <tag k="source:datetime" v="2018-02-16T13:57:43Z"/>
-        <tag k="source:ingest:datetime" v="2018-02-13T20:09:15.960Z"/>
-        <tag k="usage" v="high_speed_rail"/>
-        <tag k="uuid" v="{2154ca17-2a83-4a8a-b425-07cff4f5c4b2}"/>
     </way>
     <way visible="true" id="-132" timestamp="2018-02-16T13:57:43Z" version="1">
         <nd ref="-5"/>


### PR DESCRIPTION
Updated Railway and River conflation scripts to use the weighted distance extractor just like Powerlines.

In the unit tests there was no change in the river tests but railway tests removed some "extra" lines that didn't conflate right.