### PR TITLE
Add Overpass API to ParallelBoundedReader

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -1970,6 +1970,20 @@ OpenstreetMap OAuth Access Token for gaining access to the OAuth protected OSM A
 
 OpenstreetMap OAuth Private Access Token for gaining access to the OAuth protected OSM API
 
+=== hoot.pkcs12.key.path
+
+* Data Type: string
+* Default Value: ``
+
+File path for the PKCS-12 key used to authenticate for reading/writing to protected resources
+
+=== hoot.pkcs12.key.phrase
+
+* Data Type: string
+* Default Value: ``
+
+Passphrase for PKCS-12 key loaded from `hoot.pkcs12.key.path`, both arguments are required for authentication
+
 === hoot.services.auth.access.token
 
 * Data Type: string
@@ -3947,6 +3961,15 @@ Add a tag with the bounding box for each element
 
 Overpass API URL host name. Used by the JSON readers to distinguish Overpass JSON web sources from
 GeoJSON web sources.
+
+=== overpass.api.query.path
+
+* Data Type: string
+* Default Value: ``
+
+Pathname of Overpass Query Language query file.
+
+NOTE: The OQL file must contain either `{{bbox}}` or `{{polygon}}` that is replaced by `bounds` value.
 
 === pbf.writer.compression.level
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmJsonReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmJsonReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2012, 2013, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ParallelBoundedApiReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ParallelBoundedApiReaderTest.cpp
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. Maxar
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2022 Maxar (http://www.maxar.com/)
+ */
+
+// Hoot
+#include <hoot/core/TestUtils.h>
+#include <hoot/core/io/ParallelBoundedApiReader.h>
+
+namespace hoot
+{
+
+class ParallelBoundedApiReaderTest : public HootTestFixture
+{
+  CPPUNIT_TEST_SUITE(ParallelBoundedApiReaderTest);
+  CPPUNIT_TEST(parseErrorTest);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  ParallelBoundedApiReaderTest() = default;
+
+  void parseErrorTest()
+  {
+    ParallelBoundedApiReader uut;
+    QString result =
+        "{"
+        "\"version\": 0.6,"
+        "\"generator\": \"NOME Overpass API 0.7.57 c954ae26\","
+        "\"osm3s\": {"
+        "  \"timestamp_osm_base\": \"2021-09-09T17:21:17Z\","
+        "  \"copyright\": \"The data included in this document is from NOME and OpenStreetMap. The data is made available under ODbL. data included in this document falls under NOME Terms of Use https://nome.vgihub.geointservices.io/disclaimer/NOME_Enclave_Disclaimer_V4.pdf\""
+        "},"
+        "\"elements\": ["
+        "],"
+        "\"remark\": \"runtime error: Query ran out of memory in \"query\" at line 1. It would need at least 95 MB of RAM to continue.\""
+        "}";
+    QString error;
+    CPPUNIT_ASSERT(uut._isQueryError(result, error));
+    HOOT_STR_EQUALS("runtime error: Query ran out of memory in \"query\" at line 1. It would need at least 95 MB of RAM to continue.", error);
+  }
+
+};
+
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ParallelBoundedApiReaderTest, "quick");
+
+}
+

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementId.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementId.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "ElementId.h"

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementId.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementId.cpp
@@ -30,14 +30,15 @@
 namespace hoot
 {
 
-ElementId::ElementId() :
-_type(ElementType::Unknown),
-_id(-std::numeric_limits<int>::max())
+ElementId::ElementId()
+  : _type(ElementType::Unknown),
+    _id(-std::numeric_limits<int>::max())
 {
 }
 
-ElementId::ElementId(ElementType type, long id) :
-_type(type), _id(id)
+ElementId::ElementId(ElementType type, long id)
+  : _type(type),
+    _id(id)
 {
 }
 
@@ -51,18 +52,14 @@ ElementId::ElementId(QString str)
 
     const QStringList strParts = str.trimmed().split("(");
     if (strParts.size() != 2)
-    {
       throw IllegalArgumentException(errorMsg);
-    }
 
     _type = ElementType::fromString(strParts[0].toLower().trimmed());
 
     bool ok = false;
     _id = strParts[1].split(")")[0].trimmed().toLong(&ok);
     if (!ok)
-    {
       throw IllegalArgumentException(errorMsg);
-    }
   }
   else if (!str.isEmpty())
   {
@@ -70,23 +67,17 @@ ElementId::ElementId(QString str)
 
     const QStringList strParts = str.trimmed().split(":");
     if (strParts.size() != 2)
-    {
       throw IllegalArgumentException(errorMsg);
-    }
 
     _type = ElementType::fromString(strParts[0].toLower().trimmed());
 
     bool ok = false;
     _id = strParts[1].trimmed().toLong(&ok);
     if (!ok)
-    {
       throw IllegalArgumentException(errorMsg);
-    }
   }
   else
