### PR TITLE
Update `changeset-derive` command to include review relations with bounds parameter

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/BoundsFileTaskGridGenerator.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/BoundsFileTaskGridGenerator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef BOUNDS_FILE_TASK_GRID_GENERATOR_H
 #define BOUNDS_FILE_TASK_GRID_GENERATOR_H

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/BoundsFileTaskGridGenerator.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/BoundsFileTaskGridGenerator.h
@@ -47,7 +47,7 @@ public:
    * @param inputs one or more bounds file inputs
    */
   BoundsFileTaskGridGenerator(const QStringList& inputs);
-  virtual ~BoundsFileTaskGridGenerator() = default;
+  ~BoundsFileTaskGridGenerator() override = default;
 
   /**
    * @see TaskGridGenerator

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/BoundsStringTaskGridGenerator.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/BoundsStringTaskGridGenerator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef BOUNDS_STRING_TASK_GRID_GENERATOR_H
 #define BOUNDS_STRING_TASK_GRID_GENERATOR_H

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/BoundsStringTaskGridGenerator.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/BoundsStringTaskGridGenerator.h
@@ -48,7 +48,7 @@ public:
    * @param output optional output path for writing the bounds file
    */
   BoundsStringTaskGridGenerator(const QString& bounds, const QString& outputPath = "");
-  virtual ~BoundsStringTaskGridGenerator() = default;
+  ~BoundsStringTaskGridGenerator() override = default;
 
   /**
    * @see TaskGridGenerator

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/NodeDensityTaskGridGenerator.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/NodeDensityTaskGridGenerator.h
@@ -53,7 +53,7 @@ public:
   NodeDensityTaskGridGenerator(const QStringList& inputs, const int maxNodesPerCell,
                                const QString& bounds = "", const QString& output = "");
 
-  virtual ~NodeDensityTaskGridGenerator() = default;
+  ~NodeDensityTaskGridGenerator() override = default;
 
   /**
    * @see TaskGridGenerator

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/UniformTaskGridGenerator.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/UniformTaskGridGenerator.h
@@ -63,7 +63,8 @@ public:
    */
   UniformTaskGridGenerator(const QStringList& inputs, const int gridDimensionSize = 2,
                            const QString& output = "");
-  virtual ~UniformTaskGridGenerator() = default;
+
+  ~UniformTaskGridGenerator() override = default;
 
   /**
    * @see TaskGridGenerator

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/UniformTaskGridGenerator.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/UniformTaskGridGenerator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef UNIFORM_TASK_GRID_GENERATOR_H
 #define UNIFORM_TASK_GRID_GENERATOR_H

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/MaximalSubline.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/subline-matching/MaximalSubline.h
@@ -113,7 +113,7 @@ public:
   public:
 
     ThresholdMatchCriteria(Meters maxDistance, Radians maxAngleDiff);
-    virtual ~ThresholdMatchCriteria() = default;
+    ~ThresholdMatchCriteria() override = default;
 
     double match(int index1, int index2) const override;
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/matching/Match.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/matching/Match.h
@@ -74,11 +74,6 @@ public:
   virtual MatchMembers getMatchMembers() const { return MatchMembers::None; }
 
   /**
-   * TODO: This already exists in ApiEntityInfo
-   */
-  virtual QString getName() const = 0;
-
-  /**
    * Returns the score associated with this match. Score is a bit abstract at this point and may
    * end up being feature specific. In the case of roads it is the probability * length.
    */
@@ -151,9 +146,10 @@ public:
   virtual void setIsOneToMany(bool isOneToMany) { _isOneToMany = isOneToMany; }
 
   /**
-   * @todo This already exists in ApiEntityInfo
+   * See ApiEntityInfo
    */
-  virtual QString toString() const = 0;
+  QString getName() const override { return className(); }
+  QString toString() const override { return className(); }
 
   /**
    * Returns a collection of matches indexed by the IDs of the elements involved

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/Merger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/Merger.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef MERGE_H
 #define MERGE_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/Merger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/Merger.h
@@ -55,8 +55,7 @@ public:
    *
    * @param replaced A deque of all element Ids that were replaced as part of this Merger operation.
    */
-  virtual void apply(
-    const OsmMapPtr& map, std::vector<std::pair<ElementId, ElementId>>& replaced) = 0;
+  virtual void apply(const OsmMapPtr& map, std::vector<std::pair<ElementId, ElementId>>& replaced) = 0;
 
   /**
    * Returns all the element ids that are impacted by this merger operation.
@@ -75,9 +74,9 @@ public:
   virtual void replace(ElementId oldEid, ElementId newEid) = 0;
 
   /**
-   * TODO: This already exists in ApiEntityInfo
+   * See ApiEntityInfo
    */
-  virtual QString toString() const = 0;
+  QString toString() const override { return className(); }
 };
 
 using MergerPtr = std::shared_ptr<Merger>;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeMatchSetFinder.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/EdgeMatchSetFinder.cpp
@@ -338,7 +338,7 @@ bool EdgeMatchSetFinder::_recordMatch(ConstEdgeMatchPtr em)
     similarityValuesToIterate[EDGE_MATCH_SIMILAR_FIRST_REVERSED_KEY] = em->getFirstReversedSimilarityString();
     EdgeMatchScore existingSimilarMatch;
     // This will iterate over the similarity indexes in the order we want.
-    for (auto it = similarityValuesToIterate.begin(); it != similarityValuesToIterate.end(); ++it)
+    for (auto it = similarityValuesToIterate.cbegin(); it != similarityValuesToIterate.cend(); ++it)
     {
       existingSimilarMatch = _edgeMatchSimilarities[it.key()][it.value()];
       if (existingSimilarMatch.score != -1.0)
@@ -375,7 +375,7 @@ bool EdgeMatchSetFinder::_recordMatch(ConstEdgeMatchPtr em)
     EdgeMatchScore newMatch;
     newMatch.match = em;
     newMatch.score = score;
-    for (auto it = similarityValuesToIterate.begin(); it != similarityValuesToIterate.end(); ++it)
+    for (auto it = similarityValuesToIterate.cbegin(); it != similarityValuesToIterate.cend(); ++it)
       _edgeMatchSimilarities[it.key()][it.value()] = newMatch;
 
     // add our new match

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkDetails.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkDetails.cpp
@@ -739,7 +739,7 @@ Meters NetworkDetails::getSearchRadius(ConstWayPtr w1, ConstWayPtr w2) const
   return result;
 }
 
