### PR TITLE
Overpass queries fail

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/geometry/GeometryUtilsTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/geometry/GeometryUtilsTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2015, 2016, 2017, 2018, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2013, 2015, 2016, 2017, 2018, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 // Hoot
@@ -91,9 +91,8 @@ public:
     }
     CPPUNIT_ASSERT(exceptionMsg.contains("Invalid envelope string"));
 
-    HOOT_STR_EQUALS(
-      "-71.48090000000001,-71.45688,42.4808,42.493",
-      GeometryUtils::envelopeToString(Envelope("-71.4809,42.4808,-71.45688,42.49368")));
+    HOOT_STR_EQUALS("-71.4809000000000054,-71.4568799999999982,42.4808000000000021,42.4930000000000021",
+                    GeometryUtils::toLonLatString(Envelope("-71.4809,42.4808,-71.45688,42.49368")));
   }
 
   void polygonTest()
@@ -101,24 +100,16 @@ public:
     QString exceptionMsg;
 
     // closed poly
-    CPPUNIT_ASSERT(
-      GeometryUtils::isPolygonString(
-        "-71.4745,42.4841;-71.4669,42.4918;-71.4619,42.4839;-71.4745,42.4841"));
+    CPPUNIT_ASSERT(GeometryUtils::isPolygonString("-71.4745,42.4841;-71.4669,42.4918;-71.4619,42.4839;-71.4745,42.4841"));
     // not closed but valid b/c the parser will automatically close it up
-    CPPUNIT_ASSERT(
-      GeometryUtils::isPolygonString(
-        "-71.4745,42.4841;-71.4669,42.4918;-71.4619,42.4839"));
+    CPPUNIT_ASSERT(GeometryUtils::isPolygonString("-71.4745,42.4841;-71.4669,42.4918;-71.4619,42.4839"));
     CPPUNIT_ASSERT(!GeometryUtils::isPolygonString(" "));
     // not enough points
-    CPPUNIT_ASSERT(
-      !GeometryUtils::isPolygonString("-71.4745,42.4841;-71.4669,42.4918"));
-    CPPUNIT_ASSERT(
-      !GeometryUtils::isPolygonString("-71.4745,42.4841;-71.4669,a;-71.4619,42.4839"));
+    CPPUNIT_ASSERT(!GeometryUtils::isPolygonString("-71.4745,42.4841;-71.4669,42.4918"));
+    CPPUNIT_ASSERT(!GeometryUtils::isPolygonString("-71.4745,42.4841;-71.4669,a;-71.4619,42.4839"));
 
-    HOOT_STR_EQUALS(
-      "POLYGON ((-71.4745000000000061 42.4840999999999980, -71.4668999999999954 42.4917999999999978, -71.4619000000000000 42.4838999999999984, -71.4745000000000061 42.4840999999999980))",
-      GeometryUtils::polygonFromString(
-        "-71.4745,42.4841;-71.4669,42.4918;-71.4619,42.4839;-71.4745,42.4841")->toString());
+    HOOT_STR_EQUALS("POLYGON ((-71.4745000000000061 42.4840999999999980, -71.4668999999999954 42.4917999999999978, -71.4619000000000000 42.4838999999999984, -71.4745000000000061 42.4840999999999980))",
+                    GeometryUtils::polygonFromString("-71.4745,42.4841;-71.4669,42.4918;-71.4619,42.4839;-71.4745,42.4841")->toString());
 
     exceptionMsg = "";
     try
@@ -153,19 +144,14 @@ public:
     }
     CPPUNIT_ASSERT(exceptionMsg.contains("Invalid polygon y coordinate value"));
 
-    HOOT_STR_EQUALS(
-      "POLYGON ((-71.4745000000000061 42.4840999999999980, -71.4668999999999954 42.4917999999999978, -71.4619000000000000 42.4838999999999984, -71.4745000000000061 42.4840999999999980))",
-      GeometryUtils::polygonFromString(
-        "-71.4745,42.4841;-71.4669,42.4918;-71.4619,42.4839;-71.4745,42.4841")->toString());
+    HOOT_STR_EQUALS("POLYGON ((-71.4745000000000061 42.4840999999999980, -71.4668999999999954 42.4917999999999978, -71.4619000000000000 42.4838999999999984, -71.4745000000000061 42.4840999999999980))",
+                    GeometryUtils::polygonFromString("-71.4745,42.4841;-71.4669,42.4918;-71.4619,42.4839;-71.4745,42.4841")->toString());
 
-    HOOT_STR_EQUALS(
-      "POLYGON ((-71.4809000000000054 -71.4568799999999982, -71.4809000000000054 42.4930000000000021, 42.4808000000000021 42.4930000000000021, 42.4808000000000021 -71.4568799999999982, -71.4809000000000054 -71.4568799999999982))",
-      GeometryUtils::envelopeToPolygon(Envelope("-71.4809,42.4808,-71.45688,42.49368"))->toString());
+    HOOT_STR_EQUALS("POLYGON ((-71.4809000000000054 -71.4568799999999982, -71.4809000000000054 42.4930000000000021, 42.4808000000000021 42.4930000000000021, 42.4808000000000021 -71.4568799999999982, -71.4809000000000054 -71.4568799999999982))",
+                    GeometryUtils::envelopeToPolygon(Envelope("-71.4809,42.4808,-71.45688,42.49368"))->toString());
 
