### PR TITLE
Update `ParallelBoundedReader::_isQueryError()` to handle XML responses

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/ParallelBoundedApiReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ParallelBoundedApiReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2022, 2023 Maxar (http://www.maxar.com/)
  */
 
 // Hoot
@@ -44,8 +44,9 @@ public:
 
   void parseErrorTest()
   {
+    QString expected_result = "runtime error: Query ran out of memory in \"query\" at line 1. It would need at least 95 MB of RAM to continue.";
     ParallelBoundedApiReader uut;
-    QString result =
+    QString json_result =
         "{"
         "\"version\": 0.6,"
         "\"generator\": \"NOME Overpass API 0.7.57 c954ae26\","
@@ -58,8 +59,19 @@ public:
         "\"remark\": \"runtime error: Query ran out of memory in \"query\" at line 1. It would need at least 95 MB of RAM to continue.\""
         "}";
     QString error;
-    CPPUNIT_ASSERT(uut._isQueryError(result, error));
-    HOOT_STR_EQUALS("runtime error: Query ran out of memory in \"query\" at line 1. It would need at least 95 MB of RAM to continue.", error);
+    CPPUNIT_ASSERT(uut._isQueryError(json_result, error));
+    HOOT_STR_EQUALS(expected_result, error);
+
+    QString xml_result =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<osm version=\"0.6\" generator=\"NOME Overpass API 0.7.57 c954ae26\">"
+        "<note>The data included in this document is from NOME and OpenStreetMap. The data is made available under ODbL. data included in this document falls under NOME Terms of Use https://nome.vgihub.geointservices.io/disclaimer/NOME_Enclave_Disclaimer_V4.pdf</note>"
+        "<meta osm_base=\"2021-09-09T17:21:17Z\"/>"
+        "<remark> runtime error: Query ran out of memory in \"query\" at line 1. It would need at least 95 MB of RAM to continue. </remark>"
+        "</osm>";
+    error = "";
+    CPPUNIT_ASSERT(uut._isQueryError(xml_result, error));
+    HOOT_STR_EQUALS(expected_result, error);
   }
 
 };


### PR DESCRIPTION
Update error handling for XML responses in `_isQueryError` and unit tests.

Closes #5545 