### PR TITLE
Including `bounds` parameter with `ParallelBoundedReader` should still stream

### DIFF
--- a/LocalConfig.pri.orig
+++ b/LocalConfig.pri.orig
@@ -8,7 +8,8 @@ CONFIG -= debug
 debug {
   DEFINES += DEBUG
 
-  QMAKE_CXXFLAGS+=-g -Og
+  # Generally -Og is recommended instead of -O0 but GDB and QtCreator struggle with -Og
+  QMAKE_CXXFLAGS+=-g -O0
   QMAKE_CXXFLAGS+=-fno-omit-frame-pointer
 
   # Runs expensive validation on several data structures to make sure everything is in sync.

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTest.cpp
@@ -58,6 +58,7 @@ class OsmApiReaderTest : public HootTestFixture
   CPPUNIT_TEST(runFailureTest);
   CPPUNIT_TEST(runPolygonBoundsTest);
 #endif
+  CPPUNIT_TEST(runStreamTest);
 
 #ifdef RUN_PRODUCTION_TESTS
   CPPUNIT_TEST(runOsmApiXmlTest);
@@ -76,6 +77,7 @@ public:
   const int PORT_SPLIT_GEO =      9901;
   const int PORT_SPLIT_ELEMENTS = 9902;
   const int PORT_POLYGON =        9903;
+  const int PORT_STREAM =         9904;
 
   OsmApiReaderTest()
     : HootTestFixture("test-files/io/OsmApiReaderTest/",
@@ -298,6 +300,16 @@ public:
     writer.write(map, output);
     writer.close();
 #endif
+  }
+
+  void runStreamTest()
+  {
+//#ifdef RUN_LOCAL_TEST_SERVER
+    OverpassReaderTestServer server(PORT_STREAM);
+    server.start();
+    server.wait();
+    server.shutdown();
+//#endif
   }
 };
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTest.cpp
@@ -43,6 +43,9 @@
 //  Run tests against a production (OSM API and Overpass API)
 //#define RUN_PRODUCTION_TESTS
 
+//  Qt
+#include <QProcess>
+
 namespace hoot
 {
 
@@ -57,8 +60,8 @@ class OsmApiReaderTest : public HootTestFixture
   CPPUNIT_TEST(runSplitElementsTest);
   CPPUNIT_TEST(runFailureTest);
   CPPUNIT_TEST(runPolygonBoundsTest);
-#endif
   CPPUNIT_TEST(runStreamTest);
+#endif
 
 #ifdef RUN_PRODUCTION_TESTS
   CPPUNIT_TEST(runOsmApiXmlTest);
@@ -304,12 +307,31 @@ public:
 
   void runStreamTest()
   {
-//#ifdef RUN_LOCAL_TEST_SERVER
+#ifdef RUN_LOCAL_TEST_SERVER
     OverpassReaderTestServer server(PORT_STREAM);
     server.start();
-    server.wait();
+
+    QString output_dir = _outputPath + "stream_test";
+    QString output_file = output_dir + ".shp";
+
+    FileUtils::removeDir(output_dir);
+
+    QString cmd = "hoot";
+    QStringList args;
+    args << "convert"
+         << "-D reader.http.bbox.max.size=0.025"
+         << "-D schema.translation.script=translations/TDSv71.js"
+         << "-D bounds=2.277303,48.851684,2.311635,48.864701"
+         << "-D overpass.api.host=localhost"
+         << "\"http://localhost:9904/api/interpreter?data=[out:xml];(node({{bbox}});(._;<;>;););out meta;\""
+         << output_file;
+
+    QProcess p;
+    p.start(cmd, args,QIODevice::ReadOnly);
+    p.waitForFinished();
+
     server.shutdown();
-//#endif
+#endif
   }
 };
 

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTestServer.cpp
@@ -41,7 +41,7 @@ bool SimpleReaderTestServer::respond(HttpConnectionPtr& connection)
   parse_request(connection);
   //  Reply with ToyTestA.osm or with an HTTP 404 error
   HttpResponsePtr response;
-  if (_headers.find(OsmApiEndpoints::API_PATH_MAP) != std::string::npos)
+  if (_headers.find(OsmApiEndpoints::OSM_API_PATH_MAP) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, FileUtils::readFully("test-files/ToyTestA.osm").toStdString());
   else
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_NOT_FOUND);
@@ -58,7 +58,7 @@ bool GeographicSplitReaderTestServer::respond(HttpConnectionPtr& connection)
   parse_request(connection);
   HttpResponsePtr response;
   //  Reply with some split up parts of ToyTestA.osm or with an HTTP 404 error
-  if (_headers.find(OsmApiEndpoints::API_PATH_MAP) != std::string::npos && _current < _max)
+  if (_headers.find(OsmApiEndpoints::OSM_API_PATH_MAP) != std::string::npos && _current < _max)
   {
     response = get_sequence_response(_headers);
     //  After the fourth section, shutdown the test server
@@ -106,7 +106,7 @@ bool ElementSplitReaderTestServer::respond(HttpConnectionPtr& connection)
   parse_request(connection);
   HttpResponsePtr response;
   //  Reply with some split up parts of ToyTestA.osm or with an HTTP 404 error
-  if (_headers.find(OsmApiEndpoints::API_PATH_MAP) != std::string::npos && _current < _max)
+  if (_headers.find(OsmApiEndpoints::OSM_API_PATH_MAP) != std::string::npos && _current < _max)
   {
     response = get_sequence_response(_headers);
     //  After the fourth section, shutdown the test server
@@ -152,6 +152,54 @@ HttpResponsePtr ElementSplitReaderTestServer::get_sequence_response(const std::s
         response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, FileUtils::readFully(path).toStdString());
         _sequence_responses[request] = response;
       }
+    }
+  }
+  return response;
+}
+
+bool OverpassReaderTestServer::respond(HttpConnectionPtr& connection)
+{
+  //  Stop processing by setting this to false
+  bool continue_processing = true;
+  //  Read the HTTP request
+  parse_request(connection);
+  HttpResponsePtr response;
+  //  Reply with some split up parts of ToyTestA.osm or with an HTTP 404 error
+  if (_headers.find(OsmApiEndpoints::OVERPASS_API_PATH) != std::string::npos && _current < _max)
+  {
+    response = get_sequence_response(_headers);
+    //  After the fourth section, shutdown the test server
+    if (_current == _max)
+      continue_processing = false;
+  }
+  else
+  {
+    response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_NOT_FOUND);
+    continue_processing = false;
+  }
+  //  Write out the response
+  write_response(connection, response->to_string());
+  //  Continue processing while there is still something to process or while he haven't been interupted
+  return continue_processing && !get_interupt();
+}
+
+HttpResponsePtr OverpassReaderTestServer::get_sequence_response(const std::string& request)
+{
+  HttpResponsePtr response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_NOT_FOUND);
+  //  Only respond up until the max is reached, then shutdown
+  if (_current < _max)
+  {
+    //  If the same thing is being requested again, respond with the previous value
+    std::map<std::string, HttpResponsePtr>::iterator it = _sequence_responses.find(request);
+    if (it != _sequence_responses.end())
+      response = it->second;
+    else
+    {
+      //  Increment the sequence
+      _current++;
+      QString path = QString("test-files/io/OsmApiReaderTest/ToyTestAOverpass%1.osm").arg(_current);
+      response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, FileUtils::readFully(path).toStdString());
+      _sequence_responses[request] = response;
     }
   }
   return response;

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTestServer.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "OsmApiReaderTestServer.h"

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTestServer.h
@@ -77,6 +77,21 @@ protected:
   bool _split_forced;
 };
 