-    HOOT_STR_EQUALS(
-      "-71.47450000000001,42.4839,-71.4619,42.4918",
-      GeometryUtils::polygonStringToEnvelopeString(
-        "-71.4745,42.4841;-71.4669,42.4918;-71.4619,42.4839;-71.4745,42.4841"));
+    HOOT_STR_EQUALS("-71.4745000000000061,42.4838999999999984,-71.4619000000000000,42.4917999999999978",
+                    GeometryUtils::polygonStringToLonLatString("-71.4745,42.4841;-71.4669,42.4918;-71.4619,42.4839;-71.4745,42.4841"));
   }
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/BoundsStringTaskGridGenerator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/BoundsStringTaskGridGenerator.cpp
@@ -41,7 +41,7 @@ BoundsStringTaskGridGenerator::BoundsStringTaskGridGenerator(const QString& boun
 
 TaskGrid BoundsStringTaskGridGenerator::generateTaskGrid()
 {
-  LOG_INFO("Generating task grid for bounds: " << GeometryUtils::envelopeToString(_bounds) << "...");
+  LOG_INFO("Generating task grid for bounds: " << GeometryUtils::toLonLatString(_bounds) << "...");
 
   TaskGrid taskGrid;
   TaskGrid::TaskGridCell taskGridCell;

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/UniformTaskGridGenerator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/UniformTaskGridGenerator.cpp
@@ -22,16 +22,16 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #include "UniformTaskGridGenerator.h"
 
 // Hoot
-#include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/geometry/GeometryUtils.h>
+#include <hoot/core/io/IoUtils.h>
+#include <hoot/core/io/OsmMapWriterFactory.h>
 #include <hoot/core/util/ConfigOptions.h>
 #include <hoot/core/util/StringUtils.h>
-#include <hoot/core/io/IoUtils.h>
 #include <hoot/core/visitors/CalculateMapBoundsVisitor.h>
 
 namespace hoot
@@ -49,10 +49,10 @@ UniformTaskGridGenerator::UniformTaskGridGenerator(const QStringList& inputs, co
     _output(output)
 {
   OsmMapPtr map = std::make_shared<OsmMap>();
-  for (const auto& input : inputs)
+  for (const auto& input : qAsConst(inputs))
     IoUtils::loadMap(map, input, true, Status::Invalid);
 
-  _bounds = GeometryUtils::envelopeToString(CalculateMapBoundsVisitor::getGeosBounds(map));
+  _bounds = GeometryUtils::toLonLatString(CalculateMapBoundsVisitor::getGeosBounds(map));
 }
 
 TaskGrid UniformTaskGridGenerator::generateTaskGrid()

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ExtentCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ExtentCmd.cpp
@@ -85,7 +85,7 @@ public:
     OsmMapPtr map = std::make_shared<OsmMap>();
     IoUtils::loadMaps(map, inputs, false, Status::Invalid);
 
-    const QString bounds = GeometryUtils::envelopeToString(CalculateMapBoundsVisitor::getGeosBounds(map));
+    const QString bounds = GeometryUtils::toLonLatString(CalculateMapBoundsVisitor::getGeosBounds(map));
     std::cout << "Map extent (minx,miny,maxx,maxy): " << bounds << std::endl;
 
     LOG_STATUS("Map extent calculated in " << StringUtils::millisecondsToDhms(timer.elapsed()) << " total.");

--- a/hoot-core/src/main/cpp/hoot/core/conflate/ConflateUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/ConflateUtils.cpp
@@ -65,7 +65,7 @@ int ConflateUtils::writeNonConflatable(const ConstOsmMapPtr& map, const QString&
 void ConflateUtils::writeDiff(const QString& mapUrl1, const QString& mapUrl2, const geos::geom::Envelope& bounds,
                               const QString& output)
 {
-  conf().set(ConfigOptions::getBoundsKey(), GeometryUtils::toConfigString(bounds));
+  conf().set(ConfigOptions::getBoundsKey(), GeometryUtils::toLonLatString(bounds));
 
   ConflateExecutor conflator;
   conflator.setIsDiffConflate(true);

--- a/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/tile/NodeDensityTileBoundsCalculator.cpp
@@ -64,10 +64,7 @@ void NodeDensityTileBoundsCalculator::calculateTiles(const ConstOsmMapPtr& map)
   else if (map->getNodeCount() == 0)
     throw IllegalArgumentException("Empty map passed to node density tile calculator.");
   else if (_maxNodesPerTile == 0)
-  {
-    throw IllegalArgumentException(
-      QString("Invalid maximum nodes per tile requirement equal to zero passed to node density tile calculator."));
-  }
+    throw IllegalArgumentException("Invalid maximum nodes per tile requirement equal to zero passed to node density tile calculator.");
 
   LOG_VARD(map->getNodeCount());
   if (map->getNodeCount() <= _maxNodesPerTile)
@@ -96,15 +93,13 @@ void NodeDensityTileBoundsCalculator::calculateTiles(const ConstOsmMapPtr& map)
     {
       tryCtr++;
 
-      QString msg =
-        "Running node density tiles calculation attempt " + QString::number(tryCtr) + " / " +
-         QString::number(_maxNumTries) + " with pixel size: " + QString::number(_pixelSize) +
-         ", max allowed nodes: " + StringUtils::formatLargeNumber(_maxNodesPerTile) +
-         ", total input node size: " + StringUtils::formatLargeNumber(map->getNodeCount());
+      QString msg = QString("Running node density tiles calculation attempt %1 / %2 with pixel size: %3, max allowed nodes: %4, total input node size: %5")
+                      .arg(QString::number(tryCtr), QString::number(_maxNumTries), QString::number(_pixelSize),
+                           StringUtils::formatLargeNumber(_maxNodesPerTile), StringUtils::formatLargeNumber(map->getNodeCount()));
       if (_maxTimePerAttempt == -1)
         msg += ", and with no timeout...";
       else
-        msg += ", and with a timeout of " + QString::number(_maxTimePerAttempt) + " seconds...";
+        msg += QString(", and with a timeout of %1 seconds...").arg(QString::number(_maxTimePerAttempt));
       LOG_STATUS(msg);
 
       cv::Mat r1, r2;
@@ -176,7 +171,7 @@ QString NodeDensityTileBoundsCalculator::tilesToString(const vector<Envelope>& t
 {
   QString str;
   for (const auto& tile : tiles)
-    str += GeometryUtils::toConfigString(tile) + "\n";
+    str += GeometryUtils::toLonLatString(tile) + "\n";
   str.chop(1);
   return str;
 }
@@ -260,10 +255,8 @@ void NodeDensityTileBoundsCalculator::_calculateTiles()
   }
 
   if (_maxNodeCountInOneTile == 0)
-  {
-    throw TileCalcException(
-      "The maximum node density tiles node count in one tile is zero. Try reducing the pixel size or increasing the maximum allowed nodes per tile.");
-  }
+    throw TileCalcException("The maximum node density tiles node count in one tile is zero. Try reducing the pixel size or increasing the maximum allowed nodes per tile.");
+
   LOG_TRACE("Tiles: " + tilesToString(_tiles));
 
   _exportResult(boxes, "tmp/result.png");
@@ -390,10 +383,7 @@ bool NodeDensityTileBoundsCalculator::_isDone(const std::vector<PixelBox>& boxes
   }
 
   if (minSize == true && smallEnough == false)
-  {
-    throw TileCalcException(
-      "Could not find a node density tiles solution. Try reducing the pixel size or increasing the maximum nodes allowed per tile.");
-  }
+    throw TileCalcException("Could not find a node density tiles solution. Try reducing the pixel size or increasing the maximum nodes allowed per tile.");
   else
     return smallEnough;
 }
@@ -411,8 +401,7 @@ void NodeDensityTileBoundsCalculator::_renderImage(const ConstOsmMapPtr& map)
   _exportImage(_min, "tmp/min.png");
 }
 
-void NodeDensityTileBoundsCalculator::_renderImage(const ConstOsmMapPtr& map, cv::Mat& r1,
-                                                   cv::Mat& r2)
+void NodeDensityTileBoundsCalculator::_renderImage(const ConstOsmMapPtr& map, cv::Mat& r1, cv::Mat& r2)
 {
   LOG_INFO("Rendering images...");
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/tile/TileUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/tile/TileUtils.cpp
@@ -58,7 +58,7 @@ geos::geom::Envelope TileUtils::getRandomTile(const std::vector<geos::geom::Enve
 {
   const int randomTileIndex = getRandomTileIndex(tiles, randomSeed);
   LOG_VARD(randomTileIndex);
-  LOG_DEBUG("Randomly selected tile: " << GeometryUtils::toConfigString(tiles[randomTileIndex]));
+  LOG_DEBUG("Randomly selected tile: " << GeometryUtils::toLonLatString(tiles[randomTileIndex]));
   return tiles[randomTileIndex];
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/Way.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Way.cpp
@@ -47,6 +47,9 @@
 using namespace geos::geom;
 using namespace std;
 
+//  Enable way debugging, checking for duplicated node IDs
+//#define WAY_DEBUGGING
+
 namespace hoot
 {
 
@@ -71,12 +74,14 @@ void Way::addNode(long id)
   _wayData->addNode(id);
   _postGeometryChange();
 
-//  // for debugging only; SLOW
-//  if (_nodeIdsAreDuplicated(getNodeIds()))
-//  {
-//    LOG_VARE(getNodeIds());
-//    throw IllegalArgumentException("Duplicate way node IDs: addNode");
-//  }
+#ifdef WAY_DEBUGGING
+  // for debugging only; SLOW
+  if (_nodeIdsAreDuplicated(getNodeIds()))
+  {
+    LOG_VARE(getNodeIds());
+    throw IllegalArgumentException("Duplicate way node IDs: addNode");
+  }
+#endif
 }
 
 void Way::insertNode(long index, long id)
@@ -86,24 +91,28 @@ void Way::insertNode(long index, long id)
   _wayData->insertNode(index, id);
   _postGeometryChange();
 
-//  // for debugging only; SLOW
-//  if (_nodeIdsAreDuplicated(getNodeIds()))
-//  {
-//    LOG_VARE(getNodeIds());
-//    throw IllegalArgumentException("Duplicate way node IDs: insertNode");
-//  }
+#ifdef WAY_DEBUGGING
+  // for debugging only; SLOW
+  if (_nodeIdsAreDuplicated(getNodeIds()))
+  {
+    LOG_VARE(getNodeIds());
+    throw IllegalArgumentException("Duplicate way node IDs: insertNode");
+  }
+#endif
 }
 
 void Way::addNodes(const vector<long>& ids)
 {
   addNodes(ids.begin(), ids.end());
 
-  //  // for debugging only; SLOW
-  //  if (_nodeIdsAreDuplicated(getNodeIds()))
-  //  {
-  //    LOG_VARE(getNodeIds());
-  //    throw IllegalArgumentException("Duplicate way node IDs: addNodes");
-  //  }
+#ifdef WAY_DEBUGGING
+  // for debugging only; SLOW
+  if (_nodeIdsAreDuplicated(getNodeIds()))
+  {
+    LOG_VARE(getNodeIds());
+    throw IllegalArgumentException("Duplicate way node IDs: addNodes");
+  }
+#endif
 }
 
 bool Way::_nodeIdsAreDuplicated(const vector<long>& ids) const
@@ -221,12 +230,14 @@ void Way::setNodes(const vector<long>& newNodes)
 
   _postGeometryChange();
 
-  //  // for debugging only; SLOW
-  //  if (_nodeIdsAreDuplicated(getNodeIds()))
-  //  {
-  //    LOG_VARE(getNodeIds());
-  //    throw IllegalArgumentException("Duplicate way node IDs: setNodes");
-  //  }
+#ifdef WAY_DEBUGGING
+  // for debugging only; SLOW
+  if (_nodeIdsAreDuplicated(getNodeIds()))
+  {
+    LOG_VARE(getNodeIds());
+    throw IllegalArgumentException("Duplicate way node IDs: setNodes");
+  }
+#endif
 }
 
 int Way::getNodeIndex(long nodeId) const
@@ -283,11 +294,11 @@ void Way::removeNode(long id) const
   std::vector<long>& nodes = _wayData->getNodeIds();
   size_t newCount = 0;
   // copy the array in place and remove the unwanted nodes.
-  for (size_t i = 0; i < nodes.size(); i++)
+  for (auto node_id : nodes)
   {
-    if (nodes[i] != id)
+    if (node_id != id)
     {
-      nodes[newCount] = nodes[i];
+      nodes[newCount] = node_id;
       newCount++;
     }
   }
@@ -343,16 +354,18 @@ void Way::replaceNode(long oldId, long newId)
 
     LOG_TRACE("IDs after replacement: " << getNodeIds());
 
-//    // for debugging only; SLOW
-//    if (_nodeIdsAreDuplicated(getNodeIds()))
-//    {
-//      LOG_ERROR(
-//        "Attempting to replace node: " << oldId << " with: " << newId << " in way: " << getId() <<
-//        "...");
-//      LOG_ERROR("Original IDs: " << oldIdsCopy);
-//      LOG_ERROR("New IDs: " << getNodeIds());
-//      throw IllegalArgumentException("Duplicate way node IDs: replaceNode");
-//    }
+#ifdef WAY_DEBUGGING
+    // for debugging only; SLOW
+    if (_nodeIdsAreDuplicated(getNodeIds()))
+    {
+      LOG_ERROR(
+        "Attempting to replace node: " << oldId << " with: " << newId << " in way: " << getId() <<
+        "...");
+      LOG_ERROR("Original IDs: " << oldIdsCopy);
+      LOG_ERROR("New IDs: " << getNodeIds());
+      throw IllegalArgumentException("Duplicate way node IDs: replaceNode");
+    }
+#endif
   }
 }
 
@@ -377,7 +390,7 @@ QString Way::toString() const
   Tgs::operator << (ss, getNodeIds());
   ss << endl;
   ss << "tags: " << getTags().toString().toStdString();
-  ss << "cached envelope: " << GeometryUtils::toString(_cachedEnvelope).toStdString() << endl;
+  ss << "cached envelope: " << GeometryUtils::toMinMaxString(_cachedEnvelope).toStdString() << endl;
   ss << "status: " << getStatusString().toStdString() << endl;
   ss << "version: " << getVersion() << endl;
   ss << "visible: " << getVisible() << endl;
@@ -436,9 +449,8 @@ bool Way::hasSharedEndNode(const Way& other) const
   const long lastNodeId = nodeIds1.at(nodeIds1.size() - 1);
   const long otherFirstNodeId = nodeIds2.at(0);
   const long otherLastNodeId = nodeIds2.at(nodeIds2.size() - 1);
-  return
-    firstNodeId == otherFirstNodeId || firstNodeId == otherLastNodeId ||
-    lastNodeId == otherFirstNodeId || lastNodeId == otherLastNodeId;
+  return firstNodeId == otherFirstNodeId || firstNodeId == otherLastNodeId ||
+         lastNodeId == otherFirstNodeId || lastNodeId == otherLastNodeId;
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/geometry/GeometryUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/GeometryUtils.cpp
@@ -132,7 +132,7 @@ std::shared_ptr<OGREnvelope> GeometryUtils::toOGREnvelope(const geos::geom::Enve
   return result;
 }
 
-QString GeometryUtils::toString(const Envelope& e)
+QString GeometryUtils::toMinMaxString(const Envelope& e)
 {
   const int precision = ConfigOptions().getWriterPrecision();
   return QString("%1,%2,%3,%4")
@@ -142,7 +142,7 @@ QString GeometryUtils::toString(const Envelope& e)
           .arg(e.getMaxY(), 0, 'f', precision);
 }
 
-QString GeometryUtils::toConfigString(const Envelope& e)
+QString GeometryUtils::toLonLatString(const Envelope& e)
 {
   const int precision = ConfigOptions().getWriterPrecision();
   return QString("%1,%2,%3,%4")
@@ -150,6 +150,16 @@ QString GeometryUtils::toConfigString(const Envelope& e)
           .arg(e.getMinY(), 0, 'f', precision)
           .arg(e.getMaxX(), 0, 'f', precision)
           .arg(e.getMaxY(), 0, 'f', precision);
+}
+
+QString GeometryUtils::toLatLonString(const Envelope& e)
+{
+  const int precision = ConfigOptions().getWriterPrecision();
+  return QString("%1,%2,%3,%4")
+          .arg(e.getMinY(), 0, 'f', precision)
+          .arg(e.getMinX(), 0, 'f', precision)
+          .arg(e.getMaxY(), 0, 'f', precision)
+          .arg(e.getMaxX(), 0, 'f', precision);
 }
 
 bool GeometryUtils::isEnvelopeString(const QString& str)
@@ -180,18 +190,6 @@ bool GeometryUtils::isPolygonString(const QString& str)
   return poly.get() != nullptr;
 }
 
-QString GeometryUtils::envelopeToString(const Envelope& bounds)
-{
-  LOG_VART(bounds);
-  const int precision = ConfigOptions().getWriterPrecision();
-  return
-    QString("%1,%2,%3,%4")
-      .arg(QString::number(bounds.getMinX(), 'g', precision),
-           QString::number(bounds.getMinY(), 'g', precision),
-           QString::number(bounds.getMaxX(), 'g', precision),
-           QString::number(bounds.getMaxY(), 'g', precision));
-}
-
 Envelope GeometryUtils::envelopeFromString(const QString& boundsStr)
 {
   LOG_VART(boundsStr);
@@ -210,9 +208,8 @@ Envelope GeometryUtils::envelopeFromString(const QString& boundsStr)
   {
     throw IllegalArgumentException(errorMsg);
   }
-  return
-    Envelope(boundsParts.at(0).toDouble(), boundsParts.at(2).toDouble(),
-      boundsParts.at(1).toDouble(), boundsParts.at(3).toDouble());
+  return Envelope(boundsParts.at(0).toDouble(), boundsParts.at(2).toDouble(),
+                  boundsParts.at(1).toDouble(), boundsParts.at(3).toDouble());
 }
 
 std::shared_ptr<geos::geom::Polygon> GeometryUtils::envelopeToPolygon(const geos::geom::Envelope& env)
@@ -221,8 +218,7 @@ std::shared_ptr<geos::geom::Polygon> GeometryUtils::envelopeToPolygon(const geos
   if (env.isNull())
     return std::shared_ptr<geos::geom::Polygon>();
 
-  CoordinateSequence* coordSeq =
-    GeometryFactory::getDefaultInstance()->getCoordinateSequenceFactory()->create(5, 2).release();
+  CoordinateSequence* coordSeq = GeometryFactory::getDefaultInstance()->getCoordinateSequenceFactory()->create(5, 2).release();
   coordSeq->setAt(geos::geom::Coordinate(env.getMinX(), env.getMinY()), 0);
   coordSeq->setAt(geos::geom::Coordinate(env.getMinX(), env.getMaxY()), 1);
   coordSeq->setAt(geos::geom::Coordinate(env.getMaxX(), env.getMaxY()), 2);
@@ -292,9 +288,9 @@ std::shared_ptr<Polygon> GeometryUtils::polygonFromString(const QString& str)
   return std::shared_ptr<Polygon>(GeometryFactory::getDefaultInstance()->createPolygon(outer, holes));
 }
 
-QString GeometryUtils::polygonStringToEnvelopeString(const QString& str)
+QString GeometryUtils::polygonStringToLonLatString(const QString& str)
 {
-  return envelopeToString(*(polygonFromString(str)->getEnvelopeInternal()));
+  return toLonLatString(*(polygonFromString(str)->getEnvelopeInternal()));
 }
 
 QString GeometryUtils::polygonToString(const std::shared_ptr<Polygon>& poly)

--- a/hoot-core/src/main/cpp/hoot/core/geometry/GeometryUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/GeometryUtils.h
@@ -76,15 +76,23 @@ public:
 
   static std::shared_ptr<OGREnvelope> toOGREnvelope(const geos::geom::Envelope& e);
 
-  /** Creates a bounds string in the format (minx,maxx,miny,maxy)
+  /** Creates a bounds string in the format
+   *  (minx,maxx,miny,maxy) or (min_lon,max_lon,min_lat,max_lat)
    *  from an envelope using the `writer.precision` value
    */
-  static QString toString(const geos::geom::Envelope& e);
+  static QString toMinMaxString(const geos::geom::Envelope& e);
 
-  /** Creates a bounds string in the format (minx,maxx,miny,maxy)
+  /** Creates a bounds string in the format
+   *  (minx,miny,maxx,maxy) or (min_lon,min_lat,max_lon,max_lat)
    *  from an envelope using the `writer.precision` value
    */
-  static QString toConfigString(const geos::geom::Envelope& e);
+  static QString toLonLatString(const geos::geom::Envelope& e);
+
+  /** Creates a bounds string in the format
+   *  (miny,minx,maxy,maxx) or (min_lat,min_lon,max_lat,max_lon)
+   *  from an envelope using the `writer.precision` value
+   */
+  static QString toLatLonString(const geos::geom::Envelope& e);
 
   /**
    * Determines if a string represents an envelope
@@ -93,16 +101,6 @@ public:
    * @return true if the input represents an envelope; false otherwise
    */
   static bool isEnvelopeString(const QString& str);
-
-  /**
-   * Creates a bounds string in the format used in the hoot options config (minx,miny,maxx,maxy)
-   * from an envelope
-   *
-   * @param boundsStr bounds string in the format used in the hoot options config to an envelope
-   * @return an envelope string
-   * @todo This should be replaced by toConfigString.
-   */
-  static QString envelopeToString(const geos::geom::Envelope& bounds);
 
   /**
    * Converts a bounds in the format used in the hoot options config (minx,miny,maxx,maxy) to an
@@ -167,7 +165,7 @@ public:
    * @param str the string to convert
    * @return an envelope string
    */
-  static QString polygonStringToEnvelopeString(const QString& str);
+  static QString polygonStringToLonLatString(const QString& str);
 
   static geos::geom::Geometry* validateGeometry(const geos::geom::Geometry* g);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.cpp
@@ -161,8 +161,7 @@ ElementId ApiDbReader::_mapElementId(const OsmMap& map, ElementId oldId)
       }
       break;
     default:
-      throw IllegalArgumentException("Expected a valid element type, but got: " +
-        QString::number(oldId.getType().getEnum()));
+      throw IllegalArgumentException("Expected a valid element type, but got: " + QString::number(oldId.getType().getEnum()));
     }
   }
 
