### PR TITLE
Add a tag limit of 30 when getting attribute info for translation assistant

### DIFF
--- a/hoot-services/src/main/java/hoot/services/controllers/ogr/ExtractAttributesCommand.java
+++ b/hoot-services/src/main/java/hoot/services/controllers/ogr/ExtractAttributesCommand.java
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 package hoot.services.controllers.ogr;
 

--- a/hoot-services/src/main/java/hoot/services/controllers/ogr/ExtractAttributesCommand.java
+++ b/hoot-services/src/main/java/hoot/services/controllers/ogr/ExtractAttributesCommand.java
@@ -59,7 +59,7 @@ class ExtractAttributesCommand extends ExternalCommand {
 
         //Technically this command now works for all data source, not just OGR, so we could move this class and associated classes out of the
         //hoot.services.controllers.ogr namespace.
-        String command = "hoot.bin tag-info --${DEBUG_LEVEL} ${INPUT_FILES}";
+        String command = "hoot.bin tag-info --${DEBUG_LEVEL} --tag-values-limit 30 ${INPUT_FILES}";
 
         super.configureCommand(command, substitutionMap, caller);
     }

--- a/hoot-services/src/test/java/hoot/services/controllers/ogr/ExtractAttributesCommandTest.java
+++ b/hoot-services/src/test/java/hoot/services/controllers/ogr/ExtractAttributesCommandTest.java
@@ -68,7 +68,7 @@ public class ExtractAttributesCommandTest {
         assertNotNull(extractAttributesCommand.getWorkDir());
         assertNotNull(extractAttributesCommand.getCommand());
 
-        String expectedCommand = "hoot.bin tag-info --${DEBUG_LEVEL} ${INPUT_FILES}";
+        String expectedCommand = "hoot.bin tag-info --${DEBUG_LEVEL} --tag-values-limit 30 ${INPUT_FILES}";
         assertEquals(expectedCommand, extractAttributesCommand.getCommand());
 
         assertTrue(extractAttributesCommand.getSubstitutionMap().containsKey("DEBUG_LEVEL"));

--- a/hoot-services/src/test/java/hoot/services/controllers/ogr/ExtractAttributesCommandTest.java
+++ b/hoot-services/src/test/java/hoot/services/controllers/ogr/ExtractAttributesCommandTest.java
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 package hoot.services.controllers.ogr;
 


### PR DESCRIPTION
this used to be a default but got refactored here
ba4f8342799ea94a26c6f0470f40362a1ffb3895
to be no limit
this was causing performance problems in the Translations Assistant UI
when inputs had 10k+ unique attribute values