### PR TITLE
Re-enable RelationToMultiPolygonConverter::_classifyRings() function and test if it is needed

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/geometry/RelationToMultiPolygonConverterTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/geometry/RelationToMultiPolygonConverterTest.cpp
@@ -145,6 +145,7 @@ public:
     OsmMapPtr map = std::make_shared<OsmMap>();
     RelationPtr uut =
       std::make_shared<Relation>(Status::Unknown1, 1, 10, MetadataTags::RelationMultiPolygon());
+    RelationPtr r = std::make_shared<Relation>(Status::Unknown1, 2, 10, MetadataTags::RelationMultiPolygon());
     WayPtr w;
     w = std::make_shared<Way>(Status::Unknown1, map->createNextWayId(), 10);
     map->addWay(w);
@@ -155,6 +156,7 @@ public:
     addPoint(map, w, 14, 4);
     closeWay(w);
     uut->addElement(MetadataTags::RoleOuter(), w);
+    r->addElement("", w);
 
     w = std::make_shared<Way>(Status::Unknown1, map->createNextWayId(), 10);
     map->addWay(w);
@@ -164,6 +166,7 @@ public:
     addPoint(map, w, 12, 7);
     closeWay(w);
     uut->addElement(MetadataTags::RoleInner(), w);
+    r->addElement("", w);
 
     w = std::make_shared<Way>(Status::Unknown1, map->createNextWayId(), 10);
     map->addWay(w);
@@ -173,8 +176,15 @@ public:
     addPoint(map, w, 10, 7);
     closeWay(w);
     uut->addElement(MetadataTags::RoleOuter(), w);
+    r->addElement("", w);
 
     std::shared_ptr<Geometry> g = RelationToMultiPolygonConverter(map, uut).createMultipolygon();
+
+    CPPUNIT_ASSERT_EQUAL(string("MULTIPOLYGON (((9.0000000000000000 1.0000000000000000, 2.0000000000000000 6.0000000000000000, 6.0000000000000000 12.0000000000000000, 13.0000000000000000 11.0000000000000000, 14.0000000000000000 4.0000000000000000, 9.0000000000000000 1.0000000000000000), (10.0000000000000000 2.0000000000000000, 5.0000000000000000 6.0000000000000000, 8.0000000000000000 11.0000000000000000, 12.0000000000000000 7.0000000000000000, 10.0000000000000000 2.0000000000000000)), ((9.0000000000000000 5.0000000000000000, 7.0000000000000000 6.0000000000000000, 8.0000000000000000 7.0000000000000000, 10.0000000000000000 7.0000000000000000, 9.0000000000000000 5.0000000000000000)))"),
+                         g->toString());
+
+    //  Run the same test but without roles and make RelationToMultiPolygonConverter::createMultipolygon() decide
+    g = RelationToMultiPolygonConverter(map,  r).createMultipolygon();
 
     CPPUNIT_ASSERT_EQUAL(string("MULTIPOLYGON (((9.0000000000000000 1.0000000000000000, 2.0000000000000000 6.0000000000000000, 6.0000000000000000 12.0000000000000000, 13.0000000000000000 11.0000000000000000, 14.0000000000000000 4.0000000000000000, 9.0000000000000000 1.0000000000000000), (10.0000000000000000 2.0000000000000000, 5.0000000000000000 6.0000000000000000, 8.0000000000000000 11.0000000000000000, 12.0000000000000000 7.0000000000000000, 10.0000000000000000 2.0000000000000000)), ((9.0000000000000000 5.0000000000000000, 7.0000000000000000 6.0000000000000000, 8.0000000000000000 7.0000000000000000, 10.0000000000000000 7.0000000000000000, 9.0000000000000000 5.0000000000000000)))"),
                          g->toString());

--- a/hoot-core/src/main/cpp/hoot/core/Hoot.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/Hoot.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #include "Hoot.h"
 
@@ -35,6 +35,7 @@
 #include <geos/version.h>
 
 // hoot
+#include <hoot/core/proto/FileFormat.pb.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/ConfPath.h>
 #include <hoot/core/util/Factory.h>
@@ -62,6 +63,12 @@ namespace hoot
 Hoot::Hoot()
 {
   _init();
+}
+
+Hoot::~Hoot()
+{
+  // Shutdown the protobuf library
+  ::google::protobuf::ShutdownProtobufLibrary();
 }
 
 Hoot& Hoot::getInstance()
@@ -139,9 +146,7 @@ void Hoot::loadLibrary(const QString& name) const
       LOG_WARN(lib.errorString());  // no biggie.
     }
     else
-    {
       throw HootException("Error loading libary: " + lib.errorString());
-    }
   }
 }
 
@@ -187,9 +192,7 @@ long Hoot::_toBytes(const QString& str) const
   long result = s.toLong(&ok) * multiplier;
 
   if (!ok)
-  {
     throw HootException("Unable to parse max memory usage: " + s);
-  }
 
   return result;
 }

--- a/hoot-core/src/main/cpp/hoot/core/Hoot.h
+++ b/hoot-core/src/main/cpp/hoot/core/Hoot.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef HOOT_H
 #define HOOT_H
@@ -62,7 +62,7 @@ private:
   //  Constructor
   Hoot();
   /** Default destructor */
-  ~Hoot() = default;
+  ~Hoot();
   /** Delete copy constructor and assignment operator */
   Hoot(const Hoot&) = delete;
   Hoot& operator=(const Hoot&) = delete;

--- a/hoot-core/src/main/cpp/hoot/core/geometry/RelationToMultiPolygonConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/RelationToMultiPolygonConverter.h
@@ -66,6 +66,13 @@ class RelationToMultiPolygonConverter
 {
 public:
 
+  enum class MultiPolygonRelationRole
+  {
+    NoRole = -1,
+    Inner,
+    Outer
+  };
+
   static QString className() { return "RelationToMultiPolygonConverter"; }
 
   static int logWarnCount;
@@ -113,8 +120,8 @@ private:
    * Given two Linear Rings, determine the realtionship between the two.
    * Inner, Outer or "" for neither
    */
-  QString _findRelationship(const geos::geom::LinearRing* ring1,
-                            const geos::geom::LinearRing* ring2) const;
+  MultiPolygonRelationRole _findRelationship(const geos::geom::LinearRing* ring1,
+                                             const geos::geom::LinearRing* ring2) const;
 
   bool _isValidInner(const geos::geom::LinearRing* innerRing) const;
 


### PR DESCRIPTION
Fixed function to classify all unknown rings and fixed crash.

Closes #5255