### PR TITLE
Overpass queries in XML failing

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
@@ -232,7 +232,7 @@ void OsmApiReader::initializePartial()
   }
 
   //  Spin up the threads. Use the envelope of the bounds to throw away any non-retangular bounds
-  // that may have been  passed.
+  //  that may have been passed.
   beginRead(_url, *(_bounds->getEnvelopeInternal()));
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
@@ -231,7 +231,7 @@ void OsmApiReader::initializePartial()
     finalizePartial();
   }
 
-  //  Spin up the threads. Use the envelope of the boundsto throw away any non-retangular bounds
+  //  Spin up the threads. Use the envelope of the bounds to throw away any non-retangular bounds
   // that may have been  passed.
   beginRead(_url, *(_bounds->getEnvelopeInternal()));
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
@@ -862,6 +862,7 @@ void OsmJsonReader::_readFromHttp()
   if (urlQuery.hasQueryItem("srsname"))
     urlQuery.removeQueryItem("srsname");
   urlQuery.addQueryItem("srsname", "EPSG:4326");
+  _sourceUrl.setQuery(urlQuery);
   geos::geom::Envelope env;
 
   if (!_bounds) // If no bounds was set, the read method still expects an empty one.

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
@@ -862,14 +862,6 @@ void OsmJsonReader::_readFromHttp()
   if (urlQuery.hasQueryItem("srsname"))
     urlQuery.removeQueryItem("srsname");
   urlQuery.addQueryItem("srsname", "EPSG:4326");
-  //  Load the query from a file if requested
-  if (!urlQuery.hasQueryItem("data") && !_queryFilepath.isEmpty())
-  {
-    QString query = FileUtils::readFully(_queryFilepath).replace("\r", "").replace("\n", "");
-    //  Should the query be validated here?
-    urlQuery.addQueryItem("data", query);
-  }
-  _sourceUrl.setQuery(urlQuery);
   geos::geom::Envelope env;
 
   if (!_bounds) // If no bounds was set, the read method still expects an empty one.

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
@@ -77,6 +77,14 @@ void ParallelBoundedApiReader::beginRead(const QUrl& endpoint, const geos::geom:
     throw UnsupportedException(QString("Cannot request areas larger than %1 square degrees.").arg(QString::number(_maxGridSize, 'f', 4)));
   //  Save the endpoint URL to query
   _sourceUrl = endpoint;
+  //  Load the query from a file if requested
+  if (!urlQuery.hasQueryItem("data") && !_queryFilepath.isEmpty())
+  {
+    QString query = FileUtils::readFully(_queryFilepath).replace("\r", "").replace("\n", "");
+    //  Should the query be validated here?
+    urlQuery.addQueryItem("data", query);
+  }
+  _sourceUrl.setQuery(urlQuery);
   //  Split the envelope if it is bigger than the prescribed max
   int lon_div = 1;
   int lat_div = 1;
@@ -275,7 +283,7 @@ void ParallelBoundedApiReader::_process()
             //  Reset the timeout because this thread has successfully received a response
             timeout = 0;
             //  Update the user status
-            LOG_STATUS("Downloaded area (" << GeometryUtils::toMinMaxString(envelope) << ")");
+            LOG_STATUS("Downloaded area (" << GeometryUtils::toLonLatString(envelope) << ")");
           }
         }
         catch(const std::bad_alloc&)

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
@@ -78,6 +78,7 @@ void ParallelBoundedApiReader::beginRead(const QUrl& endpoint, const geos::geom:
   //  Save the endpoint URL to query
   _sourceUrl = endpoint;
   //  Load the query from a file if requested
+  QUrlQuery urlQuery(_sourceUrl);
   if (!urlQuery.hasQueryItem("data") && !_queryFilepath.isEmpty())
   {
     QString query = FileUtils::readFully(_queryFilepath).replace("\r", "").replace("\n", "");

--- a/hoot-core/src/main/cpp/hoot/core/util/DateTimeUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/DateTimeUtils.h
@@ -31,7 +31,7 @@
 namespace hoot
 {
 
-typedef quint64 OsmTimestamp;
+using OsmTimestamp = quint64;
 
 /**
  * Utilities for date/time manipulation


### PR DESCRIPTION
Load overpass queryfile in `ParallelBoundedReader` instead of `OsmJsonReader` so that both XML and JSON Overpass queries use the query.

Closes #5543 