### PR TITLE
Polygon boundaries for overpass reader

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/WayJoinerConflateTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/WayJoinerConflateTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 //  Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/WayJoinerConflateTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/WayJoinerConflateTest.cpp
@@ -54,9 +54,9 @@ class WayJoinerConflateTest : public HootTestFixture
 
 public:
 
-  WayJoinerConflateTest() :
-  HootTestFixture(
-    "test-files/algorithms/WayJoinerConflateTest/", "test-output/algorithms/WayJoinerConflateTest/")
+  WayJoinerConflateTest()
+    : HootTestFixture("test-files/algorithms/WayJoinerConflateTest/",
+                      "test-output/algorithms/WayJoinerConflateTest/")
   {
     setResetType(ResetAll);
   }
@@ -87,7 +87,7 @@ public:
     OpExecutor(ConfigOptions().getConflatePostOps()).apply(map);
     MapProjector::projectToWgs84(map);
 
-    RemoveTagsVisitor hashRemover(QStringList(MetadataTags::HootHash()));
+    RemoveTagsVisitor hashRemover(QStringList({MetadataTags::HootHash()}));
     map->visitRw(hashRemover);
 
     OsmXmlWriter writer;
@@ -120,7 +120,7 @@ public:
     OpExecutor(ConfigOptions().getConflatePostOps()).apply(map);
     MapProjector::projectToWgs84(map);
 
-    RemoveTagsVisitor hashRemover(QStringList(MetadataTags::HootHash()));
+    RemoveTagsVisitor hashRemover(QStringList({MetadataTags::HootHash()}));
     map->visitRw(hashRemover);
 
     OsmXmlWriter writer;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/ScoreMatchesDiff.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/ScoreMatchesDiff.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #include "ScoreMatchesDiff.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/ScoreMatchesDiff.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/ScoreMatchesDiff.cpp
