### PR TITLE
Improve OAuth error messages (mostly from server misconfiguration)

### DIFF
--- a/hoot-services/src/main/java/hoot/services/controllers/auth/OAuth2Resource.java
+++ b/hoot-services/src/main/java/hoot/services/controllers/auth/OAuth2Resource.java
@@ -239,11 +239,11 @@ import hoot.services.models.db.Users;
         public Response callback(@Context HttpServletRequest request, @QueryParam("state") String state, @QueryParam("code") String code) {
 
             if (code == null) {
-                return Response.status(401).build();
+                return Response.status(401).entity("code must not be null").build();
             }
 
             if (!states.containsKey(state)) {
-                return Response.status(401).build();
+                return Response.status(401).entity("state is unknown to server").build();
             } else {
                 states.remove(state);
             };
@@ -253,7 +253,7 @@ import hoot.services.models.db.Users;
                 ResponseEntity<String> tokenResponse = doTokenRequest(code);
 
                 if (!tokenResponse.getStatusCode().equals(HttpStatus.OK)) {
-                    return Response.status(401).build();
+                    return Response.status(401).entity("token request failed").build();
                 }
 
                 JsonNode tokenResponseJson = new ObjectMapper()
@@ -265,7 +265,7 @@ import hoot.services.models.db.Users;
                 ResponseEntity<String> userDetailsRequest = doUserDetailsRequest(tokenType, accessToken);
 
                 if (!userDetailsRequest.getStatusCode().equals(HttpStatus.OK)) {
-                    return Response.status(401).build();
+                    return Response.status(401).entity("user details request failed").build();
                 }
 
                 JsonNode userDetailsJson = new ObjectMapper().readTree(userDetailsRequest.getBody());

--- a/hoot-services/src/main/java/hoot/services/controllers/auth/OAuth2Resource.java
+++ b/hoot-services/src/main/java/hoot/services/controllers/auth/OAuth2Resource.java
@@ -242,11 +242,11 @@ import hoot.services.models.db.Users;
         public Response callback(@Context HttpServletRequest request, @QueryParam("state") String state, @QueryParam("code") String code) {
 
             if (code == null) {
-                return Response.status(Response.Status.BAD_REQUEST).entity("Missing code parameter in URL").build();
+                return Response.status(Response.Status.BAD_REQUEST).entity("Code parameter is missing in OAuth callback URL").build();
             }
 
             if (!states.containsKey(state)) {
-                return Response.status(Response.Status.BAD_REQUEST).entity("Provided state parameter is unknown to server").build();
+                return Response.status(Response.Status.BAD_REQUEST).entity("State parameter is missing or unknown to server in OAuth callback URL").build();
             } else {
                 states.remove(state);
             };
@@ -312,15 +312,6 @@ import hoot.services.models.db.Users;
         @Path("/oauth2/logout")
         @Produces(MediaType.TEXT_PLAIN)
         public Response logout(@Context HttpServletRequest request) {
-            // Invalidate HTTP Session
-            HttpSession sess = request.getSession();
-            sess.invalidate();
-
-            // Clear the security context
-            SecurityContext sc = SecurityContextHolder.getContext();
-            sc.setAuthentication(null);
-            SecurityContextHolder.clearContext();
-
             // Revoke the osm access token
             String errMessage = "Failed to revoke OAuth access token";
             try {
@@ -331,6 +322,15 @@ import hoot.services.models.db.Users;
             } catch (RestClientException ex) {
                 logger.error(errMessage);
                 return Response.status(Response.Status.BAD_GATEWAY).entity(errMessage).build();
+            } finally {
+                // Invalidate HTTP Session
+                HttpSession sess = request.getSession();
+                sess.invalidate();
+
+                // Clear the security context
+                SecurityContext sc = SecurityContextHolder.getContext();
+                sc.setAuthentication(null);
+                SecurityContextHolder.clearContext();
             }
 
             return Response.ok().build();

--- a/hoot-services/src/main/java/hoot/services/controllers/auth/OAuth2Resource.java
+++ b/hoot-services/src/main/java/hoot/services/controllers/auth/OAuth2Resource.java
@@ -26,10 +26,8 @@
  */
 package hoot.services.controllers.auth;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
@@ -42,7 +40,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.xml.parsers.ParserConfigurationException;
 
 import net.jodah.expiringmap.ExpiringMap;
 
@@ -55,7 +52,6 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -72,10 +68,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-import org.xml.sax.SAXException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -276,7 +270,7 @@ import hoot.services.models.db.Users;
             ResponseEntity<String> userDetailsRequest;
             try {
                 userDetailsRequest = doUserDetailsRequest(tokenType, accessToken);
-            } catch (Exception e) {
+            } catch (RestClientException e) {
                 String msg = "Failed to retrieve user from OAuth provider";
                 logger.error(msg);
                 return Response.status(Response.Status.BAD_GATEWAY).entity(msg).build();
@@ -313,13 +307,10 @@ import hoot.services.models.db.Users;
         @Produces(MediaType.TEXT_PLAIN)
         public Response logout(@Context HttpServletRequest request) {
             // Revoke the osm access token
-            String errMessage = "Failed to revoke OAuth access token";
             try {
                 ResponseEntity<String> revokeResponse = doTokenRevoke();
-                if (!revokeResponse.getStatusCode().equals(HttpStatus.OK)) {
-                    return Response.status(Response.Status.BAD_GATEWAY).entity(errMessage).build();
-                }
             } catch (RestClientException ex) {
+                String errMessage = "Failed to revoke OAuth access token";
                 logger.error(errMessage);
                 return Response.status(Response.Status.BAD_GATEWAY).entity(errMessage).build();
             } finally {

--- a/hoot-services/src/main/java/hoot/services/controllers/auth/UserManager.java
+++ b/hoot-services/src/main/java/hoot/services/controllers/auth/UserManager.java
@@ -40,9 +40,8 @@ import hoot.services.models.db.Users;
 
 @Service
 public interface UserManager {
-    Users upsert(JsonNode userDetailsJson, String tokenType, String accessToken, String sessionId) throws SAXException, IOException, ParserConfigurationException, InvalidUserProfileException;
-    Users parseUser(String xml) throws SAXException, IOException, ParserConfigurationException, InvalidUserProfileException;
-    Users parseUser(JsonNode userDetailsJson) throws InvalidUserProfileException;
+    Users upsert(JsonNode userDetailsJson, String tokenType, String accessToken, String sessionId);
+    Users parseUser(JsonNode userDetailsJson);
 
     Timestamp parseTimestamp(String timestamp);
 

--- a/hoot-services/src/main/java/hoot/services/controllers/auth/UserManagerImpl.java
+++ b/hoot-services/src/main/java/hoot/services/controllers/auth/UserManagerImpl.java
@@ -120,7 +120,7 @@ public class UserManagerImpl implements UserManager {
     }
 
     @Override
-    public Users parseUser(JsonNode userDetailsJson) throws InvalidUserProfileException {
+    public Users parseUser(JsonNode userDetailsJson) {
         Users user = new Users();
         JsonNode details = userDetailsJson.get("user");
 
@@ -129,31 +129,6 @@ public class UserManagerImpl implements UserManager {
         user.setProviderCreatedAt(parseTimestamp(details.get("account_created").asText()));
         user.setHootservicesLastAuthorize(new Timestamp(System.currentTimeMillis()));
 
-        return user;
-    }
-
-    @Override
-    public Users parseUser(String xml) throws SAXException, IOException, ParserConfigurationException, InvalidUserProfileException {
-        Users user = new Users();
-        Document doc = XmlDocumentBuilder.parse(xml);
-
-        // Get User node:
-        NodeList l = doc.getElementsByTagName("user");
-        if (l.getLength() != 1) {
-            throw new InvalidUserProfileException(xml);
-        }
-        Node userNode = l.item(0);
-
-        // Store attributes from User node:
-        Element userElement = (Element) userNode;
-        user.setDisplayName(userElement.getAttribute("display_name"));
-        user.setId(Long.parseLong(userElement.getAttribute("id")));
-        user.setProviderCreatedAt(parseTimestamp(userElement.getAttribute("account_created")));
-        user.setHootservicesLastAuthorize(new Timestamp(System.currentTimeMillis()));
-        if(user.getId() <= 0L) {
-            logger.warn("empty -or- invalid user profiles can result from misconfigured oauth, check hoot-services.conf::oauthProviderURL");
-            throw new InvalidUserProfileException(xml);
-        }
         return user;
     }
 
@@ -180,7 +155,7 @@ public class UserManagerImpl implements UserManager {
 
 
     @Override
-    public Users upsert(JsonNode userDetailsJson, String tokenType, String accessToken, String sessionId) throws InvalidUserProfileException {
+    public Users upsert(JsonNode userDetailsJson, String tokenType, String accessToken, String sessionId) {
         Users user = parseUser(userDetailsJson);
         user.setProviderAccessKey(accessToken);
         user.setProviderAccessToken(tokenType);

--- a/hoot-services/src/test/java/hoot/services/controllers/auth/UserManagerTest.java
+++ b/hoot-services/src/test/java/hoot/services/controllers/auth/UserManagerTest.java
@@ -48,47 +48,15 @@ import hoot.services.models.db.Users;
 @ContextConfiguration(classes = HootServicesSpringTestConfig.class, loader = AnnotationConfigContextLoader.class)
 @Transactional
 public class UserManagerTest extends HootServicesJerseyTestAbstract {
-	@Autowired
-	private UserManager userManager;
+    @Autowired
+    private UserManager userManager;
 
-	@Test
-	@Category(UnitTest.class)
-	public void testParseUser() throws Exception {
-		//@formatter:off
-		String xml = "\n" +
-				"<osm generator=\"OpenStreetMap server\" version=\"0.6\">\n" +
-				"    <user account_created=\"2018-08-22T21:30:14Z\" display_name=\"Arni Sumarlidason (work)\" id=\"8723740\">\n" +
-				"        <description/>\n" +
-				"        <contributor-terms agreed=\"true\" pd=\"false\"/>\n" +
-				"        <roles/>\n" +
-				"        <changesets count=\"0\"/>\n" +
-				"        <traces count=\"0\"/>\n" +
-				"        <blocks>\n" +
-				"            <received active=\"0\" count=\"0\"/>\n" +
-				"        </blocks>\n" +
-				"        <languages>\n" +
-				"            <lang>en-US</lang>\n" +
-				"            <lang>en</lang>\n" +
-				"        </languages>\n" +
-				"        <messages>\n" +
-				"            <received count=\"0\" unread=\"0\"/>\n" +
-				"            <sent count=\"0\"/>\n" +
-				"        </messages>\n" +
-				"    </user>\n" +
-				"</osm>";
-		//@formatter:on
-		Users user = userManager.parseUser(xml);
-
-		assertEquals("Arni Sumarlidason (work)", user.getDisplayName());
-		assertEquals(new Long(8723740L), user.getId());
-	}
-
-	@Test
-	@Category(UnitTest.class)
-	public void testParseAccountCreated() throws Exception {
-		final String datetime = "2018-08-22T21:30:14Z";
-		Timestamp ts = userManager.parseTimestamp(datetime);
-		assertEquals(1534973414000L, ts.getTime());
-	}
+    @Test
+    @Category(UnitTest.class)
+    public void testParseAccountCreated() throws Exception {
+        final String datetime = "2018-08-22T21:30:14Z";
+        Timestamp ts = userManager.parseTimestamp(datetime);
+        assertEquals(1534973414000L, ts.getTime());
+    }
 
 }

--- a/hoot-services/src/test/java/hoot/services/controllers/auth/UserManagerTest.java
+++ b/hoot-services/src/test/java/hoot/services/controllers/auth/UserManagerTest.java
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 package hoot.services.controllers.auth;
 


### PR DESCRIPTION
This PR adds more detailed error messages when the OAuth2 handshake doesn't complete successfully, most likely due to a misconfiguration in oauth2-client.properties.

If the redirect-uri is incorrect (or not registered with the oauth provider for this client key) the oauth popup will report the error `The requested redirect uri is malformed or doesn't match client redirect URI.`

If the oauth client id is incorrect the oauth popup will report the error `Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.`

If the oauth client secret or the token uri is incorrect the UI alerts `Failed to retrieve access token from OAuth provider`.

If the authorization uri is incorrect the remote oauth provider will show an unknown route server error in the oauth popup.

If the user details url is misconfigured or can't be retrieved the UI alerts `Failed to retrieve user from OAuth provider`.

If the scope (permissions) doesn't match what is registered with the oauth provider, the oauth popup will report the error `The requested scope is invalid, unknown, or malformed.`


The PR also removes support for parsing the xml formatted user details from OAuth1 (in favor of the json format)