@@ -196,8 +195,7 @@ void ApiDbReader::_updateMetadataOnElement(ElementPtr element) const
       {
         if (logWarnCount < Log::getWarnMessageLimit())
         {
-          LOG_WARN("Invalid status: " + statusStr + " for element with ID: " +
-                   QString::number(element->getId()));
+          LOG_WARN("Invalid status: " + statusStr + " for element with ID: " + QString::number(element->getId()));
         }
         else if (logWarnCount == Log::getWarnMessageLimit())
         {
@@ -208,7 +206,8 @@ void ApiDbReader::_updateMetadataOnElement(ElementPtr element) const
     }
     // We don't need to carry this tag around once the value is set on the element...it will
     // be reinstated by some writers, though.
-    if (!_keepStatusTag) { tags.remove(MetadataTags::HootStatus()); }
+    if (!_keepStatusTag)
+      tags.remove(MetadataTags::HootStatus());
   }
 
   if (tags.contains("type"))
@@ -501,9 +500,7 @@ void ApiDbReader::_readByBounds(OsmMapPtr map, const Envelope& bounds)
 
         if (!additionalNodeIds.empty())
         {
-          LOG_DEBUG(
-            "Retrieving nodes falling outside of the query bounds but belonging to a selected " <<
-            "way...");
+          LOG_DEBUG("Retrieving nodes falling outside of the query bounds but belonging to a selected way...");
           std::shared_ptr<QSqlQuery> additionalWayNodeItr = _getDatabase()->selectElementsByElementIdList(additionalNodeIds, TableType::Node);
           while (additionalWayNodeItr->next())
           {
@@ -519,9 +516,7 @@ void ApiDbReader::_readByBounds(OsmMapPtr map, const Envelope& bounds)
     }
   }
 