@@ -44,9 +44,9 @@
 namespace hoot
 {
 
-ScoreMatchesDiff::ScoreMatchesDiff() :
-_numManualMatches(0),
-_reviewDifferential(0)
+ScoreMatchesDiff::ScoreMatchesDiff()
+  : _numManualMatches(0),
+    _reviewDifferential(0)
 {
 }
 
@@ -68,9 +68,8 @@ void ScoreMatchesDiff::clear()
   _input2 = "";
   _output = "";
   if (_outputFile)
-  {
     _outputFile->close();
-  }
+
   _outputFile.reset();
 
   _numManualMatches = 0;
@@ -79,15 +78,9 @@ void ScoreMatchesDiff::clear()
 void ScoreMatchesDiff::calculateDiff(const QString& input1, const QString& input2)
 {
   if (!OsmXmlReader().isSupported(input1))
-  {
-    throw IllegalArgumentException(
-      "Unsupported input format: " + input1 + " Must be an .osm file.");
-  }
+    throw IllegalArgumentException("Unsupported input format: " + input1 + " Must be an .osm file.");
   else if (!OsmXmlReader().isSupported(input2))
-  {
-    throw IllegalArgumentException(
-      "Unsupported input format: " + input2 + " Must be an .osm file.");
-  }
+    throw IllegalArgumentException("Unsupported input format: " + input2 + " Must be an .osm file.");
 
   _input1 = input1;
   _input2 = input2;
@@ -122,26 +115,14 @@ void ScoreMatchesDiff::calculateDiff(const QString& input1, const QString& input
   LOG_VARD(numManualMatches1);
   LOG_VARD(numManualMatches2);
 
-  // TODO: This ends up being true a lot, so maybe not a good check?
-//  if (numManualMatches1 != numManualMatches2)
-//  {
-//    throw HootException(
-//      QString("The two input datasets have a different number of manual matches (") +
-//      QString::number(numManualMatches1) + " and " + QString::number(numManualMatches2) +
-//      QString(") and, therefore, must not been derived from the same input data."));
-//  }
   _numManualMatches = numManualMatches1;
 
   // get all expected/actual match types
 
-  const QMap<ElementId, QString> expected1 =
-    _getMatchStatuses(map1, MetadataTags::HootExpected());
-  const QMap<ElementId, QString> actual1 =
-    _getMatchStatuses(map1, MetadataTags::HootActual());
-  const QMap<ElementId, QString> expected2 =
-    _getMatchStatuses(map2, MetadataTags::HootExpected());
-  const QMap<ElementId, QString> actual2 =
-    _getMatchStatuses(map2, MetadataTags::HootActual());
+  const QMap<ElementId, QString> expected1 = _getMatchStatuses(map1, MetadataTags::HootExpected());
+  const QMap<ElementId, QString> actual1 = _getMatchStatuses(map1, MetadataTags::HootActual());
+  const QMap<ElementId, QString> expected2 = _getMatchStatuses(map2, MetadataTags::HootExpected());
+  const QMap<ElementId, QString> actual2 = _getMatchStatuses(map2, MetadataTags::HootActual());
 
   LOG_VARD(expected1.size());
   LOG_VARD(actual1.size());
@@ -171,14 +152,12 @@ void ScoreMatchesDiff::calculateDiff(const QString& input1, const QString& input
   _newlyCorrectMatchSwitches = _getMatchScoringDiff(_newlyCorrect, expected2, actual2);
 
   LOG_VARD(_newlyWrongMatchSwitches.size());
-  for (QMap<QString, QSet<ElementId>>::const_iterator itr = _newlyWrongMatchSwitches.begin();
-       itr != _newlyWrongMatchSwitches.end(); ++itr)
+  for (auto itr = _newlyWrongMatchSwitches.begin(); itr != _newlyWrongMatchSwitches.end(); ++itr)
   {
     LOG_DEBUG(itr.key() << " " << itr.value().size());
   }
   LOG_VARD(_newlyCorrectMatchSwitches.size());
-  for (QMap<QString, QSet<ElementId>>::const_iterator itr = _newlyCorrectMatchSwitches.begin();
-       itr != _newlyCorrectMatchSwitches.end(); ++itr)
+  for (auto itr = _newlyCorrectMatchSwitches.begin(); itr != _newlyCorrectMatchSwitches.end(); ++itr)
   {
     LOG_DEBUG(itr.key() << " " << itr.value().size());
   }
@@ -285,29 +264,24 @@ QSet<ElementId> ScoreMatchesDiff::_getWrong(const ConstOsmMapPtr& map)
   return CollectionUtils::stdSetToQSet(idVis.getElementSet());
 }
 
-QMap<QString, QSet<ElementId>> ScoreMatchesDiff::_getMatchScoringDiff(
-  const QSet<ElementId>& elementIds, const QMap<ElementId, QString>& expectedTagMappings,
-  const QMap<ElementId, QString>& actualTagMappings) const
+QMap<QString, QSet<ElementId>> ScoreMatchesDiff::_getMatchScoringDiff(const QSet<ElementId>& elementIds,
+                                                                      const QMap<ElementId, QString>& expectedTagMappings,
+                                                                      const QMap<ElementId, QString>& actualTagMappings) const
 {
   LOG_DEBUG("Calculating match scoring diff...");
   QMap<QString, QSet<ElementId>> matchSwitches;
-  for (QSet<ElementId>::const_iterator itr = elementIds.begin(); itr != elementIds.end(); ++itr)
+  for (const auto& id : qAsConst(elementIds))
   {
-    const ElementId id = *itr;
+    //  This ends up happening a lot, so maybe not a good reason to throw an error?
     if (!expectedTagMappings.contains(id))
-    {
-      // TODO: This ends up happening a lot, so maybe not a good reason to throw an error?
-      //throw HootException("Can't find ID: " + id.toString() + " for expected.");
       continue;
-    }
+
     QString expectedMatchTypeStr = expectedTagMappings[id];
     MatchType expectedMatchType = MatchType(expectedMatchTypeStr);
+    //  See note above.
     if (!actualTagMappings.contains(id))
-    {
-      // See note above.
-      //throw HootException("Can't find ID: " + id.toString() + " for actual.");
       continue;
-    }
+
     QString actualMatchTypeStr = actualTagMappings[id];
     MatchType actualMatchType = MatchType(actualMatchTypeStr);
 
@@ -315,41 +289,25 @@ QMap<QString, QSet<ElementId>> ScoreMatchesDiff::_getMatchScoringDiff(
     LOG_VART(actualMatchTypeStr);
 
     if (expectedMatchType == MatchType::Match && actualMatchType == MatchType::Miss)
-    {
       matchSwitches[MatchStatusChange(MatchStatusChange::MatchToMiss).toString()].insert(id);
-    }
     else if (expectedMatchType == MatchType::Match && actualMatchType == MatchType::Review)
-    {
       matchSwitches[MatchStatusChange(MatchStatusChange::MatchToReview).toString()].insert(id);
-    }
     else if (expectedMatchType == MatchType::Miss && actualMatchType == MatchType::Match)
-    {
       matchSwitches[MatchStatusChange(MatchStatusChange::MissToMatch).toString()].insert(id);
-    }
     else if (expectedMatchType == MatchType::Miss && actualMatchType == MatchType::Review)
-    {
       matchSwitches[MatchStatusChange(MatchStatusChange::MissToReview).toString()].insert(id);
-    }
     else if (expectedMatchType == MatchType::Review && actualMatchType == MatchType::Match)
-    {
       matchSwitches[MatchStatusChange(MatchStatusChange::ReviewToMatch).toString()].insert(id);
-    }
     else if (expectedMatchType == MatchType::Review && actualMatchType == MatchType::Miss)
-    {
       matchSwitches[MatchStatusChange(MatchStatusChange::ReviewToMiss).toString()].insert(id);
-    }
-    else
-    {
-      // shouldn't ever get here
+    else  // shouldn't ever get here
       throw HootException("Error parsing match types with ScoreMatchesDiff.");
-    }
   }
   return matchSwitches;
 }
 
-void ScoreMatchesDiff::_setAddedAndRemovedElements(
-  const QSet<ElementId>& all1Ids, const QSet<ElementId>& all2Ids,
-  QSet<ElementId>& elementIdsAdded, QSet<ElementId>& elementIdsRemoved) const
+void ScoreMatchesDiff::_setAddedAndRemovedElements(const QSet<ElementId>& all1Ids, const QSet<ElementId>& all2Ids,
+                                                   QSet<ElementId>& elementIdsAdded, QSet<ElementId>& elementIdsRemoved) const
 {
   LOG_DEBUG("Recording added/removed elements...");
   QSet<ElementId> allIds = all1Ids;
@@ -364,156 +322,108 @@ void ScoreMatchesDiff::_writeConflateStatusSummary(QTextStream& out)
 {
   LOG_DEBUG("Writing conflate status summary...");
 
-  QString summary;
-  summary += "Match Scoring Differential Summary:\n\n";
-  summary +=
-    StringUtils::formatLargeNumber(_numManualMatches) + " manual matches.\n";
-  summary +=
-    StringUtils::formatLargeNumber(_elementIdsRemoved.size()) +
-    " elements from the first file were removed in the second file.\n";
-  summary +=
-    StringUtils::formatLargeNumber(_elementIdsAdded.size()) +
-    " new elements were added to the second file.\n";
-  summary +=
-    StringUtils::formatLargeNumber(_newlyWrong.size()) +
-    " new elements are involved in wrong matches.\n";
-  summary +=
-    StringUtils::formatLargeNumber(_newlyCorrect.size()) +
-    " new elements are involved in correct matches.\n";
-  for (QMap<QString, QSet<ElementId>>::const_iterator itr = _newlyWrongMatchSwitches.begin();
-       itr != _newlyWrongMatchSwitches.end(); ++itr)
+  QStringList summary;
+  summary += "Match Scoring Differential Summary:\n";
+  summary += StringUtils::formatLargeNumber(_numManualMatches) + " manual matches.";
+  summary += StringUtils::formatLargeNumber(_elementIdsRemoved.size()) + " elements from the first file were removed in the second file.";
+  summary += StringUtils::formatLargeNumber(_elementIdsAdded.size()) + " new elements were added to the second file.";
+  summary += StringUtils::formatLargeNumber(_newlyWrong.size()) + " new elements are involved in wrong matches.";
+  summary += StringUtils::formatLargeNumber(_newlyCorrect.size()) + " new elements are involved in correct matches.";
+  for (auto itr = _newlyWrongMatchSwitches.begin(); itr != _newlyWrongMatchSwitches.end(); ++itr)
   {
     const QString changeType = itr.key();
     const int numChanged = itr.value().size();
-    summary +=
-      StringUtils::formatLargeNumber(numChanged) + " new wrong matches switched from " +
-      changeType + ".\n";
+    summary += StringUtils::formatLargeNumber(numChanged) + " new wrong matches switched from " + changeType + ".";
   }
-  for (QMap<QString, QSet<ElementId>>::const_iterator itr = _newlyCorrectMatchSwitches.begin();
-       itr != _newlyCorrectMatchSwitches.end(); ++itr)
+  for (auto itr = _newlyCorrectMatchSwitches.begin(); itr != _newlyCorrectMatchSwitches.end(); ++itr)
   {
     const QString changeType = itr.key();
     const int numChanged = itr.value().size();
-    summary +=
-      StringUtils::formatLargeNumber(numChanged) + " new correct matches switched from " +
-      changeType + ".\n";
+    summary += StringUtils::formatLargeNumber(numChanged) + " new correct matches switched from " + changeType + ".";
   }
   if (_reviewDifferential > 0)
-  {
-    summary += QString::number(_reviewDifferential) + " reviews were added.\n";
-  }
+    summary += QString::number(_reviewDifferential) + " reviews were added.";
   else if (_reviewDifferential == 0)
-  {
-    summary += "No reviews were added.\n";
-  }
+    summary += "No reviews were added.";
   else if (_reviewDifferential < 0)
-  {
-    summary += QString::number(abs(_reviewDifferential)) + " reviews were lost.\n";
-  }
+    summary += QString::number(abs(_reviewDifferential)) + " reviews were lost.";
 
-  summary = summary.trimmed();
-  std::cout << summary << std::endl;
-  std::cout << "\nDetailed information available in: " << _output << "." << std::endl;
+  QString summary_string = summary.join("\n");
+  std::cout << summary_string << std::endl << std::endl;
+  std::cout << "Detailed information available in: " << _output << "." << std::endl;
 
-  out << summary;
+  out << summary_string;
 }
 
 void ScoreMatchesDiff::_writeConflateStatusDetail(QTextStream& out)
 {
   LOG_DEBUG("Printing conflate status detail...");
 
-  QString detail;
+  QStringList detail;
   detail += "\n\nMatch Type Changes\n";
   if (_newlyWrongMatchSwitches.size() + _newlyCorrectMatchSwitches.size() == 0)
-  {
     detail += "none";
-  }
   else
   {
-    detail += "\nNew Wrong Matches:\n";
+    detail += "New Wrong Matches:\n";
     if (_newlyWrongMatchSwitches.empty())
-    {
-      detail += "none";
-    }
+      detail += "none\n";
     else
     {
-      for (QMap<QString, QSet<ElementId>>::const_iterator itr = _newlyWrongMatchSwitches.begin();
-           itr != _newlyWrongMatchSwitches.end(); ++itr)
+      for (auto itr = _newlyWrongMatchSwitches.begin(); itr != _newlyWrongMatchSwitches.end(); ++itr)
       {
         const QString matchSwitchTypeStr = itr.key();
-        detail += "\n" + matchSwitchTypeStr + ":\n\n";
+        detail += matchSwitchTypeStr + ":\n";
         QList<ElementId> ids = itr.value().toList();
         qSort(ids);
-        for (QList<ElementId>::const_iterator itr2 = ids.begin(); itr2 != ids.end(); ++itr2)
-        {
-          const ElementId id = *itr2;
-          detail += id.toString() + "\n";
-        }
+        for (const auto& id : qAsConst(ids))
+          detail += id.toString();
+        detail += "";
       }
-      detail = detail.trimmed();
     }
 
-    detail += "\n\nNew Correct Matches:\n\n";
+    detail += "New Correct Matches:\n";
     if (_newlyCorrectMatchSwitches.empty())
-    {
-      detail += "none";
-    }
+      detail += "none\n";
     else
     {
-      for (QMap<QString, QSet<ElementId>>::const_iterator itr = _newlyCorrectMatchSwitches.begin();
-           itr != _newlyCorrectMatchSwitches.end(); ++itr)
+      for (auto itr = _newlyCorrectMatchSwitches.begin(); itr != _newlyCorrectMatchSwitches.end(); ++itr)
       {
         const QString matchSwitchTypeStr = itr.key();
-        detail += "\n" + matchSwitchTypeStr + "\n\n";
+        detail += matchSwitchTypeStr + "\n";
         QList<ElementId> ids = itr.value().toList();
         qSort(ids);
-        for (QList<ElementId>::const_iterator itr2 = ids.begin(); itr2 != ids.end(); ++itr2)
-        {
-          const ElementId id = *itr2;
-          detail += id.toString() + "\n";
-        }
+        for (const auto& id  : qAsConst(ids))
+          detail += id.toString();
+        detail += "";
       }
     }
-    detail = detail.trimmed();
   }
 
-  detail +="\n\nAdded Elements:\n\n";
+  detail +="Added Elements:\n";
   if (_elementIdsAdded.empty())
-  {
-    detail += "none";
-  }
+    detail += "none\n";
   else
   {
     QList<ElementId> elementIdsAdded = _elementIdsAdded.toList();
     qSort(elementIdsAdded);
-    for (QList<ElementId>::const_iterator itr = elementIdsAdded.begin();
-         itr != elementIdsAdded.end(); ++itr)
-    {
-      const ElementId id = *itr;
-      detail += id.toString() + "\n";
-    }
-    detail = detail.trimmed();
+    for (const auto& id : qAsConst(elementIdsAdded))
+      detail += id.toString();
+    detail += "";
   }
 
-  detail += "\n\nRemoved Elements:\n\n";
+  detail += "Removed Elements:\n";
   if (_elementIdsRemoved.empty())
-  {
-     detail += "none";
-  }
+     detail += "none\n";
   else
   {
     QList<ElementId> elementIdsRemoved = _elementIdsRemoved.toList();
     qSort(elementIdsRemoved);
-    for (QList<ElementId>::const_iterator itr = elementIdsRemoved.begin();
-         itr != elementIdsRemoved.end(); ++itr)
-    {
-      const ElementId id = *itr;
-      detail += id.toString() + "\n";
-    }
-    detail = detail.trimmed();
+    for (const auto& id : qAsConst(elementIdsRemoved))
+      detail += id.toString();
+    detail += "";
   }
-
-  out << detail;
+  out << detail.join("\n");
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/ScoreMatchesDiff.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/ScoreMatchesDiff.h
@@ -28,8 +28,8 @@
 #define SCORE_MATCHES_DIFF_H
 
 // Hoot
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/conflate/matching/MatchType.h>
+#include <hoot/core/elements/OsmMap.h>
 
 // Qt
 #include <QTextStream>
@@ -124,16 +124,15 @@ private:
    * For a given set of elements, groups them by how their match statuses changed between the two
    * inputs
    */
-  QMap<QString, QSet<ElementId>> _getMatchScoringDiff(
-    const QSet<ElementId>& elementIds, const QMap<ElementId, QString>& actualTagMappings1,
-    const QMap<ElementId, QString>& actualTagMappings2) const;
+  QMap<QString, QSet<ElementId>> _getMatchScoringDiff(const QSet<ElementId>& elementIds,
+                                                      const QMap<ElementId, QString>& actualTagMappings1,
+                                                      const QMap<ElementId, QString>& actualTagMappings2) const;
 
   /*
    * Records element differences between the two inputs
    */
-  void _setAddedAndRemovedElements(
-    const QSet<ElementId>& all1Ids, const QSet<ElementId>& all2Ids,
-    QSet<ElementId>& elementIdsAdded, QSet<ElementId>& elementIdsRemoved) const;
+  void _setAddedAndRemovedElements(const QSet<ElementId>& all1Ids, const QSet<ElementId>& all2Ids,
+                                   QSet<ElementId>& elementIdsAdded, QSet<ElementId>& elementIdsRemoved) const;
 
   void _writeConflateStatusSummary(QTextStream& out);
   void _writeConflateStatusDetail(QTextStream& out);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/ScoreMatchesDiff.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/ScoreMatchesDiff.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef SCORE_MATCHES_DIFF_H
 #define SCORE_MATCHES_DIFF_H

--- a/hoot-core/src/main/cpp/hoot/core/elements/WayUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/WayUtils.cpp
@@ -40,6 +40,7 @@
 
 // Std
 #include <float.h>
+#include <typeinfo>
 
 namespace hoot
 {
@@ -49,26 +50,21 @@ QString WayUtils::getWayNodesDetailedString(const ConstWayPtr& way, const ConstO
   return NodeUtils::nodeCoordsToString(NodeUtils::nodeIdsToNodes(way->getNodeIds(), map));
 }
 
-std::set<long> WayUtils::getContainingWayIds(
-  const long nodeId, const ConstOsmMapPtr& map, const ElementCriterionPtr& wayCriterion)
+std::set<long> WayUtils::getContainingWayIds(const long nodeId, const ConstOsmMapPtr& map, const ElementCriterionPtr& wayCriterion)
 {
   LOG_VART(nodeId);
   std::set<long> containingWayIds;
 
-  const std::set<long>& idsOfWaysContainingNode =
-    map->getIndex().getNodeToWayMap()->getWaysByNode(nodeId);
+  const std::set<long>& idsOfWaysContainingNode = map->getIndex().getNodeToWayMap()->getWaysByNode(nodeId);
   LOG_VART(idsOfWaysContainingNode);
-  for (std::set<long>::const_iterator containingWaysItr = idsOfWaysContainingNode.begin();
-       containingWaysItr != idsOfWaysContainingNode.end(); ++containingWaysItr)
+  for (auto containingWayId : idsOfWaysContainingNode)
   {
-    const long containingWayId = *containingWaysItr;
     LOG_VART(containingWayId);
 
     if (wayCriterion)
     {
-      LOG_VART(typeid(*wayCriterion).name());
-      std::shared_ptr<ChainCriterion> chainCrit =
-        std::dynamic_pointer_cast<ChainCriterion>(wayCriterion);
+      LOG_VART(typeid(wayCriterion.get()).name());
+      std::shared_ptr<ChainCriterion> chainCrit = std::dynamic_pointer_cast<ChainCriterion>(wayCriterion);
       if (chainCrit)
       {
         LOG_VART(chainCrit->toString());
@@ -77,61 +73,48 @@ std::set<long> WayUtils::getContainingWayIds(
     }
 
     if (!wayCriterion || wayCriterion->isSatisfied(map->getWay(containingWayId)))
-    {
       containingWayIds.insert(containingWayId);
-    }
   }
 
   LOG_VART(containingWayIds);
   return containingWayIds;
 }
 
-std::vector<ConstWayPtr> WayUtils::getContainingWaysConst(
-  const long nodeId, const ConstOsmMapPtr& map,
-  const ElementCriterionPtr& wayCriterion)
+std::vector<ConstWayPtr> WayUtils::getContainingWaysConst(const long nodeId, const ConstOsmMapPtr& map,
+                                                          const ElementCriterionPtr& wayCriterion)
 {
   std::vector<ConstWayPtr> containingWays;
   const std::set<long> containingWayIds = getContainingWayIds(nodeId, map, wayCriterion);
-  for (std::set<long>::const_iterator containingWayIdsItr = containingWayIds.begin();
-       containingWayIdsItr != containingWayIds.end(); ++containingWayIdsItr)
+  for (auto way_id : containingWayIds)
   {
-    ConstWayPtr containingWay = map->getWay(*containingWayIdsItr);
+    ConstWayPtr containingWay = map->getWay(way_id);
     if (containingWay)
-    {
       containingWays.push_back(containingWay);
-    }
   }
   return containingWays;
 }
 
-std::vector<WayPtr> WayUtils::getContainingWays(
-  const long nodeId, const ConstOsmMapPtr& map,
-  const ElementCriterionPtr& wayCriterion)
+std::vector<WayPtr> WayUtils::getContainingWays(const long nodeId, const ConstOsmMapPtr& map,
+                                                const ElementCriterionPtr& wayCriterion)
 {
   std::vector<WayPtr> waysToReturn;
   std::vector<ConstWayPtr> ways = getContainingWaysConst(nodeId, map, wayCriterion);
-  for (std::vector<ConstWayPtr>::const_iterator itr = ways.begin(); itr != ways.end(); ++itr)
-  {
-    waysToReturn.push_back(std::const_pointer_cast<Way>(*itr));
-  }
+  for (const auto& way : ways)
+    waysToReturn.push_back(std::const_pointer_cast<Way>(way));
   return waysToReturn;
 }
 
-std::set<QString> WayUtils::getContainingWaysMostSpecificTypes(
-  const long nodeId, const ConstOsmMapPtr& map)
+std::set<QString> WayUtils::getContainingWaysMostSpecificTypes(const long nodeId, const ConstOsmMapPtr& map)
 {
   std::set<QString> uniqueTypes;
   std::vector<ConstWayPtr> containingWays = getContainingWaysConst(nodeId, map);
   std::sort(containingWays.begin(), containingWays.end());
   OsmSchema& schema = OsmSchema::getInstance();
-  for (std::vector<ConstWayPtr>::const_iterator containingWaysItr = containingWays.begin();
-       containingWaysItr != containingWays.end(); ++containingWaysItr)
+  for (const auto& way : containingWays)
   {
-    const QString mostSpecificType = schema.mostSpecificType((*containingWaysItr)->getTags());
+    const QString mostSpecificType = schema.mostSpecificType(way->getTags());
     if (!mostSpecificType.isEmpty())
-    {
       uniqueTypes.insert(mostSpecificType);
-    }
   }
   return uniqueTypes;
 }
@@ -145,9 +128,8 @@ QSet<long> WayUtils::getConnectedWays(const long wayId, const ConstOsmMapPtr& ma
   {
     LOG_VART(way->getElementId());
     const std::vector<long>& wayNodeIds = way->getNodeIds();
-    for (size_t i = 0; i < wayNodeIds.size(); i++)
+    for (auto wayNodeId : wayNodeIds)
     {
-      const long wayNodeId = wayNodeIds.at(i);
       LOG_VART(wayNodeId);
       const QSet<long>& idsOfWaysContainingNode =
         CollectionUtils::stdSetToQSet(map->getIndex().getNodeToWayMap()->getWaysByNode(wayNodeId));
@@ -171,40 +153,31 @@ bool WayUtils::hasConnectedWays(const long wayId, const ConstOsmMapPtr& map)
   return getNumberOfConnectedWays(wayId, map) > 0;
 }
 
-bool WayUtils::endWayNodeIsCloserToNodeThanStart(
-  const ConstNodePtr& node, const ConstWayPtr& way, const ConstOsmMapPtr& map)
+bool WayUtils::endWayNodeIsCloserToNodeThanStart(const ConstNodePtr& node, const ConstWayPtr& way, const ConstOsmMapPtr& map)
 {
   if (way->isSimpleLoop())
-  {
     return false;
-  }
-  const double distanceToStartNode =
-    Distance::euclidean(node->toCoordinate(), map->getNode(way->getFirstNodeId())->toCoordinate());
-  const double distanceToEndNode =
-    Distance::euclidean(node->toCoordinate(), map->getNode(way->getLastNodeId())->toCoordinate());
+  const double distanceToStartNode = Distance::euclidean(node->toCoordinate(), map->getNode(way->getFirstNodeId())->toCoordinate());
+  const double distanceToEndNode = Distance::euclidean(node->toCoordinate(), map->getNode(way->getLastNodeId())->toCoordinate());
   return distanceToEndNode < distanceToStartNode;
 }
 
-geos::geom::Coordinate WayUtils::closestWayCoordToNode(
-  const ConstNodePtr& node, const ConstWayPtr& way, double& distance,
-  const double discretizationSpacing, const ConstOsmMapPtr& map)
+geos::geom::Coordinate WayUtils::closestWayCoordToNode(const ConstNodePtr& node, const ConstWayPtr& way, double& distance,
+                                                       const double discretizationSpacing, const ConstOsmMapPtr& map)
 {
   // split the way up into coords
   std::vector<geos::geom::Coordinate> discretizedWayCoords;
   WayDiscretizer wayDiscretizer(map, way);
   if (!wayDiscretizer.discretize(discretizationSpacing, discretizedWayCoords))
-  {
     return geos::geom::Coordinate();
-  }
 
   // Add the first and last coords in. One or both could already be there, but it won't hurt if
   // they're duplicated.
   ConstNodePtr firstNode = map->getNode(way->getFirstNodeId());
   ConstNodePtr lastNode = map->getNode(way->getLastNodeId());
   if (!firstNode || !lastNode)
-  {
     return geos::geom::Coordinate();
-  }
+
   discretizedWayCoords.insert(discretizedWayCoords.begin(), firstNode->toCoordinate());
   discretizedWayCoords.push_back(lastNode->toCoordinate());
   LOG_VART(discretizedWayCoords.size());
@@ -213,25 +186,20 @@ geos::geom::Coordinate WayUtils::closestWayCoordToNode(
   // determine which end of the way is closer to our input node (to handle ways looping back on
   // themselves)
   if (endWayNodeIsCloserToNodeThanStart(node, way, map))
-  {
     std::reverse(discretizedWayCoords.begin(), discretizedWayCoords.end());
-  }
   LOG_VART(discretizedWayCoords.size());
 
   // find the closest coord to the input node
   double shortestDistance = DBL_MAX;
   double lastDistance = DBL_MAX;
   geos::geom::Coordinate closestWayCoordToNode;
-  for (size_t i = 0; i < discretizedWayCoords.size(); i++)
+  for (const auto& wayCoord : discretizedWayCoords)
   {
-    const geos::geom::Coordinate wayCoord = discretizedWayCoords[i];
     const double distanceBetweenNodeAndWayCoord = wayCoord.distance(node->toCoordinate());
     // Since we're going in node order and started at the closest end of the way, if we start
     // seeing larger distances, then we're done.
     if (distanceBetweenNodeAndWayCoord > lastDistance)
-    {
       break;
-    }
     if (distanceBetweenNodeAndWayCoord < shortestDistance)
     {
       closestWayCoordToNode = wayCoord;
@@ -246,16 +214,15 @@ geos::geom::Coordinate WayUtils::closestWayCoordToNode(
   return closestWayCoordToNode;
 }
 
-long WayUtils::closestWayNodeIdToNode(
-  const ConstNodePtr& node, const ConstWayPtr& way, const ConstOsmMapPtr& map)
+long WayUtils::closestWayNodeIdToNode(const ConstNodePtr& node, const ConstWayPtr& way, const ConstOsmMapPtr& map)
 {
   double shortestDistance = DBL_MAX;
   long closestWayNodeId = 0;
 
   const std::vector<long>& wayNodeIds = way->getNodeIds();
-  for (size_t i = 0; i < wayNodeIds.size(); i++)
+  for (auto node_id : wayNodeIds)
   {
-    ConstNodePtr wayNode = map->getNode(wayNodeIds[i]);
+    ConstNodePtr wayNode = map->getNode(node_id);
     const double distanceFromNodeToWayNode =
       Distance::euclidean(node->toCoordinate(), wayNode->toCoordinate());
     if (distanceFromNodeToWayNode < shortestDistance)
@@ -270,8 +237,7 @@ long WayUtils::closestWayNodeIdToNode(
   return closestWayNodeId;
 }
 
-long WayUtils::closestWayNodeIndexToNode(
-  const ConstNodePtr& node, const ConstWayPtr& way, const ConstOsmMapPtr& map)
+long WayUtils::closestWayNodeIndexToNode(const ConstNodePtr& node, const ConstWayPtr& way, const ConstOsmMapPtr& map)
 {
   LOG_VART(way->getNodeCount());
 
@@ -282,60 +248,44 @@ long WayUtils::closestWayNodeIndexToNode(
   return index;
 }
 
-long WayUtils::closestWayNodeInsertIndex(
-  const ConstNodePtr& node, const ConstWayPtr& way, const ConstOsmMapPtr& map)
+long WayUtils::closestWayNodeInsertIndex(const ConstNodePtr& node, const ConstWayPtr& way, const ConstOsmMapPtr& map)
 {
   // get the way location of the node
   const WayLocation nodeLoc = LocationOfPoint::locate(map, way, node->toCoordinate());
   if (!nodeLoc.isValid())
-  {
     return -1;
-  }
 
   // get the closest way node index to it and get its way location
   const long closestWayNodeIndex = closestWayNodeIndexToNode(node, way, map);
   LOG_VART(closestWayNodeIndex);
   if (closestWayNodeIndex == -1)
-  {
     return -1;
-  }
-  ConstNodePtr closestWayNode = map->getNode(way->getNodeId(closestWayNodeIndex));
+
+  ConstNodePtr closestWayNode = map->getNode(way->getNodeId(static_cast<int>(closestWayNodeIndex)));
   LOG_VART(closestWayNode->getElementId());
   if (!closestWayNode)
-  {
     return -1;
-  }
-  const WayLocation closestNodeLoc =
-    LocationOfPoint::locate(map, way, closestWayNode->toCoordinate());
+
+  const WayLocation closestNodeLoc = LocationOfPoint::locate(map, way, closestWayNode->toCoordinate());
   if (!closestNodeLoc.isValid())
-  {
     return -1;
-  }
 
   // If the closest index way location is after the node's way location we want to insert before
   // the index, so return the index.
   LOG_VART(closestNodeLoc >= nodeLoc);
   if (closestNodeLoc >= nodeLoc)
-  {
     return closestWayNodeIndex;
-  }
-  else
-  {
-    // Otherwise, if the closest index way location is before the node's way location we want to
-    // insert after the index, so return the index + 1.
+  else  // The closest index way location is before the node's way location insert after the index, return index + 1.
     return closestWayNodeIndex + 1;
-  }
 }
 
 bool WayUtils::nodesAreContainedInTheSameWay(const long nodeId1, const long nodeId2,
                                              const ConstOsmMapPtr& map)
 {
-  const std::set<long>& waysContainingNode1 =
-    map->getIndex().getNodeToWayMap()->getWaysByNode(nodeId1);
+  const std::set<long>& waysContainingNode1 = map->getIndex().getNodeToWayMap()->getWaysByNode(nodeId1);
   LOG_VART(waysContainingNode1);
 
-  const std::set<long>& waysContainingNode2 =
-    map->getIndex().getNodeToWayMap()->getWaysByNode(nodeId2);
+  const std::set<long>& waysContainingNode2 = map->getIndex().getNodeToWayMap()->getWaysByNode(nodeId2);
   LOG_VART(waysContainingNode2);
 
   std::set<long> commonNodesBetweenWayGroups;
@@ -359,7 +309,8 @@ bool WayUtils::nodeContainedByAnyWay(const long nodeId, const std::set<long>& wa
   std::set<long> waysContainingNode = map->getIndex().getNodeToWayMap()->getWaysByNode(nodeId);
   std::set<long> commonWayIds;
   std::set_intersection(
-    waysContainingNode.begin(), waysContainingNode.end(), wayIds.begin(), wayIds.end(),
+    waysContainingNode.begin(), waysContainingNode.end(),
+    wayIds.begin(), wayIds.end(),
     std::inserter(commonWayIds, commonWayIds.begin()));
   return !commonWayIds.empty();
 }
@@ -376,17 +327,13 @@ std::vector<long> WayUtils::getIntersectingWayIds(const long wayId, const OsmMap
   if (way)
   {
     std::vector<long> nearbyWayIds = map->getIndex().findWays(way->getEnvelopeInternal(map));
-    for (std::vector<long>::const_iterator it = nearbyWayIds.begin(); it != nearbyWayIds.end();
-         ++it)
+    for (auto otherWayId : nearbyWayIds)
     {
-      const long otherWayId = *it;
       if (otherWayId != wayId)
       {
         WayPtr otherWay = map->getWay(otherWayId);
         if (otherWay && way->hasSharedNode(*otherWay))
-        {
           intersectingWayIds.push_back(otherWay->getId());
-        }
       }
     }
   }
@@ -397,15 +344,11 @@ std::vector<WayPtr> WayUtils::getIntersectingWays(const long wayId, const OsmMap
 {
   std::vector<WayPtr> intersectingWays;
   const std::vector<long> intersectingWayIds = getIntersectingWayIds(wayId, map);
-  for (std::vector<long>::const_iterator itr = intersectingWayIds.begin();
-       itr != intersectingWayIds.end(); ++itr)
+  for (auto intersectingWayId : intersectingWayIds)
   {
-    const long intersectingWayId = *itr;
     WayPtr way = map->getWay(intersectingWayId);
     if (way)
-    {
       intersectingWays.push_back(way);
-    }
   }
   return intersectingWays;
 }
@@ -417,42 +360,30 @@ std::vector<long> WayUtils::getIntersectingWayIdsConst(const long wayId, const C
   if (way)
   {
     std::vector<long> nearbyWayIds = map->getIndex().findWays(way->getEnvelopeInternal(map));
-    for (std::vector<long>::const_iterator it = nearbyWayIds.begin(); it != nearbyWayIds.end();
-         ++it)
+    for (auto otherWayId : nearbyWayIds)
     {
-      const long otherWayId = *it;
       if (otherWayId != wayId)
       {
         ConstWayPtr otherWay = map->getWay(otherWayId);
         if (otherWay && way->hasSharedNode(*otherWay))
-        {
           intersectingWayIds.push_back(otherWay->getId());
-        }
       }
     }
   }
   return intersectingWayIds;
 }
 
-bool WayUtils::nodeContainedByWaySharingNodesWithAnotherWay(
-  const long nodeId, const long wayId, const OsmMapPtr& map)
+bool WayUtils::nodeContainedByWaySharingNodesWithAnotherWay(const long nodeId, const long wayId, const OsmMapPtr& map)
 {
   ConstWayPtr way = map->getWay(wayId);
   if (!way)
-  {
     return false;
-  }
 
-  const std::vector<ConstWayPtr> waysContainingNode =
-    getContainingWaysConst(nodeId, map);
-  for (std::vector<ConstWayPtr>::const_iterator containingWayItr = waysContainingNode.begin();
-       containingWayItr != waysContainingNode.end(); ++containingWayItr)
+  const std::vector<ConstWayPtr> waysContainingNode = getContainingWaysConst(nodeId, map);
+  for (const auto& containingWay : waysContainingNode)
   {
-    ConstWayPtr containingWay = *containingWayItr;
     if (containingWay && containingWay->hasSharedNode(*way))
-    {
       return true;
-    }
   }
   return false;
 }

--- a/hoot-core/src/main/cpp/hoot/core/elements/WayUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/WayUtils.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "WayUtils.h"

--- a/hoot-core/src/main/cpp/hoot/core/elements/WayUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/WayUtils.h
@@ -93,9 +93,8 @@ public:
    * @return a valid coordinate or an empty coordinate if the closest coordinate could not be
    * calculated
    */
-  static geos::geom::Coordinate closestWayCoordToNode(
-    const ConstNodePtr& node, const ConstWayPtr& way, double& distance,
-    const double discretizationSpacing, const ConstOsmMapPtr& map);
+  static geos::geom::Coordinate closestWayCoordToNode(const ConstNodePtr& node, const ConstWayPtr& way, double& distance,
+                                                      const double discretizationSpacing, const ConstOsmMapPtr& map);
 
   /**
    * Determines the ID of the closest way node on a way to another node not on the way
@@ -105,8 +104,7 @@ public:
    * @param map the map containing the input node and way
    * @return a way node ID
    */
-  static long closestWayNodeIdToNode(
-    const ConstNodePtr& node, const ConstWayPtr& way, const ConstOsmMapPtr& map);
+  static long closestWayNodeIdToNode(const ConstNodePtr& node, const ConstWayPtr& way, const ConstOsmMapPtr& map);
 
   /**
    * Finds the closest way node index in a way to a specified node
@@ -116,8 +114,7 @@ public:
    * @param map map owning the node and way
    * @return closest index on the way to node or -1 if no index is found
    */
-  static long closestWayNodeIndexToNode(
-    const ConstNodePtr& node, const ConstWayPtr& way, const ConstOsmMapPtr& map);
+  static long closestWayNodeIndexToNode(const ConstNodePtr& node, const ConstWayPtr& way, const ConstOsmMapPtr& map);
 
   /**
    * Finds the closest way node insert index in a way to a specified node. The index can be used
@@ -128,8 +125,7 @@ public:
    * @param map map owning the node and way
    * @return closest insert index on the way to node or -1 if no index is found
    */
-  static long closestWayNodeInsertIndex(
-    const ConstNodePtr& node, const ConstWayPtr& way, const ConstOsmMapPtr& map);
+  static long closestWayNodeInsertIndex(const ConstNodePtr& node, const ConstWayPtr& way, const ConstOsmMapPtr& map);
 
   /**
    * Determines whether the start or end of a way is closer to a specified node
@@ -139,8 +135,7 @@ public:
    * @param map map containing the inputs way and node
    * @return true if the node is closer to the end of the way; false otherwise
    */
-  static bool endWayNodeIsCloserToNodeThanStart(
-    const ConstNodePtr& node, const ConstWayPtr& way, const ConstOsmMapPtr& map);
+  static bool endWayNodeIsCloserToNodeThanStart(const ConstNodePtr& node, const ConstWayPtr& way, const ConstOsmMapPtr& map);
 
   /**
    * Determines if two nodes belong to the same way
@@ -150,8 +145,7 @@ public:
    * @param map the map containing the nodes
    * @return true if there is at least one way that contains both nodes; false otherwise
    */
-  static bool nodesAreContainedInTheSameWay(
-    const long nodeId1, const long nodeId2, const ConstOsmMapPtr& map);
+  static bool nodesAreContainedInTheSameWay(const long nodeId1, const long nodeId2, const ConstOsmMapPtr& map);
 
   /**
    * Returns the IDs of all ways containing an input node
@@ -161,9 +155,8 @@ public:
    * @param wayCriterion an optional ElementCriterion to further filter the containing ways
    * @return a collection of way IDs
    */
-  static std::set<long> getContainingWayIds(
-    const long nodeId, const ConstOsmMapPtr& map,
-    const ElementCriterionPtr& wayCriterion = ElementCriterionPtr());
+  static std::set<long> getContainingWayIds(const long nodeId, const ConstOsmMapPtr& map,
+                                            const ElementCriterionPtr& wayCriterion = ElementCriterionPtr());
 
   /**
    * Returns all ways containing an input node
@@ -173,9 +166,8 @@ public:
    * @param wayCriterion an optional ElementCriterion to further filter the containing ways
    * @return a collection of const ways
    */
-  static std::vector<ConstWayPtr> getContainingWaysConst(
-    const long nodeId, const ConstOsmMapPtr& map,
-    const ElementCriterionPtr& wayCriterion = ElementCriterionPtr());
+  static std::vector<ConstWayPtr> getContainingWaysConst(const long nodeId, const ConstOsmMapPtr& map,
+                                                         const ElementCriterionPtr& wayCriterion = ElementCriterionPtr());
 
   /**
    * Returns all ways containing an input node
@@ -185,9 +177,8 @@ public:
    * @param wayCriterion an optional ElementCriterion to further filter the containing ways
    * @return a collection of ways
    */
-  static std::vector<WayPtr> getContainingWays(
-    const long nodeId, const ConstOsmMapPtr& map,
-    const ElementCriterionPtr& wayCriterion = ElementCriterionPtr());
+  static std::vector<WayPtr> getContainingWays(const long nodeId, const ConstOsmMapPtr& map,
+                                               const ElementCriterionPtr& wayCriterion = ElementCriterionPtr());
 
   /**
    * Returns the most specific feature types, as identified by the schema, for all ways containing
@@ -197,8 +188,7 @@ public:
    * @param map map which owns the input node
    * @return a unique collection of type key/value pair strings
    */
-  static std::set<QString> getContainingWaysMostSpecificTypes(
-    const long nodeId, const ConstOsmMapPtr& map);
+  static std::set<QString> getContainingWaysMostSpecificTypes(const long nodeId, const ConstOsmMapPtr& map);
 
   /**
    * Determines if a specified node is contained by a way, given a list of way IDs
@@ -208,8 +198,7 @@ public:
    * @param map the map containing the nodes/ways
    * @return true if any way in the ID list contains the node; false otherwise
    */
-  static bool nodeContainedByAnyWay(
-    const long nodeId, const std::set<long>& wayIds, const ConstOsmMapPtr& map);
+  static bool nodeContainedByAnyWay(const long nodeId, const std::set<long>& wayIds, const ConstOsmMapPtr& map);
 
   /**
    * Determines if a node is contained by any way in a map
@@ -265,8 +254,7 @@ public:
    * @return true if the node with ID nodeId belongs to a way that has any way nodes in common with
    * the way having ID wayId; false otherwise
    */
-  static bool nodeContainedByWaySharingNodesWithAnotherWay(
-    const long nodeId, const long wayId, const OsmMapPtr& map);
+  static bool nodeContainedByWaySharingNodesWithAnotherWay(const long nodeId, const long wayId, const OsmMapPtr& map);
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/elements/WayUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/WayUtils.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef WAY_UTILS_H

--- a/hoot-core/src/main/cpp/hoot/core/io/ArffWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ArffWriter.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "ArffWriter.h"

--- a/hoot-core/src/main/cpp/hoot/core/io/ArffWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ArffWriter.cpp
@@ -37,16 +37,16 @@ using namespace std;
 namespace hoot
 {
 
-ArffWriter::ArffWriter(ostream* strm, bool useNulls) :
-_strm(strm),
-_useNulls(useNulls)
+ArffWriter::ArffWriter(ostream* strm, bool useNulls)
+  : _strm(strm),
+    _useNulls(useNulls)
 {
 }
 
-ArffWriter::ArffWriter(QString path, bool useNulls) :
-_path(path),
-_autoStrm(std::make_shared<std::fstream>()),
-_useNulls(useNulls)
+ArffWriter::ArffWriter(QString path, bool useNulls)
+  : _path(path),
+    _autoStrm(std::make_shared<std::fstream>()),
+    _useNulls(useNulls)
 {
   _autoStrm->exceptions(fstream::failbit | fstream::badbit);
   _autoStrm->open(path.toUtf8().data(), ios_base::out);
@@ -62,76 +62,55 @@ void ArffWriter::write(const vector<Sample>& samples)
 {
   QString msg = "Writing attribute-relation model file";
   if (!_path.isEmpty())
-  {
     msg += " to " + FileUtils::toLogFormat(_path, 50);
-  }
   msg += "...";
   LOG_INFO(msg);
 
   set<QString> attributes;
-
-  for (vector<Sample>::const_iterator it = samples.begin(); it != samples.end(); ++it)
+  for (const auto& s : samples)
   {
-    const Sample& s = *it;
-    for (Sample::const_iterator jt = s.begin(); jt != s.end(); ++jt)
+    for (auto jt = s.begin(); jt != s.end(); ++jt)
     {
       if (jt->first != "class")
-      {
         attributes.insert(jt->first);
-      }
     }
   }
 
   _w("@RELATION manipulations");
   _w("");
 
-  for (set<QString>::const_iterator it = attributes.begin(); it != attributes.end(); ++it)
-  {
-    _w(QString("@ATTRIBUTE %1 NUMERIC").arg(*it));
-  }
+  for (const auto& attribute : attributes)
+    _w(QString("@ATTRIBUTE %1 NUMERIC").arg(attribute));
+
   _w("@ATTRIBUTE class {match,miss,review}\n");
 
   _w("@DATA");
 
   const int precision = ConfigOptions().getArffWriterPrecision();
-  for (vector<Sample>::const_iterator st = samples.begin(); st != samples.end(); ++st)
+  for (const auto& s : samples)
   {
-    const Sample& s = *st;
-
     QStringList l;
-    for (set<QString>::const_iterator it = attributes.begin(); it != attributes.end(); ++it)
+    for (const auto& attribute : attributes)
     {
-      if (s.find(*it) != s.end())
+      if (s.find(attribute) != s.end())
       {
-        double v = s.find(*it)->second;
+        double v = s.find(attribute)->second;
         if (__isnan(v))
         {
           if (_useNulls)
-          {
             l.append("?");
-          }
           else
-          {
             l.append("-1");
-          }
         }
-        else
-        {
-          // 17 digits is guaranteed to be the same by IEEE 754
-          // http://en.wikipedia.org/wiki/Double-precision_floating-point_format
+        else  // 17 digits is guaranteed to be the same by IEEE 754 (http://en.wikipedia.org/wiki/Double-precision_floating-point_format)
           l.append(QString("%1").arg(v, 0, 'g', precision));
-        }
       }
       else
       {
         if (_useNulls)
-        {
           l.append("?");
-        }
         else
-        {
           l.append("-1");
-        }
       }
     }
     MatchType type = MatchType(s.find("class")->second);

--- a/hoot-core/src/main/cpp/hoot/core/io/ImplicitTagRulesSqliteReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ImplicitTagRulesSqliteReader.cpp
@@ -479,7 +479,7 @@ void ImplicitTagRulesSqliteReader::_removeTagsWithDuplicatedValues(Tags& tags) c
 {
   QStringList tagValues;
   QStringList tagKeysWithDuplicatedValues;
-  for (auto tagItr = tags.begin(); tagItr != tags.end(); ++tagItr)
+  for (auto tagItr = tags.constBegin(); tagItr != tags.constEnd(); ++tagItr)
   {
     const QString tagValue = tagItr.value();
     if (!tagValues.contains(tagValue))

--- a/hoot-core/src/main/cpp/hoot/core/io/ImplicitTagRulesSqliteReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ImplicitTagRulesSqliteReader.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "ImplicitTagRulesSqliteReader.h"

--- a/hoot-core/src/main/cpp/hoot/core/io/ImplicitTagRulesSqliteReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ImplicitTagRulesSqliteReader.cpp
@@ -338,12 +338,11 @@ void ImplicitTagRulesSqliteReader::_queryWords(const QSet<QString>& words,
   //the WHERE IN clause is case sensitive, so OR'ing the words together with LIKE instead
   //(no wildcards)
   QString queryStr = "SELECT id, word FROM words WHERE ";
-  for (QSet<QString>::const_iterator wordItr = words.begin(); wordItr != words.end(); ++wordItr)
+  for (auto word : qAsConst(words))
   {
     //LIKE is case insensitive by default, so using that instead of '='; using toUpper() with '='
     //for comparisons won't work for unicode chars in SQLite w/o quite a bit of additional setup
     //to link in special unicode libs (I think)
-    QString word = *wordItr;
     //escape '
     word = word.replace("'", "''");
     queryStr += "word LIKE '" + word + "' OR ";
@@ -354,8 +353,7 @@ void ImplicitTagRulesSqliteReader::_queryWords(const QSet<QString>& words,
   {
     throw HootException(
       QString("Error executing query: %1; Error: %2")
-        .arg(selectWordIdsForWords.lastQuery())
-        .arg(selectWordIdsForWords.lastError().text()));
+        .arg(selectWordIdsForWords.lastQuery(), selectWordIdsForWords.lastError().text()));
   }
 
   while (selectWordIdsForWords.next())
@@ -382,10 +380,8 @@ void ImplicitTagRulesSqliteReader::_modifyWordIdsForMultipleRules(QSet<long>& qu
 
   long wordIdWithHighestTagOccurrenceCount = -1;
   long highestTagOccurrenceCount = -1;
-  for (QSet<long>::const_iterator wordIdItr = queriedWordIds.begin();
-       wordIdItr != queriedWordIds.end(); ++wordIdItr)
+  for (auto wordId : qAsConst(queriedWordIds))
   {
-    const long wordId = *wordIdItr;
     _tagCountsForWordIdsQuery.bindValue(":wordId", (qlonglong)wordId);
     LOG_VART(_tagCountsForWordIdsQuery.lastQuery());
     if (!_tagCountsForWordIdsQuery.exec())
@@ -423,17 +419,15 @@ Tags ImplicitTagRulesSqliteReader::_getTagsForWords(const QSet<long>& queriedWor
                                                     bool& wordsInvolvedInMultipleRules)
 {
   Tags tags;
-  for (QSet<long>::const_iterator wordIdItr = queriedWordIds.begin();
-       wordIdItr != queriedWordIds.end(); ++wordIdItr)
+  for (auto word_id : qAsConst(queriedWordIds))
   {
-    _tagsForWordIdsQuery.bindValue(":wordId", (qlonglong)*wordIdItr);
+    _tagsForWordIdsQuery.bindValue(":wordId", static_cast<qlonglong>(word_id));
     LOG_VART(_tagsForWordIdsQuery.lastQuery());
     if (!_tagsForWordIdsQuery.exec())
     {
       throw HootException(
         QString("Error executing query: %1; Error: %2")
-          .arg(_tagsForWordIdsQuery.lastQuery())
-          .arg(_tagsForWordIdsQuery.lastError().text()));
+          .arg(_tagsForWordIdsQuery.lastQuery(), _tagsForWordIdsQuery.lastError().text()));
     }
 
     Tags tags2;
@@ -446,19 +440,15 @@ Tags ImplicitTagRulesSqliteReader::_getTagsForWords(const QSet<long>& queriedWor
       const QStringList kvps = kvp.split(";");
       if (!_addTopTagOnly || (_addTopTagOnly && tags2.isEmpty()))
       {
-        for (int i = 0; i < kvps.size(); i++)
-        {
-          tags2.appendValue(kvps.at(i));
-        }
+        for (const auto& value : qAsConst(kvps))
+          tags2.appendValue(value);
       }
     }
     LOG_VART(tags);
     LOG_VART(tags2);
 
     if (tags.isEmpty())
-    {
       tags = tags2;
-    }
     else if (!tags2.isEmpty() && tags != tags2)
     {
       wordsInvolvedInMultipleRules = true;
@@ -476,8 +466,7 @@ Tags ImplicitTagRulesSqliteReader::_getTagsForWords(const QSet<long>& queriedWor
         moreTagsToCache.insert("wordsInvolvedInMultipleRules", "true");
         _cacheTags(inputWords, moreTagsToCache);
       }
-      LOG_TRACE(
-        "Words: " << matchingWords << " involved in multiple rules due to tag sets not matching.");
+      LOG_TRACE("Words: " << matchingWords << " involved in multiple rules due to tag sets not matching.");
       LOG_VART(tags);
       LOG_VART(tags2);
       return Tags();
@@ -490,22 +479,17 @@ void ImplicitTagRulesSqliteReader::_removeTagsWithDuplicatedValues(Tags& tags) c
 {
   QStringList tagValues;
   QStringList tagKeysWithDuplicatedValues;
-  for (Tags::const_iterator tagItr = tags.begin(); tagItr != tags.end(); ++tagItr)
+  for (auto tagItr = tags.begin(); tagItr != tags.end(); ++tagItr)
   {
     const QString tagValue = tagItr.value();
     if (!tagValues.contains(tagValue))
-    {
       tagValues.append(tagValue);
-    }
     else
-    {
       tagKeysWithDuplicatedValues.append(tagItr.key());
-    }
   }
   LOG_VART(tagKeysWithDuplicatedValues);
-  for (int i = 0; i < tagKeysWithDuplicatedValues.size(); i++)
+  for (const auto& tagKey : qAsConst(tagKeysWithDuplicatedValues))
   {
-    const QString tagKey = tagKeysWithDuplicatedValues[i];
     tags.remove(tagKey);
     LOG_TRACE("Removed tag key: " << tagKey << " due to value duplication.");
   }

--- a/hoot-core/src/main/cpp/hoot/core/io/ImplicitTagRulesSqliteReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ImplicitTagRulesSqliteReader.h
@@ -78,8 +78,7 @@ public:
    * @return a set of implicitly derived tags, if they exist, for the given input words; an empty
    * tag set otherwise
    */
-  Tags getImplicitTags(
-    const QSet<QString>& words, QSet<QString>& matchingWords, bool& wordsInvolvedInMultipleRules);
+  Tags getImplicitTags(const QSet<QString>& words, QSet<QString>& matchingWords, bool& wordsInvolvedInMultipleRules);
 
   /**
    * Return a string containing relevant info about the rule database

--- a/hoot-core/src/main/cpp/hoot/core/io/ImplicitTagRulesSqliteReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ImplicitTagRulesSqliteReader.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef IMPLICITTAGRULESSQLITEREADER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/IoUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/IoUtils.cpp
@@ -166,11 +166,8 @@ QStringList IoUtils::getSupportedInputsRecursively(const QStringList& topLevelPa
     // If its a file and not a dir, go ahead and add it if its supported.
     if (!QFileInfo(path).isDir())
     {
-      if ((nameFilters.isEmpty() || StringUtils::matchesWildcard(path, nameFilters)) &&
-           isSupportedInputFormat(path))
-      {
+      if ((nameFilters.isEmpty() || StringUtils::matchesWildcard(path, nameFilters)) && isSupportedInputFormat(path))
         validInputs.append(path);
-      }
     }
     else
     {
@@ -276,13 +273,10 @@ bool IoUtils::areStreamableInputs(const QStringList& inputs, const bool logUnstr
 bool IoUtils::isStreamableInput(const QString& url)
 {
   bool result = false;
-  std::shared_ptr<OsmMapReader> reader =
-    OsmMapReaderFactory::createReader(url, true, Status::Unknown1);
-  std::shared_ptr<ElementInputStream> eis =
-    std::dynamic_pointer_cast<ElementInputStream>(reader);
+  std::shared_ptr<OsmMapReader> reader = OsmMapReaderFactory::createReader(url, true, Status::Unknown1);
+  std::shared_ptr<ElementInputStream> eis = std::dynamic_pointer_cast<ElementInputStream>(reader);
   if (eis)
     result = true;
-
   return result;
 }
 
@@ -290,11 +284,9 @@ bool IoUtils::isStreamableOutput(const QString& url)
 {
   bool result = false;
   std::shared_ptr<OsmMapWriter> writer = OsmMapWriterFactory::createWriter(url);
-  std::shared_ptr<ElementOutputStream> streamWriter =
-    std::dynamic_pointer_cast<ElementOutputStream>(writer);
+  std::shared_ptr<ElementOutputStream> streamWriter = std::dynamic_pointer_cast<ElementOutputStream>(writer);
   if (streamWriter)
     result = true;
-
   return result;
 }
 
@@ -306,13 +298,11 @@ bool IoUtils::areValidStreamingOps(const QStringList& ops)
   {
     if (!opName.trimmed().isEmpty())
     {
-      const QString unstreamableMsg =
-        "Unable to stream I/O due to op: " + opName + ". Loading entire map...";
+      const QString unstreamableMsg = "Unable to stream I/O due to op: " + opName + ". Loading entire map...";
 
       if (Factory::getInstance().hasBase<ElementCriterion>(opName))
       {
-        ElementCriterionPtr criterion =
-          Factory::getInstance().constructObject<ElementCriterion>(opName);
+        ElementCriterionPtr criterion = Factory::getInstance().constructObject<ElementCriterion>(opName);
         // when streaming we can't provide a reliable OsmMap.
         if (dynamic_cast<OsmMapConsumer*>(criterion.get()) != nullptr)
         {
@@ -322,8 +312,7 @@ bool IoUtils::areValidStreamingOps(const QStringList& ops)
       }
       else if (Factory::getInstance().hasBase<ElementVisitor>(opName))
       {
-        ElementVisitorPtr vis =
-          Factory::getInstance().constructObject<ElementVisitor>(opName);
+        ElementVisitorPtr vis = Factory::getInstance().constructObject<ElementVisitor>(opName);
         // when streaming we can't provide a reliable OsmMap.
         if (dynamic_cast<OsmMapConsumer*>(vis.get()) != nullptr)
         {
@@ -333,8 +322,7 @@ bool IoUtils::areValidStreamingOps(const QStringList& ops)
       }
       else if (Factory::getInstance().hasBase<ConstElementVisitor>(opName))
       {
-        ConstElementVisitorPtr vis =
-          Factory::getInstance().constructObject<ConstElementVisitor>(opName);
+        ConstElementVisitorPtr vis = Factory::getInstance().constructObject<ConstElementVisitor>(opName);
         // when streaming we can't provide a reliable OsmMap.
         if (dynamic_cast<OsmMapConsumer*>(vis.get()) != nullptr)
         {
@@ -350,7 +338,6 @@ bool IoUtils::areValidStreamingOps(const QStringList& ops)
       }
     }
   }
-
   return true;
 }
 
@@ -367,16 +354,14 @@ QList<ElementVisitorPtr> IoUtils::toStreamingOps(const QStringList& ops)
       if (!Factory::getInstance().hasBase<ElementVisitor>(opName) &&
           !Factory::getInstance().hasBase<ConstElementVisitor>(opName))
       {
-        throw IllegalArgumentException(
-          "Streaming operations must be an ElementVisitor or a ConstElementVisitor.");
+        throw IllegalArgumentException("Streaming operations must be an ElementVisitor or a ConstElementVisitor.");
       }
 
       // When streaming we can't provide a reliable OsmMap.
       const QString osmMapConsumerErrorMsg = "A streaming operations may not be an OsmMapConsumer.";
       if (Factory::getInstance().hasBase<ElementVisitor>(opName))
       {
-        ElementVisitorPtr vis =
-          Factory::getInstance().constructObject<ElementVisitor>(opName);
+        ElementVisitorPtr vis = Factory::getInstance().constructObject<ElementVisitor>(opName);
         if (dynamic_cast<OsmMapConsumer*>(vis.get()) != nullptr)
           throw IllegalArgumentException(osmMapConsumerErrorMsg);
 
@@ -384,8 +369,7 @@ QList<ElementVisitorPtr> IoUtils::toStreamingOps(const QStringList& ops)
       }
       else if (Factory::getInstance().hasBase<ConstElementVisitor>(opName))
       {
-        ConstElementVisitorPtr vis =
-          Factory::getInstance().constructObject<ConstElementVisitor>(opName);
+        ConstElementVisitorPtr vis = Factory::getInstance().constructObject<ConstElementVisitor>(opName);
         if (dynamic_cast<OsmMapConsumer*>(vis.get()) != nullptr)
           throw IllegalArgumentException(osmMapConsumerErrorMsg);
 
@@ -393,7 +377,6 @@ QList<ElementVisitorPtr> IoUtils::toStreamingOps(const QStringList& ops)
       }
     }
   }
-
   return opsToReturn;
 }
 
@@ -415,8 +398,7 @@ ElementInputStreamPtr IoUtils::getFilteredInputStream(ElementInputStreamPtr stre
       if (Factory::getInstance().hasBase<ElementCriterion>(opName))
       {
         LOG_INFO("Initializing operation: " << opName << "...");
-        ElementCriterionPtr criterion =
-          Factory::getInstance().constructObject<ElementCriterion>(opName);
+        ElementCriterionPtr criterion = Factory::getInstance().constructObject<ElementCriterion>(opName);
 
         std::shared_ptr<Configurable> critConfig;
         if (criterion.get())
@@ -444,10 +426,7 @@ ElementInputStreamPtr IoUtils::getFilteredInputStream(ElementInputStreamPtr stre
         streamToFilter = std::make_shared<ElementVisitorInputStream>(streamToFilter, visitor);
       }
       else
-      {
-        throw HootException(
-          "An unsupported operation was passed to a streaming conversion: " + opName);
-      }
+        throw HootException("An unsupported operation was passed to a streaming conversion: " + opName);
     }
   }
 
@@ -477,11 +456,8 @@ void IoUtils::loadMap(const OsmMapPtr& map, const QString& path, bool useFileId,
     // This reader closes itself.
     reader.read(justPath, pathLayer.size() > 1 ? pathLayer[1] : "", map, jobSource, numTasks);
   }
-  else
-  {
-    // This handles all non-OGR format reading.
+  else  // This handles all non-OGR format reading.
     OsmMapReaderFactory::read(map, path, useFileId, defaultStatus);
-  }
 }
 
 void IoUtils::loadMaps(const OsmMapPtr& map, const QStringList& paths, bool useFileId, Status defaultStatus,
@@ -490,14 +466,10 @@ void IoUtils::loadMaps(const OsmMapPtr& map, const QStringList& paths, bool useF
 {
   // TODO: it would be nice to allow this to take in Progress for updating
   for (const auto& path : paths)
-  {
-    loadMap(map, path, useFileId, defaultStatus, translationScript, ogrFeatureLimit, jobSource,
-            numTasks);
-  }
+    loadMap(map, path, useFileId, defaultStatus, translationScript, ogrFeatureLimit, jobSource, numTasks);
 }
 
-void IoUtils::cropToBounds(OsmMapPtr& map, const geos::geom::Envelope& bounds,
-                           const bool keepConnectedOobWays)
+void IoUtils::cropToBounds(OsmMapPtr& map, const geos::geom::Envelope& bounds, const bool keepConnectedOobWays)
 {
   cropToBounds(map, GeometryUtils::envelopeToPolygon(bounds), keepConnectedOobWays);
 }
@@ -509,8 +481,7 @@ void IoUtils::saveMap(const OsmMapPtr& map, const QString& path)
   OsmMapWriterFactory::write(map, path);
 }
 
-void IoUtils::cropToBounds(OsmMapPtr& map, const std::shared_ptr<geos::geom::Geometry>& bounds,
-                           const bool keepConnectedOobWays)
+void IoUtils::cropToBounds(OsmMapPtr& map, const std::shared_ptr<geos::geom::Geometry>& bounds, const bool keepConnectedOobWays)
 {
   LOG_INFO(
     "Applying bounds filtering to input data: ..." <<
@@ -520,10 +491,8 @@ void IoUtils::cropToBounds(OsmMapPtr& map, const std::shared_ptr<geos::geom::Geo
 
   MapCropper cropper;
   cropper.setBounds(bounds);
-  cropper.setKeepEntireFeaturesCrossingBounds(
-    ConfigOptions().getBoundsKeepEntireFeaturesCrossingBounds());
-  const bool strictBoundsHandling =
-    ConfigOptions().getBoundsKeepOnlyFeaturesInsideBounds();
+  cropper.setKeepEntireFeaturesCrossingBounds(ConfigOptions().getBoundsKeepEntireFeaturesCrossingBounds());
+  const bool strictBoundsHandling = ConfigOptions().getBoundsKeepOnlyFeaturesInsideBounds();
   cropper.setKeepOnlyFeaturesInsideBounds(strictBoundsHandling);
   cropper.setRemoveMissingElements(ConfigOptions().getBoundsRemoveMissingElements());
 
@@ -572,21 +541,18 @@ void IoUtils::writeOutputDir(const QString& dirName)
     throw IllegalArgumentException("Unable to create output path for: " + dirName);
 }
 
-QString IoUtils::getOutputUrlFromInput(
-  const QString& inputUrl, const QString& appendText, const QString& outputFormat)
+QString IoUtils::getOutputUrlFromInput(const QString& inputUrl, const QString& appendText, const QString& outputFormat)
 {
   if (DbUtils::isOsmApiDbUrl(inputUrl) || inputUrl.startsWith("http://"))
   {
     throw IllegalArgumentException(
-      QString("--separate-output cannot be used with OSM API database (osmapidb://) or OSM API ") +
-      QString("web (http://) inputs."));
+      QString("--separate-output cannot be used with OSM API database (osmapidb://) or OSM API web (http://) inputs."));
   }
   // This check prevents the overwriting of the input URL.
   if (appendText.isEmpty() && outputFormat.isEmpty())
   {
     throw IllegalArgumentException(
-      QString("Either text to append or an output format must be specified when generating an ") +
-      QString("output URL from an input URL."));
+      QString("Either text to append or an output format must be specified when generating an output URL from an input URL."));
   }
 
   LOG_VART(inputUrl);
@@ -631,10 +597,7 @@ QString IoUtils::getOutputUrlFromInput(
   LOG_VART(existingExtension);
 
   if (!existingExtension.isEmpty() && !outputFormat.isEmpty() && existingExtension == outputFormat)
-  {
-    throw IllegalArgumentException(
-      "Generated output URL for format: " + outputFormat + " will overwrite input URL: " + inputUrl);
-  }
+    throw IllegalArgumentException("Generated output URL for format: " + outputFormat + " will overwrite input URL: " + inputUrl);
 
   // Create the output url to be the input url with the custom text appended to it. This prevents
   // us from overwriting any output.
@@ -643,11 +606,8 @@ QString IoUtils::getOutputUrlFromInput(
   // If a format was passed in, then the output format is potentially different than the input
   // format. If the input URL was a file or dir format with an extension, we need to swap that
   // extension out for the output format.
-  if (!outputFormat.isEmpty() && !DbUtils::isHootApiDbUrl(outputFormat) &&
-      !existingExtension.isEmpty())
-  {
+  if (!outputFormat.isEmpty() && !DbUtils::isHootApiDbUrl(outputFormat) && !existingExtension.isEmpty())
     str = str.replace(existingExtension, outputFormat);
-  }
   return str;
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbBulkInserter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbBulkInserter.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "OsmApiDbBulkInserter.h"

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbBulkInserter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbBulkInserter.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef OSMAPIDBBULKINSERTER_H
 #define OSMAPIDBBULKINSERTER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbBulkInserter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbBulkInserter.h
@@ -28,16 +28,16 @@
 #define OSMAPIDBBULKINSERTER_H
 
 // Hoot
-#include <hoot/core/io/PartialOsmMapWriter.h>
-#include <hoot/core/util/Configurable.h>
-#include <hoot/core/io/OsmApiDb.h>
 #include <hoot/core/elements/Node.h>
 #include <hoot/core/elements/Way.h>
 #include <hoot/core/elements/Relation.h>
+#include <hoot/core/io/OsmApiDb.h>
+#include <hoot/core/io/PartialOsmMapWriter.h>
+#include <hoot/core/util/Configurable.h>
 
 // Qt
-#include <QTemporaryFile>
 #include <QElapsedTimer>
+#include <QTemporaryFile>
 
 // Tgs
 #include <tgs/BigContainers/BigMap.h>
@@ -159,25 +159,19 @@ public:
   void setStartingNodeId(long id)
   {
     if (id < 1)
-    {
       throw HootException("Invalid starting ID: " + QString::number(id));
-    }
     _idMappings.startingNodeId = id;
   }
   void setStartingWayId(long id)
   {
     if (id < 1)
-    {
       throw HootException("Invalid starting ID: " + QString::number(id));
-    }
     _idMappings.startingWayId = id;
   }
   void setStartingRelationId(long id)
   {
     if (id < 1)
-    {
       throw HootException("Invalid starting ID: " + QString::number(id));
-    }
     _idMappings.startingRelationId = id;
   }
   void setStxxlMapMinSize(long size) { _stxxlMapMinSize = size; }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.h
@@ -95,14 +95,9 @@ private:
    */
   bool _loadBounds();
 
-  /** Value of the bounds envelope string */
   QString _boundsString;
-  /** Value of the bounds filename string */
   QString _boundsFilename;
-  /** Is the bounds a polygon */
-  bool _isPolygon;
-  /** Value of the bounding box or polygon */
-  std::shared_ptr<geos::geom::Geometry> _boundingPoly;
+
   /** For testing */
   friend class OsmApiReaderTest;
 };

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.h
@@ -64,7 +64,7 @@ namespace hoot
  * Also, be aware that this class can stream large datasets into an OsmMap so there is only one copy
  * of everything in memory. Be careful if you want to use it with large datasets.
  */
-class OsmJsonReader : public OsmMapReader, public Boundable, private ParallelBoundedApiReader
+class OsmJsonReader : public OsmMapReader, public Boundable, protected ParallelBoundedApiReader
 {
 public:
 
@@ -150,6 +150,10 @@ public:
   void setConfiguration(const Settings& conf) override;
 
   bool isValidJson(const QString& jsonStr);
+
+  /** See Boundable */
+  void setBounds(std::shared_ptr<geos::geom::Geometry> bounds) override;
+  void setBounds(const geos::geom::Envelope& bounds) override;
 
   /**
    * @brief getVersion Overpass API version, if that's where JSON comes from
@@ -301,6 +305,15 @@ private:
 
   void _reset();
   void _resetIds();
+  /**
+   * @brief _loadBounds - Get either the `bounds` parameter value
+   *  or the bounds of a file listed in `bounds.file` parameter
+   * @return true if the bounds were parsed correctly
+   */
+  bool _loadBounds();
+
+  QString _boundsString;
+  QString _boundsFilename;
 
 protected:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.h
@@ -180,8 +180,6 @@ public:
   { _keepImmediatelyConnectedWaysOutsideBounds = keep; }
   void setLogWarningsForMissingElements(bool log) { _logWarningsForMissingElements = log; }
 
-  bool isError() const { return ParallelBoundedApiReader::isError(); }
-
 protected:
 
   // Items to conform to OsmMapReader ifc
@@ -328,6 +326,8 @@ protected:
   unsigned int _getTimestamp(const std::string& field_name, const boost::property_tree::ptree& item) const;
   std::string _getUser(const std::string& field_name, const boost::property_tree::ptree& item) const;
   long _getUid(const std::string& field_name, const boost::property_tree::ptree& item) const;
+
+  friend class OsmJsonReaderTest;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
@@ -36,6 +36,9 @@
 //  Qt
 #include <QUrl>
 
+//  Geos
+#include <geos/geom/Geometry.h>
+
 namespace hoot
 {
 

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
@@ -119,7 +119,7 @@ protected:
   /** Type of data that is being downloaded, for internal use in derived classes */
   enum DataType
   {
-    Text,
+    PlainText,
     OsmXml,
     GeoJson,
     Json
@@ -131,6 +131,10 @@ protected:
   double _coordGridSize;
   /** Number of threads to process the HTTP requests */
   int _threadCount;
+  /** Is the bounds a polygon */
+  bool _isPolygon;
+  /** Value of the bounding box or polygon */
+  std::shared_ptr<geos::geom::Geometry> _boundingPoly;
 
   /**
    * @brief _sleep Sleep the current thread

--- a/hoot-core/src/main/cpp/hoot/core/ops/ReuseNodeIdsOnWayOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/ReuseNodeIdsOnWayOp.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #include "ReuseNodeIdsOnWayOp.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/ReuseNodeIdsOnWayOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/ReuseNodeIdsOnWayOp.cpp
@@ -105,22 +105,23 @@ void ReuseNodeIdsOnWayOp::apply(const std::shared_ptr<OsmMap>& map)
   std::shared_ptr<IdSwap> swap = std::make_shared<IdSwap>();
   //  For closed ways the use the unique node count
   size_t toNodeCount = to->getNodeCount();
-  if (toNodeCount > 1 && to->getNodeId(0) == to->getNodeId(toNodeCount - 1))
+  if (toNodeCount > 1 && to->getNodeId(0) == to->getNodeId(static_cast<int>(toNodeCount) - 1))
     toNodeCount--;
   size_t fromNodeCount = from->getNodeCount();
-  if (fromNodeCount > 1 && from->getNodeId(0) == from->getNodeId(fromNodeCount - 1))
+  if (fromNodeCount > 1 && from->getNodeId(0) == from->getNodeId(static_cast<int>(fromNodeCount) - 1))
     fromNodeCount--;
-  //  Iterate all of the "from" way's node IDs making sure not to iterate
-  //  off of the end of the "to" way either
-  for (size_t fromIndex = 0, toIndex = 0;
-       fromIndex < fromNodeCount && toIndex < toNodeCount;
-       ++fromIndex)
+  size_t toIndex = 0;
+  //  Iterate all of the "from" way's node IDs
+  for (size_t fromIndex = 0; fromIndex < fromNodeCount; ++fromIndex)
   {
-    long fromNodeId = from->getNodeId(fromIndex);
+    //  Make sure not to iterate off of the end of the "to" way
+    if (toIndex >= toNodeCount)
+      break;
+    long fromNodeId = from->getNodeId(static_cast<int>(fromIndex));
     //  Skip any shared node in the from way
     if (nodeToWayMap->getWaysByNode(fromNodeId).size() == 1)
     {
-      long toNodeId = to->getNodeId(toIndex);
+      long toNodeId = to->getNodeId(static_cast<int>(toIndex));
       //  Skip any shared node in the to way
       while (nodeToWayMap->getWaysByNode(toNodeId).size() > 1 && toIndex < toNodeCount)
       {

--- a/hoot-core/src/main/cpp/hoot/core/schema/AttributeCoOccurrence.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/AttributeCoOccurrence.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "AttributeCoOccurrence.h"

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MatchFeatureExtractor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MatchFeatureExtractor.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "MatchFeatureExtractor.h"

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MatchFeatureExtractor.h
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MatchFeatureExtractor.h
@@ -91,7 +91,6 @@ private:
   // If true, then make sure there is an even representation from each class and only fully
   // populated records are represented.
   bool _evenClasses;
-  bool _useNulls;
   const MatchFactory* _matchFactory;
 
   MatchType _getActualMatchType(const std::set<ElementId> &eids,

--- a/hoot-core/src/main/cpp/hoot/core/scoring/MatchFeatureExtractor.h
+++ b/hoot-core/src/main/cpp/hoot/core/scoring/MatchFeatureExtractor.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef MANIPULATORFEATUREEXTRACTOR_H

--- a/hoot-josm/src/main/cpp/hoot/josm/ops/JosmMapCleaner.h
+++ b/hoot-josm/src/main/cpp/hoot/josm/ops/JosmMapCleaner.h
@@ -55,22 +55,22 @@ public:
   static QString className() { return "JosmMapCleaner"; }
 
   JosmMapCleaner();
-  virtual ~JosmMapCleaner() = default;
+  ~JosmMapCleaner() override = default;
 
   /**
    * @see OsmMapOperation
    */
-  virtual void apply(std::shared_ptr<OsmMap>& map) override;
+  void apply(std::shared_ptr<OsmMap>& map) override;
 
   /**
    * @see Configurable
    */
-  virtual void setConfiguration(const Settings& conf);
+  void setConfiguration(const Settings& conf) override;
 
   /**
    * @see OperationStatus
    */
-  virtual QString getInitStatusMessage() const
+  QString getInitStatusMessage() const override
   { return "Cleaning elements with JOSM..."; }
 
   int getNumElementsCleaned() const { return _numElementsCleaned; }
@@ -96,12 +96,12 @@ protected:
   /*
    * @see JosmMapValidatorAbstract
    */
-  virtual OsmMapPtr _getUpdatedMap(OsmMapPtr& inputMap);
+  OsmMapPtr _getUpdatedMap(OsmMapPtr& inputMap) override;
 
   /*
    * @see JosmMapValidatorAbstract
    */
-  virtual void _getStats();
+  void _getStats() override;
 
 private:
 
@@ -126,9 +126,8 @@ private:
   /*
    * clean the map from a file and write the cleaned map out to another file
    */
-  void _clean(
-    const QStringList& validators, const QString& inputMapPath, const QString& outputMapPath,
-    const bool addDetailTags);
+  void _clean(const QStringList& validators, const QString& inputMapPath, const QString& outputMapPath,
+              const bool addDetailTags);
 
   int _getNumElementsCleaned();
   QSet<ElementId> _getDeletedElementIds();
@@ -138,9 +137,8 @@ private:
   /*
    * Converts the error status info returned by hoot-josm into a readable string
    */
-  QString _errorCountsByTypeToSummaryStr(
-    const QMap<QString, int>& errorCountsByType,
-    const QMap<QString, int>& errorFixCountsByType) const;
+  QString _errorCountsByTypeToSummaryStr(const QMap<QString, int>& errorCountsByType,
+                                         const QMap<QString, int>& errorFixCountsByType) const;
 
   /*
    * Converts element ID strings used in hoot-josm code to hoot-core element IDs

--- a/hoot-josm/src/main/cpp/hoot/josm/ops/JosmMapCleaner.h
+++ b/hoot-josm/src/main/cpp/hoot/josm/ops/JosmMapCleaner.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef JOSM_MAP_CLEANER_H
 #define JOSM_MAP_CLEANER_H

--- a/test-files/cmd/quick/ScoreMatchesDiffCmdTest/output
+++ b/test-files/cmd/quick/ScoreMatchesDiffCmdTest/output
@@ -10,7 +10,9 @@ Match Scoring Differential Summary:
 4 new wrong matches switched from MatchToMiss.
 1 new wrong matches switched from MatchToReview.
 1 new wrong matches switched from MissToReview.
-59 reviews were lost.Match Type Changes
+59 reviews were lost.
+
+Match Type Changes
 
 New Wrong Matches:
 

--- a/tgs/src/main/cpp/tgs/Interpolation/DelaunayInterpolator.cpp
+++ b/tgs/src/main/cpp/tgs/Interpolation/DelaunayInterpolator.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2019, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #include "DelaunayInterpolator.h"
 


### PR DESCRIPTION
Allow the `ParallelBoundedApiReader` and derived classes to take in a polygon (file or text) as boundaries.  For simplicity the envelope of the bounds is queried and then the polygon is filtered.

Closes #5398 