### PR TITLE
update fasterxml to 2.14.1

### DIFF
--- a/hoot-services/pom.xml
+++ b/hoot-services/pom.xml
@@ -28,7 +28,7 @@
         <apache.commons.exec.version>1.3</apache.commons.exec.version>
         <apache.commons.io.version>2.10.0</apache.commons.io.version>
         <apache.commons.lang3.version>3.12.0</apache.commons.lang3.version>
-        <fasterxml-jackson.version>2.13.4</fasterxml-jackson.version>
+        <fasterxml-jackson.version>2.14.1</fasterxml-jackson.version>
         <guava.version>30.1.1-jre</guava.version>
         <httpasyncclient.version>4.1.4</httpasyncclient.version>
         <httpclient.version>4.5.13</httpclient.version>


### PR DESCRIPTION
Soon as I updated to 2.13.4 I got another dependabot finding.
Reading through the [issue](https://github.com/FasterXML/jackson-databind/issues/3590) for fasterxml there are patch `2.12.7.1` releases in some package manager that is not the maven [repo](https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/) is reading from. Issue also describes updating to greater than or equal to 2.14.0 should remove the vulnerability