### PR TITLE
Way rejoin perf 4631

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoiner.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoiner.cpp
@@ -441,7 +441,6 @@ bool WayJoiner::_joinWays(const WayPtr& parent, const WayPtr& child)
   LOG_VART(child->getStatus());
 
   //  Check if the two ways are able to be joined back up
-
   vector<long> child_nodes = child->getNodeIds();
   vector<long> parent_nodes = parent->getNodeIds();
 
@@ -529,7 +528,6 @@ bool WayJoiner::_joinWays(const WayPtr& parent, const WayPtr& child)
   ReplaceElementOp(child->getElementId(), parent->getElementId()).apply(_map);
   child->getTags().clear();
 
-  // Micah says: this looks very, very innefficient
   //  Update any ways that have the child's ID as their parent to the parent's ID
   std::list<std::pair<long, long>> newEntries;
   auto iterPair = _parentIDsToWays.equal_range(child->getId());
@@ -540,25 +538,17 @@ bool WayJoiner::_joinWays(const WayPtr& parent, const WayPtr& child)
       // If the way exists, update it
       _map->getWay(it->second)->setPid(parent->getId());
 
-      // Store the new/updated entry
+      // Store the new/updated entry - the new map from parentID to wayID
       newEntries.push_back(std::pair<long, long>(parent->getId(), it->second));
     }
   }
 
-  // Delete stale entries
+  // Delete stale entries - these have all been modified
   _parentIDsToWays.erase(child->getId());
 
   // Insert updated entries
   for (auto it = newEntries.begin(); it != newEntries.end(); ++it)
     _parentIDsToWays.insert(*it);
-
-
-  /* Old Way
-  UpdateWayParentVisitor visitor(child->getId(), parent->getId());
-  _map->setEnableProgressLogging(false);
-  _map->visitWaysRw(visitor);
-  _map->setEnableProgressLogging(true);
-  */
 
   //  Delete the child
   RecursiveElementRemover(child->getElementId()).apply(_map);

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoiner.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoiner.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef WAYJOINER_H

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoiner.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoiner.h
@@ -89,6 +89,8 @@ protected:
 
   // mapping of joined ways ids; ID before joining mapped to ID after joining
   QHash<long, long> _joinedWayIdMappings;
+
+  // mapping of parentIDs to the ways that references them.
   std::multimap<long, long> _parentIDsToWays;
 
   int _numJoined;
@@ -150,7 +152,10 @@ private:
   void _writeParentIdsToChildIds() const;
 
   /**
-   * @brief _updateParentIdMap clears and rebuilds our map of parentIDs to Ways
+   * @brief _updateParentIdMap clears and rebuilds our map of parentIDs to
+   *    Ways. This map is used to speed up _joinWays by letting us quickly
+   *    modify parentIDs after ways have been joined. This will iterate through
+   *    all of the ways in the map, so use carefully.
    */
   void _updateParentIdMap();
 };

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoiner.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/WayJoiner.h
@@ -89,6 +89,7 @@ protected:
 
   // mapping of joined ways ids; ID before joining mapped to ID after joining
   QHash<long, long> _joinedWayIdMappings;
+  std::multimap<long, long> _parentIDsToWays;
 
   int _numJoined;
   int _numProcessed;
@@ -147,6 +148,11 @@ private:
    * @see _writePidToChildId
    */
   void _writeParentIdsToChildIds() const;
+
+  /**
+   * @brief _updateParentIdMap clears and rebuilds our map of parentIDs to Ways
+   */
+  void _updateParentIdMap();
 };
 
 }


### PR DESCRIPTION
Fixes #4631

Add a mapping of parentIDs to ways, to facilitate faster way joining. For the large road datasets I was using, this change reduced way re-joining from 46 seconds to 1 second.