-  {
     throw IllegalArgumentException(errorMsg);
-  }
 }
 
 bool ElementId::isNull() const
@@ -107,17 +98,11 @@ bool ElementId::operator==(const ElementId& other) const
 bool ElementId::operator<(const ElementId& other) const
 {
   if (getType().getEnum() < other.getType().getEnum())
-  {
     return true;
-  }
   else if (getType().getEnum() > other.getType().getEnum())
-  {
     return false;
-  }
   else
-  {
     return getId() < other.getId();
-  }
 }
 
 QString ElementId::toString() const

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementId.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementId.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef ELEMENTID_H
 #define ELEMENTID_H

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementId.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementId.h
@@ -127,8 +127,7 @@ struct hash<hoot::ElementId>
 {
   size_t operator() (const hoot::ElementId& eid) const
   {
-    size_t key = size_t(eid.getId()) ^ ((size_t)eid.getType().getEnum() << 58);
-    return key;
+    return size_t(eid.getId()) ^ ((size_t)eid.getType().getEnum() << 58);
   }
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/index/OsmMapIndex.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/index/OsmMapIndex.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "OsmMapIndex.h"

--- a/hoot-core/src/main/cpp/hoot/core/index/OsmMapIndex.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/index/OsmMapIndex.cpp
@@ -165,8 +165,7 @@ void OsmMapIndex::_buildWayTree() const
   {
     ConstWayPtr w = it->second;
 
-    std::shared_ptr<LineString> ls =
-      ElementToGeometryConverter(_map.shared_from_this()).convertToLineString(w);
+    std::shared_ptr<LineString> ls = ElementToGeometryConverter(_map.shared_from_this()).convertToLineString(w);
     if (ls)
     {
       const Envelope* e = ls->getEnvelopeInternal();
@@ -244,8 +243,7 @@ vector<long> OsmMapIndex::findNodes(const Coordinate& from, Meters maxDistance) 
   return result;
 }
 
-vector<long> OsmMapIndex::findWayNeighbors(const ConstWayPtr &way, Meters buffer,
-                                           bool addError) const
+vector<long> OsmMapIndex::findWayNeighbors(const ConstWayPtr &way, Meters buffer, bool addError) const
 {
   vector<long> result;
 
@@ -270,8 +268,7 @@ vector<long> OsmMapIndex::findWayNeighborsBruteForce(ConstWayPtr way, Meters buf
   vector<long> result;
 
   // grab the geometry for the way that we're comparing all others against.
-  std::shared_ptr<LineString> ls1 =
-    ElementToGeometryConverter(_map.shared_from_this()).convertToLineString(way);
+  std::shared_ptr<LineString> ls1 = ElementToGeometryConverter(_map.shared_from_this()).convertToLineString(way);
 
   // go through all other ways
   const WayMap& ways = _map.getWays();
@@ -281,8 +278,7 @@ vector<long> OsmMapIndex::findWayNeighborsBruteForce(ConstWayPtr way, Meters buf
     ConstWayPtr n = it->second;
     if (n != nullptr && nId != way->getId())
     {
-      std::shared_ptr<LineString> ls2 =
-        ElementToGeometryConverter(_map.shared_from_this()).convertToLineString(n);
+      std::shared_ptr<LineString> ls2 = ElementToGeometryConverter(_map.shared_from_this()).convertToLineString(n);
       Meters d = ls1->distance(ls2.get());
       if (d < buffer)
         result.push_back(nId);
@@ -307,8 +303,7 @@ long OsmMapIndex::findNearestWay(Coordinate c) const
     ConstWayPtr n = it->second;
     if (n != nullptr && n->getNodeCount() > 1)
     {
-      std::shared_ptr<LineString> ls2 =
-        ElementToGeometryConverter(_map.shared_from_this()).convertToLineString(n);
+      std::shared_ptr<LineString> ls2 = ElementToGeometryConverter(_map.shared_from_this()).convertToLineString(n);
       Meters d = p->distance(ls2.get());
       if (d < bestDistance)
       {
@@ -335,8 +330,7 @@ std::vector<long> OsmMapIndex::findWayNeighbors(const Coordinate& from, Meters b
     ConstWayPtr n = it->second;
     if (n != nullptr && n->getNodeCount() > 1)
     {
-      std::shared_ptr<LineString> ls2 =
-        ElementToGeometryConverter(_map.shared_from_this()).convertToLineString(n);
+      std::shared_ptr<LineString> ls2 = ElementToGeometryConverter(_map.shared_from_this()).convertToLineString(n);
       Meters d = p->distance(ls2.get());
       if (d < buffer)
         result.push_back(nId);
@@ -563,8 +557,7 @@ void OsmMapIndex::removeWay(ConstWayPtr w)
     _nodeToWayMap->removeWay(w);
   }
 
-  if (_wayTree != nullptr &&
-      _pendingWayRemoval.size() > std::max((size_t)100, _map.getWays().size() / 8))
+  if (_wayTree != nullptr && _pendingWayRemoval.size() > std::max((size_t)100, _map.getWays().size() / 8))
   {
     LOG_DEBUG("pending removal size: " << _pendingWayRemoval.size());
     _wayTree.reset();

--- a/hoot-core/src/main/cpp/hoot/core/index/OsmMapIndex.h
+++ b/hoot-core/src/main/cpp/hoot/core/index/OsmMapIndex.h
@@ -29,8 +29,8 @@
 #define OSMMAPINDEX_H
 
 // Hoot
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/elements/ElementListener.h>
+#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/index/ElementToRelationMap.h>
 
 // TGS
@@ -73,8 +73,7 @@ public:
    * Should run in approximately O(log(n)).
    * Due to the buffer added to ways, this is only efficient with a planar projection.
    */
-  std::vector<long> findWayNeighbors(const ConstWayPtr& way, Meters buffer,
-                                     bool addError = false) const;
+  std::vector<long> findWayNeighbors(const ConstWayPtr& way, Meters buffer, bool addError = false) const;
   /**
    * Very inefficient.
    */

--- a/hoot-core/src/main/cpp/hoot/core/index/OsmMapIndex.h
+++ b/hoot-core/src/main/cpp/hoot/core/index/OsmMapIndex.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef OSMMAPINDEX_H

--- a/hoot-core/src/main/cpp/hoot/core/io/HootNetworkRequest.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootNetworkRequest.h
@@ -55,6 +55,12 @@ public:
   /** Constructor */
   HootNetworkRequest();
   /**
+   * @brief HootNetworkRequest
+   * @param key_path - Path to PKCS12 SSL key
+   * @param pass_phrase - Passphrase for SSL key
+   */
+  HootNetworkRequest(const QString& key_path, const QString& pass_phrase);
+  /**
    * @brief HootNetworkRequest - oauth1
    * @param consumer_key - OAuth consumer key
    * @param consumer_secret - OAuth consumer secret key
@@ -191,12 +197,15 @@ private:
   std::shared_ptr<OAuth::Consumer> _consumer;
   /** OAuth 1.0 request token object */
   std::shared_ptr<OAuth::Token> _tokenRequest;
-
   /** OAuth 2.0 flag and token */
   bool _useOAuth2;
   QString _oauth2AccessToken;
   /** Flag set when the timer times out */
   bool _timedOut;
+  /** Pathname for PKCS-12 SSL key */
+  QString _key_path;
+  /** Passphrase for PKCS-12 SSL key */
+  QString _pass_phrase;
 };
 
 using HootNetworkRequestPtr = std::shared_ptr<HootNetworkRequest>;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.h
@@ -176,6 +176,8 @@ public:
   { _keepImmediatelyConnectedWaysOutsideBounds = keep; }
   void setLogWarningsForMissingElements(bool log) { _logWarningsForMissingElements = log; }
 
+  bool isError() const { return ParallelBoundedApiReader::isError(); }
+
 protected:
 
   // Items to conform to OsmMapReader ifc
@@ -258,6 +260,8 @@ private:
   bool _addChildRefsWhenMissing;
   // determines whether missing elements trigger a warning
   bool _logWarningsForMissingElements;
+
+  QString _queryFilepath;
 
   /**
    * @brief parseOverpassJson Traverses our property tree and adds elements to the map. Removes

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
@@ -136,6 +136,13 @@ protected:
    * @brief _sleep Sleep the current thread
    */
   void _sleep() const;
+  /**
+   * @brief _isQueryError
+   * @param result
+   * @param error
+   * @return
+   */
+  bool _isQueryError(const QString& result, QString& error) const;
 
 private:
 
@@ -197,6 +204,8 @@ private:
   std::mutex _filenumberMutex;
   /** HTTP timeout in seconds */
   int _timeout;
+  /**  Allow test class to access protected members for white box testing */
+  friend class ParallelBoundedApiReaderTest;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/ops/RemoveWayByEid.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/RemoveWayByEid.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #include "RemoveWayByEid.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/RemoveWayByEid.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/RemoveWayByEid.cpp
@@ -27,8 +27,8 @@
 #include "RemoveWayByEid.h"
 
 // hoot
-#include <hoot/core/index/OsmMapIndex.h>
 #include <hoot/core/elements/NodeToWayMap.h>
+#include <hoot/core/index/OsmMapIndex.h>
 #include <hoot/core/util/Validate.h>
 
 using namespace std;
@@ -36,15 +36,15 @@ using namespace std;
 namespace hoot
 {
 
-RemoveWayByEid::RemoveWayByEid(bool removeFully) :
-_wayIdToRemove(-std::numeric_limits<int>::max()),
-_removeFully(removeFully)
+RemoveWayByEid::RemoveWayByEid(bool removeFully)
+  : _wayIdToRemove(-std::numeric_limits<int>::max()),
+    _removeFully(removeFully)
 {
 }
 
-RemoveWayByEid::RemoveWayByEid(long wId, bool removeFully) :
-_wayIdToRemove(wId),
-_removeFully(removeFully)
+RemoveWayByEid::RemoveWayByEid(long wId, bool removeFully)
+  : _wayIdToRemove(wId),
+    _removeFully(removeFully)
 {
 }
 
@@ -57,19 +57,16 @@ void RemoveWayByEid::_removeWay(const OsmMapPtr& map, long wId) const
     map->_ways.erase(wId);
 
     LOG_VART(map->_ways.find(wId) == map->_ways.end());
-    LOG_VART(
-      map->_index->getElementToRelationMap()->getRelationByElement(ElementId::way(wId)).size());
+    LOG_VART(map->_index->getElementToRelationMap()->getRelationByElement(ElementId::way(wId)).size());
   }
 }
 
 void RemoveWayByEid::_removeWayFully(const OsmMapPtr& map, long wId) const
 {
   // copy the set because we may modify it later.
-  set<long> rid =
-    map->_index->getElementToRelationMap()->getRelationByElement(ElementId::way(wId));
-  for (set<long>::const_iterator it = rid.begin(); it != rid.end(); ++it)
+  set<long> rid = map->_index->getElementToRelationMap()->getRelationByElement(ElementId::way(wId));
+  for (auto relationId : rid)
   {
-    const long relationId = *it;
     LOG_TRACE("Removing way: " << ElementId::way(wId) << " from relation: " << relationId << "...");
     map->getRelation(relationId)->removeElement(ElementId::way(wId));
   }
@@ -80,9 +77,7 @@ void RemoveWayByEid::_removeWayFully(const OsmMapPtr& map, long wId) const
 void RemoveWayByEid::apply(OsmMapPtr& map)
 {
   if (_wayIdToRemove == -std::numeric_limits<int>::max())
-  {
     throw IllegalArgumentException("No way ID specified for RemoveWayByEid.");
-  }
 
   if (_removeFully)
     _removeWayFully(map, _wayIdToRemove);

--- a/test-files/io/OsmJsonReaderTest/overpass_query.oql
+++ b/test-files/io/OsmJsonReaderTest/overpass_query.oql
@@ -1,0 +1,6 @@
+[out:json][bbox];
+(
+way;
+relation;
+);
+out;


### PR DESCRIPTION
Refs #5398 

Parses overpass data.  Loads queries from file or from URL.  `OsmJsonReader` can now authenticate using PKCS-12 credentials.

NOTE:  Does not allow for polygon bounds yet.