### PR TITLE
Translation server remove dependency on "English" version of translations

### DIFF
--- a/translations/GGDMv30.js
+++ b/translations/GGDMv30.js
@@ -29,6 +29,11 @@
 // Convert GGDMv30 to/from OSM+
 //
 
+// include HootJs if loaded from mocha test
+if (typeof hoot === 'undefined') {
+  var hoot = require(process.env.HOOT_HOME + '/lib/HootJs');
+}
+
 hoot.require('SchemaTools');
 hoot.require('ggdm30');
 hoot.require('ggdm30_schema');
@@ -77,3 +82,8 @@ function translateToOgr(tags, elementType, geometryType)
 
 } // End of translateToOgr
 
+
+// module method for use in Translation Server
+if (typeof exports !== 'undefined') {
+  exports.toOsm = ggdm30.toOsm;
+}

--- a/translations/MGCP_TRD4.js
+++ b/translations/MGCP_TRD4.js
@@ -24,10 +24,15 @@
  *
  * @copyright Copyright (C) 2013, 2014, 2021 Maxar (http://www.maxar.com/)
  */
- 
+
 //
 // MGCP Conversion
 //
+
+// include HootJs if loaded from mocha test
+if (typeof hoot === 'undefined') {
+    var hoot = require(process.env.HOOT_HOME + '/lib/HootJs');
+}
 
 // hoot.require('config')
 hoot.require('mgcp')
@@ -74,3 +79,7 @@ function translateToOgr(tags, elementType, geometryType)
 } // End of translateToOgr
 
 
+// module method for use in Translation Server
+if (typeof exports !== 'undefined') {
+    exports.toOsm = mgcp.toOsm;
+}

--- a/translations/TDSv40.js
+++ b/translations/TDSv40.js
@@ -29,6 +29,11 @@
 // Convert TDSv4 to/from OSM+
 //
 
+// include HootJs if loaded from mocha test
+if (typeof hoot === 'undefined') {
+  var hoot = require(process.env.HOOT_HOME + '/lib/HootJs');
+}
+
 hoot.require('tds40');
 hoot.require('tds40_schema');
 hoot.require('tds40_rules');
@@ -73,3 +78,8 @@ function translateToOgr(tags, elementType, geometryType)
 
 } // End of translateToOgr
 
+
+// module method for use in Translation Server
+if (typeof exports !== 'undefined') {
+  exports.toOsm = tds40.toOsm;
+}

--- a/translations/TDSv61.js
+++ b/translations/TDSv61.js
@@ -29,6 +29,11 @@
 // Convert TDSv61 to/from OSM+
 //
 
+// include HootJs if loaded from mocha test
+if (typeof hoot === 'undefined') {
+  var hoot = require(process.env.HOOT_HOME + '/lib/HootJs');
+}
+
 hoot.require('SchemaTools');
 hoot.require('tds61');
 hoot.require('tds61_schema');
@@ -74,3 +79,8 @@ function translateToOgr(tags, elementType, geometryType)
 
 } // End of translateToOgr
 
+
+// module method for use in Translation Server
+if (typeof exports !== 'undefined') {
+  exports.toOsm = tds61.toOsm;
+}

--- a/translations/TDSv70.js
+++ b/translations/TDSv70.js
@@ -29,6 +29,11 @@
 // Convert TDSv70 to/from OSM+
 //
 
+// include HootJs if loaded from mocha test
+if (typeof hoot === 'undefined') {
+  var hoot = require(process.env.HOOT_HOME + '/lib/HootJs');
+}
+
 hoot.require('SchemaTools');
 hoot.require('tds70');
 hoot.require('tds70_schema');
@@ -74,3 +79,8 @@ function translateToOgr(tags, elementType, geometryType)
 
 } // End of translateToOgr
 
+
+// module method for use in Translation Server
+if (typeof exports !== 'undefined') {
+  exports.toOsm = tds70.toOsm;
+}

--- a/translations/TDSv71.js
+++ b/translations/TDSv71.js
@@ -29,6 +29,11 @@
 // Convert TDSv70 to/from OSM+
 //
 