+class OverpassReaderTestServer : public HttpSequencedServer
+{
+public:
+  /** Constructor */
+  OverpassReaderTestServer(int port)
+    : HttpSequencedServer(2, port)
+  { }
+
+protected:
+  /** respond() function that responds once to the OSM API Capabilities request */
+  virtual bool respond(HttpConnectionPtr& connection) override;
+  /** get_sequence_response() function that gets the response message based on the URL requested */
+  virtual HttpResponsePtr get_sequence_response(const std::string& url) override;
+};
+
 }
 
 #endif  //  OSM_API_READER_TEST_SERVER_H

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTestServer.h
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiReaderTestServer.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef OSM_API_READER_TEST_SERVER_H

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #include "OsmApiWriterTestServer.h"

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmApiWriterTestServer.cpp
@@ -40,7 +40,7 @@ bool CapabilitiesTestServer::respond(HttpConnectionPtr &connection)
   parse_request(connection);
   //  Make sure that the capabilities were requested
   HttpResponsePtr response;
-  if (_headers.find(OsmApiEndpoints::API_PATH_CAPABILITIES) != std::string::npos)
+  if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CAPABILITIES) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CAPABILITIES_RESPONSE);
   else
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_NOT_FOUND);
@@ -56,7 +56,7 @@ bool PermissionsTestServer::respond(HttpConnectionPtr &connection)
   parse_request(connection);
   //  Make sure that the permissions were requested
   HttpResponsePtr response;
-  if (_headers.find(OsmApiEndpoints::API_PATH_PERMISSIONS) != std::string::npos)
+  if (_headers.find(OsmApiEndpoints::OSM_API_PATH_PERMISSIONS) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_PERMISSIONS_RESPONSE);
   else
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_NOT_FOUND);
@@ -74,18 +74,18 @@ bool RetryConflictsTestServer::respond(HttpConnectionPtr& connection)
   parse_request(connection);
   //  Determine the response message's HTTP header
   HttpResponsePtr response;
-  if (_headers.find(OsmApiEndpoints::API_PATH_CAPABILITIES) != std::string::npos)
+  if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CAPABILITIES) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CAPABILITIES_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_PERMISSIONS) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_PERMISSIONS) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_PERMISSIONS_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_CREATE_CHANGESET) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CREATE_CHANGESET) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, "1");
   else if (_headers.find("POST") != std::string::npos)
   {
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_METHOD_NOT_ALLOWED);
     response->add_header("Allow", "GET");
   }
-  else if (_headers.find(QString(OsmApiEndpoints::API_PATH_CLOSE_CHANGESET).arg(1).toStdString()) != std::string::npos)
+  else if (_headers.find(QString(OsmApiEndpoints::OSM_API_PATH_CLOSE_CHANGESET).arg(1).toStdString()) != std::string::npos)
   {
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK);
     continue_processing = false;
@@ -120,16 +120,16 @@ bool RetryVersionTestServer::respond(HttpConnectionPtr &connection)
   //  Determine the response message's HTTP response
   HttpResponsePtr response;
   //  Capabilities
-  if (_headers.find(OsmApiEndpoints::API_PATH_CAPABILITIES) != std::string::npos)
+  if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CAPABILITIES) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CAPABILITIES_RESPONSE);
   //  Permissions
-  else if (_headers.find(OsmApiEndpoints::API_PATH_PERMISSIONS) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_PERMISSIONS) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_PERMISSIONS_RESPONSE);
   //  Create changeset
-  else if (_headers.find(OsmApiEndpoints::API_PATH_CREATE_CHANGESET) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CREATE_CHANGESET) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, "1");
   //  Upload changeset 1
-  else if (_headers.find(QString(OsmApiEndpoints::API_PATH_UPLOAD_CHANGESET).arg(1).toStdString()) != std::string::npos)
+  else if (_headers.find(QString(OsmApiEndpoints::OSM_API_PATH_UPLOAD_CHANGESET).arg(1).toStdString()) != std::string::npos)
   {
     //  The first time through, the 'version' of element 1 should fail.
     if (!_has_error)
@@ -141,10 +141,10 @@ bool RetryVersionTestServer::respond(HttpConnectionPtr &connection)
       response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CHANGESET_1_RESPONSE);
   }
   //  Get way 1's updated version
-  else if (_headers.find(QString(OsmApiEndpoints::API_PATH_GET_ELEMENT).arg("way").arg(1).toStdString()) != std::string::npos)
+  else if (_headers.find(QString(OsmApiEndpoints::OSM_API_PATH_GET_ELEMENT).arg("way").arg(1).toStdString()) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_ELEMENT_1_GET_RESPONSE);
   //  Close changeset
-  else if (_headers.find(QString(OsmApiEndpoints::API_PATH_CLOSE_CHANGESET).arg(1).toStdString()) != std::string::npos)
+  else if (_headers.find(QString(OsmApiEndpoints::OSM_API_PATH_CLOSE_CHANGESET).arg(1).toStdString()) != std::string::npos)
   {
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK);
     continue_processing = false;
@@ -169,11 +169,11 @@ bool ChangesetOutputTestServer::respond(HttpConnectionPtr& connection)
   parse_request(connection);
   //  Determine the response message's HTTP header
   HttpResponsePtr response;
-  if (_headers.find(OsmApiEndpoints::API_PATH_CAPABILITIES) != std::string::npos)
+  if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CAPABILITIES) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CAPABILITIES_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_PERMISSIONS) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_PERMISSIONS) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_PERMISSIONS_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_CREATE_CHANGESET) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CREATE_CHANGESET) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, "1");
   else if (_headers.find("POST") != std::string::npos)
   {
@@ -182,7 +182,7 @@ bool ChangesetOutputTestServer::respond(HttpConnectionPtr& connection)
     else
       response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CHANGESET_SUCCESS_2_RESPONSE);
   }
-  else if (_headers.find(QString(OsmApiEndpoints::API_PATH_CLOSE_CHANGESET).arg(1).toStdString()) != std::string::npos)
+  else if (_headers.find(QString(OsmApiEndpoints::OSM_API_PATH_CLOSE_CHANGESET).arg(1).toStdString()) != std::string::npos)
   {
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK);
     continue_processing = false;
