### PR TITLE
Updated GEOS from 3.9.2 to 3.9.3 available from geoint-deps

### DIFF
--- a/VagrantProvisionVars.sh
+++ b/VagrantProvisionVars.sh
@@ -18,7 +18,7 @@ export GOOGLE_CHROME_VERSION=91.0.4472.114
 # Geoint deps library versions
 export ARMADILLO_VERSION=10.8.2
 export GDAL_VERSION=3.2.3
-export GEOS_VERSION=3.9.2
+export GEOS_VERSION=3.9.3
 export LIBGEOTIFF_VERSION=1.6.0
 export PROJ_VERSION=7.2.1
 

--- a/configure.ac
+++ b/configure.ac
@@ -56,8 +56,8 @@ fi
 if test "${GEOS_VERSION}" = "3.3.2" ; then
   AC_MSG_WARN([There is a serious bug in GEOS v3.3.2 distance calculations. GEOS v3.2.2 is known to work.]);
 fi
-if test "${GEOS_VERSION}" != "3.9.2" ; then
-  AC_MSG_WARN([Most development occurs with GEOS v3.9.2, using v$GEOS_VERSION. Please run all tests after build (make test).]);
+if test "${GEOS_VERSION}" != "3.9.3" ; then
+  AC_MSG_WARN([Most development occurs with GEOS v3.9.3, using v$GEOS_VERSION. Please run all tests after build (make test).]);
 fi
 
 # Python


### PR DESCRIPTION
After testing there were no changes required by the unit tests.