+// include HootJs if loaded from mocha test
+if (typeof hoot === 'undefined') {
+  var hoot = require(process.env.HOOT_HOME + '/lib/HootJs');
+}
+
 hoot.require('SchemaTools');
 hoot.require('tds71');
 hoot.require('tds71_schema');
@@ -72,3 +77,8 @@ function translateToOgr(tags, elementType, geometryType)
   return tds71.toOgr(tags, elementType, geometryType);
 } // End of translateToOgr
 
+
+// module method for use in Translation Server
+if (typeof exports !== 'undefined') {
+  exports.toOsm = tds71.toOsm;
+}

--- a/translations/TranslationServer.js
+++ b/translations/TranslationServer.js
@@ -21,6 +21,9 @@ if (typeof hoot === 'undefined') {
     hoot.Settings.set({"writer.include.circular.error.tags": "false"});
     // hoot.Settings.set({"ogr.debug.dumptags": "true"});
 
+    // Throw errors instead of returning partial translations/o2s_X features
+    hoot.Settings.set({'ogr.throw.error':'true'});
+
     // Setting this here as a placeholder. The default is "true"
     hoot.Settings.set({"reader.drop.defaults": "true"});
 

--- a/translations/TranslationServer.js
+++ b/translations/TranslationServer.js
@@ -49,12 +49,12 @@ var schemaMap = {
 
 //Getting osm tags for fcode
 var fcodeLookup = {
-    TDSv40: require(HOOT_HOME + '/translations/etds40_osm.js'),
-    TDSv61: require(HOOT_HOME + '/translations/etds61_osm.js'),
-    TDSv70: require(HOOT_HOME + '/translations/etds70_osm.js'),
-    TDSv71: require(HOOT_HOME + '/translations/etds71_osm.js'),
-    MGCP: require(HOOT_HOME + '/translations/emgcp_osm.js'),
-    GGDMv30: require(HOOT_HOME + '/translations/eggdm30_osm.js')
+    TDSv40: require(HOOT_HOME + '/translations/TDSv40.js'),
+    TDSv61: require(HOOT_HOME + '/translations/TDSv61.js'),
+    TDSv70: require(HOOT_HOME + '/translations/TDSv70.js'),
+    TDSv71: require(HOOT_HOME + '/translations/TDSv71.js'),
+    MGCP: require(HOOT_HOME + '/translations/MGCP_TRD4.js'),
+    GGDMv30: require(HOOT_HOME + '/translations/GGDMv30.js')
 };
 
 var translationsMap = {
@@ -457,9 +457,13 @@ var ogr2osm = function(params) {
         // var osm = translateToOsm.toosm[params.translation].toOSM({
         //     'FCODE': params.fcode
         createUuid = hoot.UuidHelper.createUuid;
-        var osm = fcodeLookup[params.translation].toOSM({
-            'Feature Code': params.fcode
+        var osm = fcodeLookup[params.translation].toOsm({
+            'FCODE': params.fcode
         }, '', params.geom || '');
+
+        if (JSON.stringify(osm) === '{}') {
+            return {'error':'Feature Code ' + params.fcode + ' is not valid for MGCP'};
+        }
 
         return osm;
     }

--- a/translations/test/TranslationServer.js
+++ b/translations/test/TranslationServer.js
@@ -158,7 +158,7 @@ describe('TranslationServer', function () {
                 translation: 'TDSv71',
                 method: 'GET',
                 path: '/translateFrom'
-            }).attrs;
+            });
             assert.equal(attrs.building, 'yes')
         })
 
@@ -168,7 +168,7 @@ describe('TranslationServer', function () {
                 translation: 'TDSv70',
                 method: 'GET',
                 path: '/translateFrom'
-            }).attrs;
+            });
             assert.equal(attrs.building, 'yes')
         })
 
@@ -179,7 +179,7 @@ describe('TranslationServer', function () {
                 translation: 'TDSv61',
                 method: 'GET',
                 path: '/translateFrom'
-            }).attrs;
+            });
             assert.equal(attrs.building, 'yes');
         });
 
@@ -190,7 +190,7 @@ describe('TranslationServer', function () {
                 translation: 'TDSv40',
                 method: 'GET',
                 path: '/translateFrom'
-            }).attrs;
+            });
             assert.equal(attrs.highway, 'road');
         });
 