@@ -207,13 +207,13 @@ bool ChangesetOutputThrottleTestServer::respond(HttpConnectionPtr& connection)
   parse_request(connection);
   //  Determine the response message's HTTP header
   HttpResponsePtr response;
-  if (_headers.find(OsmApiEndpoints::API_PATH_CAPABILITIES) != std::string::npos)
+  if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CAPABILITIES) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CAPABILITIES_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_PERMISSIONS) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_PERMISSIONS) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_PERMISSIONS_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_MAP) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_MAP) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CGIMAP_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_CREATE_CHANGESET) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CREATE_CHANGESET) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, "1");
   else if (_headers.find("POST") != std::string::npos)
   {
@@ -222,7 +222,7 @@ bool ChangesetOutputThrottleTestServer::respond(HttpConnectionPtr& connection)
     else
       response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CHANGESET_SUCCESS_2_RESPONSE);
   }
-  else if (_headers.find(QString(OsmApiEndpoints::API_PATH_CLOSE_CHANGESET).arg(1).toStdString()) != std::string::npos)
+  else if (_headers.find(QString(OsmApiEndpoints::OSM_API_PATH_CLOSE_CHANGESET).arg(1).toStdString()) != std::string::npos)
   {
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK);
     continue_processing = false;
@@ -247,11 +247,11 @@ bool ChangesetCreateFailureTestServer::respond(HttpConnectionPtr& connection)
   parse_request(connection);
   //  Determine the response message's HTTP header
   HttpResponsePtr response;
-  if (_headers.find(OsmApiEndpoints::API_PATH_CAPABILITIES) != std::string::npos)
+  if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CAPABILITIES) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CAPABILITIES_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_PERMISSIONS) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_PERMISSIONS) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_PERMISSIONS_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_CREATE_CHANGESET) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CREATE_CHANGESET) != std::string::npos)
   {
     static int count = 0;
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_UNAUTHORIZED, "User is not authorized");
@@ -278,11 +278,11 @@ bool CreateWaysFailNodesTestServer::respond(HttpConnectionPtr& connection)
   parse_request(connection);
   //  Determine the response message's HTTP header
   HttpResponsePtr response;
-  if (_headers.find(OsmApiEndpoints::API_PATH_CAPABILITIES) != std::string::npos)
+  if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CAPABILITIES) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CAPABILITIES_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_PERMISSIONS) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_PERMISSIONS) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_PERMISSIONS_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_CREATE_CHANGESET) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CREATE_CHANGESET) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, "1");
   else if (_headers.find("POST") != std::string::npos)
   {
@@ -291,7 +291,7 @@ bool CreateWaysFailNodesTestServer::respond(HttpConnectionPtr& connection)
     else
       response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CHANGESET_FAILURE_RESPONSE_2);
   }
-  else if (_headers.find(QString(OsmApiEndpoints::API_PATH_CLOSE_CHANGESET).arg(1).toStdString()) != std::string::npos)
+  else if (_headers.find(QString(OsmApiEndpoints::OSM_API_PATH_CLOSE_CHANGESET).arg(1).toStdString()) != std::string::npos)
   {
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK);
     continue_processing = false;
@@ -317,11 +317,11 @@ bool VersionFailureTestServer::respond(HttpConnectionPtr& connection)
   parse_request(connection);
   //  Determine the response message's HTTP header
   HttpResponsePtr response;
-  if (_headers.find(OsmApiEndpoints::API_PATH_CAPABILITIES) != std::string::npos)
+  if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CAPABILITIES) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CAPABILITIES_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_PERMISSIONS) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_PERMISSIONS) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_PERMISSIONS_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_CREATE_CHANGESET) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CREATE_CHANGESET) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, "1");
   else if (_headers.find("POST") != std::string::npos)
   {
@@ -330,13 +330,13 @@ bool VersionFailureTestServer::respond(HttpConnectionPtr& connection)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_CONFLICT,
                    QString(OsmApiSampleRequestResponse::SAMPLE_CHANGESET_VERSION_FAILURE_RESPONSE).arg(v).arg(++version).toStdString());
   }
-  else if (_headers.find(QString(OsmApiEndpoints::API_PATH_GET_ELEMENT).arg("way").arg(1).toStdString()) != std::string::npos)
+  else if (_headers.find(QString(OsmApiEndpoints::OSM_API_PATH_GET_ELEMENT).arg("way").arg(1).toStdString()) != std::string::npos)
   {
     //  Update the GET response with a different ID
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK,
                    QString(OsmApiSampleRequestResponse::SAMPLE_CHANGESET_VERSION_FAILURE_GET_RESPONSE).arg(++version).toStdString());
   }
-  else if (_headers.find(QString(OsmApiEndpoints::API_PATH_CLOSE_CHANGESET).arg(1).toStdString()) != std::string::npos)
+  else if (_headers.find(QString(OsmApiEndpoints::OSM_API_PATH_CLOSE_CHANGESET).arg(1).toStdString()) != std::string::npos)
   {
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK);
     continue_processing = false;
@@ -361,13 +361,13 @@ bool ElementGoneTestServer::respond(HttpConnectionPtr& connection)
   parse_request(connection);
   //  Determine the response message's HTTP header
   HttpResponsePtr response;
-  if (_headers.find(OsmApiEndpoints::API_PATH_CAPABILITIES) != std::string::npos)
+  if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CAPABILITIES) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CAPABILITIES_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_PERMISSIONS) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_PERMISSIONS) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_PERMISSIONS_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_MAP) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_MAP) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CGIMAP_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_CREATE_CHANGESET) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CREATE_CHANGESET) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, "1");
   else if (_headers.find("POST") != std::string::npos)
   {
@@ -376,7 +376,7 @@ bool ElementGoneTestServer::respond(HttpConnectionPtr& connection)
     else
       response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CHANGESET_1_RESPONSE);
   }
-  else if (_headers.find(QString(OsmApiEndpoints::API_PATH_CLOSE_CHANGESET).arg(1).toStdString()) != std::string::npos)
+  else if (_headers.find(QString(OsmApiEndpoints::OSM_API_PATH_CLOSE_CHANGESET).arg(1).toStdString()) != std::string::npos)
   {
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK);
     continue_processing = false;
@@ -402,13 +402,13 @@ bool ChangesetSplitDeleteTestServer::respond(HttpConnectionPtr& connection)
   parse_request(connection);
   //  Determine the response message's HTTP header
   HttpResponsePtr response;
