### PR TITLE
SONAR: Ignore `enum class` rule

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,10 +1,56 @@
 sonar.organization=hootenanny
 sonar.projectKey=hoot
-sonar.exclusions=**/*.pb.cc,**/*.pb.h,**/*.sql,**/*.o,**/*.gcda,**/*.gcno,**/*.qmake,**/*.pro,**/VersionDefines.h,**/ConfigDefaults.h,**/ConfigOptions.h,**/TgsConfig.h,**/*.hh
+sonar.exclusions=**/*.pb.cc, \
+                 **/*.pb.h, \
+                 **/*.sql, \
+                 **/*.o, \
+                 **/*.gcda, \
+                 **/*.gcno, \
+                 **/*.qmake, \
+                 **/*.pro, \
+                 **/VersionDefines.h, \
+                 **/ConfigDefaults.h, \
+                 **/ConfigOptions.h, \
+                 **/TgsConfig.h, \
+                 **/*.hh
 sonar.github.repository=ngageoint/hootenanny
 sonar.host.url=https://sonarcloud.io
 sonar.sources=./hoot-core/src/main,./hoot-js/src/main,./hoot-josm/src/main/cpp,./tbs/src/main,./tgs/src/main
-sonar.issue.ignore.multicriteria=cout1,cout3,cout4,cout5,cout6,cout7,cout8,protected1,undef1,empty1,explicit1,override1,ruleOf5,floatcounter,commentedCode,singleDeclaration,literalSuffix,generalCatch,macroParenthesis,misraMacro,cognitiveComplexity,initializer,classSize,structSize,hootLog,tripleNest,forEach,noAuto,namespace,subexpressions,nullptrAuto1,nullptrAuto2,ruleOfZero,usingTypedef1,usingTypedef2,ignoreTodo,ignoreNodiscard,ignoreArguments,ignoreBreaks,ignoreNestedBlock,ignoreStdLess
+sonar.issue.ignore.multicriteria=cout1,cout3,cout4,cout5,cout6,cout7,cout8, \
+                                 protected1, \
+                                 undef1, \
+                                 empty1, \
+                                 explicit1, \
+                                 override1, \
+                                 ruleOf5, \
+                                 floatcounter, \
+                                 commentedCode, \
+                                 singleDeclaration, \
+                                 literalSuffix, \
+                                 generalCatch, \
+                                 macroParenthesis, \
+                                 misraMacro, \
+                                 cognitiveComplexity, \
+                                 initializer, \
+                                 classSize, \
+                                 structSize, \
+                                 hootLog, \
+                                 tripleNest, \
+                                 forEach, \
+                                 noAuto, \
+                                 namespace, \
+                                 subexpressions, \
+                                 nullptrAuto1,nullptrAuto2, \
+                                 ruleOfZero, \
+                                 usingTypedef1,usingTypedef2, \
+                                 ignoreTodo, \
+                                 ignoreNodiscard, \
+                                 ignoreArguments, \
+                                 ignoreBreaks, \
+                                 ignoreNestedBlock, \
+                                 ignoreStdLess, \
+                                 ignoreEnumClass
+
 # Remove the "Incremental analysis cache" warning
 sonar.cfamily.cache.enabled=false
 
@@ -155,3 +201,8 @@ sonar.issue.ignore.multicriteria.ignoreNestedBlock.resourceKey=**/*
 # Ignore the transparent comparator std::less<> rule
 sonar.issue.ignore.multicriteria.ignoreStdLess.ruleKey=cpp:S6045
 sonar.issue.ignore.multicriteria.ignoreStdLess.resourceKey=**/*
+
+# Ignore the scoped enumeration use
+sonar.issue.ignore.multicriteria.ignoreEnumClass.ruleKey=cpp:S3642
+sonar.issue.ignore.multicriteria.ignoreEnumClass.resourceKey=**/*
+


### PR DESCRIPTION
Updated sonar-project.properties to ignore the `enum class` rule and reformatted the file.