### PR TITLE
Fixed Vineyards

### DIFF
--- a/translations/ggdm30.js
+++ b/translations/ggdm30.js
@@ -1171,6 +1171,11 @@ ggdm30 = {
       if (! tags.leisure) tags.leisure = 'garden';
       break;
 
+    case 'EA050': // Vineyard
+      // Landuse = vineyard implies crop=grape
+      if (tags.crop == 'grape') delete tags.crop;
+      break;
+
     case 'EC015': // Forest
       if (geometryType == 'Line')
       {
@@ -2281,6 +2286,19 @@ ggdm30 = {
       }
     }
 
+    // Vineyards
+    if (tags.landuse == 'vineyard')
+    {
+      // In the spec, this is the _only_ value for crop so we store orig value
+      if (tags.crop)
+      {
+        tags.tcrop = tags.crop;
+        delete tags.crop;
+      }
+
+      tags.crop = 'grape';
+    }
+
   }, // End applyToOgrPreProcessing
 
   // #####################################################################################################
@@ -2659,6 +2677,13 @@ ggdm30 = {
         delete attrs.ZI017_GAW;
         notUsedTags.gauge = tags.gauge;
       }
+    }
+
+    // Cleanup crop value if applicable
+    if (notUsedTags.tcrop)
+    {
+      notUsedTags.crop = notUsedTags.tcrop;
+      delete notUsedTags.tcrop;
     }
   }, // End applyToOgrPostProcessing
 

--- a/translations/tds40.js
+++ b/translations/tds40.js
@@ -1040,6 +1040,11 @@ tds40 = {
       if (! tags.leisure) tags.leisure = 'garden';
       break;
 
+    case 'EA050': // Vineyard
+      // Landuse = vineyard implies crop=grape
+      if (tags.crop == 'grape') delete tags.crop;
+      break;
+
     case 'EC015': // Forest
       if (geometryType == 'Line')
       {
@@ -2245,6 +2250,19 @@ tds40 = {
       }
     }
 
+    // Vineyards
+    if (tags.landuse == 'vineyard')
+    {
+      // In the spec, this is the _only_ value for crop so we store orig value
+      if (tags.crop)
+      {
+        tags.tcrop = tags.crop;
+        delete tags.crop;
+      }
+
+      tags.crop = 'grape';
+    }
+
   }, // End applyToOgrPreProcessing
 
   // #####################################################################################################
@@ -2565,6 +2583,13 @@ tds40 = {
         delete attrs.ZI017_GAW;
         notUsedTags.gauge = tags.gauge;
       }
+    }
+
+    // Cleanup crop value if applicable
+    if (notUsedTags.tcrop)
+    {
+      notUsedTags.crop = notUsedTags.tcrop;
+      delete notUsedTags.tcrop;
     }
 
   }, // End applyToOgrPostProcessing

--- a/translations/tds61.js
+++ b/translations/tds61.js
@@ -1137,6 +1137,11 @@ tds61 = {
       if (! tags.leisure) tags.leisure = 'garden';
       break;
 
+    case 'EA050': // Vineyard
+      // Landuse = vineyard implies crop=grape
+      if (tags.crop == 'grape') delete tags.crop;
+      break;
+
     case 'EC015': // Forest
       if (geometryType == 'Line')
       {
@@ -2292,6 +2297,19 @@ tds61 = {
       }
     }
 
+    // Vineyards
+    if (tags.landuse == 'vineyard')
+    {
+      // In the spec, this is the _only_ value for crop so we store orig value
+      if (tags.crop)
+      {
+        tags.tcrop = tags.crop;
+        delete tags.crop;
+      }
+
+      tags.crop = 'grape';
+    }
+
   }, // End applyToOgrPreProcessing
 
   // #####################################################################################################
@@ -2690,6 +2708,13 @@ tds61 = {
         delete attrs.ZI017_GAW;
         notUsedTags.gauge = tags.gauge;
       }
+    }
+
+    // Cleanup crop value if applicable
+    if (notUsedTags.tcrop)
+    {
+      notUsedTags.crop = notUsedTags.tcrop;
+      delete notUsedTags.tcrop;
     }
 
   }, // End applyToOgrPostProcessing

--- a/translations/tds70.js
+++ b/translations/tds70.js
@@ -1155,9 +1155,13 @@ tds70 = {
       }
       break;
 
-
     case 'EA031': // Botanic Garden
       if (! tags.leisure) tags.leisure = 'garden';
+      break;
+
+    case 'EA050': // Vineyard
+      // Landuse = vineyard implies crop=grape
+      if (tags.crop == 'grape') delete tags.crop;
       break;
 
     case 'EC015': // Forest
@@ -2308,6 +2312,19 @@ tds70 = {
       }
     }
 
+    // Vineyards
+    if (tags.landuse == 'vineyard')
+    {
+      // In the spec, this is the _only_ value for crop so we store orig value
+      if (tags.crop)
+      {
+        tags.tcrop = tags.crop;
+        delete tags.crop;
+      }
+
+      tags.crop = 'grape';
+    }
+
   }, // End applyToOgrPreProcessing
 
   // #####################################################################################################
@@ -2706,6 +2723,13 @@ tds70 = {
         delete attrs.ZI017_GAW;
         notUsedTags.gauge = tags.gauge;
       }
+    }
+
+    // Cleanup crop value if applicable
+    if (notUsedTags.tcrop)
+    {
+      notUsedTags.crop = notUsedTags.tcrop;
+      delete notUsedTags.tcrop;
     }
   }, // End applyToOgrPostProcessing
 

--- a/translations/tds71.js
+++ b/translations/tds71.js
@@ -1125,9 +1125,13 @@ tds71 = {
       }
       break;
 
-
     case 'EA031': // Botanic Garden
       if (! tags.leisure) tags.leisure = 'garden';
+      break;
+
+    case 'EA050': // Vineyard
+      // Landuse = vineyard implies crop=grape
+      if (tags.crop == 'grape') delete tags.crop;
       break;
 
     case 'EC015': // Forest
@@ -2290,6 +2294,19 @@ tds71 = {
       }
     }
 
+    // Vineyards
+    if (tags.landuse == 'vineyard')
+    {
+      // In the spec, this is the _only_ value for crop so we store orig value
+      if (tags.crop)
+      {
+        tags.tcrop = tags.crop;
+        delete tags.crop;
+      }
+
+      tags.crop = 'grape';
+    }
+
   }, // End applyToOgrPreProcessing
 
   // #####################################################################################################
@@ -2698,6 +2715,14 @@ tds71 = {
         notUsedTags.gauge = tags.gauge;
       }
     }
+
+    // Cleanup crop value if applicable
+    if (notUsedTags.tcrop)
+    {
+      notUsedTags.crop = notUsedTags.tcrop;
+      delete notUsedTags.tcrop;
+    }
+
   }, // End applyToOgrPostProcessing
 
   // #####################################################################################################


### PR DESCRIPTION
In TDS && GGDM Vineyards (EA050) only have one Crop value (grape) and no option for `NoInformation` or `Other`. 
The translation was throwing an error when it tried to assign an `Other` value to the attribute