### PR TITLE
Update sherlock match conflation command for IDs

### DIFF
--- a/docker/hoot_external_command_nightly/scripts/RunCommandsAcrossContainers.sh
+++ b/docker/hoot_external_command_nightly/scripts/RunCommandsAcrossContainers.sh
@@ -4,4 +4,4 @@
 
 # Commands can be added here
 # TODO: create functions for different commands when they are added and add flag to specify which command to run
-hoot conflate -C UnifyingAlgorithm.conf -C ReferenceConflation.conf -D conflate.match.only=true -D writer.include.conflate.score.tags=true -D match.creators="BuildingMatchCreator;HighwayMatchCreator" -D conflate.use.data.source.ids.1=false -D writer.include.debug.tags=true -D uuid.helper.repeatable=true -D conflate.post.ops-="WayJoinerOp" -D id.generator=PositiveIdGenerator -D building.match.threshold=$4 -D building.review.threshold=$5 $1 $2 $3
+hoot conflate -C UnifyingAlgorithm.conf -C ReferenceConflation.conf -D conflate.match.only=true -D writer.include.conflate.score.tags=true -D match.creators="BuildingMatchCreator;HighwayMatchCreator" -D conflate.use.data.source.ids.2=true -D writer.include.debug.tags=true -D uuid.helper.repeatable=true -D conflate.post.ops-="WayJoinerOp" -D building.match.threshold=$4 -D building.review.threshold=$5 $1 $2 $3


### PR DESCRIPTION
- This PR is for sherlock to retain the original IDs from the data source when running the conflation (match only) command