-  if (_headers.find(OsmApiEndpoints::API_PATH_CAPABILITIES) != std::string::npos)
+  if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CAPABILITIES) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CAPABILITIES_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_PERMISSIONS) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_PERMISSIONS) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_PERMISSIONS_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_MAP) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_MAP) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CGIMAP_RESPONSE);
-  else if (_headers.find(OsmApiEndpoints::API_PATH_CREATE_CHANGESET) != std::string::npos)
+  else if (_headers.find(OsmApiEndpoints::OSM_API_PATH_CREATE_CHANGESET) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, "1");
   else if (_headers.find("POST") != std::string::npos)
   {
@@ -421,7 +421,7 @@ bool ChangesetSplitDeleteTestServer::respond(HttpConnectionPtr& connection)
     else
       response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::SAMPLE_CHANGESET_SPLIT_SUCCESS_RESPONSE_3);
   }
-  else if (_headers.find(QString(OsmApiEndpoints::API_PATH_CLOSE_CHANGESET).arg(1).toStdString()) != std::string::npos)
+  else if (_headers.find(QString(OsmApiEndpoints::OSM_API_PATH_CLOSE_CHANGESET).arg(1).toStdString()) != std::string::npos)
   {
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK);
     continue_processing = false;
@@ -461,7 +461,7 @@ bool ChangesetValidateUploadTestServer::respond(HttpConnectionPtr& connection)
   //  Determine the response message's HTTP response
   HttpResponsePtr response;
   //  Reply with the node information
-  if (_headers.find(QString(OsmApiEndpoints::API_PATH_GET_ELEMENT).arg("node").arg(1).toStdString()) != std::string::npos)
+  if (_headers.find(QString(OsmApiEndpoints::OSM_API_PATH_GET_ELEMENT).arg("node").arg(1).toStdString()) != std::string::npos)
     response = std::make_shared<HttpResponse>(HttpResponseCode::HTTP_OK, OsmApiSampleRequestResponse::VALIDATE_NODE_RESPONSE);
   else
   {

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementInputStream.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementInputStream.h
@@ -60,6 +60,14 @@ public:
   virtual bool hasMoreElements() = 0;
 
   virtual ElementPtr readNextElement() = 0;
+
+  /**
+   * @brief canStreamBounded Most stream objects cannot stream correctly when bounded, some input streams
+   *  apply the bounds at the API level (for instance) and are applied outside of Hootenanny and therefore all
+   *  elements can be streamed.
+   * @return false The default is bounded inputs cannot stream.
+   */
+  virtual bool canStreamBounded() const { return false; }
 };
 
 using ElementInputStreamPtr = std::shared_ptr<ElementInputStream>;

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementInputStream.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementInputStream.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 #ifndef ELEMENTINPUTSTREAM_H
 #define ELEMENTINPUTSTREAM_H

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.h
@@ -75,7 +75,8 @@ private:
    * @param convertOps conversion operations to apply to data
    * @return the number of elements written
    */
-  long _streamFromOgr(const OgrReader& reader, QString& input, ElementOutputStream& writer,
+  long _streamFromOgr(const std::shared_ptr<OgrReader>& reader, QString& input,
+                      const std::shared_ptr<ElementOutputStream>& writer,
                       const QStringList& convertOps = QStringList(), Progress progress = Progress()) const;
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/io/HootNetworkRequest.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/HootNetworkRequest.h
@@ -148,6 +148,8 @@ public:
    */
   void logConnectionError() const;
 
+  const std::map<QString, QString>& getResponseHeaders() const { return _responseHeaders; }
+
 private:
   /**
    * @brief _networkRequest Function to make the actual request
@@ -206,6 +208,8 @@ private:
   QString _key_path;
   /** Passphrase for PKCS-12 SSL key */
   QString _pass_phrase;
+  /** Response headers */
+  std::map<QString, QString> _responseHeaders;
 };
 
 using HootNetworkRequestPtr = std::shared_ptr<HootNetworkRequest>;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
@@ -29,7 +29,6 @@
 
 // Hoot
 #include <hoot/core/criterion/ChildElementCriterion.h>
-#include <hoot/core/criterion/InBoundsCriterion.h>
 #include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/geometry/GeometryUtils.h>
 #include <hoot/core/io/OsmMapReaderFactory.h>
@@ -40,9 +39,6 @@
 #include <hoot/core/util/StringUtils.h>
 #include <hoot/core/visitors/RemoveElementsVisitor.h>
 #include <hoot/core/visitors/ReportMissingElementsVisitor.h>
-
-// Qt
-#include <QBuffer>
 
 //  Geos
 #include <geos/geom/GeometryFactory.h>
@@ -103,7 +99,7 @@ bool OsmApiReader::isSupported(const QString& url) const
   QStringList validPrefixes = supportedFormats().split(";");
   const QString checkString(url.toLower());
   //  Check the OSM API endpoint
-  if (!checkString.endsWith(OsmApiEndpoints::API_PATH_MAP))
+  if (!checkString.endsWith(OsmApiEndpoints::OSM_API_PATH_MAP))
     return false;
   //  Support HTTP and HTTPS URLs to OSM API servers
   for (const auto& prefix : qAsConst(validPrefixes))
@@ -125,38 +121,11 @@ void OsmApiReader::open(const QString& url)
 
 void OsmApiReader::read(const OsmMapPtr& map)
 {
-  LOG_VART(_status);
-  LOG_VART(_useDataSourceId);
-  LOG_VART(_useFileStatus);
-  LOG_VART(_keepStatusTag);
-  LOG_VART(_preserveAllTags);
-
-  //  Set the bounds once we begin the read if setBounds() hasn't already been called
-  if (_bounds == nullptr && _loadBounds())
-    setBounds(_boundingPoly);
-
-  if (_bounds == nullptr)
-    throw IllegalArgumentException("OsmApiReader requires rectangular bounds");
-
-  //  Reusing the reader for multiple reads has two options, the first is the
-  //  default where the reader is reset and duplicates error out.  The second
-  //  is where duplicates are ignored in the same dataset and across datasets
-  //  so the ID maps aren't reset
-  if (!_ignoreDuplicates)
-  {
-    _nodeIdMap.clear();
-    _relationIdMap.clear();
-    _wayIdMap.clear();
-
-    _numRead = 0;
-    finalizePartial();
-  }
   _map = map;
   _map->appendSource(_url);
 
-  //  Spin up the threads. Use the envelope of the boundsto throw away any non-retangular bounds
-  // that may have been  passed.
-  beginRead(_url, *(_bounds->getEnvelopeInternal()));
+  //  Initialize the object
+  initializePartial();
 
   //  Iterate all of the XML results
   while (hasMoreResults())
@@ -195,18 +164,16 @@ void OsmApiReader::read(const OsmMapPtr& map)
   if (_isPolygon)
   {
     size_t element_count = _map->getElementCount();
-    std::shared_ptr<InBoundsCriterion> crit = std::make_shared<InBoundsCriterion>(false);
-    crit->setBounds(_boundingPoly);
     //  Remove any elements that don't meet the criterion
     RemoveElementsVisitor v(true);
-    v.addCriterion(crit);
+    v.addCriterion(_polyCriterion);
     v.setRecursive(true);
     v.setOsmMap(_map.get());
     _map->visitRw(v);
     size_t elements_filtered = element_count - _map->getElementCount();
     if (elements_filtered > 0)
       LOG_STATUS("Filtered " << elements_filtered << " out of bounds elements from OSM API.");
- }
+  }
   _map.reset();
 }
 