-const NetworkDetails::SublineCache NetworkDetails::_getSublineCache(ConstWayPtr w1, ConstWayPtr w2)
+NetworkDetails::SublineCache NetworkDetails::_getSublineCache(ConstWayPtr w1, ConstWayPtr w2)
 {
   ElementId e1 = w1->getElementId();
   ElementId e2 = w2->getElementId();

--- a/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkDetails.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/network/NetworkDetails.h
@@ -28,7 +28,6 @@
 #define NETWORKDETAILS_H
 
 // hoot
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/algorithms/linearreference/WaySublineMatchString.h>
 #include <hoot/core/conflate/network/EdgeMatch.h>
 #include <hoot/core/conflate/network/EdgeString.h>
@@ -37,6 +36,7 @@
 #include <hoot/core/conflate/network/LegacyVertexMatcher.h>
 #include <hoot/core/conflate/network/OsmNetwork.h>
 #include <hoot/core/conflate/network/SearchRadiusProvider.h>
+#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/util/Configurable.h>
 
 namespace hoot
@@ -197,7 +197,7 @@ private:
   double _getEdgeAngleScore(ConstNetworkVertexPtr v1, ConstNetworkVertexPtr v2, ConstNetworkEdgePtr e1,
                             ConstNetworkEdgePtr e2) const;
 
-  const SublineCache _getSublineCache(ConstWayPtr w1, ConstWayPtr w2);
+  SublineCache _getSublineCache(ConstWayPtr w1, ConstWayPtr w2);
 
   LegacyVertexMatcherPtr _getVertexMatcher();
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/polygon/BuildingMatchCreator.cpp
@@ -288,7 +288,7 @@ private:
   int _taskStatusUpdateInterval;
   int _memoryCheckUpdateInterval;
 
-  void _markNonOneToOneMatchesAsReview(std::vector<MatchPtr>& matches) const
+  void _markNonOneToOneMatchesAsReview(const std::vector<MatchPtr>& matches) const
   {
     for (const auto& match : matches)
     {
@@ -372,7 +372,7 @@ private:
       std::vector<MatchPtr> modifiedMatches;
       for (auto it = highestOverlapMatches.constBegin(); it != highestOverlapMatches.constEnd(); ++it)
         modifiedMatches.push_back(it.value());
-      matches = modifiedMatches;
+      matches = std::move(modifiedMatches);
     }
     highestOverlapMatches.clear();
     LOG_VART(matches);

--- a/hoot-core/src/main/cpp/hoot/core/elements/Status.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Status.cpp
@@ -119,7 +119,7 @@ Status::Type Status::fromString(QString statusString)
   if (statusString.contains(";"))
   {
     QStringList values = statusString.split(";");
-    if (values.size() > 0)
+    if (!values.empty())
       statusString = values[0];
     else
       return Invalid;

--- a/hoot-core/src/main/cpp/hoot/core/elements/WayData.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/WayData.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef __ELEMENT_WAY_DATA_H__
 #define __ELEMENT_WAY_DATA_H__

--- a/hoot-core/src/main/cpp/hoot/core/elements/WayData.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/WayData.h
@@ -47,7 +47,7 @@ public:
 
   WayData(const WayData& from);
 
-  ~WayData() = default;
+  ~WayData() override = default;
 
   void addNode(long id) { _nodes.push_back(id); }
   void insertNode(long index, long id ) { _nodes.insert(_nodes.begin() + index, id); }

--- a/hoot-core/src/main/cpp/hoot/core/geometry/CoordinateExt.h
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/CoordinateExt.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef COORDINATEEXT_H
 #define COORDINATEEXT_H

--- a/hoot-core/src/main/cpp/hoot/core/geometry/CoordinateExt.h
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/CoordinateExt.h
@@ -36,10 +36,10 @@ namespace hoot
 class CoordinateExt : public geos::geom::Coordinate
 {
 public:
+  //  Include base class constructors
+  using geos::geom::Coordinate::Coordinate;
 
   CoordinateExt(geos::geom::Coordinate c) : geos::geom::Coordinate(c) { }
-  CoordinateExt(double xNew = 0.0, double yNew = 0.0, double zNew = geos::DoubleNotANumber)
-    : Coordinate( xNew, yNew, zNew ) { }
 
   double length() const
   {
@@ -94,9 +94,8 @@ public:
   }
 
   // https://www.codeproject.com/Tips/862988/Find-the-Intersection-Point-of-Two-Line-Segments
-  static std::shared_ptr<CoordinateExt> lineSegementsIntersect(
-    const CoordinateExt& p1, const CoordinateExt& p2, const CoordinateExt& q1,
-    const CoordinateExt& q2)
+  static std::shared_ptr<CoordinateExt> lineSegementsIntersect(const CoordinateExt& p1, const CoordinateExt& p2,
+                                                               const CoordinateExt& q1, const CoordinateExt& q2)
   {
     std::shared_ptr<CoordinateExt> intersection;
 

--- a/hoot-core/src/main/cpp/hoot/core/geometry/RelationToMultiPolygonConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/RelationToMultiPolygonConverter.cpp
@@ -81,7 +81,7 @@ Geometry* RelationToMultiPolygonConverter::_addHoles(vector<LinearRing*>& outers
   holes.reserve(outers.size());
 
   vector<LinearRing*> noHoles;
-  for (const auto outer : outers)
+  for (const auto& outer : outers)
   {
     Polygon* p = gf.createPolygon(*outer, noHoles);
     tmpPolygons.push_back(p);
@@ -285,12 +285,12 @@ void RelationToMultiPolygonConverter::_classifyRings(std::vector<LinearRing*>& n
   // A list of things we haven't found yet.
   deque<LinearRing*> notFound;
 
-  for (const auto member : noRole)
+  for (const auto& member : noRole)
   {
     MultiPolygonRelationRole status = MultiPolygonRelationRole::NoRole;
 
     // Check if we have an inner polygon.
-    for (auto outer : outers)
+    for (const auto& outer : outers)
     {
       status = _findRelationship(member, outer);
 
@@ -311,7 +311,7 @@ void RelationToMultiPolygonConverter::_classifyRings(std::vector<LinearRing*>& n
     if (status == MultiPolygonRelationRole::NoRole)
     {
       // Look for an outer polygon
-      for (const auto inner : inners)
+      for (const auto& inner : inners)
       {
         status =_findRelationship(member, inner);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbSqlStatementFormatter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbSqlStatementFormatter.h
@@ -53,7 +53,7 @@ class HootApiDbSqlStatementFormatter : public ApiDbSqlStatementFormatter
 public:
 
   HootApiDbSqlStatementFormatter(const QString& delimiter, const long mapId);
-  ~HootApiDbSqlStatementFormatter() = default;
+  ~HootApiDbSqlStatementFormatter() override = default;
 
   QString nodeToSqlString(const ConstNodePtr& node, const long nodeId, const long changesetId,
                           const long version, const bool validate = false);

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.h
@@ -45,7 +45,7 @@ public:
   static QString className() { return "HootApiDbWriter"; }
 
   HootApiDbWriter();
-  ~HootApiDbWriter();
+  ~HootApiDbWriter() override;
 
   void close() override;
   bool isSupported(const QString& urlStr) const override;

--- a/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootApiDbWriter.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef HOOTAPIDBWRITER_H
 #define HOOTAPIDBWRITER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/MapStatsWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/MapStatsWriter.cpp
@@ -50,7 +50,7 @@ using namespace std;
 namespace hoot
 {
 
-void MapStatsWriter::_appendUnique(QList<SingleStat>& stats, QStringList& names) const
+void MapStatsWriter::_appendUnique(const QList<SingleStat>& stats, QStringList& names) const
 {
   for (const auto& stat : qAsConst(stats))
   {
@@ -59,7 +59,7 @@ void MapStatsWriter::_appendUnique(QList<SingleStat>& stats, QStringList& names)
   }
 }
 
-void MapStatsWriter::writeStatsToJson(QList<QList<SingleStat>>& stats, const QString& statsOutputFilePath) const
+void MapStatsWriter::writeStatsToJson(const QList<QList<SingleStat>>& stats, const QString& statsOutputFilePath) const
 {
   try
   {
@@ -106,7 +106,7 @@ void MapStatsWriter::writeStatsToJson(QList<QList<SingleStat>>& stats, const QSt
   }
 }
 
-void MapStatsWriter::writeStatsToText(QList<QList<SingleStat>>& stats, const QString &statsOutputFilePath) const
+void MapStatsWriter::writeStatsToText(const QList<QList<SingleStat>>& stats, const QString &statsOutputFilePath) const
 {
   LOG_INFO("Writing stats to file: " << statsOutputFilePath);
 
@@ -158,12 +158,12 @@ void MapStatsWriter::writeStats(const QString& mapInputPath, const QString& stat
   }
 }
 
-QString MapStatsWriter::statsToString(QList<QList<SingleStat>>& stats, QString sep) const
+QString MapStatsWriter::statsToString(const QList<QList<SingleStat>>& stats, QString sep) const
 {
   QStringList allStatNames;
 
-  for (int i = 0; i < stats.size(); i++)
-    _appendUnique(stats[i], allStatNames);
+  for (const auto& stat_list : qAsConst(stats))
+    _appendUnique(stat_list, allStatNames);
 
   int precision = ConfigOptions().getWriterPrecision();
   QString result;
@@ -174,15 +174,15 @@ QString MapStatsWriter::statsToString(QList<QList<SingleStat>>& stats, QString s
     QStringList l;
     l << name;
 
-    for (int j = 0; j < stats.size(); j++)
+    for (const auto& stat_list : qAsConst(stats))
     {
       bool foundIt = false;
 
-      for (int k = 0; k < stats[j].size(); k++)
+      for (const auto& stat : qAsConst(stat_list))
       {
-        if (stats[j][k].name == name)
+        if (stat.name == name)
         {
-          QString value = QString::number(stats[j][k].value, 'g', precision);
+          QString value = QString::number(stat.value, 'g', precision);
           l << ((value != "nan") ? value : "-");
           foundIt = true;
         }

--- a/hoot-core/src/main/cpp/hoot/core/io/MapStatsWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/MapStatsWriter.h
@@ -54,7 +54,7 @@ public:
     @param map stats
     @param statsOutputFilePath path of the output stats file
     */
-  void writeStatsToJson(QList<QList<SingleStat>>& stats, const QString& statsOutputFilePath) const;
+  void writeStatsToJson(const QList<QList<SingleStat>>& stats, const QString& statsOutputFilePath) const;
 
   /**
     Write map stats to a text file
@@ -62,7 +62,7 @@ public:
     @param map stats
     @param statsOutputFilePath path of the output stats file
     */
-  void writeStatsToText(QList<QList<SingleStat>>& stats, const QString& statsOutputFilePath) const;
+  void writeStatsToText(const QList<QList<SingleStat>>& stats, const QString& statsOutputFilePath) const;
 
   /**
     Creates a string for map stats
@@ -70,11 +70,11 @@ public:
     @param stats the stats to create the string for
     @param stats string separator
     */
-  QString statsToString(QList<QList<SingleStat>>& stats, QString sep) const;
+  QString statsToString(const QList<QList<SingleStat>>& stats, QString sep) const;
 
 private:
 
-  void _appendUnique(QList<SingleStat>& stats, QStringList& names) const;
+  void _appendUnique(const QList<SingleStat>& stats, QStringList& names) const;
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbReader.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef OSMAPIDBREADER_H
 #define OSMAPIDBREADER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbReader.h
@@ -43,7 +43,7 @@ public:
   static QString className() { return "OsmApiDbReader"; }
 
   OsmApiDbReader();
-  ~OsmApiDbReader();
+  ~OsmApiDbReader() override;
 
   void open(const QString& urlStr) override;
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.h
@@ -64,7 +64,7 @@ public:
   /** Constructors with one or multiple files consisting of one large changeset */
   OsmApiWriter(const QUrl& url, const QString& changeset);
   OsmApiWriter(const QUrl& url, const QList<QString>& changesets);
-  ~OsmApiWriter() = default;
+  ~OsmApiWriter() override = default;
   /**
    * @brief setConfiguration Update the configuration settings with new configuration
    * @param conf - Updated configurations

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfWriter.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef OSMPBFWRITER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmPbfWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmPbfWriter.h
@@ -67,7 +67,7 @@ public:
   static const char* const OSM_HEADER;
 
   OsmPbfWriter();
-  ~OsmPbfWriter();
+  ~OsmPbfWriter() override;
 
   /**
    * Used to finalize a call to writePartial.

--- a/hoot-core/src/main/cpp/hoot/core/ops/MetadataOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/MetadataOp.cpp
@@ -56,7 +56,7 @@ void MetadataOp::apply(std::shared_ptr<OsmMap>& pMap)
   if (_datasetIndicator.first.length() == 0)
     return;
 
-  _numProcessed = static_cast<size_t>(_pMap->getElementCount());
+  _numProcessed = _pMap->getElementCount();
 
   _apply();
 }

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
@@ -1120,10 +1120,13 @@ private:
     for (size_t i = 0; i < vid.size(); ++i)
     {
       bool aAncestor = false;
-      for (size_t j = 0; j < vid.size() && aAncestor == false; ++j)
+      for (size_t j = 0; j < vid.size(); ++j)
       {
         if (i != j && _isAncestor(vid[j], vid[i]))
+        {
           aAncestor = true;
+          break;
+        }
       }
       if (!aAncestor)
         result.push_back(vid[i]);

--- a/hoot-core/src/main/cpp/hoot/core/schema/TranslatedTagDifferencer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/TranslatedTagDifferencer.cpp
@@ -89,14 +89,12 @@ double TranslatedTagDifferencer::diff(const ConstOsmMapPtr& map, const ConstElem
   vector<ScriptToOgrSchemaTranslator::TranslatedFeature> tf1 = _translate(map, e1);
   vector<ScriptToOgrSchemaTranslator::TranslatedFeature> tf2 = _translate(map, e2);
 
-  class CostFunction :
-      public SingleAssignmentProblemSolver<
-        ScriptToOgrSchemaTranslator::TranslatedFeature,
-        ScriptToOgrSchemaTranslator::TranslatedFeature>::CostFunction
+  class CostFunction : public SingleAssignmentProblemSolver<ScriptToOgrSchemaTranslator::TranslatedFeature,
+                                                            ScriptToOgrSchemaTranslator::TranslatedFeature>::CostFunction
   {
   public:
     CostFunction() = default;
-    virtual ~CostFunction() = default;
+    ~CostFunction() override = default;
 
     const TranslatedTagDifferencer* ttd;
     /**
@@ -114,7 +112,7 @@ double TranslatedTagDifferencer::diff(const ConstOsmMapPtr& map, const ConstElem
   CostFunction cost;
   cost.ttd = this;
   using Saps = SingleAssignmentProblemSolver<ScriptToOgrSchemaTranslator::TranslatedFeature,
-      ScriptToOgrSchemaTranslator::TranslatedFeature> ;
+                                             ScriptToOgrSchemaTranslator::TranslatedFeature> ;
   Saps sap(cost);
 
   for (const auto& feature1 : tf1)
@@ -142,8 +140,7 @@ std::shared_ptr<ScriptToOgrSchemaTranslator> TranslatedTagDifferencer::_getTrans
 {
   if (_translator == nullptr)
   {
-    std::shared_ptr<ScriptSchemaTranslator> st =
-      ScriptSchemaTranslatorFactory::getInstance().createTranslator(_script);
+    std::shared_ptr<ScriptSchemaTranslator> st = ScriptSchemaTranslatorFactory::getInstance().createTranslator(_script);
 
     st->setErrorTreatment(StrictOff);
     _translator = std::dynamic_pointer_cast<ScriptToOgrSchemaTranslator>(st);

--- a/hoot-core/src/main/cpp/hoot/core/validation/Validator.h
+++ b/hoot-core/src/main/cpp/hoot/core/validation/Validator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef VALIDATOR_H
 #define VALIDATOR_H

--- a/hoot-core/src/main/cpp/hoot/core/validation/Validator.h
+++ b/hoot-core/src/main/cpp/hoot/core/validation/Validator.h
@@ -39,6 +39,9 @@ public:
 
   static QString className() { return "Validator"; }
 
+  Validator() = default;
+  virtual ~Validator() = default;
+
   /**
    * @brief Enables validation on the validator.
    *

--- a/hoot-core/src/main/cpp/hoot/core/visitors/AddBboxVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/AddBboxVisitor.h
@@ -40,7 +40,7 @@ public:
   static QString className() { return "AddBboxVisitor"; }
 
   AddBboxVisitor() = default;
-  ~AddBboxVisitor() = default;
+  ~AddBboxVisitor() override = default;
 
   /**
    * @see ElementVisitor

--- a/hoot-core/src/main/cpp/hoot/core/visitors/AddBboxVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/AddBboxVisitor.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef ADDBBOXVISITOR_H
 #define ADDBBOXVISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/MembersPerRelationVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/MembersPerRelationVisitor.cpp
@@ -48,7 +48,7 @@ void MembersPerRelationVisitor::visit(const ConstElementPtr& e)
   if (_crit.isSatisfied(e))
   {
     ConstRelationPtr relation = std::dynamic_pointer_cast<const Relation>(e);
-    const int numMembers = relation->getMemberCount();
+    const int numMembers = static_cast<int>(relation->getMemberCount());
     _totalMembers += numMembers;
     if (_minMembersPerRelation == 0 || numMembers < _minMembersPerRelation)
       _minMembersPerRelation = numMembers;

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RandomWaySplitter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RandomWaySplitter.cpp
@@ -103,9 +103,9 @@ vector<ElementPtr> RandomWaySplitter::_split(ElementPtr element)
     _splitRecursionLevel++;
     LOG_VART(_splitRecursionLevel);
 
-    const int numNodesBeforeSplit = _map->getNodeCount();
+    const int numNodesBeforeSplit = static_cast<int>(_map->getNodeCount());
     LOG_VART(numNodesBeforeSplit);
-    const int numWaysBeforeSplit = _map->getWayCount();
+    const int numWaysBeforeSplit = static_cast<int>(_map->getWayCount());
     LOG_VART(numWaysBeforeSplit);
 
     WayLocation waySplitPoint;
@@ -163,7 +163,7 @@ vector<ElementPtr> RandomWaySplitter::_split(ElementPtr element)
       newElementsAfterSplit.push_back(match);
     }
 
-    const int numNodesAfterSplit = _map->getNodeCount();
+    const int numNodesAfterSplit = static_cast<int>(_map->getNodeCount());
     LOG_VART(numNodesAfterSplit);
     const int numNewNodesCreatedBySplit = numNodesAfterSplit - numNodesBeforeSplit;
     LOG_VART(numNewNodesCreatedBySplit);

--- a/hoot-core/src/main/cpp/hoot/core/visitors/SplitNameVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/SplitNameVisitor.cpp
@@ -124,7 +124,7 @@ void SplitNameVisitor::visit(const std::shared_ptr<Element>& e)
   Tags& t = e->getTags();
   QStringList extraNames;
   Tags copy = t;
-  for (auto it = copy.begin(); it != copy.end(); ++it)
+  for (auto it = copy.cbegin(); it != copy.cend(); ++it)
   {
     const QString& k = it.key();
     const QString& v = it.value();

--- a/hoot-core/src/main/cpp/hoot/core/visitors/geometrymodifiers/PolyClusterGeoModifierAction.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/geometrymodifiers/PolyClusterGeoModifierAction.cpp
@@ -359,13 +359,14 @@ void PolyClusterGeoModifierAction::_createClusterPolygons()
     std::shared_ptr<Geometry> pAlphaGeom = alphashape.toGeometry();
 
     // combine polys from this cluster with AlphaShape
-    vector<Geometry*>* geomvect = new vector<Geometry*>();
-    geomvect->push_back(pAlphaGeom.get());
+    vector<const Geometry*> geomvect ;
+    geomvect.push_back(pAlphaGeom.get());
     for (auto wayId : cluster)
-      geomvect->push_back(_polyByWayId[wayId].get());
+      geomvect.push_back(_polyByWayId[wayId].get());
 
-    // GeometryFactory takes ownership of geomvect here.
-    const Geometry* mp = GeometryFactory::getDefaultInstance()->createMultiPolygon(geomvect);
+    //  Create the multipolygon
+    std::shared_ptr<Geometry> mp(GeometryFactory::getDefaultInstance()->createMultiPolygon(geomvect));
+    //  UnaryUnionOp::Union() doesn't take ownership of the reference
     std::shared_ptr<Geometry> pCombinedPoly = geos::operation::geounion::UnaryUnionOp::Union(*mp);
 
     // create a new element with cluster representation

--- a/hoot-josm/src/main/cpp/hoot/josm/jni/JniConversion.cpp
+++ b/hoot-josm/src/main/cpp/hoot/josm/jni/JniConversion.cpp
@@ -180,7 +180,7 @@ QMap<QString, int> JniConversion::fromJavaStringIntMap(JNIEnv* javaEnv, jobject 
 
   // yes, this is kind of kludgy...could time to come up with a templated version at some point
   QMap<QString, QString> tempResult = fromJavaStringMap(javaEnv, javaMap);
-  for (auto mapItr = tempResult.begin(); mapItr != tempResult.end(); ++mapItr)
+  for (auto mapItr = tempResult.cbegin(); mapItr != tempResult.cend(); ++mapItr)
   {
     bool ok = false;
     const int val = mapItr.value().toInt(&ok);

--- a/hoot-josm/src/main/cpp/hoot/josm/ops/JosmMapCleaner.cpp
+++ b/hoot-josm/src/main/cpp/hoot/josm/ops/JosmMapCleaner.cpp
@@ -195,7 +195,7 @@ void JosmMapCleaner::_getStats()
 int JosmMapCleaner::_getNumElementsCleaned()
 {
   const int numCleaned =
-    (int)_javaEnv->CallIntMethod(
+    _javaEnv->CallIntMethod(
       _josmInterface,
       // Java sig: int getNumElementsCleaned()
       _javaEnv->GetMethodID(_josmInterfaceClass, "getNumElementsCleaned", "()I"));

--- a/hoot-josm/src/main/cpp/hoot/josm/ops/JosmMapValidator.h
+++ b/hoot-josm/src/main/cpp/hoot/josm/ops/JosmMapValidator.h
@@ -47,12 +47,12 @@ public:
   static QString className() { return "JosmMapValidator"; }
 
   JosmMapValidator() = default;
-  virtual ~JosmMapValidator() = default;
+  ~JosmMapValidator() override = default;
 
   /**
    * @see OperationStatus
    */
-  virtual QString getInitStatusMessage() const { return "Validating elements with JOSM..."; }
+  QString getInitStatusMessage() const override { return "Validating elements with JOSM..."; }
 
   /**
    * @see ApiEntityInfo
@@ -72,7 +72,7 @@ protected:
   /*
    * @see JosmMapValidatorAbstract
    */
-  virtual OsmMapPtr _getUpdatedMap(OsmMapPtr& inputMap);
+  OsmMapPtr _getUpdatedMap(OsmMapPtr& inputMap) override;
 
 private:
 

--- a/hoot-josm/src/main/cpp/hoot/josm/ops/JosmMapValidatorAbstract.cpp
+++ b/hoot-josm/src/main/cpp/hoot/josm/ops/JosmMapValidatorAbstract.cpp
@@ -78,7 +78,7 @@ void JosmMapValidatorAbstract::_initJosmImplementation()
   QString coreLogLevel;
   // When testing, we're not interested in seeing logging from josm or hoot-josm.
   if (ConfigOptions().getTestValidationEnable())
-    coreLogLevel = Log::getInstance().levelToString(Log::None);
+    coreLogLevel = Log::levelToString(Log::None);
   else
     coreLogLevel = Log::getInstance().getLevelAsString();
 
@@ -178,15 +178,13 @@ void JosmMapValidatorAbstract::_getStats()
   _numFailingValidators = failingValidatorInfo.size();
 
   // TODO: Try to simplify this with SingleStat.
-  _errorSummary =
-    "Found " + StringUtils::formatLargeNumber(_numValidationErrors) +
-    " validation errors in " + StringUtils::formatLargeNumber(_numAffected) +
-    " features with JOSM.\n";
-  // convert the validation error info to a readable summary string
-  _errorSummary += _errorCountsByTypeToSummaryStr(_getValidationErrorCountsByType());
-  _errorSummary += "Total failing JOSM validators: " + QString::number(_numFailingValidators) + "\n";
+  _errorSummary = QString("Found %1 validation errors in %2 features with JOSM.\n%3Total failing JOSM validators: %4\n")
+                    .arg(StringUtils::formatLargeNumber(_numValidationErrors),
+                         StringUtils::formatLargeNumber(_numAffected),
+                         _errorCountsByTypeToSummaryStr(_getValidationErrorCountsByType()),
+                         QString::number(_numFailingValidators));
   for (const auto& validatorName : failingValidatorInfo.keys())
-    _errorSummary += "Validator: " + validatorName + " failed with error: " + failingValidatorInfo[validatorName] + ".\n";
+    _errorSummary.append(QString("Validator: %1 failed with error: %2.\n").arg(validatorName, failingValidatorInfo[validatorName]));
 
   _errorSummary = _errorSummary.trimmed();
   LOG_VART(_errorSummary);
@@ -195,7 +193,7 @@ void JosmMapValidatorAbstract::_getStats()
 int JosmMapValidatorAbstract::_getNumValidationErrors()
 {
   const int numValidationErrors =
-    (int)_javaEnv->CallIntMethod(
+    _javaEnv->CallIntMethod(
       _josmInterface,
       // Java sig: int getNumValidationErrors()
       _javaEnv->GetMethodID(_josmInterfaceClass, "getNumValidationErrors", "()I"));

--- a/hoot-josm/src/main/cpp/hoot/josm/ops/JosmMapValidatorAbstract.h
+++ b/hoot-josm/src/main/cpp/hoot/josm/ops/JosmMapValidatorAbstract.h
@@ -56,7 +56,7 @@ class JosmMapValidatorAbstract : public OsmMapOperation, public Configurable
 public:
 
   JosmMapValidatorAbstract();
-  ~JosmMapValidatorAbstract();
+  ~JosmMapValidatorAbstract() override;
 
   /**
    * @see Configurable

--- a/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/conflate/matching/ScriptMatch.cpp
@@ -424,7 +424,7 @@ std::map<QString, double> ScriptMatch::getFeatures(const ConstOsmMapPtr& map) co
   QVariantMap vm = toCpp<QVariantMap>(v);
   long valCtr = 0;
   LOG_VART(vm.size());
-  for (auto it = vm.begin(); it != vm.end(); ++it)
+  for (auto it = vm.cbegin(); it != vm.cend(); ++it)
   {
     if (it.value().isNull() == false)
     {

--- a/tgs/src/main/cpp/tgs/Optimization/FitnessFunction.h
+++ b/tgs/src/main/cpp/tgs/Optimization/FitnessFunction.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef FITNESSFUNCTION_H
 #define FITNESSFUNCTION_H

--- a/tgs/src/main/cpp/tgs/Optimization/FitnessFunction.h
+++ b/tgs/src/main/cpp/tgs/Optimization/FitnessFunction.h
@@ -38,9 +38,10 @@ public:
 
   /**
    * Calculates the fitness of the specified state. Lower values are better.
-   *
    * While not required fitness functions that return values from [0, 1] may work better.
    */
+  FitnessFunction() = default;
+  virtual ~FitnessFunction() = default;
   /**
    * @brief f Calculates the fitness of the specified state. Lower values are better.
    * @param s a simulated annealing state

--- a/tgs/src/main/cpp/tgs/RStarTree/RStarTree.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/RStarTree.cpp
@@ -508,8 +508,7 @@ bool RStarTree::_sanityCheck(const RTreeNode* node) const
     }
     else
     {
-      RTreeNode* n = const_cast<RTreeNode*>(node);
-      if (n->getChildId(i) < 0)
+      if (node->getChildId(i) < 0)
         return false;
     }
   }

--- a/tgs/src/main/cpp/tgs/RStarTree/RStarTreePrinter.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/RStarTreePrinter.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "RStarTreePrinter.h"

--- a/tgs/src/main/cpp/tgs/RStarTree/RStarTreePrinter.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/RStarTreePrinter.cpp
@@ -35,19 +35,17 @@ using namespace std;
 namespace Tgs
 {
 
-RStarTreePrinter::RStarTreePrinter(const std::shared_ptr<const RStarTree>& tree) :
-_tree(tree)
+RStarTreePrinter::RStarTreePrinter(const std::shared_ptr<const RStarTree>& tree)
+  : _tree(tree)
 {
 }
 
 string RStarTreePrinter::_indentStr(int size) const
 {
   string result;
-  for (int i = 0; i < size; i++)
-  {
-    result = result + "  ";
-  }
-
+  result.reserve(size * 2);
+  for (int i = 0; i < size * 2; i++)
+    result[i] = ' ';
   return result;
 }
 
@@ -72,9 +70,7 @@ void RStarTreePrinter::print(const RTreeNode *node, int indent)
   cout << is << "Envelope: " << node->calculateEnvelope().toString() << endl;
   cout << is << "Child Count: " << node->getChildCount() << endl;
   if (node->isLeafNode())
-  {
     cout << is << "Leaf Node" << endl;
-  }
 
   for (int i = 0; i < node->getChildCount(); i++)
   {
@@ -85,15 +81,11 @@ void RStarTreePrinter::print(const RTreeNode *node, int indent)
     }
     else
     {
-      RTreeNode* n = const_cast<RTreeNode*>(node);
-      if (n->getChildId(i) < 0)
-      {
-        cout << is << "  *** BAD *** user id: " << n->getChildId(i) << endl;
-      }
+      int childId = node->getChildId(i);
+      if (childId < 0)
+        cout << is << "  *** BAD *** user id: " << childId << endl;
       else
-      {
-        cout << is << "  user id: " << n->getChildId(i) << endl;
-      }
+        cout << is << "  user id: " << childId << endl;
     }
   }
 }

--- a/tgs/src/main/cpp/tgs/RStarTree/RTreeNode.cpp
+++ b/tgs/src/main/cpp/tgs/RStarTree/RTreeNode.cpp
@@ -237,10 +237,9 @@ BoxInternalData RTreeNode::getChildEnvelope(int childIndex) const
   return bid;
 }
 
-int RTreeNode::getChildId(int childIndex)
+int RTreeNode::getChildId(int childIndex) const
 {
-  int id = _getChildPtr(childIndex)->id;
-  return id;
+  return _getChildPtr(childIndex)->id;
 }
 
 int RTreeNode::getChildNodeId(int childIndex) const

--- a/tgs/src/main/cpp/tgs/RStarTree/RTreeNode.h
+++ b/tgs/src/main/cpp/tgs/RStarTree/RTreeNode.h
@@ -171,9 +171,9 @@ public:
 
   /**
    * This method should rarely be used, and probably only be internal structure, not iterators
-   * You probably want to use either getChildUserId. This is not const for that reason.
+   * You probably want to use either getChildUserId.
    */
-  int getChildId(int childIndex);
+  int getChildId(int childIndex) const;
 
   /**
    * Returns the node ID for a specific child index. Calling this method is not valid if this

--- a/tgs/src/main/cpp/tgs/RandomForest/InfoGainCalculator.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/InfoGainCalculator.cpp
@@ -38,270 +38,236 @@
 
 namespace Tgs
 {
-  double InfoGainCalculator::_calcLogFunc(double n) const
-  {
-    if (n < std::numeric_limits<double>::epsilon())
-    {
-      n = std::numeric_limits<double>::epsilon();
-    }
+double InfoGainCalculator::_calcLogFunc(double n) const
+{
+  if (n < std::numeric_limits<double>::epsilon())
+    n = std::numeric_limits<double>::epsilon();
 
-    return (-n * (log(n)/log(2.0)));
-  }
+  return (-n * (log(n)/log(2.0)));
+}
 
-  double InfoGainCalculator::computeEntropyByClass(
-    const DataFrame& df, const std::vector<unsigned int>& indices) const
-  {
-    double entSum = 0;
-    HashMap<std::string, int> popMap;
-    df.getClassPopulations(indices, popMap);
+double InfoGainCalculator::computeEntropyByClass(const DataFrame& df, const std::vector<unsigned int>& indices) const
+{
+  double entSum = 0;
+  HashMap<std::string, int> popMap;
+  df.getClassPopulations(indices, popMap);
 
-    HashMap<std::string, int>::iterator itr;
+  for (auto itr = popMap.begin(); itr != popMap.end(); ++itr)
+    entSum += _calcLogFunc((double)itr->second / (double)indices.size());
 
-    for (itr = popMap.begin(); itr != popMap.end(); ++itr)
-    {
-      entSum += _calcLogFunc((double)itr->second / (double)indices.size()); 
-    }
+  return entSum;
+}
 
-    return entSum;
-  }
- 
-  void InfoGainCalculator::_findCandidateSplits(
-    const DataFrame& df, std::vector<unsigned int>& indices, unsigned int fIdx,
-    std::vector<unsigned int>& splits) const
-  {
-     splits.clear();
- 
-     // The split will be based on any difference between the value of 2 contiguous values
-     // Note the miniumum split idx is always 1
-     for (unsigned int i = 1; i < indices.size(); i++)
-     {
-       double val1 = df.getDataVector(indices[i-1])[fIdx];
-       double val2 = df.getDataVector(indices[i])[fIdx];
-       if (fabs(val1 - val2) >= std::numeric_limits<double>::epsilon())
-       {
-         splits.push_back(i);
-       }
-     }
+void InfoGainCalculator::_findCandidateSplits(const DataFrame& df, std::vector<unsigned int>& indices, unsigned int fIdx,
+                                              std::vector<unsigned int>& splits) const
+{
+   splits.clear();
+
+   // The split will be based on any difference between the value of 2 contiguous values
+   // Note the miniumum split idx is always 1
+   for (unsigned int i = 1; i < indices.size(); i++)
+   {
+     double val1 = df.getDataVector(indices[i - 1])[fIdx];
+     double val2 = df.getDataVector(indices[i])[fIdx];
+     if (fabs(val1 - val2) >= std::numeric_limits<double>::epsilon())
+       splits.push_back(i);
    }
+ }
 
-  bool InfoGainCalculator::findDataSplit(
-    const DataFrame& df, std::vector<unsigned int>& fIndices, std::vector<unsigned int>& indices,
-    unsigned int& splitIdx, unsigned int& fIdx, double& splitVal, double& purityDelta) const
+bool InfoGainCalculator::findDataSplit(const DataFrame& df, std::vector<unsigned int>& fIndices, std::vector<unsigned int>& indices,
+                                       unsigned int& splitIdx, unsigned int& fIdx, double& splitVal, double& purityDelta) const
+{
+  if (!df.empty())
   {
-    if (!df.empty())
+    //First find the class entropy
+    double classEntropy = computeEntropyByClass(df, indices);
+
+    //Set up container to hold results
+    std::vector<double> infoGain;
+    infoGain.resize(fIndices.size());
+    std::vector<unsigned int> splitIndices;
+    splitIndices.resize(fIndices.size());
+    std::vector<std::vector<unsigned int>> sortedIndices;
+    sortedIndices.resize(fIndices.size());
+
+    // Sort each indices set based on the factor values. This maintains a list of indices for each
+    // factor being considered. Trade off is memory vs. cost of resorting indices on winning
+    // factor. Note fIndices is the list of factor indices to consider.
+    for (unsigned int i = 0; i < fIndices.size(); i++)
     {
-      //First find the class entropy
-      double classEntropy = computeEntropyByClass(df, indices);
-
-      //Set up container to hold results
-      std::vector<double> infoGain;
-      infoGain.resize(fIndices.size());
-      std::vector<unsigned int> splitIndices;
-      splitIndices.resize(fIndices.size());
-      std::vector<std::vector<unsigned int>> sortedIndices;
-      sortedIndices.resize(fIndices.size());
-
-      // Sort each indices set based on the factor values. This maintains a list of indices for each
-      // factor being considered. Trade off is memory vs. cost of resorting indices on winning
-      // factor. Note fIndices is the list of factor indices to consider.
-      for (unsigned int i = 0; i < fIndices.size(); i++)
-      {
-        sortedIndices[i] = indices;                                  //Load up all the data vectors of interest
-        df.sortIndicesOnFactorValue( sortedIndices[i], fIndices[i]); //Sort the data vectors by the factor values
-        infoGain[i] = getMaxInfoGainByFactor(df, sortedIndices[i], fIndices[i], classEntropy, splitIndices[i]);
-      }
-
-      double maxGr = -1E10;
-      unsigned int maxFactIdx = 0;
-      unsigned int maxIdx = 0;
-      for (unsigned int j = 0; j < fIndices.size(); j++)
-      {
-        //std::cout << "IGC: " << infoGain[j] << " " << j << std::endl;
-        if (infoGain[j] > maxGr)
-        {
-          maxGr = infoGain[j];  //Get the max info gain ratio
-          maxFactIdx = fIndices[j];
-          maxIdx = j;
-        }
-      }
-
-      if (fabs(maxGr - -1E10) <= std::numeric_limits<double>::epsilon())
-      {
-        return false;
-      }
-     
-      //Set values for return
-      fIdx = maxFactIdx;
-     
-      indices = sortedIndices[maxIdx];
-      splitIdx = splitIndices[maxIdx];
-      purityDelta = maxGr;
-
-      splitVal = (df.getDataVector(indices[splitIdx])[fIdx] + df.getDataVector(indices[splitIdx - 1])[fIdx]) / 2.0;
-
-      return true;
-
+      sortedIndices[i] = indices;                                  //Load up all the data vectors of interest
+      df.sortIndicesOnFactorValue(sortedIndices[i], fIndices[i]); //Sort the data vectors by the factor values
+      infoGain[i] = getMaxInfoGainByFactor(df, sortedIndices[i], fIndices[i], classEntropy, splitIndices[i]);
     }
-    else
-    {
-      throw Exception("SaUrgent::DataFrame::findDataSplitFromInfoGain - Unable to operate on empty dataset");
-    }
-  }
-
-  double InfoGainCalculator::getMaxInfoGainByFactor(const DataFrame& df,
-    std::vector<unsigned int>& indices, unsigned int fIdx, double totalEntropy,
-    unsigned int& bestSplit) const
-  {
-    //Indices need to be sorted on the factor to use this as a public function 
-
-    //Next find a list of candidate splits per factor
-    //Split rules
-    // - split value can not split adjacent vectors with same value
-    std::vector<unsigned int> splits;
-    _findCandidateSplits(df, indices, fIdx, splits);  //Find all potential splits among the factor data
-
-    std::vector<double> leftEntVec;
-    std::vector<double> rightEntVec;
-    std::vector<unsigned int> tmpIndices;
-    tmpIndices.resize(1);
-    double entSum = 0;
-    HashMap<std::string, int> popMap;
-    HashMap<std::string, int>::iterator itr;
-
-    ////
-    // Calculate left entropy for all possible splits (not just candidate splits)
-    ////
-    leftEntVec.reserve(indices.size());
-    for (unsigned int i = 0; i < indices.size(); i++)
-    {
-      tmpIndices[0] = indices[i];
-      df.getClassPopulations(tmpIndices, popMap);
-
-      entSum = 0.0;
-      for (itr = popMap.begin(); itr != popMap.end(); ++itr)
-      {
-        entSum += _calcLogFunc((double)itr->second / (double)(i + 1)); 
-      }
-      leftEntVec.push_back(entSum);
-    }
-
-    ////
-    // Calculate right entropy for all possible splits (not just candidate splits)
-    ////
-    popMap.clear();
-    rightEntVec.resize(indices.size());
-    for (int i = ((int)indices.size()) - 1; i >= 0; i--)
-    {
-      tmpIndices[0] = indices[i];
-      df.getClassPopulations(tmpIndices, popMap);
-
-      int tmpSize = indices.size() - i;
-      entSum = 0.0;
-      for (itr = popMap.begin(); itr != popMap.end(); ++itr)
-      {
-        entSum += _calcLogFunc((double)itr->second / (double)tmpSize); 
-      }
-      rightEntVec[i] = entSum;
-    }
-
-    double maxIg = -1E20;
-    unsigned int maxSplitIdx = 1;
-    // Compute the class entropy per split
-    for (unsigned int i = 0; i < splits.size(); i++)
-    {
-      double leftEnt;
-      if (splits[i] <= 0)
-      {
-        leftEnt = 0.0;
-      }
-      else
-      {
-        leftEnt = leftEntVec[splits[i] - 1];
-      }
-      double rightEnt;
-      if (splits[i] <= 0)
-      {
-        rightEnt = 0.0;
-      }
-      else
-      {
-        rightEnt = rightEntVec[splits[i]];
-      }
-      
-      double splitEnt = (double)(splits[i])/(double)(indices.size()) * leftEnt +
-        (double)(indices.size() - splits[i])/(double)(indices.size()) * rightEnt;
-      double infoGain = totalEntropy - splitEnt;
-
-      if (infoGain > maxIg)
-      {
-        maxIg = infoGain;
-        maxSplitIdx = splits[i];
-      }
-    }
-
-    bestSplit = maxSplitIdx;
-    return maxIg;
-  }
-
-  double InfoGainCalculator::getMaxInfoGainRatioByFactor(
-    const DataFrame& df, std::vector<unsigned int>& indices, unsigned int fIdx, double totalEntropy,
-    unsigned int& bestSplit) const
-  {
-    //Indices need to be sorted on the factor to use this as a public function 
-
-    //Next find a list of candidate splits per factor
-    //Split rules
-    // - split value can not split adjacent vectors with same value
-    std::vector<unsigned int> splits;
-    _findCandidateSplits(df, indices, fIdx, splits);
 
     double maxGr = -1E10;
-    unsigned int maxSplitIdx = 0;
-    //Compute the class entropy per split
-    for (unsigned int i = 0; i < splits.size(); i++)
+    unsigned int maxFactIdx = 0;
+    unsigned int maxIdx = 0;
+    for (unsigned int j = 0; j < fIndices.size(); j++)
     {
-      std::vector<unsigned int> leftSplit;
-      std::vector<unsigned int> rightSplit;
-
-      for (unsigned int j = 0; j < indices.size(); j++)
+      //std::cout << "IGC: " << infoGain[j] << " " << j << std::endl;
+      if (infoGain[j] > maxGr)
       {
-        if (j < splits[i])
-        {
-          leftSplit.push_back(indices[j]);
-        }
-        else
-        {
-          rightSplit.push_back(indices[j]);
-        }
-      }
-
-      double leftEnt = computeEntropyByClass(df, leftSplit);
-      double rightEnt = computeEntropyByClass(df, rightSplit);
-      double splitEnt = (double)(splits[i])/(double)(indices.size()) * leftEnt +
-        (double)(indices.size() - splits[i])/(double)(indices.size()) * rightEnt;
-      double infoGain = totalEntropy - splitEnt;
-      double splitInfo = leftEnt + rightEnt;
-
-      if (splitInfo <= 0)
-      {
-        splitInfo = 1E-10;
-      }
-      double gainRatio = infoGain / splitInfo;
-
-      //std::cout << " InfoGain1 " << infoGain << std::endl;
-      //std::cout << "left " << leftEnt << " right " << rightEnt << " split " << splitEnt << std::endl;
-      //std::cout << "leftSize " << leftSplit.size() << " rightSize " << rightSplit.size() << std::endl;
-
-      if (gainRatio > maxGr)
-      {
-        maxGr = gainRatio;
-        maxSplitIdx = splits[i];
+        maxGr = infoGain[j];  //Get the max info gain ratio
+        maxFactIdx = fIndices[j];
+        maxIdx = j;
       }
     }
 
-    bestSplit = maxSplitIdx;
-    return maxGr;
+    if (fabs(maxGr - -1E10) <= std::numeric_limits<double>::epsilon())
+      return false;
+
+    //Set values for return
+    fIdx = maxFactIdx;
+
+    indices = sortedIndices[maxIdx];
+    splitIdx = splitIndices[maxIdx];
+    purityDelta = maxGr;
+
+    splitVal = (df.getDataVector(indices[splitIdx])[fIdx] + df.getDataVector(indices[splitIdx - 1])[fIdx]) / 2.0;
+
+    return true;
   }
+  else
+    throw Exception("SaUrgent::DataFrame::findDataSplitFromInfoGain - Unable to operate on empty dataset");
+}
+
+double InfoGainCalculator::getMaxInfoGainByFactor(const DataFrame& df, std::vector<unsigned int>& indices, unsigned int fIdx,
+                                                  double totalEntropy, unsigned int& bestSplit) const
+{
+  //Indices need to be sorted on the factor to use this as a public function
+
+  //Next find a list of candidate splits per factor
+  //Split rules
+  // - split value can not split adjacent vectors with same value
+  std::vector<unsigned int> splits;
+  _findCandidateSplits(df, indices, fIdx, splits);  //Find all potential splits among the factor data
+
+  std::vector<double> leftEntVec;
+  std::vector<double> rightEntVec;
+  std::vector<unsigned int> tmpIndices;
+  tmpIndices.resize(1);
+  double entSum = 0;
+  HashMap<std::string, int> popMap;
+
+  ////
+  // Calculate left entropy for all possible splits (not just candidate splits)
+  ////
+  leftEntVec.reserve(indices.size());
+  for (unsigned int i = 0; i < indices.size(); i++)
+  {
+    tmpIndices[0] = indices[i];
+    df.getClassPopulations(tmpIndices, popMap);
+
+    entSum = 0.0;
+    for (auto itr = popMap.begin(); itr != popMap.end(); ++itr)
+      entSum += _calcLogFunc((double)itr->second / (double)(i + 1));
+
+    leftEntVec.push_back(entSum);
+  }
+
+  ////
+  // Calculate right entropy for all possible splits (not just candidate splits)
+  ////
+  popMap.clear();
+  rightEntVec.resize(indices.size());
+  for (int i = ((int)indices.size()) - 1; i >= 0; i--)
+  {
+    tmpIndices[0] = indices[i];
+    df.getClassPopulations(tmpIndices, popMap);
+
+    int tmpSize = indices.size() - i;
+    entSum = 0.0;
+    for (auto itr = popMap.begin(); itr != popMap.end(); ++itr)
+      entSum += _calcLogFunc((double)itr->second / (double)tmpSize);
+
+    rightEntVec[i] = entSum;
+  }
+
+  double maxIg = -1E20;
+  unsigned int maxSplitIdx = 1;
+  // Compute the class entropy per split
+  for (auto split : splits)
+  {
+    double leftEnt;
+    if (split <= 0)
+      leftEnt = 0.0;
+    else
+      leftEnt = leftEntVec[split - 1];
+
+    double rightEnt;
+    if (split <= 0)
+      rightEnt = 0.0;
+    else
+      rightEnt = rightEntVec[split];
+
+    double splitEnt = (double)(split)/(double)(indices.size()) * leftEnt +
+                      (double)(indices.size() - split)/(double)(indices.size()) * rightEnt;
+    double infoGain = totalEntropy - splitEnt;
+
+    if (infoGain > maxIg)
+    {
+      maxIg = infoGain;
+      maxSplitIdx = split;
+    }
+  }
+
+  bestSplit = maxSplitIdx;
+  return maxIg;
+}
+
+double InfoGainCalculator::getMaxInfoGainRatioByFactor(const DataFrame& df, std::vector<unsigned int>& indices, unsigned int fIdx,
+                                                       double totalEntropy, unsigned int& bestSplit) const
+{
+  //Indices need to be sorted on the factor to use this as a public function
+
+  //Next find a list of candidate splits per factor
+  //Split rules
+  // - split value can not split adjacent vectors with same value
+  std::vector<unsigned int> splits;
+  _findCandidateSplits(df, indices, fIdx, splits);
+
+  double maxGr = -1E10;
+  unsigned int maxSplitIdx = 0;
+  //Compute the class entropy per split
+  for (auto split : splits)
+  {
+    std::vector<unsigned int> leftSplit;
+    std::vector<unsigned int> rightSplit;
+
+    for (unsigned int j = 0; j < indices.size(); j++)
+    {
+      if (j < split)
+        leftSplit.push_back(indices[j]);
+      else
+        rightSplit.push_back(indices[j]);
+    }
+
+    double leftEnt = computeEntropyByClass(df, leftSplit);
+    double rightEnt = computeEntropyByClass(df, rightSplit);
+    double splitEnt = (double)(split)/(double)(indices.size()) * leftEnt +
+                      (double)(indices.size() - split)/(double)(indices.size()) * rightEnt;
+    double infoGain = totalEntropy - splitEnt;
+    double splitInfo = leftEnt + rightEnt;
+
+    if (splitInfo <= 0)
+      splitInfo = 1E-10;
+
+    double gainRatio = infoGain / splitInfo;
+
+    //std::cout << " InfoGain1 " << infoGain << std::endl;
+    //std::cout << "left " << leftEnt << " right " << rightEnt << " split " << splitEnt << std::endl;
+    //std::cout << "leftSize " << leftSplit.size() << " rightSize " << rightSplit.size() << std::endl;
+
+    if (gainRatio > maxGr)
+    {
+      maxGr = gainRatio;
+      maxSplitIdx = split;
+    }
+  }
+
+  bestSplit = maxSplitIdx;
+  return maxGr;
+}
   
 }//end namespace
-

--- a/tgs/src/main/cpp/tgs/RandomForest/InfoGainCalculator.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/InfoGainCalculator.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2018, 2019, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "InfoGainCalculator.h"

--- a/tgs/src/main/cpp/tgs/RandomForest/InfoGainCalculator.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/InfoGainCalculator.h
@@ -33,100 +33,100 @@
 
 namespace Tgs
 {
+/**
+*  This class handles all the information gain calculations
+* to find entropy with a dataset or subsets of the data
+*/
+class TGS_EXPORT InfoGainCalculator
+{
+public:
+
   /**
-  *  This class handles all the information gain calculations
-  * to find entropy with a dataset or subsets of the data
+  *  Constructor
   */
-  class TGS_EXPORT InfoGainCalculator
-  {
-  public:
+  InfoGainCalculator() = default;
 
-    /**
-    *  Constructor
-    */
-    InfoGainCalculator() = default;
+  /**
+  *  Destructor
+  */
+  ~InfoGainCalculator() = default;
 
-    /**
-    *  Destructor
-    */
-    ~InfoGainCalculator() = default;
+  /**
+  *  Computes the entropy of a dataset based only on the class label
+  *
+  *  @param df the source data set
+  *  @param indices a list of data vector indices in the data set
+  */
+  double computeEntropyByClass(const DataFrame& df, const std::vector<unsigned int>& indices) const;
 
-    /**
-    *  Computes the entropy of a dataset based only on the class label
-    *
-    *  @param df the source data set
-    *  @param indices a list of data vector indices in the data set
-    */
-    double computeEntropyByClass(
-      const DataFrame& df, const std::vector<unsigned int>& indices) const;
+  /**
+  * Using the list of data vector indices as input this method
+  * uses max information gain to find the best split resulting in
+  * the best information gain.
+  *
+  * @param df the source data set
+  * @param fIndices the list of factor indices to consider for this data split
+  * @param dIndices the input data vectors indices subset sorted on the factor fIdx
+  * @param splitIdx an output variable to hold the split index in indices
+  * @param fIdx an output variable to hold the factor index to split on
+  * @param splitVal an output variable to hold the factor value to split on
+  * @param purityDelta the contribution of the data split in increasing the info gain
+  * @return false if a split is not possible (all factor values are same across all factors)
+  */
+  bool findDataSplit(const DataFrame & df, std::vector<unsigned int> & fIndices, std::vector<unsigned int> & dIndices,
+                     unsigned int & splitIdx, unsigned int & fIdx, double & splitVal, double & purityDelta) const;
 
-    /**
-    * Using the list of data vector indices as input this method
-    * uses max information gain to find the best split resulting in
-    * the best information gain.
-    *
-    * @param df the source data set
-    * @param fIndices the list of factor indices to consider for this data split
-    * @param dIndices the input data vectors indices subset sorted on the factor fIdx
-    * @param splitIdx an output variable to hold the split index in indices
-    * @param fIdx an output variable to hold the factor index to split on
-    * @param splitVal an output variable to hold the factor value to split on
-    * @param purityDelta the contribution of the data split in increasing the info gain
-    * @return false if a split is not possible (all factor values are same across all factors)
-    */
-    bool findDataSplit(const DataFrame & df, std::vector<unsigned int> & fIndices,
-      std::vector<unsigned int> & dIndices, unsigned int & splitIdx, unsigned int & fIdx,
-      double & splitVal, double & purityDelta) const;
+  /**
+  * This method looks at a single factor and computes the maximum gain against
+  * all possible data splits and also provides the index for the best split
+  *
+  * @param df the source data set
+  * @param indices a subset of data vectors by their index value in the dataset sorted
+  * on the factor value specified by fIdx
+  * @param fIdx the factor index in the data vectors
+  * @param totalEntropy entropy for the subset of data referenced by indices
+  * @param bestSplit the index for the split in indices corresponding to the max gain
+  * @return the information gain corresponding to bestSplit
+  */
+  double getMaxInfoGainByFactor(const DataFrame& df, std::vector<unsigned int> & indices, unsigned int fIdx,
+                                double totalEntropy, unsigned int & bestSplit) const;
 
-    /**
-    * This method looks at a single factor and computes the maximum gain against
-    * all possible data splits and also provides the index for the best split
-    *
-    * @param df the source data set
-    * @param indices a subset of data vectors by their index value in the dataset sorted
-    * on the factor value specified by fIdx
-    * @param fIdx the factor index in the data vectors
-    * @param totalEntropy entropy for the subset of data referenced by indices
-    * @param bestSplit the index for the split in indices corresponding to the max gain
-    * @return the information gain corresponding to bestSplit
-    */
-    double getMaxInfoGainByFactor(const DataFrame& df, std::vector<unsigned int> & indices,
-      unsigned int fIdx, double totalEntropy, unsigned int & bestSplit) const;
+  /**
+  * This method looks at a single factor and computes the maximum gain ratio against
+  * all possible data splits and also provides the index for the best split
+  *
+  * @param df the source data set
+  * @param indices a subset of data vectors by their index value in the dataset sorted
+  * on the factor value specified by fIdx
+  * @param fIdx the factor index in the data vectors
+  * @param totalEntropy entropy for the subset of data referenced by indices
+  * @param bestSplit the index for the split in indices corresponding to the max gain
+  * @return the information gain ratio corresponding to bestSplit
+  */
+  double getMaxInfoGainRatioByFactor(const DataFrame & df, std::vector<unsigned int> & indices, unsigned int fIdx,
+                                     double totalEntropy, unsigned int & bestSplit) const;
 
-    /**
-    * This method looks at a single factor and computes the maximum gain ratio against
-    * all possible data splits and also provides the index for the best split
-    *
-    * @param df the source data set
-    * @param indices a subset of data vectors by their index value in the dataset sorted
-    * on the factor value specified by fIdx
-    * @param fIdx the factor index in the data vectors
-    * @param totalEntropy entropy for the subset of data referenced by indices
-    * @param bestSplit the index for the split in indices corresponding to the max gain
-    * @return the information gain ratio corresponding to bestSplit
-    */
-    double getMaxInfoGainRatioByFactor(const DataFrame & df, std::vector<unsigned int> & indices,
-      unsigned int fIdx, double totalEntropy, unsigned int & bestSplit) const;
+private:
 
-  private:
+  /**
+  *  Computes the entropy function -n * log2(n)
+  */
+  double _calcLogFunc(double n) const;
 
-    /**
-    *  Computes the entropy function -n * log2(n)
-    */
-    double _calcLogFunc(double n) const;
+  /**
+  * This methods takes a subset of data vectors held by indices and finds
+  * a list of candidate splits based on indices sorted on the factor value
+  * indexed by fIdx
+  *
+  * @param df the source data set
+  * @param indices a subset of data vectors by their index value in the dataset
+  * @param fIdx the factor index in the data vectors
+  * @param splits the potential splits in the data to consider
+  */
+  void _findCandidateSplits(const DataFrame& df, std::vector<unsigned int>& indices, unsigned int fIdx,
+                            std::vector<unsigned int>& splits) const;
+};
 
-    /**
-    * This methods takes a subset of data vectors held by indices and finds
-    * a list of candidate splits based on indices sorted on the factor value
-    * indexed by fIdx
-    *
-    * @param df the source data set
-    * @param indices a subset of data vectors by their index value in the dataset 
-    * @param fIdx the factor index in the data vectors
-    * @param splits the potential splits in the data to consider 
-    */
-    void _findCandidateSplits(const DataFrame& df, std::vector<unsigned int>& indices,
-      unsigned int fIdx, std::vector<unsigned int>& splits) const;
-  };
 }  //End Namespace
+
 #endif 

--- a/tgs/src/main/cpp/tgs/RandomForest/InfoGainCalculator.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/InfoGainCalculator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2018, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2018, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef __INFO_GAIN_CALCULATOR_H__

--- a/tgs/src/main/cpp/tgs/RandomForest/MissingDataHandler.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/MissingDataHandler.cpp
@@ -33,160 +33,128 @@
 
 namespace Tgs
 {
-  void MissingDataHandler::replaceMissingValuesFast(double missingDataValue,
-    std::shared_ptr<DataFrame> data)
+
+void MissingDataHandler::replaceMissingValuesFast(double missingDataValue, std::shared_ptr<DataFrame> data)
+{
+  try
   {
-    try
-    {
-      unsigned int numFactors = data->getNumFactors();
+    unsigned int numFactors = data->getNumFactors();
 
-      //For each factor check if the null value is supposed to be a missing value and proceed from there
-      //If null treatment has not been set for the factor then default to replace as missing values
-      for (unsigned int fIdx = 0; fIdx < numFactors; fIdx++)
+    //For each factor check if the null value is supposed to be a missing value and proceed from there
+    //If null treatment has not been set for the factor then default to replace as missing values
+    for (unsigned int fIdx = 0; fIdx < numFactors; fIdx++)
+    {
+      if (!data->hasNullTreatments() || data->getNullTreatment(fIdx) == DataFrame::NullAsMissingValue)
       {
-        if (!data->hasNullTreatments() || data->getNullTreatment(fIdx) == DataFrame::NullAsMissingValue)
-        {
-          DataFrame::FactorType fType;
+        DataFrame::FactorType fType;
 
-          if (data->hasFactorTypes())
-          {
-            fType = (DataFrame::FactorType)data->getFactorTypes()[fIdx];
-          }
-          else
-          {
-            //Default to numeric
-            fType = DataFrame::Numerical;
-          }
+        if (data->hasFactorTypes())
+          fType = (DataFrame::FactorType)data->getFactorTypes()[fIdx];
+        else  //  Default to numeric
+          fType = DataFrame::Numerical;
 
-          if (fType == DataFrame::Numerical)
-          {
-            _replaceMissingNumericValuesFast(missingDataValue, data, fIdx);
-          }
-          else
-          {
-            _replaceMissingNominalValuesFast(missingDataValue, data, fIdx);
-          }
-        }
+        if (fType == DataFrame::Numerical)
+          _replaceMissingNumericValuesFast(missingDataValue, data, fIdx);
+        else
+          _replaceMissingNominalValuesFast(missingDataValue, data, fIdx);
       }
-    }
-    catch(const Exception & e)
-    {
-      throw Exception("MissingDataHandler", __FUNCTION__, __LINE__, e);
     }
   }
-
-  void MissingDataHandler::_replaceMissingNominalValuesFast(double missingDataValue,
-    std::shared_ptr<DataFrame> data, unsigned int factorIndex)
+  catch(const Exception & e)
   {
-    try
+    throw Exception("MissingDataHandler", __FUNCTION__, __LINE__, e);
+  }
+}
+
+void MissingDataHandler::_replaceMissingNominalValuesFast(double missingDataValue, std::shared_ptr<DataFrame> data,
+                                                          unsigned int factorIndex)
+{
+  try
+  {
+    unsigned int numDataVectors = data->getNumDataVectors();
+    std::map<std::string, std::map<double, unsigned int>> frequencyMap;
+    for (unsigned int dataIndex = 0; dataIndex < numDataVectors; dataIndex++)
     {
-      unsigned int numDataVectors = data->getNumDataVectors();
-
-      std::map<std::string, std::map<double, unsigned int>> frequencyMap;
-
-      for (unsigned int dataIndex = 0; dataIndex < numDataVectors; dataIndex++)
+      double value = data->getDataVector(dataIndex)[factorIndex];
+      if (value != missingDataValue)
       {
-        double value = data->getDataVector(dataIndex)[factorIndex];
-
-        if (value != missingDataValue)
-        {
-          std::string className = data->getTrainingLabel(dataIndex);
-
-          frequencyMap[className][value]++;
-        }
+        std::string className = data->getTrainingLabel(dataIndex);
+        frequencyMap[className][value]++;
       }
-
-      std::map<std::string, double> maxFrequencyMap;
-
-      std::map<double, unsigned int >::iterator valueItr;
-      std::map<std::string, std::map<double, unsigned int>>::iterator classItr;
-
-      for (classItr = frequencyMap.begin(); classItr != frequencyMap.end(); ++classItr)
-      {
-        double maxValue = 0.0;
-        int maxCount = -1;
-
-        for (valueItr = classItr->second.begin(); valueItr != classItr->second.end(); ++valueItr)
-        {
-          int valueCount = valueItr->second;
-
-          if (valueCount > maxCount)
-          {
-            maxValue = valueItr->first;
-            maxCount = valueCount;
-          }
-        }
-
-        maxFrequencyMap[classItr->first] = maxValue;
-      }
-
-      for (unsigned int dataIndex = 0; dataIndex < numDataVectors; dataIndex++)
-      {
-        double value = data->getDataVector(dataIndex)[factorIndex];
-
-        if (value == missingDataValue)
-        {
-          std::string className = data->getTrainingLabel(dataIndex);
-
-          data->setDataElement(dataIndex, factorIndex, maxFrequencyMap[className]);
-        }
-      }
-
     }
-    catch(const Exception & e)
+
+    std::map<std::string, double> maxFrequencyMap;
+    for (auto classItr = frequencyMap.begin(); classItr != frequencyMap.end(); ++classItr)
     {
-      throw Exception("MissingDataHandler", __FUNCTION__, __LINE__, e);
+      double maxValue = 0.0;
+      int maxCount = -1;
+      for (auto valueItr = classItr->second.begin(); valueItr != classItr->second.end(); ++valueItr)
+      {
+        int valueCount = valueItr->second;
+        if (valueCount > maxCount)
+        {
+          maxValue = valueItr->first;
+          maxCount = valueCount;
+        }
+      }
+      maxFrequencyMap[classItr->first] = maxValue;
+    }
+
+    for (unsigned int dataIndex = 0; dataIndex < numDataVectors; dataIndex++)
+    {
+      double value = data->getDataVector(dataIndex)[factorIndex];
+      if (value == missingDataValue)
+      {
+        std::string className = data->getTrainingLabel(dataIndex);
+        data->setDataElement(dataIndex, factorIndex, maxFrequencyMap[className]);
+      }
     }
   }
-
-  void MissingDataHandler::_replaceMissingNumericValuesFast(double missingDataValue,
-    std::shared_ptr<DataFrame> data, unsigned int factorIndex)
+  catch(const Exception & e)
   {
-    try
+    throw Exception("MissingDataHandler", __FUNCTION__, __LINE__, e);
+  }
+}
+
+void MissingDataHandler::_replaceMissingNumericValuesFast(double missingDataValue, std::shared_ptr<DataFrame> data,
+                                                          unsigned int factorIndex)
+{
+  try
+  {
+    unsigned int numDataVectors = data->getNumDataVectors();
+    std::map<std::string, std::vector<double>> sortMap;
+
+    for (unsigned int dataIndex = 0; dataIndex < numDataVectors; dataIndex++)
     {
-      unsigned int numDataVectors = data->getNumDataVectors();
-
-      std::map<std::string, std::vector<double>> sortMap;
-
-      for (unsigned int dataIndex = 0; dataIndex < numDataVectors; dataIndex++)
+      double value = data->getDataVector(dataIndex)[factorIndex];
+      if (value != missingDataValue)
       {
-        double value = data->getDataVector(dataIndex)[factorIndex];
-
-        if (value != missingDataValue)
-        {
-          std::string className = data->getTrainingLabel(dataIndex);
-
-          sortMap[className].push_back(value);
-        }
+        std::string className = data->getTrainingLabel(dataIndex);
+        sortMap[className].push_back(value);
       }
-
-      std::map<std::string, double> medianMap;
-      std::map<std::string, std::vector<double>>::iterator sortItr;
-
-      for (sortItr = sortMap.begin(); sortItr != sortMap.end(); ++sortItr)
-      {
-        std::sort(sortItr->second.begin(), sortItr->second.end());
-        medianMap[sortItr->first] = sortItr->second[sortItr->second.size() / 2];
-      }
-
-      for (unsigned int dataIndex = 0; dataIndex < numDataVectors; dataIndex++)
-      {
-        double value = data->getDataVector(dataIndex)[factorIndex];
-
-        if (value == missingDataValue)
-        {
-          std::string className = data->getTrainingLabel(dataIndex);
-
-          data->setDataElement(dataIndex, factorIndex, medianMap[className]);
-        }
-      }
-
     }
-    catch(const Exception & e)
+
+    std::map<std::string, double> medianMap;
+    for (auto sortItr = sortMap.begin(); sortItr != sortMap.end(); ++sortItr)
     {
-      throw Exception("MissingDataHandler", __FUNCTION__, __LINE__, e);
+      std::sort(sortItr->second.begin(), sortItr->second.end());
+      medianMap[sortItr->first] = sortItr->second[sortItr->second.size() / 2];
+    }
+
+    for (unsigned int dataIndex = 0; dataIndex < numDataVectors; dataIndex++)
+    {
+      double value = data->getDataVector(dataIndex)[factorIndex];
+      if (value == missingDataValue)
+      {
+        std::string className = data->getTrainingLabel(dataIndex);
+        data->setDataElement(dataIndex, factorIndex, medianMap[className]);
+      }
     }
   }
-
+  catch(const Exception & e)
+  {
+    throw Exception("MissingDataHandler", __FUNCTION__, __LINE__, e);
+  }
+}
 
 }

--- a/tgs/src/main/cpp/tgs/RandomForest/MissingDataHandler.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/MissingDataHandler.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2018, 2019, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #include "MissingDataHandler.h"
 

--- a/tgs/src/main/cpp/tgs/RandomForest/MissingDataHandler.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/MissingDataHandler.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2018, 2019, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef MISSINGDATAHANDLER_H
 #define MISSINGDATAHANDLER_H

--- a/tgs/src/main/cpp/tgs/RandomForest/MissingDataHandler.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/MissingDataHandler.h
@@ -31,45 +31,45 @@
 
 namespace Tgs
 {
+
+/**
+ * @brief The MissingDataHandler class resolves missing values within a DataFrame
+ */
+class MissingDataHandler
+{
+public:
   /**
-   * @brief The MissingDataHandler class resolves missing values within a DataFrame
+   * @brief replaceMissingValuesFast
+   *
+   * Numeric missing feature values are replaced with the median value of that
+   * feature of other objects in their class while categorical missing values
+   * are replaced with the most frequent category value
+   *
+   * @param missingDataValue the value representing missing data
+   * @param data the input data set object
    */
-  class MissingDataHandler
-  {
-  public:
-    /**
-     * @brief replaceMissingValuesFast
-     *
-     * Numeric missing feature values are replaced with the median value of that
-     * feature of other objects in their class while categorical missing values
-     * are replaced with the most frequent category value
-     *
-     * @param missingDataValue the value representing missing data
-     * @param data the input data set object
-     */
-    static void replaceMissingValuesFast(double missingDataValue,
-      std::shared_ptr<DataFrame> data);
+  static void replaceMissingValuesFast(double missingDataValue, std::shared_ptr<DataFrame> data);
 
-  private:
+private:
 
-    /**
-     * @brief _replaceMissingNominalValuesFast
-     * @param data the data frame
-     * @param factorIndex the index of the factor of interest
-     */
-    static void _replaceMissingNominalValuesFast(double missingDataValue,
-      std::shared_ptr<DataFrame> data, unsigned int factorIndex);
+  /**
+   * @brief _replaceMissingNominalValuesFast
+   * @param data the data frame
+   * @param factorIndex the index of the factor of interest
+   */
+  static void _replaceMissingNominalValuesFast(double missingDataValue, std::shared_ptr<DataFrame> data,
+                                               unsigned int factorIndex);
 
-    /**
-     * @brief _replaceMissingNumericValuesFast
-     * @param data the data frame
-     * @param factorIndex the index of the factor of interest
-     */
-    static void _replaceMissingNumericValuesFast(double missingDataValue,
-      std::shared_ptr<DataFrame> data, unsigned int factorIndex);
+  /**
+   * @brief _replaceMissingNumericValuesFast
+   * @param data the data frame
+   * @param factorIndex the index of the factor of interest
+   */
+  static void _replaceMissingNumericValuesFast(double missingDataValue, std::shared_ptr<DataFrame> data,
+                                               unsigned int factorIndex);
 
+};
 
-  };
 } //End namespace
 
 #endif // MISSINGDATAHANDLER_H

--- a/tgs/src/main/cpp/tgs/RandomForest/MultithreadedRandomForest.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/MultithreadedRandomForest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2018, 2019, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #include "MultithreadedRandomForest.h"
 

--- a/tgs/src/main/cpp/tgs/RandomForest/MultithreadedRandomForest.cpp
+++ b/tgs/src/main/cpp/tgs/RandomForest/MultithreadedRandomForest.cpp
@@ -30,8 +30,8 @@
 #include <cmath>
 
 // Qt
-#include <QtConcurrent/QtConcurrent>
 #include <QThreadPool>
+#include <QtConcurrent/QtConcurrent>
 
 // Tgs
 #include <tgs/TgsException.h>
@@ -39,180 +39,142 @@
 namespace Tgs
 {
 
-
-  MultithreadedRandomForest::MultithreadedRandomForest()
+std::shared_ptr<RandomTree> MultithreadedRandomForest::train(const std::shared_ptr<RandomTree>& tree)
+{
+  try
   {
-    try
-    {
-
-    }
-    catch(const Exception & e)
-    {
-      throw Exception(typeid(this).name(), __FUNCTION__, __LINE__, e);
-    }
+    tree->trainMulticlass(_trainInputs.data, _trainInputs.numFactors, _trainInputs.nodeSize, _trainInputs.balanced);
+    return tree;
   }
-
-  std::shared_ptr<RandomTree> MultithreadedRandomForest::train(const std::shared_ptr<RandomTree>& tree)
+  catch(const Exception & e)
   {
-    try
-    {
-      tree->trainMulticlass(_trainInputs.data, _trainInputs.numFactors, _trainInputs.nodeSize,
-        _trainInputs.balanced);
-
-      return tree;
-    }
-    catch(const Exception & e)
-    {
-      throw Exception("MultithreadedRandomForest", __FUNCTION__, __LINE__, e);
-    }
-  }
-
-  void MultithreadedRandomForest::trainBinary(const std::shared_ptr<DataFrame>& /*data*/,
-    unsigned int /*numTrees*/, unsigned int /*numFactors*/, const std::string& /*posClass*/,
-    unsigned int /*nodeSize*/, double /*retrain*/, bool /*balanced*/)
-  {
-    try
-    {
-      throw Exception(__LINE__, "Not implemented");
-    }
-    catch(const Exception & e)
-    {
-      throw Exception(typeid(this).name(), __FUNCTION__, __LINE__, e);
-    }
-  }
-
-  void MultithreadedRandomForest::trainMulticlass(const std::shared_ptr<DataFrame>& data,
-    unsigned int numTrees, unsigned int numFactors, unsigned int nodeSize, double retrain,
-    bool balanced)
-  {
-    try
-    {
-      std::cerr << "DEBUG MTRF TRAINMULTI" << std::endl;
-
-      data->validateData();
-
-      _trainInputs.data = data;
-      _trainInputs.numFactors = numFactors;
-      _trainInputs.nodeSize = nodeSize;
-      _trainInputs.balanced = balanced;
-
-      _factorLabels = data->getFactorLabels();
-      _forest.clear();
-      numFactors = std::min<size_t>(data->getActiveFactorCount(), numFactors);
-      _numSplitFactors = numFactors;
-
-      if (!data->empty())
-      {
-        _forest.reserve(numTrees);
-
-        //Initialize the thread pool
-        QThreadPool pool;
-        pool.setExpiryTimeout(-1);
-
-        QList<std::shared_ptr<RandomTree>> mapTrees;
-        for (unsigned int i = 0; i < numTrees; i++)
-        {
-          mapTrees.append(std::make_shared<RandomTree>());
-        }
-
-        QList<std::shared_ptr<RandomTree>> forestList =
-          QtConcurrent::blockingMapped(mapTrees, train);
-
-        for (unsigned int i = 0; i < numTrees; i++)
-        {
-          _forest.push_back(forestList[i]);
-        }
-
-        if (retrain >= 0 && retrain < 1.0)
-        {
-          std::cout << "Retraining model on top " << (retrain * 100) << "% of factors" << std::endl;
-          std::map<std::string, double> topFactors;
-          std::map<std::string, double>::iterator mapItr;
-
-          getFactorImportance(data, topFactors);
-
-          std::vector<std::string> badFactors;
-
-          unsigned int cutOffIdx =
-            topFactors.size() - (unsigned int)((double)topFactors.size() * retrain);
-
-          std::multimap<double, std::string> sortedFactors;
-          std::multimap<double, std::string>::iterator mMapItr;
-
-          //Create a map from lowest to highest of important mapped to factor type
-          for (mapItr = topFactors.begin(); mapItr != topFactors.end(); ++mapItr)
-          {
-            sortedFactors.insert(std::pair<double, std::string>(mapItr->second, mapItr->first));
-          }
-
-          unsigned int cutOffCtr = 0;
-
-          for (mMapItr = sortedFactors.begin(); mMapItr != sortedFactors.end(); ++mMapItr)
-          {
-            if (cutOffCtr <  cutOffIdx)
-            {
-              badFactors.push_back(mMapItr->second);
-              cutOffCtr++;
-            }
-            else
-            {
-              break;
-            }
-          }
-
-          for (unsigned int i = 0; i < badFactors.size(); i++)
-          {
-            data->deactivateFactor(badFactors[i]);
-          }
-
-          _forest.clear();
-
-          _forest.reserve(numTrees);
-
-          _trainInputs.numFactors = (unsigned int)sqrt((double)(topFactors.size() - cutOffIdx));
-          _trainInputs.nodeSize = 1;
-
-          QList<std::shared_ptr<RandomTree>> mapRetrainingTrees;
-          for (unsigned int i = 0; i < numTrees; i++)
-          {
-            mapRetrainingTrees.append(std::make_shared<RandomTree>());
-          }
-
-          QList<std::shared_ptr<RandomTree>> forestRetrainList =
-            QtConcurrent::blockingMapped(mapRetrainingTrees, train);
-
-          for (unsigned int i = 0; i < numTrees; i++)
-          {
-            _forest[i] = forestRetrainList[i];
-          }
-        }
-
-        _forestCreated = true;
-      }
-      else
-      {
-        throw Exception(__LINE__, "Unable to operate on empty dataset");
-      }
-    }
-    catch(const Exception & e)
-    {
-      throw Exception(typeid(this).name(), __FUNCTION__, __LINE__, e);
-    }
-  }
-
-  void MultithreadedRandomForest::trainRoundRobin(const std::shared_ptr<DataFrame>& /*data*/,
-    unsigned int /*numTrees*/, unsigned int /*numFactors*/, const std::string& /*posClass*/,
-    const std::string& /*negClass*/, unsigned int /*nodeSize*/, double /*retrain*/,
-    bool /*balanced*/)
-  {
-    try
-    {
-      throw Exception(__LINE__, "Not implemented");
-    }
-    catch(const Exception & e)
-    {
-      throw Exception(typeid(this).name(), __FUNCTION__, __LINE__, e);
-    }
+    throw Exception("MultithreadedRandomForest", __FUNCTION__, __LINE__, e);
   }
 }
 
+void MultithreadedRandomForest::trainBinary(const std::shared_ptr<DataFrame>& /*data*/, unsigned int /*numTrees*/,
+                                            unsigned int /*numFactors*/, const std::string& /*posClass*/,
+                                            unsigned int /*nodeSize*/, double /*retrain*/, bool /*balanced*/)
+{
+  try
+  {
+    throw Exception(__LINE__, "Not implemented");
+  }
+  catch(const Exception & e)
+  {
+    throw Exception(typeid(this).name(), __FUNCTION__, __LINE__, e);
+  }
+}
+
+void MultithreadedRandomForest::trainMulticlass(const std::shared_ptr<DataFrame>& data, unsigned int numTrees,
+                                                unsigned int numFactors, unsigned int nodeSize, double retrain,
+                                                bool balanced)
+{
+  try
+  {
+    std::cerr << "DEBUG MTRF TRAINMULTI" << std::endl;
+
+    data->validateData();
+
+    _trainInputs.data = data;
+    _trainInputs.numFactors = numFactors;
+    _trainInputs.nodeSize = nodeSize;
+    _trainInputs.balanced = balanced;
+
+    _factorLabels = data->getFactorLabels();
+    _forest.clear();
+    numFactors = std::min<size_t>(data->getActiveFactorCount(), numFactors);
+    _numSplitFactors = numFactors;
+
+    if (!data->empty())
+    {
+      _forest.reserve(numTrees);
+
+      //Initialize the thread pool
+      QThreadPool pool;
+      pool.setExpiryTimeout(-1);
+
+      QList<std::shared_ptr<RandomTree>> mapTrees;
+      for (unsigned int i = 0; i < numTrees; i++)
+        mapTrees.append(std::make_shared<RandomTree>());
+
+      QList<std::shared_ptr<RandomTree>> forestList = QtConcurrent::blockingMapped(mapTrees, train);
+
+      for (unsigned int i = 0; i < numTrees; i++)
+        _forest.push_back(forestList[i]);
+
+      if (retrain >= 0 && retrain < 1.0)
+      {
+        std::cout << "Retraining model on top " << (retrain * 100) << "% of factors" << std::endl;
+        std::map<std::string, double> topFactors;
+
+        getFactorImportance(data, topFactors);
+
+        std::vector<std::string> badFactors;
+
+        unsigned int cutOffIdx = topFactors.size() - (unsigned int)((double)topFactors.size() * retrain);
+
+        //Create a map from lowest to highest of important mapped to factor type
+        std::multimap<double, std::string> sortedFactors;
+        for (auto mapItr = topFactors.begin(); mapItr != topFactors.end(); ++mapItr)
+          sortedFactors.insert(std::pair<double, std::string>(mapItr->second, mapItr->first));
+
+        unsigned int cutOffCtr = 0;
+
+        for (auto mMapItr = sortedFactors.begin(); mMapItr != sortedFactors.end(); ++mMapItr)
+        {
+          if (cutOffCtr <  cutOffIdx)
+          {
+            badFactors.push_back(mMapItr->second);
+            cutOffCtr++;
+          }
+          else
+            break;
+        }
+
+        for (const auto& factor : badFactors)
+          data->deactivateFactor(factor);
+
+        _forest.clear();
+
+        _forest.reserve(numTrees);
+
+        _trainInputs.numFactors = (unsigned int)sqrt((double)(topFactors.size() - cutOffIdx));
+        _trainInputs.nodeSize = 1;
+
+        QList<std::shared_ptr<RandomTree>> mapRetrainingTrees;
+        for (unsigned int i = 0; i < numTrees; i++)
+          mapRetrainingTrees.append(std::make_shared<RandomTree>());
+
+        QList<std::shared_ptr<RandomTree>> forestRetrainList = QtConcurrent::blockingMapped(mapRetrainingTrees, train);
+
+        for (unsigned int i = 0; i < numTrees; i++)
+          _forest[i] = forestRetrainList[i];
+      }
+      _forestCreated = true;
+    }
+    else
+      throw Exception(__LINE__, "Unable to operate on empty dataset");
+  }
+  catch(const Exception & e)
+  {
+    throw Exception(typeid(this).name(), __FUNCTION__, __LINE__, e);
+  }
+}
+
+void MultithreadedRandomForest::trainRoundRobin(const std::shared_ptr<DataFrame>& /*data*/, unsigned int /*numTrees*/,
+                                                unsigned int /*numFactors*/, const std::string& /*posClass*/,
+                                                const std::string& /*negClass*/, unsigned int /*nodeSize*/, double /*retrain*/,
+                                                bool /*balanced*/)
+{
+  try
+  {
+    throw Exception(__LINE__, "Not implemented");
+  }
+  catch(const Exception & e)
+  {
+    throw Exception(typeid(this).name(), __FUNCTION__, __LINE__, e);
+  }
+}
+
+}

--- a/tgs/src/main/cpp/tgs/RandomForest/MultithreadedRandomForest.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/MultithreadedRandomForest.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2018, 2019, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef MULTITHREADEDRANDOMFOREST_H
 #define MULTITHREADEDRANDOMFOREST_H

--- a/tgs/src/main/cpp/tgs/RandomForest/MultithreadedRandomForest.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/MultithreadedRandomForest.h
@@ -36,81 +36,77 @@
 namespace Tgs
 {
 
+/**
+ * @brief The MultithreadedRandomForest class
+ */
+class MultithreadedRandomForest : public BaseRandomForest
+{
+public:
 
   /**
-   * @brief The MultithreadedRandomForest class
+   * @brief MultithreadedRandomForest Constructor
    */
-  class MultithreadedRandomForest : public BaseRandomForest
-  {
-  public:
+  MultithreadedRandomForest() = default;
+  /**
+   * @brief ~MultithreadedRandomForest destructor
+   */
+  ~MultithreadedRandomForest() override = default;
 
-    /**
-     * @brief MultithreadedRandomForest Constructor
-     */
-    MultithreadedRandomForest();
-    /**
-     * @brief ~MultithreadedRandomForest destructor
-     */
-    ~MultithreadedRandomForest() override = default;
+  /**
+  * Build the forest from a data set
+  *
+  * @param data the data set to train on
+  * @param numTrees the number of random trees to create
+  * @param numFactors the number of factors to randomly choose as candidates for node splitting
+  * @param posClass the name of the positive class
+  * @param nodeSize the minimum number of data vectors in a set to split a node
+  * @param retrain fraction of top factors to use in retraining model (1.0 means use all factors
+  * and no retraining)
+  * @param balanced true if the forest will be balanced
+  */
+  void trainBinary(const std::shared_ptr<DataFrame>& data, unsigned int numTrees, unsigned int numFactors,
+                   const std::string& posClass, unsigned int nodeSize = 1, double retrain = 1.0,
+                   bool balanced = false) override;
 
-    /**
-    * Build the forest from a data set
-    *
-    * @param data the data set to train on
-    * @param numTrees the number of random trees to create
-    * @param numFactors the number of factors to randomly choose as candidates for node splitting
-    * @param posClass the name of the positive class
-    * @param nodeSize the minimum number of data vectors in a set to split a node
-    * @param retrain fraction of top factors to use in retraining model (1.0 means use all factors
-    * and no retraining)
-    * @param balanced true if the forest will be balanced
-    */
-    void trainBinary(
-      const std::shared_ptr<DataFrame>& data, unsigned int numTrees, unsigned int numFactors,
-      const std::string& posClass, unsigned int nodeSize = 1, double retrain = 1.0,
-      bool balanced = false) override;
+  /**
+  * Build the forest from a data set
+  *
+  * @param data the data set to train on
+  * @param numTrees the number of random trees to create
+  * @param numFactors the number of factors to randomly choose as candidates for node splitting
+  * @param nodeSize the minimum number of data vectors in a set to split a node
+  * @param retrain fraction of top factors to use in retraining model (1.0 means use all factors
+  * and no retraining)
+  * @param balanced true if the forest will be balanced
+  */
+  void trainMulticlass(const std::shared_ptr<DataFrame>& data, unsigned int numTrees, unsigned int numFactors,
+                       unsigned int nodeSize = 1, double retrain = 1.0, bool balanced = false) override;
 
-    /**
-    * Build the forest from a data set
-    *
-    * @param data the data set to train on
-    * @param numTrees the number of random trees to create
-    * @param numFactors the number of factors to randomly choose as candidates for node splitting
-    * @param nodeSize the minimum number of data vectors in a set to split a node
-    * @param retrain fraction of top factors to use in retraining model (1.0 means use all factors
-    * and no retraining)
-    * @param balanced true if the forest will be balanced
-    */
-    void trainMulticlass(
-      const std::shared_ptr<DataFrame>& data, unsigned int numTrees, unsigned int numFactors,
-      unsigned int nodeSize = 1, double retrain = 1.0, bool balanced = false) override;
+  /**
+   * @brief trainMulticlass the map class to train a tree
+   * @param tree the input tree
+   * @return the trained tree
+   */
+  static std::shared_ptr<RandomTree> train(const std::shared_ptr<RandomTree>& tree);
 
-    /**
-     * @brief trainMulticlass the map class to train a tree
-     * @param tree the input tree
-     * @return the trained tree
-     */
-    static std::shared_ptr<RandomTree> train(const std::shared_ptr<RandomTree>& tree);
+  /**
+  * Build the forest from a data set
+  *
+  * @param data the data set to train on
+  * @param numTrees the number of random trees to create
+  * @param numFactors the number of factors to randomly choose as candidates for node splitting
+  * @param posClass the name of the positive class
+  * @param negClass the name of the negative class
+  * @param nodeSize the minimum number of data vectors in a set to split a node
+  * @param retrain fraction of top factors to use in retraining model (1.0 means use all factors
+  * and no retraining)
+  * @param balanced true if the forest will be balanced
+  */
+  void trainRoundRobin(const std::shared_ptr<DataFrame>& data, unsigned int numTrees, unsigned int numFactors,
+                       const std::string& posClass, const std::string& negClass, unsigned int nodeSize = 1,
+                       double retrain = 1.0, bool balanced = false) override;
+};
 
-    /**
-    * Build the forest from a data set
-    *
-    * @param data the data set to train on
-    * @param numTrees the number of random trees to create
-    * @param numFactors the number of factors to randomly choose as candidates for node splitting
-    * @param posClass the name of the positive class
-    * @param negClass the name of the negative class
-    * @param nodeSize the minimum number of data vectors in a set to split a node
-    * @param retrain fraction of top factors to use in retraining model (1.0 means use all factors
-    * and no retraining)
-    * @param balanced true if the forest will be balanced
-    */
-    void trainRoundRobin(
-      const std::shared_ptr<DataFrame>& data, unsigned int numTrees, unsigned int numFactors,
-      const std::string& posClass, const std::string& negClass, unsigned int nodeSize = 1,
-      double retrain = 1.0, bool balanced = false) override;
-  };
 }
-
 
 #endif // MULTITHREADEDRANDOMFOREST_H

--- a/tgs/src/main/cpp/tgs/RandomForest/RandomForest.h
+++ b/tgs/src/main/cpp/tgs/RandomForest/RandomForest.h
@@ -57,7 +57,7 @@ public:
   * Default Constructor/Destructor
   */
   RandomForest() = default;
-  ~RandomForest() = default;
+  ~RandomForest() override = default;
 
   /**
   * Build the forest from a data set

--- a/tgs/src/main/cpp/tgs/StreamUtils.cpp
+++ b/tgs/src/main/cpp/tgs/StreamUtils.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "StreamUtils.h"

--- a/tgs/src/main/cpp/tgs/StreamUtils.cpp
+++ b/tgs/src/main/cpp/tgs/StreamUtils.cpp
@@ -41,23 +41,17 @@ namespace Tgs
     for (int r = 0; r < matrix.Nrows(); r++)
     {
       if (r != 0)
-      {
         o << " ";
-      }
       o << "[";
       for (int c = 0; c < matrix.Ncols(); c++)
       {
         if (c != 0)
-        {
           o << ", ";
-        }
         o << matrix.element(r, c);
       }
       o << "]";
       if (r != matrix.Nrows() - 1)
-      {
         o << endl;
-      }
     }
     o << "]" << endl;
     return o;

--- a/tgs/src/main/cpp/tgs/StreamUtils.h
+++ b/tgs/src/main/cpp/tgs/StreamUtils.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2018, 2019, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef __TGS__STREAM_UTILS_H__

--- a/tgs/src/main/cpp/tgs/StreamUtils.h
+++ b/tgs/src/main/cpp/tgs/StreamUtils.h
@@ -66,7 +66,7 @@ namespace Tgs
   TGS_EXPORT std::ostream& operator<<(std::ostream & o, const NEWMAT::Matrix& matrix);
 #endif
 
-#include <tgs/StreamUtils.hh>
+#include <tgs/StreamUtils.hh> // Has to be last
 
 }
 


### PR DESCRIPTION
Included restriction and review relations in the geometry conversion routine so that they can be compared against a `bound` parameter.

Also fixed a bunch of sonar issues.

Fixes #5453 