### PR TITLE
Attribute Conflation Errors

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -142,6 +142,7 @@ turned off when running certain unit tests which are incompatible with it being 
 ** `avenue=ave`
 ** `boulevard=blvd`
 ** `circle=cir`
+** `drive=dr`
 ** `freeway=fwy`
 ** `highway=hwy`
 ** `lane=ln`

--- a/hoot-core/src/main/cpp/hoot/core/elements/Tags.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Tags.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
  */
 
 #include "Tags.h"

--- a/hoot-core/src/main/cpp/hoot/core/elements/Tags.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/Tags.cpp
@@ -28,6 +28,7 @@
 #include "Tags.h"
 
 // Hoot
+#include <hoot/core/conflate/address/Address.h>
 #include <hoot/core/schema/MetadataTags.h>
 #include <hoot/core/schema/OsmSchema.h>
 #include <hoot/core/util/ConfigOptions.h>
@@ -393,9 +394,15 @@ bool Tags::haveMatchingName(const Tags& tags1, const Tags& tags2, const bool str
   const QStringList tag2Names = tags2.getNames(!strictNameMatch);
   for (const auto& tag1Name : tag1Names)
   {
+    Address addr1(tag1Name);
+    if (!strictNameMatch)
+      addr1.removeStreetTypes();
     for (const auto& tag2Name : tag2Names)
     {
-      if (tag1Name.compare(tag2Name, Qt::CaseInsensitive) == 0)
+      Address addr2(tag2Name);
+      if (!strictNameMatch)
+        addr2.removeStreetTypes();
+      if (addr1.getAddressStr().compare(addr2.getAddressStr(), Qt::CaseInsensitive) == 0)
         return true;
     }
   }


### PR DESCRIPTION
Update the name matching in the Tags class to ignore street types
Expand the address.street.types to include drive

Closes #5549 