### PR TITLE
POI to Polygon conflation of cemeteries doesn't work

### DIFF
--- a/conf/schema/amenity.json
+++ b/conf/schema/amenity.json
@@ -755,15 +755,12 @@
         "objectType": "tag"
     },
     {
-        "categories": [
-            "multiuse"
-        ],
         "isA": "amenity",
         "name": "amenity=grave_yard",
         "objectType": "tag",
         "similarTo": [
-            { "name": "amenity=cemetery", "weight": 0.6 },
-            { "name": "landuse=cemetery", "weight": 0.6 }
+            { "name": "amenity=cemetery", "weight": 0.8 },
+            { "name": "landuse=cemetery", "weight": 0.8 }
         ]
     },
     {

--- a/conf/schema/landuse.json
+++ b/conf/schema/landuse.json
@@ -23,10 +23,10 @@
         "isA": "landuse",
         "name": "landuse=cemetery",
         "objectType": "tag",
-        "similarTo": {
-                "name": "cemetery",
-                "weight": 0.8
-         }
+        "similarTo": [
+            { "name": "cemetery", "weight": 0.8 },
+            { "name": "amenity=cemetery", "weight": 0.8 }
+         ]
     },
     {
         "#": "TODO: This doesn't seem to exist in public OSM.",

--- a/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonReviewReducer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/poi-polygon/PoiPolygonReviewReducer.cpp
@@ -102,8 +102,6 @@ bool PoiPolygonReviewReducer::triggersRule(ConstNodePtr poi, ConstElementPtr pol
 {
   LOG_TRACE("Checking review reduction rules...");
   _triggeredRuleDescription = "";
-  //QElapsedTimer timer;
-  //const int timingThreshold = 1000000;  //nanosec
 
   const Tags& poiTags = poi->getTags();
   const Tags& polyTags = poly->getTags();
@@ -409,7 +407,7 @@ bool PoiPolygonReviewReducer::triggersRule(ConstNodePtr poi, ConstElementPtr pol
   // Don't review park poi's against large non-park polys.
   ruleDescription = "#22: park poi/poly 1";
   LOG_TRACE("Checking rule : " << ruleDescription << "...");
-  if (poiHasType && polyHasType && !_nameMatch && !polyIsPark &&
+  if (poiHasType && polyHasType && !_nameMatch && poiIsParkish && !polyIsPark &&
       (((polyHasLanduse && !poiHasLanduse) ||
        (polyIsNatural && !poiIsNatural) ||
         polyLeisureVal == QLatin1String("common")) ||
@@ -451,6 +449,7 @@ bool PoiPolygonReviewReducer::triggersRule(ConstNodePtr poi, ConstElementPtr pol
       // relation member.
       if (numPolyAddresses < 2 && _infoCache->containsMember(poly, poi->getElementId()))
       {
+        //  Do nothing
       }
       else if (_addressScore < 0.8)
       {
@@ -516,8 +515,7 @@ bool PoiPolygonReviewReducer::triggersRule(ConstNodePtr poi, ConstElementPtr pol
         //timer.restart();
         if (poiIsSport && _infoCache->isType(polyNeighbor, PoiPolygonSchemaType::Sport) &&
             _infoCache->elementContains(polyNeighbor, poi) &&
-            PoiPolygonTypeScoreExtractor(_infoCache).extract(*_map, poi, polyNeighbor) >=
-             _typeScoreThreshold)
+            PoiPolygonTypeScoreExtractor(_infoCache).extract(*_map, poi, polyNeighbor) >= _typeScoreThreshold)
         {
           sportPoiOnOtherSportPolyWithTypeMatch = true;
         }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.cpp
@@ -360,6 +360,13 @@ void OsmXmlWriter::_writeRelations(ConstOsmMapPtr map)
 
 void OsmXmlWriter::_writeBounds(const Envelope& bounds) const
 {
+  //  Validate the bounds before writing the "bounds" XML element
+  if (bounds.getMinX() == geos::DoubleNegInfinity || bounds.getMaxX() == geos::DoubleInfinity ||
+      bounds.getMinY() == geos::DoubleNegInfinity || bounds.getMaxY() == geos::DoubleInfinity ||
+      bounds.isNull())
+  {
+    return;
+  }
   _writer->writeStartElement("bounds");
   _writer->writeAttribute("minlat", QString::number(bounds.getMinY(), 'g', _precision));
   _writer->writeAttribute("minlon", QString::number(bounds.getMinX(), 'g', _precision));


### PR DESCRIPTION
Fix conflation between POIs with `amenity=grave_yard` and polygons with `landuse=cemetery` that weren't conflating.

Closes #5533 