### PR TITLE
Fix OsmXmlDiskCache temp dir error

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlDiskCache.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlDiskCache.cpp
@@ -40,8 +40,15 @@ namespace hoot
 
 OsmXmlDiskCache::OsmXmlDiskCache()
 {
+  // Check for temp dir
+  // If $HOOT_HOME/tmp doesn't exist, and we can't make it, then use /tmp
+  QString tempDir = ConfPath::getHootHome() + "/tmp";
+  if (!QDir(tempDir).exists())
+    if (!QDir(tempDir).mkpath("."))
+      tempDir = "/tmp";
+
   // Setup our temp file & get guaranteed unique name
-  QString fnameTemplate = ConfPath::getHootHome() + "/tmp/disk.cache.osm.XXXXXX";
+  QString fnameTemplate = tempDir + "/disk.cache.osm.XXXXXX";
   _pTempFile = std::make_shared<QTemporaryFile>(fnameTemplate);
   if (!_pTempFile->open())
   {


### PR DESCRIPTION
Try to create the temp dir, and if that fails - ball back to /tmp