@@ -221,6 +188,8 @@ void OsmApiReader::setBounds(std::shared_ptr<geos::geom::Geometry> bounds)
   //  Check if the bounds are rectangular
   _isPolygon = bounds ? !bounds->isRectangle() : false;
   _boundingPoly = bounds;
+  _polyCriterion = std::make_shared<InBoundsCriterion>(false);
+  _polyCriterion->setBounds(_boundingPoly);
   Boundable::setBounds(bounds);
 }
 
@@ -229,7 +198,118 @@ void OsmApiReader::setBounds(const geos::geom::Envelope& bounds)
   //  An envelope isn't a poly bounds
   _isPolygon = false;
   _boundingPoly.reset(geos::geom::GeometryFactory::getDefaultInstance()->toGeometry(&bounds).release());
+  _polyCriterion = std::make_shared<InBoundsCriterion>(false);
+  _polyCriterion->setBounds(_boundingPoly);
   Boundable::setBounds(bounds);
+}
+
+void OsmApiReader::initializePartial()
+{
+  LOG_VART(_status);
+  LOG_VART(_useDataSourceId);
+  LOG_VART(_useFileStatus);
+  LOG_VART(_keepStatusTag);
+  LOG_VART(_preserveAllTags);
+
+  //  Set the bounds once we begin the read if setBounds() hasn't already been called
+  if (_bounds == nullptr && _loadBounds())
+    setBounds(_boundingPoly);
+
+  if (_bounds == nullptr)
+    throw IllegalArgumentException("OsmApiReader requires rectangular bounds");
+
+  //  Reusing the reader for multiple reads has two options, the first is the
+  //  default where the reader is reset and duplicates error out.  The second
+  //  is where duplicates are ignored in the same dataset and across datasets
+  //  so the ID maps aren't reset
+  if (!_ignoreDuplicates)
+  {
+    _nodeIdMap.clear();
+    _relationIdMap.clear();
+    _wayIdMap.clear();
+
+    _numRead = 0;
+    finalizePartial();
+  }
+
+  //  Spin up the threads. Use the envelope of the boundsto throw away any non-retangular bounds
+  // that may have been  passed.
+  beginRead(_url, *(_bounds->getEnvelopeInternal()));
+}
+
+bool OsmApiReader::hasMoreElements()
+{
+  //  Check if there is anything to read and parse
+  if (!hasMoreResults() && _streamReader.atEnd())
+    return false;
+  //  Check if there is an open buffer to read from
+  if (!_xmlBuffer.isOpen())
+  {
+    finalizePartial();
+    //  map needed for assigning new element ids only (not actually putting any of the elements that
+    //  are read into this map, since this is the partial reading logic)
+    _map = std::make_shared<OsmMap>();
+
+    QString xmlResult;
+    //  Get one XML string to parse
+    while (!getSingleResult(xmlResult))
+    {
+      if (!hasMoreResults())
+        return false;
+      _sleep();
+    }
+
+    if (_xmlBuffer.isOpen())
+      _xmlBuffer.close();
+    _xmlBuffer.setData(xmlResult.toUtf8());
+    _xmlBuffer.open(QBuffer::ReadOnly);
+    _streamReader.setDevice(&_xmlBuffer);
+
+    //  check for a valid osm header as soon as the file is opened
+    while (!_foundOsmHeaderXmlStartElement() && !_streamReader.atEnd())
+      _streamReader.readNext();
+
+    if (!_osmFound)
+      throw HootException("Unable to parse XML result from " + _url);
+  }
+
+  //  chew up tokens until we find a node/way/relation start element or read to the end of the file
+  while (!_foundOsmElementXmlStartElement() && !_streamReader.atEnd())
+    _streamReader.readNext();
+
+  if ((_streamReader.isEndElement() && _streamReader.name().toString() == "osm") || _streamReader.atEnd())
+  {
+    //  Close the buffer
+    _xmlBuffer.close();
+    //  Check if there are more buffers coming in
+    if (hasMoreResults())
+      return hasMoreElements();
+    else
+      return false;
+  }
+  //  Read the next element and is available in _element
+  return true;
+}
+
+ElementPtr OsmApiReader::readNextElement()
+{
+  //  Grab the next element from the OsmXmlReader
+  ElementPtr result = OsmXmlReader::readNextElement();
+  //  Make sure that the element hasn't been read before, this can happen because elements
+  //  that span more than one bounding box will be returned from the API in each of the bounding
+  //  boxes.  Write the first, ignore the subsequent ones
+  while (!_canUseElement(result))
+  {
+    //  Check for the next element and read it, otherwise return an empty element
+    if (hasMoreElements())
+      result = OsmXmlReader::readNextElement();
+    else
+      return ElementPtr();
+  }
+  //  Add the element to the set
+  _elementSet.emplace(result->getElementType(), result->getId());
+  //  Return the element read
+  return result;
 }
 
 bool OsmApiReader::_loadBounds()
@@ -252,6 +332,18 @@ bool OsmApiReader::_loadBounds()
     return true;
   }
   return false;
