### PR TITLE
GPKG writing is slow

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -3854,6 +3854,14 @@ hoot convert \
 When writing relations to OGR files, incomplete relations can cause errors setting this to
 true, the writer will ignore the errors and continue to output the results.
 
+=== ogr.writer.transaction.size
+
+* Data Type: int
+* Default Value: `256000`
+
+Some OGR datasources support transactions (currently GPKG), this is the size of the transactions
+before committing them.
+
 === osmapidb.bulk.inserter.disable.database.constraints.during.write
 
 * Data Type: bool

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrUtilities.h
@@ -30,6 +30,9 @@
 // GDAL
 #include <gdal.h>
 
+// Hoot
+#include <hoot/core/io/OgrOptions.h>
+
 class GDALDataset;
 
 namespace hoot
@@ -123,6 +126,8 @@ public:
 
 private:
 
+  std::vector<OgrDriverInfo> _drivers;
+
   /** Use getInstance() instead of the constructor */
   OgrUtilities();
   ~OgrUtilities();
@@ -134,9 +139,9 @@ private:
    * @brief loadDriverInfo Loads a hard-coded set of GDAL driver information with file
    *    extensions, prefixes, and open flags used by getDriverInfo() function
    */
-  void loadDriverInfo();
+  void _loadDriverInfo();
 
-  std::vector<OgrDriverInfo> _drivers;
+  OgrOptions _getOgrOptions(const QString& url, const OgrDriverInfo& driverInfo) const;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -342,14 +342,11 @@ void OgrWriter::_writePartial(ElementProviderPtr& provider, const ConstElementPt
       "Wrote " << StringUtils::formatLargeNumber(_numWritten) << " elements to output.");
   }
   //  Transactions should speed up the processing of larger files
-  if (_inTransaction)
+  if (_inTransaction && _numWritten % _transactionSize == 0)
   {
-    if (_numWritten % _transactionSize == 0)
-    {
-      //  Commmit the old transaction and start a new one
-      _ds->CommitTransaction();
-      _inTransaction = _ds->StartTransaction() == OGRERR_NONE;
-    }
+    //  Commmit the old transaction and start a new one
+    _ds->CommitTransaction();
+    _inTransaction = _ds->StartTransaction() == OGRERR_NONE;
   }
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -195,8 +195,6 @@ void OgrWriter::close()
   {
     _ds->CommitTransaction();
     _inTransaction = false;
-    //Create the spatial index on the layer, iterate layers?
-    //_ds->ExecuteSQL("SELECT CreateSpatialIndex('the_table','GEOMETRY')", nullptr, nullptr);
   }
   _layers.clear();
   //  Allow close() to be called multiple times without causing errors
@@ -717,7 +715,7 @@ OGRLayer* OgrWriter::_getLayer(const QString& layerName)
   return _layers[layerName];
 }
 
-void OgrWriter::_addFeature(OGRLayer* layer, const std::shared_ptr<Feature>& f, const std::shared_ptr<Geometry>& g)
+void OgrWriter::_addFeature(OGRLayer* layer, const std::shared_ptr<Feature>& f, const std::shared_ptr<Geometry>& g) const
 {
   OGRFeature* poFeature = OGRFeature::CreateFeature( layer->GetLayerDefn() );
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
@@ -126,12 +126,14 @@ private:
   int _maxFieldWidth;
 
   int _numWritten;
+  int _transactionSize;
+  bool _inTransaction;
   int _statusUpdateInterval;
 
   bool _forceSkipFailedRelations;
 
   void _addFeature(OGRLayer* layer, const std::shared_ptr<Feature>& f,
-                   const std::shared_ptr<geos::geom::Geometry>& g) const;
+                   const std::shared_ptr<geos::geom::Geometry>& g);
   void _addFeatureToLayer(OGRLayer* layer, const std::shared_ptr<Feature>& f, const geos::geom::Geometry* g,
                           OGRFeature* poFeature) const;
   void _createLayer(const std::shared_ptr<const Layer>& layer);
@@ -139,6 +141,8 @@ private:
   OGRLayer* _getLayerByName(const QString& layerName);
 
   void _strictError(const QString& warning) const;
+
+  bool _usesTransactions() const;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
@@ -133,7 +133,7 @@ private:
   bool _forceSkipFailedRelations;
 
   void _addFeature(OGRLayer* layer, const std::shared_ptr<Feature>& f,
-                   const std::shared_ptr<geos::geom::Geometry>& g);
+                   const std::shared_ptr<geos::geom::Geometry>& g) const;
   void _addFeatureToLayer(OGRLayer* layer, const std::shared_ptr<Feature>& f, const geos::geom::Geometry* g,
                           OGRFeature* poFeature) const;
   void _createLayer(const std::shared_ptr<const Layer>& layer);


### PR DESCRIPTION
Added transactions to GPKG, and added `OGR_SQLITE_CACHE`, `OGR_SQLITE_SYNCHRONOUS`, `SQLITE_USE_OGR_VFS` settings.

On sample data of substantial size, the approximate speed up of these changes was 25%.

Closes #5346 