-  LOG_DEBUG(
-    "Bounded query read " << (boundedNodeCount + boundedWayCount + boundedRelationCount) <<
-    " total elements.");
+  LOG_DEBUG("Bounded query read " << (boundedNodeCount + boundedWayCount + boundedRelationCount) << " total elements.");
   LOG_VART(boundedNodeCount);
   LOG_VART(boundedWayCount);
   LOG_VART(boundedRelationCount);
@@ -571,9 +566,7 @@ void ApiDbReader::read(const OsmMapPtr& map)
 
     if (!_readFullThenCropOnBounded)
     {
-      LOG_DEBUG(
-        "Executing API bounded read query via SQL filtering at bounds: ..." <<
-        GeometryUtils::envelopeToString(bounds).right(50) << "...");
+      LOG_DEBUG("Executing API bounded read query via SQL filtering at bounds: ..." << GeometryUtils::toLonLatString(bounds).right(50) << "...");
       _readByBounds(map, bounds);
     }
     else
@@ -584,9 +577,7 @@ void ApiDbReader::read(const OsmMapPtr& map)
       // large dataset, we can allow the full dataset to be read in from the db input and then crop
       // it after the fact as a runtime performance optimization at the expense of extra memory
       // usage.
-      LOG_DEBUG(
-        "Executing API bounded read query via read all then crop at bounds: ..." <<
-        GeometryUtils::envelopeToString(bounds).right(50) << "...");
+      LOG_DEBUG("Executing API bounded read query via read all then crop at bounds: ..." << GeometryUtils::toLonLatString(bounds).right(50) << "...");
       _readByBounds2(map, bounds);
     }
   }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
