### PR TITLE
Add clear(), push(), pop() manipulations to the Settings and Settingsjs objects

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/util/Settings.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/Settings.cpp
@@ -208,6 +208,20 @@ void Settings::clear()
   _settings.clear();
 }
 
+void Settings::push()
+{
+  _settingsStack.push(_settings);
+}
+
+void Settings::pop()
+{
+  if (!_settingsStack.empty())
+  {
+    _settings = _settingsStack.top();
+    _settingsStack.pop();
+  }
+}
+
 void Settings::_updateClassNamesInList(QStringList& list)
 {
   QStringList moddedList;

--- a/hoot-core/src/main/cpp/hoot/core/util/Settings.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Settings.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef CONFIGURATION_H

--- a/hoot-core/src/main/cpp/hoot/core/util/Settings.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Settings.h
@@ -35,6 +35,7 @@
 // Std
 // Strangely getting compile errors in hoot-test w/o this, even though its in HootCoreStable.h.
 #include <set>
+#include <stack>
 
 namespace hoot
 {
@@ -68,6 +69,19 @@ public:
    * Removes all user defined settings. This is most useful for unit testing.
    */
   void clear();
+
+  /**
+   * @brief push - Push a copy of the current settings to the stack.
+   *               Current settings remain unmodified.
+   */
+  void push();
+
+  /**
+   * @brief pop - Pops settings off the stack, and overwrites the current
+   *              settings with them. If there is nothing to pop, just
+   *              do nothing.
+   */
+  void pop();
 
   /**
    * Retrieves the default configuration. This is global.
@@ -176,6 +190,10 @@ private:
 
   static std::shared_ptr<Settings> _theInstance;
   SettingsMap _settings;
+
+  // Used to push and pop configurations
+  std::stack<SettingsMap> _settingsStack;
+
   // matches variables in the form ${My_Var_1}
   QRegularExpression _dynamicRegex;
   // matches variables in the form $(My_Var_1)

--- a/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.cpp
@@ -54,6 +54,14 @@ void SettingsJs::Init(Local<Object> exports)
                FunctionTemplate::New(current, clear)->GetFunction(context).ToLocalChecked());
   result = settings->Set(context, toV8("clear"),
                 FunctionTemplate::New(current, clear)->GetFunction(context).ToLocalChecked());
+  result = exports->Set(context, toV8("push"),
+               FunctionTemplate::New(current, push)->GetFunction(context).ToLocalChecked());
+  result = settings->Set(context, toV8("push"),
+                FunctionTemplate::New(current, push)->GetFunction(context).ToLocalChecked());
+  result = exports->Set(context, toV8("pop"),
+               FunctionTemplate::New(current, pop)->GetFunction(context).ToLocalChecked());
+  result = settings->Set(context, toV8("pop"),
+                FunctionTemplate::New(current, pop)->GetFunction(context).ToLocalChecked());
   result = exports->Set(context, toV8("get"),
                FunctionTemplate::New(current, get)->GetFunction(context).ToLocalChecked());
   result = settings->Set(context, toV8("get"),
@@ -92,6 +100,20 @@ void SettingsJs::clear(const FunctionCallbackInfo<Value>& args)
 {
   Settings* settings = &conf();
   settings->clear();
+  args.GetReturnValue().SetUndefined();
+}
+
+void SettingsJs::push(const FunctionCallbackInfo<Value>& args)
+{
+  Settings* settings = &conf();
+  settings->push();
+  args.GetReturnValue().SetUndefined();
+}
+
+void SettingsJs::pop(const FunctionCallbackInfo<Value>& args)
+{
+  Settings* settings = &conf();
+  settings->pop();
   args.GetReturnValue().SetUndefined();
 }
 

--- a/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #include "SettingsJs.h"
 

--- a/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.cpp
@@ -49,39 +49,50 @@ void SettingsJs::Init(Local<Object> exports)
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
   Local<Object> settings = Object::New(current);
-  exports->Set(context, toV8("Settings"), settings);
-  exports->Set(context, toV8("get"),
+  Maybe<bool> result = exports->Set(context, toV8("Settings"), settings);
+  result = exports->Set(context, toV8("clear"),
+               FunctionTemplate::New(current, clear)->GetFunction(context).ToLocalChecked());
+  result = settings->Set(context, toV8("clear"),
+                FunctionTemplate::New(current, clear)->GetFunction(context).ToLocalChecked());
+  result = exports->Set(context, toV8("get"),
                FunctionTemplate::New(current, get)->GetFunction(context).ToLocalChecked());
-  settings->Set(context, toV8("get"),
+  result = settings->Set(context, toV8("get"),
                 FunctionTemplate::New(current, get)->GetFunction(context).ToLocalChecked());
-  exports->Set(context, toV8("set"),
+  result = exports->Set(context, toV8("set"),
                FunctionTemplate::New(current, set)->GetFunction(context).ToLocalChecked());
-  settings->Set(context, toV8("set"),
+  result = settings->Set(context, toV8("set"),
                 FunctionTemplate::New(current, set)->GetFunction(context).ToLocalChecked());
-  exports->Set(context, toV8("appendToList"),
+  result = exports->Set(context, toV8("appendToList"),
                FunctionTemplate::New(current, appendToList)->GetFunction(context).ToLocalChecked());
-  settings->Set(context, toV8("appendToList"),
+  result = settings->Set(context, toV8("appendToList"),
                 FunctionTemplate::New(current, appendToList)->GetFunction(context).ToLocalChecked());
-  exports->Set(context, toV8("prependToList"),
+  result = exports->Set(context, toV8("prependToList"),
                FunctionTemplate::New(current, prependToList)->GetFunction(context).ToLocalChecked());
-  settings->Set(context, toV8("prependToList"),
+  result = settings->Set(context, toV8("prependToList"),
                 FunctionTemplate::New(current, prependToList)->GetFunction(context).ToLocalChecked());
-  exports->Set(context, toV8("removeFromList"),
+  result = exports->Set(context, toV8("removeFromList"),
                FunctionTemplate::New(current, removeFromList)->GetFunction(context).ToLocalChecked());
-  settings->Set(context, toV8("removeFromList"),
+  result = settings->Set(context, toV8("removeFromList"),
                 FunctionTemplate::New(current, removeFromList)->GetFunction(context).ToLocalChecked());
-  exports->Set(context, toV8("replaceInList"),
+  result = exports->Set(context, toV8("replaceInList"),
                FunctionTemplate::New(current, replaceInList)->GetFunction(context).ToLocalChecked());
-  settings->Set(context, toV8("replaceInList"),
+  result = settings->Set(context, toV8("replaceInList"),
                 FunctionTemplate::New(current, replaceInList)->GetFunction(context).ToLocalChecked());
-  exports->Set(context, toV8("placeAfterInList"),
+  result = exports->Set(context, toV8("placeAfterInList"),
                FunctionTemplate::New(current, placeAfterInList)->GetFunction(context).ToLocalChecked());
-  settings->Set(context, toV8("placeAfterInList"),
+  result = settings->Set(context, toV8("placeAfterInList"),
                 FunctionTemplate::New(current, placeAfterInList)->GetFunction(context).ToLocalChecked());
-  exports->Set(context, toV8("listContains"),
+  result = exports->Set(context, toV8("listContains"),
                FunctionTemplate::New(current, listContains)->GetFunction(context).ToLocalChecked());
-  settings->Set(context, toV8("listContains"),
+  result = settings->Set(context, toV8("listContains"),
                 FunctionTemplate::New(current, listContains)->GetFunction(context).ToLocalChecked());
+}
+
+void SettingsJs::clear(const FunctionCallbackInfo<Value>& args)
+{
+  Settings* settings = &conf();
+  settings->clear();
+  args.GetReturnValue().SetUndefined();
 }
 
 void SettingsJs::get(const FunctionCallbackInfo<Value>& args)

--- a/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.h
@@ -45,6 +45,11 @@ private:
 
   SettingsJs() = default;
 
+  /**
+   * @brief clear Removes all user defined settings. This is most useful for unit testing.
+   * @param args
+   */
+  static void clear(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void get(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void listContains(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void set(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef SETTINGSJS_H
 #define SETTINGSJS_H

--- a/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/util/SettingsJs.h
@@ -50,6 +50,20 @@ private:
    * @param args
    */
   static void clear(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  /**
+   * @brief push Pushes a copy of the current settings onto an internal stack,
+   *              leaving current settings unchanged.
+   * @param args
+   */
+  static void push(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  /**
+   * @brief pop Pops settings off the stack, and overwrites the current settings.
+   *              if the stack is empty, pop will do nothing.
+   * @param args
+   */
+  static void pop(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void get(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void listContains(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void set(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/translations/test/SettingsJs.js
+++ b/translations/test/SettingsJs.js
@@ -72,31 +72,30 @@ describe('SettingsJs', function() {
 
     }).timeout(5000);
 
-    it('Should clear the configuration', function() {
+    it('Should test push, pop, and clear configuration', function() {
 
-      var someKey = 'some.test.key';
-      var someVal = 'some.test.value';
+      var origVal = hoot.get('conflate.post.ops');
+      var testVal = 'WayJoinerOp;RelationCircularRefRemover';
 
-      var testSetting = {someKey : someVal};
+      // Save settings
+      hoot.push();
 
-      // Set a config item
-      hoot.set(testSetting);
-      var testVal = hoot.get(someKey);
-      assert.equal(someVal, testVal);
+      // Now change something and verify
+      hoot.set({'conflate.post.ops': testVal});
+      var checkVal = hoot.get('conflate.post.ops');
+      assert.equal(testVal, checkVal);
 
-      // Clear config
+      // Clear Settings & verify
       hoot.clear();
+      checkVal = hoot.get('conflate.post.ops');
+      assert.equal(undefined, checkVal);
+
+      // Set back to how it was
+      hoot.pop();
 
       // Verify
-      testVal = hoot.get(someKey);
-      assert.equal('', testVal);
-
-      hoot.set({'conflate.post.ops': defaultConflatePostOpsStr});
-
-      assert.equal(1, 'holy balls batman!');
-
-      assert.equal(1, 0);
-
+      checkVal = hoot.get('conflate.post.ops');
+      assert.equal(origVal, checkVal);
     }).timeout(5000);
 
 });

--- a/translations/test/SettingsJs.js
+++ b/translations/test/SettingsJs.js
@@ -72,4 +72,31 @@ describe('SettingsJs', function() {
 
     }).timeout(5000);
 
+    it('Should clear the configuration', function() {
+
+      var someKey = 'some.test.key';
+      var someVal = 'some.test.value';
+
+      var testSetting = {someKey : someVal};
+
+      // Set a config item
+      hoot.set(testSetting);
+      var testVal = hoot.get(someKey);
+      assert.equal(someVal, testVal);
+
+      // Clear config
+      hoot.clear();
+
+      // Verify
+      testVal = hoot.get(someKey);
+      assert.equal('', testVal);
+
+      hoot.set({'conflate.post.ops': defaultConflatePostOpsStr});
+
+      assert.equal(1, 'holy balls batman!');
+
+      assert.equal(1, 0);
+
+    }).timeout(5000);
+
 });


### PR DESCRIPTION
This is mostly to facilitate unit testing, but could be useful in other circumstances as well.

Fixes #5308