### PR TITLE
Don't require a node-export datasource named "Overpass"

### DIFF
--- a/node-export-server/config.json
+++ b/node-export-server/config.json
@@ -8,9 +8,6 @@
     },
     "RenderDb": {
       "conn": "PG:dbname='osmhaiti' host='192.168.33.12' port='5432' user='vagrant' password=''"
-    },
-    "Overpass": {
-      "conn": "https://overpass-api.de/api/interpreter"
     }
   },
   "formats": {

--- a/node-export-server/server.js
+++ b/node-export-server/server.js
@@ -157,8 +157,9 @@ app.post('/export/:datasource/:schema/:format', function(req, res) {
 /* Validate export params */
 function validateExportParams(req, res) {
     var message;
-    // check the datasource
-    if (!config.datasources[req.params.datasource]) {
+    // check the datasource if request is GET
+    // POST requests supplying own data can send whatever datasource string they want
+    if (req.method === 'GET' && !config.datasources[req.params.datasource]) {
         message = `Datasource "${req.params.datasource}" not found`;
     }
     // check the schema


### PR DESCRIPTION
when POSTing an Overpass query result to the node-export server, it uses the <datasource> path param "Overpass".  A while ago parameter validation was added, but when using the POST endpoint (data is provided in the payload) the datasource param should just be ignored.