@@ -201,7 +201,7 @@ describe('TranslationServer', function () {
                 translation: 'MGCP',
                 method: 'GET',
                 path: '/translateFrom'
-            }).attrs;
+            });
             assert.equal(attrs.waterway, 'river');
         });
 
@@ -212,7 +212,7 @@ describe('TranslationServer', function () {
                 translation: 'GGDMv30',
                 method: 'GET',
                 path: '/translateFrom'
-            }).attrs;
+            });
             assert.equal(attrs.waterway, 'river');
         });
         it('should handle invalid F_CODE in translateFrom GET for MGCP', function() {
@@ -221,7 +221,7 @@ describe('TranslationServer', function () {
                 translation: 'MGCP',
                 method: 'GET',
                 path: '/translateFrom'
-            }).attrs;
+            });
             assert.equal(attrs.error, 'Feature Code ZZTOP is not valid for MGCP');
         });
 
@@ -845,7 +845,7 @@ describe('TranslationServer', function () {
     });
 
     describe('translateFrom', function () {
-      it('should return 200', function (done) {
+      it('should return 200 with fcode and translation', function (done) {
         var request  = httpMocks.createRequest({
             method: 'GET',
             url: '/translateFrom',
@@ -859,13 +859,12 @@ describe('TranslationServer', function () {
         assert.equal(response.statusCode, '200');
         done();
       });
-      it('should return 200', function (done) {
+      it('should return 200 with fcode, geom and translation', function (done) {
         var request  = httpMocks.createRequest({
             method: 'GET',
             url: '/translateFrom',
             params: {
-                idelem: 'fcode',
-                idval: 'AL013',
+                fcode: 'AL013',
                 geom: 'Area',
                 translation: 'MGCP'
             }

--- a/translations/test/TranslationServer.js
+++ b/translations/test/TranslationServer.js
@@ -172,6 +172,28 @@ describe('TranslationServer', function () {
             assert.equal(attrs.building, 'yes')
         })
 
+        it('should handle translateFrom GET for TDSv71', function() {
+            //http://localhost:8094/translateFrom?fcode=AL013&translation=TDSv71
+            var attrs = server.handleInputs({
+                fcode: 'AL013',
+                translation: 'TDSv71',
+                method: 'GET',
+                path: '/translateFrom'
+            });
+            assert.equal(attrs.building, 'yes');
+        });
+
+        it('should handle translateFrom GET for TDSv70', function() {
+            //http://localhost:8094/translateFrom?fcode=AL013&translation=TDSv70
+            var attrs = server.handleInputs({
+                fcode: 'AL013',
+                translation: 'TDSv70',
+                method: 'GET',
+                path: '/translateFrom'
+            });
+            assert.equal(attrs.building, 'yes');
+        });
+
         it('should handle translateFrom GET for TDSv61', function() {
             //http://localhost:8094/translateFrom?fcode=AL013&translation=TDSv61
             var attrs = server.handleInputs({
@@ -184,7 +206,7 @@ describe('TranslationServer', function () {
         });
 
         it('should handle translateFrom GET for TDSv40', function() {
-            //http://localhost:8094/tdstoosm?fcode=AL013&translation=TDSv61
+            //http://localhost:8094/tdstoosm?fcode=AL013&translation=TDSv40
             var attrs = server.handleInputs({
                 fcode: 'AP030',
                 translation: 'TDSv40',
@@ -205,8 +227,8 @@ describe('TranslationServer', function () {
             assert.equal(attrs.waterway, 'river');
         });
 
-        it('should handle translateFrom GET for MGCP', function() {
-            //http://localhost:8094/tdstoosm?fcode=AL013&translation=TDSv61
+        it('should handle translateFrom GET for GGDMv30', function() {
+            //http://localhost:8094/tdstoosm?fcode=AL013&translation=GGDMv30
             var attrs = server.handleInputs({
                 fcode: 'BH140',
                 translation: 'GGDMv30',


### PR DESCRIPTION
This PR removes the translation server dependency on the "English" versions of the translation scripts.  The `translation_assistant.js` script still references them, but maybe it to could be made to work without them.