### PR TITLE
Merging multiple datasets in database causes crash

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDb.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDb.cpp
@@ -554,7 +554,7 @@ std::shared_ptr<QSqlQuery> ApiDb::selectWayIdsByWayNodeIds(const QSet<QString>& 
   }
   //this has to be prepared every time due to the varying number of IDs passed in
   QString sql = QString("SELECT DISTINCT way_id FROM %1 WHERE node_id IN (%2)")
-      .arg(tableTypeToTableName(TableType::WayNode), QStringList(nodeIds.toList()).join(","));
+      .arg(tableTypeToTableName(TableType::WayNode), nodeIds.toList().join(","));
   _selectWayIdsByWayNodeIds->prepare(sql);
   LOG_VART(_selectWayIdsByWayNodeIds->lastQuery().right(100));
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetApplier.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiDbSqlChangesetApplier.cpp
@@ -87,14 +87,14 @@ void OsmApiDbSqlChangesetApplier::write(const QString& sql)
   const QStringList sqlParts = sql.split(";");
   LOG_VARD(sqlParts.length());
 
-  if (!sqlParts[0].toUpper().startsWith("INSERT INTO CHANGESETS"))
+  if (!sqlParts[0].startsWith("INSERT INTO CHANGESETS", Qt::CaseInsensitive))
     throw HootException(QString("The first SQL statement in a changeset SQL file must create a changeset. Found: %1").arg(sqlParts[0].left(25)));
 
   for (const auto& sqlStatement : qAsConst(sqlParts))
   {
     LOG_VART(sqlStatement);
     QString changesetStatType;
-    if (sqlStatement.toUpper().startsWith("INSERT INTO CHANGESETS"))
+    if (sqlStatement.startsWith("INSERT INTO CHANGESETS", Qt::CaseInsensitive))
     {
       // flush
       if (!changesetInsertStatement.isEmpty())

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
@@ -196,9 +196,10 @@ void OsmJsonReader::read(const OsmMapPtr& map)
 
   LOG_VARD(_map->getElementCount());
 
-  // See related note in OsmXmlReader::read.
-  if (_bounds.get())
+  //  Bounded network queries are already cropped
+  if (_bounds.get() && !_isWeb)
   {
+    // See related note in OsmXmlReader::read.
     IoUtils::cropToBounds(_map, _bounds, _keepImmediatelyConnectedWaysOutsideBounds);
     LOG_VARD(StringUtils::formatLargeNumber(_map->getElementCount()));
   }
@@ -209,7 +210,8 @@ void OsmJsonReader::_readToMap()
   _parseOverpassJson();
   LOG_VARD(_map->getElementCount());
 
-  if (_bounds.get())
+  //  Bounded network queries are already cropped
+  if (_bounds.get() && _isWeb)
   {
     IoUtils::cropToBounds(_map, _bounds, _keepImmediatelyConnectedWaysOutsideBounds);
     LOG_VARD(StringUtils::formatLargeNumber(_map->getElementCount()));
@@ -268,6 +270,8 @@ bool OsmJsonReader::isValidJson(const QString& jsonStr)
 
 void OsmJsonReader::loadFromString(const QString& jsonStr, const OsmMapPtr& map)
 {
+  _isFile = false;
+  _isWeb = false;
   _map = map;
   _loadJSON(jsonStr);
   _readToMap();
@@ -276,6 +280,8 @@ void OsmJsonReader::loadFromString(const QString& jsonStr, const OsmMapPtr& map)
 
 OsmMapPtr OsmJsonReader::loadFromPtree(const boost::property_tree::ptree& tree)
 {
+  _isFile = false;
+  _isWeb = false;
   _propTree = tree;
   _map = std::make_shared<OsmMap>();
   _readToMap();
@@ -288,6 +294,8 @@ OsmMapPtr OsmJsonReader::loadFromFile(const QString& path)
   if (!infile.is_open())
     throw HootException("Unable to read JSON file: " + path);
 
+  _isFile = true;
+  _isWeb = false;
   _loadJSON(infile);
   _map = std::make_shared<OsmMap>();
   _readToMap();


### PR DESCRIPTION
All of the node/way/relation insert SQL statements in `SqlBulkInsert` appended the SQL magic of `ON CONFLICT DO NOTHING` to keep from inserting duplicate nodes/ways/relations into the database tables.  This, however, wasn't the case for the relation members table.  So when a duplicate relation was inserted that had the same exact relation members that query would fail (silently for some reason) and then the next insertion would crash Hootenanny.

Closes #5485