+}
+
+bool OsmApiReader::_canUseElement(const ElementPtr& element) const
+{
+  if (!element)
+    return false;
+  else if (_elementSet.find(element->getElementId()) != _elementSet.end())
+    return false;
+  else if (_isPolygon && element->getElementType() != ElementType::Node && !_polyCriterion->isSatisfied(element))
+    return false;
+  else
+    return true;
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiWriter.cpp
@@ -701,7 +701,7 @@ bool OsmApiWriter::queryCapabilities(HootNetworkRequestPtr request)
   try
   {
     QUrl capabilities = _url;
-    capabilities.setPath(OsmApiEndpoints::API_PATH_CAPABILITIES);
+    capabilities.setPath(OsmApiEndpoints::OSM_API_PATH_CAPABILITIES);
     request->networkRequest(capabilities, _timeout);
     QString responseXml = QString::fromUtf8(request->getResponseContent().data());
     QString printableUrl = capabilities.toString(QUrl::RemoveUserInfo);
@@ -725,7 +725,7 @@ bool OsmApiWriter::validatePermissions(HootNetworkRequestPtr request) const
   try
   {
     QUrl permissions = _url;
-    permissions.setPath(OsmApiEndpoints::API_PATH_PERMISSIONS);
+    permissions.setPath(OsmApiEndpoints::OSM_API_PATH_PERMISSIONS);
     request->networkRequest(permissions, _timeout);
     QString responseXml = QString::fromUtf8(request->getResponseContent().data());
     success = _parsePermissions(responseXml);
@@ -743,7 +743,7 @@ bool OsmApiWriter::usingCgiMap(HootNetworkRequestPtr request) const
   try
   {
     QUrl map = _url;
-    map.setPath(OsmApiEndpoints::API_PATH_MAP);
+    map.setPath(OsmApiEndpoints::OSM_API_PATH_MAP);
     QUrlQuery query(map);
     //  Use the correct type of bbox for this query
     geos::geom::Envelope envelope(-77.42249541, -77.42249539, 38.96003149, 38.96003151);
@@ -842,7 +842,7 @@ long OsmApiWriter::_createChangeset(HootNetworkRequestPtr request,
   try
   {
     QUrl changeset = _url;
-    changeset.setPath(OsmApiEndpoints::API_PATH_CREATE_CHANGESET);
+    changeset.setPath(OsmApiEndpoints::OSM_API_PATH_CREATE_CHANGESET);
     QString xml = QString(
       "<osm>"
       "  <changeset>"
@@ -881,7 +881,7 @@ void OsmApiWriter::_closeChangeset(HootNetworkRequestPtr request, long changeset
   try
   {
     QUrl changeset = _url;
-    changeset.setPath(QString(OsmApiEndpoints::API_PATH_CLOSE_CHANGESET).arg(changeset_id));
+    changeset.setPath(QString(OsmApiEndpoints::OSM_API_PATH_CLOSE_CHANGESET).arg(changeset_id));
     request->networkRequest(changeset, _timeout, QNetworkAccessManager::Operation::PutOperation);
     QString responseXml = QString::fromUtf8(request->getResponseContent().data());
     switch (request->getHttpStatus())
@@ -947,7 +947,7 @@ OsmApiWriter::OsmApiFailureInfoPtr OsmApiWriter::_uploadChangeset(HootNetworkReq
   try
   {
     QUrl change = _url;
-    change.setPath(QString(OsmApiEndpoints::API_PATH_UPLOAD_CHANGESET).arg(id));
+    change.setPath(QString(OsmApiEndpoints::OSM_API_PATH_UPLOAD_CHANGESET).arg(id));
 
     QByteArray content = changeset.toUtf8();
     QMap<QNetworkRequest::KnownHeaders, QVariant> headers;
@@ -1067,7 +1067,7 @@ QString OsmApiWriter::_getNode(HootNetworkRequestPtr request, long id) const
   if (id < 1)
     return "";
   //  Get the node by ID
-  return _getElement(request, QString(OsmApiEndpoints::API_PATH_GET_ELEMENT).arg("node").arg(id));
+  return _getElement(request, QString(OsmApiEndpoints::OSM_API_PATH_GET_ELEMENT).arg("node").arg(id));
 }
 
 QString OsmApiWriter::_getWay(HootNetworkRequestPtr request, long id) const
@@ -1076,7 +1076,7 @@ QString OsmApiWriter::_getWay(HootNetworkRequestPtr request, long id) const
   if (id < 1)
     return "";
   //  Get the way by ID
-  return _getElement(request, QString(OsmApiEndpoints::API_PATH_GET_ELEMENT).arg("way").arg(id));
+  return _getElement(request, QString(OsmApiEndpoints::OSM_API_PATH_GET_ELEMENT).arg("way").arg(id));
 }
 
 QString OsmApiWriter::_getRelation(HootNetworkRequestPtr request, long id) const
@@ -1085,13 +1085,13 @@ QString OsmApiWriter::_getRelation(HootNetworkRequestPtr request, long id) const
   if (id < 1)
     return "";
   //  Get the relation by ID
-  return _getElement(request, QString(OsmApiEndpoints::API_PATH_GET_ELEMENT).arg("relation").arg(id));
+  return _getElement(request, QString(OsmApiEndpoints::OSM_API_PATH_GET_ELEMENT).arg("relation").arg(id));
 }
 
 QString OsmApiWriter::_getElement(HootNetworkRequestPtr request, const QString& endpoint) const
 {
   //  Don't follow an uninitialized URL or empty endpoint
-  if (endpoint == OsmApiEndpoints::API_PATH_GET_ELEMENT || endpoint == "")
+  if (endpoint == OsmApiEndpoints::OSM_API_PATH_GET_ELEMENT || endpoint == "")
     return "";
   try
   {
@@ -1116,7 +1116,7 @@ bool OsmApiWriter::_hasNode(HootNetworkRequestPtr request, long id) const
   if (id < 1)
     return false;
   //  Get the way by ID
-  return _hasElement(request, QString(OsmApiEndpoints::API_PATH_GET_ELEMENT).arg("node").arg(id));
+  return _hasElement(request, QString(OsmApiEndpoints::OSM_API_PATH_GET_ELEMENT).arg("node").arg(id));
 }
 
 bool OsmApiWriter::_hasWay(HootNetworkRequestPtr request, long id) const
@@ -1125,7 +1125,7 @@ bool OsmApiWriter::_hasWay(HootNetworkRequestPtr request, long id) const
   if (id < 1)
     return false;
   //  Get the way by ID
-  return _hasElement(request, QString(OsmApiEndpoints::API_PATH_GET_ELEMENT).arg("way").arg(id));
+  return _hasElement(request, QString(OsmApiEndpoints::OSM_API_PATH_GET_ELEMENT).arg("way").arg(id));
 }
 
 bool OsmApiWriter::_hasRelation(HootNetworkRequestPtr request, long id) const
@@ -1134,13 +1134,13 @@ bool OsmApiWriter::_hasRelation(HootNetworkRequestPtr request, long id) const
   if (id < 1)
     return false;
   //  Get the way by ID
-  return _hasElement(request, QString(OsmApiEndpoints::API_PATH_GET_ELEMENT).arg("relation").arg(id));
+  return _hasElement(request, QString(OsmApiEndpoints::OSM_API_PATH_GET_ELEMENT).arg("relation").arg(id));
 }
 
 bool OsmApiWriter::_hasElement(HootNetworkRequestPtr request, const QString& endpoint) const
 {
   //  Don't follow an uninitialized URL or empty endpoint
-  if (endpoint == OsmApiEndpoints::API_PATH_GET_ELEMENT || endpoint == "")
+  if (endpoint == OsmApiEndpoints::OSM_API_PATH_GET_ELEMENT || endpoint == "")
     return false;
   try
   {

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.h
@@ -132,8 +132,6 @@ protected:
 
   long _numRead;
 
-private:
-
   static int logWarnCount;
 
   bool _osmFound;

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
@@ -65,7 +65,7 @@ public:
    */
   ParallelBoundedApiReader(bool useOsmApiBboxFormat = true, bool addProjection = false);
   /** Destructor that stops all threads if necessary */
-  virtual ~ParallelBoundedApiReader();
+  ~ParallelBoundedApiReader() override;
   /**
    * @brief beginRead - Start the reading process by dividing up the envelope if necessary
    *   and starting the receiving threads
@@ -145,7 +145,7 @@ protected:
   /**
    * @brief _sleep Sleep the current thread
    */
-  void _sleep() const;
+  void _sleep(long milliseconds = 10) const;
   /**
    * @brief _isQueryError
    * @param result

--- a/hoot-core/src/main/cpp/hoot/core/util/HootNetworkUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/HootNetworkUtils.h
@@ -41,6 +41,7 @@ namespace HttpResponseCode
   const int HTTP_CONFLICT               = 409;
   const int HTTP_GONE                   = 410;
   const int HTTP_PRECONDITION_FAILED    = 412;
+  const int HTTP_TOO_MANY_REQUESTS      = 429;
   const int HTTP_INTERNAL_SERVER_ERROR  = 500;
   const int HTTP_BAD_GATEWAY            = 502;
   const int HTTP_SERVICE_UNAVAILABLE    = 503;

--- a/hoot-core/src/main/cpp/hoot/core/util/HootNetworkUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/HootNetworkUtils.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef HOOT_NETWORK_UTILS_H

--- a/hoot-core/src/main/cpp/hoot/core/util/OsmApiUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/OsmApiUtils.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
  */
 
 #ifndef OSM_API_UTILS_H

--- a/hoot-core/src/main/cpp/hoot/core/util/OsmApiUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/OsmApiUtils.h
@@ -35,14 +35,15 @@ class OsmApiEndpoints
 {
 public:
   /** OSM API URL paths */
-  static constexpr const char* API_PATH_MAP = "/api/0.6/map";
-  static constexpr const char* API_PATH_CAPABILITIES = "/api/capabilities";
-  static constexpr const char* API_PATH_PERMISSIONS = "/api/0.6/permissions";
-  static constexpr const char* API_PATH_CREATE_CHANGESET = "/api/0.6/changeset/create";
-  static constexpr const char* API_PATH_CLOSE_CHANGESET = "/api/0.6/changeset/%1/close";
-  static constexpr const char* API_PATH_UPLOAD_CHANGESET = "/api/0.6/changeset/%1/upload";
-  static constexpr const char* API_PATH_GET_ELEMENT = "/api/0.6/%1/%2";
-
+  static constexpr const char* OSM_API_PATH_MAP = "/api/0.6/map";
+  static constexpr const char* OSM_API_PATH_CAPABILITIES = "/api/capabilities";
+  static constexpr const char* OSM_API_PATH_PERMISSIONS = "/api/0.6/permissions";
+  static constexpr const char* OSM_API_PATH_CREATE_CHANGESET = "/api/0.6/changeset/create";
+  static constexpr const char* OSM_API_PATH_CLOSE_CHANGESET = "/api/0.6/changeset/%1/close";
+  static constexpr const char* OSM_API_PATH_UPLOAD_CHANGESET = "/api/0.6/changeset/%1/upload";
+  static constexpr const char* OSM_API_PATH_GET_ELEMENT = "/api/0.6/%1/%2";
+  /** Overpass API URL path */
+  static constexpr const char* OVERPASS_API_PATH = "api/interpreter";
 };
 
 }

--- a/test-files/io/OsmApiReaderTest/ToyTestAOverpass1.osm
+++ b/test-files/io/OsmApiReaderTest/ToyTestAOverpass1.osm
@@ -1,0 +1,81 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <bounds minlat='38.8532424' minlon='-104.9024316' maxlat='38.8549614' maxlon='-104.8961823' origin='hootenanny' />
+  <node id='5' visible='true' version='1' lat='38.8549289622' lon='-104.90052531724' />
+  <node id='6' visible='true' version='1' lat='38.85482073608' lon='-104.90080790256' />
+  <node id='7' visible='true' version='1' lat='38.85433191273' lon='-104.90178768606' />
+  <node id='8' visible='true' version='1' lat='38.85412988881' lon='-104.90230653122' />
+  <node id='9' visible='true' version='1' lat='38.85405412969' lon='-104.90243160997' />
+  <node id='50' visible='true' version='1' lat='38.85416699449' lon='-104.89970698748' />
+  <node id='51' visible='true' version='1' lat='38.8545784972' lon='-104.89971713684' />
+  <node id='52' visible='true' version='1' lat='38.85426183967' lon='-104.89971713684' />
+  <node id='53' visible='true' version='1' lat='38.8539525449' lon='-104.89968403932' />
+  <node id='54' visible='true' version='1' lat='38.85362483827' lon='-104.89969349575' />
+  <node id='55' visible='true' version='1' lat='38.85325834039' lon='-104.89975429289' />
+  <node id='56' visible='true' version='1' lat='38.8532424198' lon='-104.8996868264' />
+  <node id='57' visible='true' version='1' lat='38.8533001417' lon='-104.89945288282' />
+  <node id='58' visible='true' version='1' lat='38.85334704071' lon='-104.89936718072' />
+  <node id='59' visible='true' version='1' lat='38.8535165984' lon='-104.89926989725' />
+  <node id='60' visible='true' version='1' lat='38.85356890867' lon='-104.89905680013' />
+  <node id='61' visible='true' version='1' lat='38.85355087065' lon='-104.89883212164' />
+  <node id='62' visible='true' version='1' lat='38.8536194151' lon='-104.89870704289' />
+  <node id='63' visible='true' version='1' lat='38.85372042786' lon='-104.89872325681' />
+  <node id='64' visible='true' version='1' lat='38.85395852879' lon='-104.89891550747' />
+  <node id='65' visible='true' version='1' lat='38.85413349638' lon='-104.89889002847' />
+  <node id='66' visible='true' version='1' lat='38.85417678727' lon='-104.89870704289' />
+  <node id='67' visible='true' version='1' lat='38.85423270462' lon='-104.8983109602' />
+  <node id='68' visible='true' version='1' lat='38.85442931691' lon='-104.89806543526' />
+  <node id='69' visible='true' version='1' lat='38.85460428335' lon='-104.89777590113' />
+  <node id='70' visible='true' version='1' lat='38.85471972489' lon='-104.89732191161' />
+  <node id='71' visible='true' version='1' lat='38.85486041901' lon='-104.89685865699' />
+  <node id='72' visible='true' version='1' lat='38.85490190568' lon='-104.89643941157' />
+  <node id='73' visible='true' version='1' lat='38.85495241117' lon='-104.89873889165' />
+  <node id='74' visible='true' version='1' lat='38.85493211879' lon='-104.89790503335' />
+  <node id='75' visible='true' version='1' lat='38.85496143' lon='-104.89971240863' />
+  <node id='76' visible='true' version='1' lat='38.85490731699' lon='-104.89618230526' />
+  <node id='101' visible='true' version='1' lat='38.85495396551' lon='-104.8998993' />
+  <way id='1' visible='true' version='1'>
+    <nd ref='9' />
+    <nd ref='8' />
+    <nd ref='7' />
+    <nd ref='6' />
+    <nd ref='5' />
+    <nd ref='101' />
+    <nd ref='75' />
+    <nd ref='51' />
+    <nd ref='52' />
+    <nd ref='50' />
+    <nd ref='53' />
+    <nd ref='54' />
+    <nd ref='55' />
+    <nd ref='56' />
+    <nd ref='57' />
+    <nd ref='58' />
+    <nd ref='59' />
+    <nd ref='60' />
+    <nd ref='61' />
+    <nd ref='62' />
+    <nd ref='63' />
+    <nd ref='64' />
+    <nd ref='65' />
+    <nd ref='66' />
+    <nd ref='67' />
+    <nd ref='68' />
+    <nd ref='69' />
+    <nd ref='70' />
+    <nd ref='71' />
+    <nd ref='72' />
+    <nd ref='76' />
+    <tag k='error:circular' v='15' />
+    <tag k='highway' v='road' />
+    <tag k='note' v='1' />
+  </way>
+  <way id='3' visible='true' version='1'>
+    <nd ref='75' />
+    <nd ref='73' />
+    <nd ref='74' />
+    <tag k='error:circular' v='15' />
+    <tag k='highway' v='road' />
+    <tag k='note' v='3' />
+  </way>
+</osm>

--- a/test-files/io/OsmApiReaderTest/ToyTestAOverpass2.osm
+++ b/test-files/io/OsmApiReaderTest/ToyTestAOverpass2.osm
@@ -1,0 +1,94 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <bounds minlat='38.8532424' minlon='-104.9024316' maxlat='38.8549614' maxlon='-104.8961823' origin='hootenanny' />
+  <node id='1' visible='true' version='1' lat='38.85408509997' lon='-104.90144766473' />
+  <node id='2' visible='true' version='1' lat='38.85424711137' lon='-104.9010788637' />
+  <node id='3' visible='true' version='1' lat='38.85425996138' lon='-104.90057951048' />
+  <node id='4' visible='true' version='1' lat='38.85485140016' lon='-104.90056932643' />
+  <node id='5' visible='true' version='1' lat='38.8549289622' lon='-104.90052531724' />
+  <node id='6' visible='true' version='1' lat='38.85482073608' lon='-104.90080790256' />
+  <node id='7' visible='true' version='1' lat='38.85433191273' lon='-104.90178768606' />
+  <node id='8' visible='true' version='1' lat='38.85412988881' lon='-104.90230653122' />
+  <node id='9' visible='true' version='1' lat='38.85405412969' lon='-104.90243160997' />
+  <node id='50' visible='true' version='1' lat='38.85416699449' lon='-104.89970698748' />
+  <node id='51' visible='true' version='1' lat='38.8545784972' lon='-104.89971713684' />
+  <node id='52' visible='true' version='1' lat='38.85426183967' lon='-104.89971713684' />
+  <node id='53' visible='true' version='1' lat='38.8539525449' lon='-104.89968403932' />
+  <node id='54' visible='true' version='1' lat='38.85362483827' lon='-104.89969349575' />
+  <node id='55' visible='true' version='1' lat='38.85325834039' lon='-104.89975429289' />
+  <node id='56' visible='true' version='1' lat='38.8532424198' lon='-104.8996868264' />
+  <node id='57' visible='true' version='1' lat='38.8533001417' lon='-104.89945288282' />
+  <node id='58' visible='true' version='1' lat='38.85334704071' lon='-104.89936718072' />
+  <node id='59' visible='true' version='1' lat='38.8535165984' lon='-104.89926989725' />
+  <node id='60' visible='true' version='1' lat='38.85356890867' lon='-104.89905680013' />
+  <node id='61' visible='true' version='1' lat='38.85355087065' lon='-104.89883212164' />
+  <node id='62' visible='true' version='1' lat='38.8536194151' lon='-104.89870704289' />
+  <node id='63' visible='true' version='1' lat='38.85372042786' lon='-104.89872325681' />
+  <node id='64' visible='true' version='1' lat='38.85395852879' lon='-104.89891550747' />
+  <node id='65' visible='true' version='1' lat='38.85413349638' lon='-104.89889002847' />
+  <node id='66' visible='true' version='1' lat='38.85417678727' lon='-104.89870704289' />
+  <node id='67' visible='true' version='1' lat='38.85423270462' lon='-104.8983109602' />
+  <node id='68' visible='true' version='1' lat='38.85442931691' lon='-104.89806543526' />
+  <node id='69' visible='true' version='1' lat='38.85460428335' lon='-104.89777590113' />
+  <node id='70' visible='true' version='1' lat='38.85471972489' lon='-104.89732191161' />
+  <node id='71' visible='true' version='1' lat='38.85486041901' lon='-104.89685865699' />
+  <node id='72' visible='true' version='1' lat='38.85490190568' lon='-104.89643941157' />
+  <node id='75' visible='true' version='1' lat='38.85496143' lon='-104.89971240863' />
+  <node id='76' visible='true' version='1' lat='38.85490731699' lon='-104.89618230526' />
+  <node id='101' visible='true' version='1' lat='38.85495396551' lon='-104.8998993' />
+  <node id='102' visible='true' version='1' lat='38.85426144291' lon='-104.8998993' />
+  <way id='1' visible='true' version='1'>
+    <nd ref='9' />
+    <nd ref='8' />
+    <nd ref='7' />
+    <nd ref='6' />
+    <nd ref='5' />
+    <nd ref='101' />
+    <nd ref='75' />
+    <nd ref='51' />
+    <nd ref='52' />
+    <nd ref='50' />
+    <nd ref='53' />
+    <nd ref='54' />
+    <nd ref='55' />
+    <nd ref='56' />
+    <nd ref='57' />
+    <nd ref='58' />
+    <nd ref='59' />
+    <nd ref='60' />
+    <nd ref='61' />
+    <nd ref='62' />
+    <nd ref='63' />
+    <nd ref='64' />
+    <nd ref='65' />
+    <nd ref='66' />
+    <nd ref='67' />
+    <nd ref='68' />
+    <nd ref='69' />
+    <nd ref='70' />
+    <nd ref='71' />
+    <nd ref='72' />
+    <nd ref='76' />
+    <tag k='error:circular' v='15' />
+    <tag k='highway' v='road' />
+    <tag k='note' v='1' />
+  </way>
+  <way id='2' visible='true' version='1'>
+    <nd ref='1' />
+    <nd ref='2' />
+    <nd ref='3' />
+    <nd ref='102' />
+    <nd ref='52' />
+    <tag k='error:circular' v='15' />
+    <tag k='highway' v='road' />
+    <tag k='note' v='2' />
+  </way>
+  <way id='4' visible='true' version='1'>
+    <nd ref='3' />
+    <nd ref='4' />
+    <nd ref='5' />
+    <tag k='error:circular' v='15' />
+    <tag k='highway' v='road' />
+    <tag k='note' v='4' />
+  </way>
+</osm>


### PR DESCRIPTION
Converted `OsmApiReader` to actually stream data from the API.

Closes #5489 