@@ -452,7 +452,6 @@ void OsmApiWriter::_changesetThreadFunc(int index)
           {
             //  The changeset was closed already so set the ID to -1 and reprocess
             id = -1;
-
             //  Split the changeset into half so that it is smaller and won't fail
             if ((int)workInfo->size() > _maxChangesetSize / 2)
               _splitChangeset(workInfo);
@@ -483,8 +482,7 @@ void OsmApiWriter::_changesetThreadFunc(int index)
             continue;
           }
           //  Split the changeset and retry
-          if (!_splitChangeset(workInfo, info->response) &&
-              !workInfo->getAttemptedResolveChangesetIssues())
+          if (!_splitChangeset(workInfo, info->response) && !workInfo->getAttemptedResolveChangesetIssues())
           {
             //  Set the attempt issues resolved flag
             workInfo->setAttemptedResolveChangesetIssues(true);
@@ -498,8 +496,7 @@ void OsmApiWriter::_changesetThreadFunc(int index)
         case HttpResponseCode::HTTP_BAD_REQUEST:          //  Placeholder ID is missing or not unique
         case HttpResponseCode::HTTP_NOT_FOUND:            //  Diff contains elements where the given ID could not be found
         case HttpResponseCode::HTTP_PRECONDITION_FAILED:  //  Precondition Failed, Relation with id cannot be saved due to other member
-          if (!_splitChangeset(workInfo, info->response) &&
-              !workInfo->getAttemptedResolveChangesetIssues())
+          if (!_splitChangeset(workInfo, info->response) && !workInfo->getAttemptedResolveChangesetIssues())
           {
             //  Set the attempt issues resolved flag
             workInfo->setAttemptedResolveChangesetIssues(true);
@@ -750,7 +747,7 @@ bool OsmApiWriter::usingCgiMap(HootNetworkRequestPtr request) const
     QUrlQuery query(map);
     //  Use the correct type of bbox for this query
     geos::geom::Envelope envelope(-77.42249541, -77.42249539, 38.96003149, 38.96003151);
-    QString bboxQuery = GeometryUtils::toConfigString(envelope);
+    QString bboxQuery = GeometryUtils::toLonLatString(envelope);
     query.addQueryItem("bbox", bboxQuery);
     map.setQuery(query);
     request->networkRequest(map, _timeout);

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
@@ -568,10 +568,7 @@ void OsmJsonReader::_parseOverpassNode(const pt::ptree& item)
   long uid = _getUid(item);
 
   // Construct node
-  NodePtr pNode(
-    Node::newSp(
-      _defaultStatus, newId, lon, lat, _defaultCircErr, changeset, version, timestamp,
-      QString::fromStdString(user), uid));
+  NodePtr pNode(Node::newSp(_defaultStatus, newId, lon, lat, _defaultCircErr, changeset, version, timestamp, QString::fromStdString(user), uid));
 
   // Add tags
   _addTags(item, pNode);
@@ -624,7 +621,6 @@ void OsmJsonReader::_parseOverpassWay(const pt::ptree& item)
   }
   _wayIdMap.insert(id, newId);
 
-  const QString msg = "Reading " + ElementId(ElementType::Way, newId).toString() + "...";
   long version = _getVersion(item, ElementType::Way, newId);
   long changeset = _getChangeset(item);
   unsigned int timestamp = _getTimestamp(item);
@@ -632,10 +628,7 @@ void OsmJsonReader::_parseOverpassWay(const pt::ptree& item)
   long uid = _getUid(item);
 
   // Construct Way
-  WayPtr pWay =
-    std::make_shared<Way>(
-      _defaultStatus, newId, _defaultCircErr, changeset, version, timestamp,
-      QString::fromStdString(user), uid);
+  WayPtr pWay = std::make_shared<Way>(_defaultStatus, newId, _defaultCircErr, changeset, version, timestamp, QString::fromStdString(user), uid);
 
   // Add nodes
   if (item.not_found() != item.find("nodes"))
@@ -732,10 +725,7 @@ void OsmJsonReader::_parseOverpassRelation(const pt::ptree& item)
   long uid = _getUid(item);
 
   // Construct Relation
-  RelationPtr pRelation =
-    std::make_shared<Relation>(
-      _defaultStatus, newId, _defaultCircErr, "", changeset, version, timestamp,
-      QString::fromStdString(user), uid);
+  RelationPtr pRelation = std::make_shared<Relation>(_defaultStatus, newId, _defaultCircErr, "", changeset, version, timestamp, QString::fromStdString(user), uid);
 
   // Add members
   if (item.not_found() != item.find("members"))
@@ -879,6 +869,8 @@ void OsmJsonReader::_readFromHttp()
   if (urlQuery.hasQueryItem("srsname"))
     urlQuery.removeQueryItem("srsname");
   urlQuery.addQueryItem("srsname", "EPSG:4326");
+  //  Tell the ParallelBoundedReader that this is an Overpass query
+  _isOverpass = true;
   //  Load the query from a file if requested
   if (!urlQuery.hasQueryItem("data") && !_queryFilepath.isEmpty())
   {

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
@@ -49,6 +49,7 @@ ParallelBoundedApiReader::ParallelBoundedApiReader(bool useOsmApiBboxFormat, boo
     _coordGridSize(ConfigOptions().getReaderHttpBboxMaxSize()),
     _threadCount(ConfigOptions().getReaderHttpBboxThreadCount()),
     _isPolygon(false),
+    _isOverpass(false),
     _totalResults(0),
     _totalEnvelopes(0),
     _maxGridSize(ConfigOptions().getReaderHttpBboxMaxDownloadSize()),
@@ -71,10 +72,7 @@ void ParallelBoundedApiReader::beginRead(const QUrl& endpoint, const geos::geom:
   //  Validate the size of the envelope, in square degrees, before beginning
   //  Don't allow the whole earth to be downloaded!
   if (envelope.getWidth() * envelope.getHeight() > _maxGridSize)
-  {
-    throw UnsupportedException(
-      QString("Cannot request areas larger than %1 square degrees.").arg(QString::number(_maxGridSize, 'f', 4)));
-  }
+    throw UnsupportedException(QString("Cannot request areas larger than %1 square degrees.").arg(QString::number(_maxGridSize, 'f', 4)));
   //  Save the endpoint URL to query
   _sourceUrl = endpoint;
   //  Split the envelope if it is bigger than the prescribed max
@@ -193,24 +191,47 @@ void ParallelBoundedApiReader::_process()
     if (!envelope.isNull())
     {
       //  Add the bbox to the query string
+      bool add_bbox = true;
       QUrl url = _sourceUrl;
       QUrlQuery query(_sourceUrl);
+      //  Remove any bbox that comes in so it can be updated
       if (query.hasQueryItem("bbox"))
         query.removeQueryItem("bbox");
       //  Use the correct type of bbox for this query
       QString bboxQuery;
       if (_useOsmApiBboxFormat)
-        bboxQuery = GeometryUtils::toConfigString(envelope);
+        bboxQuery = GeometryUtils::toLonLatString(envelope);
       else
-        bboxQuery = GeometryUtils::toString(envelope);
-      //  Some APIs require the bounding box's projection, add it here
-      if (_addProjection)
-        bboxQuery += ",EPSG:4326";
-      query.addQueryItem("bbox", bboxQuery);
+        bboxQuery = GeometryUtils::toMinMaxString(envelope);
+      //  Overpass queries operate a little differently with the bbox
+      if (_isOverpass)
+      {
+        //  Get the data parameter
+        QString data = query.queryItemValue("data");
+        //  Search the data parameter for {{bbox}} and replace it with the actual bounds
+        if (data.contains("{{bbox}}"))
+        {
+          //  Embedded {{bbox}} data requires a Lat/Lon string
+          bboxQuery = GeometryUtils::toLatLonString(envelope);
+          //  Remove the old 'data' query
+          query.removeQueryItem("data");
+          //  Replace the bbox place holder
+          data = data.replace("{{bbox}}", QString("%1").arg(bboxQuery));
+          //  Set the data query item back to the query
+          query.addQueryItem("data", data);
+          //  Don't add the bbox query item later because it is embedded in the data query item
+          add_bbox = false;
+        }
+      }
+      else if (_addProjection)
+        bboxQuery += ",EPSG:4326";  //  Some APIs require the bounding box's projection, add it here
+      //  Add the bbox query item if necessary
+      if (add_bbox)
+        query.addQueryItem("bbox", bboxQuery);
       url.setQuery(query);
 
       HootNetworkRequest request;
-      LOG_VART(url);
+      LOG_DEBUG(url);
       request.networkRequest(url, _timeout);
       //  Check the HTTP status code and result
       int status = request.getHttpStatus();
@@ -247,7 +268,19 @@ void ParallelBoundedApiReader::_process()
         }
         break;
       case HttpResponseCode::HTTP_BAD_REQUEST:
-        _splitEnvelope(envelope);
+        if (_isOverpass)
+        {
+          //  Overpass API 400 Bad Request means the query didn't parse correctly and the error is in the response
+          std::lock_guard<std::mutex> error_lock(_errorMutex);
+          LOG_ERROR("Overpass Error: " + _parseOverpassError(QString::fromUtf8(request.getResponseContent().data())));
+          LOG_VARD(url);
+          _fatalError = true;
+        }
+        else
+        {
+          //  OSM API 400 Bad Request means the node/way/relation limit has been exceeded
+          _splitEnvelope(envelope);
+        }
         break;
       case HttpResponseCode::HTTP_BANDWIDTH_EXCEEDED:        //  Bandwidth for downloads has been exceeded, fail immediately
       {
@@ -327,6 +360,16 @@ bool ParallelBoundedApiReader::_isQueryError(const QString& result, QString& err
     return true;
   }
   return false;
+}
+
+QString ParallelBoundedApiReader::_parseOverpassError(const QString& result) const
+{
+  //  <p><strong style="color:#FF0000">Error</strong>: line 1: parse error: Unknown query clause </p>
+  static QRegularExpression regex("<p><strong.*?>Error</strong>: (.*?)</p>", QRegularExpression::OptimizeOnFirstUsageOption);
+  QRegularExpressionMatch match = regex.match(result);
+  if (match.hasMatch())
+    return match.captured(1);
+  return "";
 }
 
 void ParallelBoundedApiReader::_splitEnvelope(const geos::geom::Envelope &envelope)

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
@@ -138,6 +138,8 @@ protected:
   bool _isPolygon;
   /** Value of the bounding box or polygon */
   std::shared_ptr<geos::geom::Geometry> _boundingPoly;
+  /** Flag indicating this query is an Overpass API query */
+  bool _isOverpass;
 
   /**
    * @brief _sleep Sleep the current thread
@@ -150,6 +152,7 @@ protected:
    * @return
    */
   bool _isQueryError(const QString& result, QString& error) const;
+  QString _parseOverpassError(const QString& result) const;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/RandomMapCropper.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/RandomMapCropper.cpp
@@ -115,9 +115,9 @@ void RandomMapCropper::apply(OsmMapPtr& map)
   SuperfluousNodeRemover::removeNodes(map);
 
   LOG_INFO("Starting map size: " << StringUtils::formatLargeNumber(startingMapSize));
-  LOG_DEBUG("Starting map bounds: " << GeometryUtils::envelopeToString(startingBounds));
+  LOG_DEBUG("Starting map bounds: " << GeometryUtils::toLonLatString(startingBounds));
   LOG_INFO("Cropped map size: " << StringUtils::formatLargeNumber(map->size()));
-  LOG_DEBUG("Cropped map bounds: " << GeometryUtils::envelopeToString(CalculateMapBoundsVisitor::getGeosBounds(map)));
+  LOG_DEBUG("Cropped map bounds: " << GeometryUtils::toLonLatString(CalculateMapBoundsVisitor::getGeosBounds(map)));
   LOG_INFO("Minimum nodes in a single tile: " << tileCalc.getMinNodeCountInOneTile());
   LOG_INFO("Maximum nodes in a single tile: " << tileCalc.getMaxNodeCountInOneTile());
 }

--- a/hoot-core/src/main/cpp/hoot/core/util/Log.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Log.h
@@ -123,7 +123,7 @@ public:
 
   static std::string ellipsisStr(const std::string& str, uint count = 33);
 
-  WarningLevel getLevel() const { return _level; }
+  inline WarningLevel getLevel() const { return _level; }
   void setLevel(WarningLevel l);
 
   void setDecorateLogs(bool decorate) { _decorateLogs = decorate; }

--- a/hoot-core/src/main/cpp/hoot/core/util/NodeDensityPlotter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/NodeDensityPlotter.cpp
@@ -65,7 +65,7 @@ void NodeDensityPlotter::plot(const QString& input, const QString& output) const
   std::shared_ptr<OsmMapReader> reader = OsmMapReaderFactory::createReader(input, true);
   reader->open(input);
   geos::geom::Envelope env = _getEnvelope(reader);
-  LOG_DEBUG("Envelope: " << GeometryUtils::toString(env));
+  LOG_DEBUG("Envelope: " << GeometryUtils::toMinMaxString(env));
 
   const double pixelSize = _getPixelSize(env);
 

--- a/test-files/cmd/quick/ExtentCmdTest.sh.stdout
+++ b/test-files/cmd/quick/ExtentCmdTest.sh.stdout
@@ -1,16 +1,16 @@
 
 Calculating the extent of one input...
 
-Map extent (minx,miny,maxx,maxy): -77.0551,38.8845,-77.0281,38.9031
+Map extent (minx,miny,maxx,maxy): -77.055100000,38.884500000,-77.028100000,38.903100000
 
 Calculating the extent of multiple inputs...
 
-Map extent (minx,miny,maxx,maxy): -104.902432,38.8532424,-77.0281,38.9031
+Map extent (minx,miny,maxx,maxy): -104.902431610,38.853242427,-77.028100000,38.903100000
 
 Calculating the extent of data recursively in a directory structure...
 
-Map extent (minx,miny,maxx,maxy): -104.919759,38.8467218,-104.714569,39.5944194
+Map extent (minx,miny,maxx,maxy): -104.919758616,38.846721812,-104.714569365,39.594419403
 
 Calculating the extent of data recursively in a directory structure with one filter...
 
-Map extent (minx,miny,maxx,maxy): -104.919759,38.8467218,-104.714569,39.5944194
+Map extent (minx,miny,maxx,maxy): -104.919758616,38.846721812,-104.714569365,39.594419403


### PR DESCRIPTION
Overpass UI does a bit of substitution for queries with embedded `{{bbox}}` bounding boxes, so in order for Hoot to work with those types of queries it needs to perform the same type of substitution.

Closes #5478 