### PR TITLE
Add option to turn on/off OGR writer polygon cropping

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -3861,6 +3861,13 @@ from a translation.
 Create all layers when using the OGR writer whether or not the layers contain features. Setting
 this to true can be useful when conforming to strict specifications.
 
+=== ogr.writer.crop.features.crossing.bounds
+
+* Data Type: bool
+* Default Value: `false`
+
+The OGR writer can crop linear and polygon elements to the `bounds` of the operation if set to true.
+
 === ogr.writer.pre.layer.name
 
 * Data Type: string

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -100,7 +100,8 @@ OgrWriter::OgrWriter()
     _numWritten(0),
     _transactionSize(ConfigOptions().getOgrWriterTransactionSize()),
     _inTransaction(false),
-    _statusUpdateInterval(ConfigOptions().getTaskStatusUpdateInterval() * 10)
+    _statusUpdateInterval(ConfigOptions().getTaskStatusUpdateInterval() * 10),
+    _cropFeaturesCrossingBounds(ConfigOptions().getOgrWriterCropFeaturesCrossingBounds())
 {
   setConfiguration(conf());
 
@@ -134,6 +135,7 @@ void OgrWriter::setConfiguration(const Settings& conf)
   _statusUpdateInterval = configOptions.getTaskStatusUpdateInterval() * 10;
   _forceSkipFailedRelations = configOptions.getOgrWriterSkipFailedRelations();
   _transactionSize = configOptions.getOgrWriterTransactionSize();
+  _cropFeaturesCrossingBounds = configOptions.getOgrWriterCropFeaturesCrossingBounds();
   //  Set the bounds for cropped lines and polygons
   setBounds(Boundable::loadBounds(configOptions));
 }
@@ -727,7 +729,7 @@ void OgrWriter::_addFeatureToLayer(OGRLayer* layer, const std::shared_ptr<Featur
     return;
   std::string wkt;
   //  Get the WKT of the geometry (full or intersection) to convert to OGR geometry
-  if (_bounds && g->intersects(_bounds.get()))
+  if (_cropFeaturesCrossingBounds && _bounds && g->intersects(_bounds.get()))
   {
     //  Get the intersection of the geometry with the bounding envelope
     std::unique_ptr<geos::geom::Geometry> intersection = g->intersection(_bounds.get());

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
@@ -113,6 +113,9 @@ private:
 
   bool _forceSkipFailedRelations;
 
+  /** Crop any features that cross the `bounds` of the operation */
+  bool _cropFeaturesCrossingBounds;
+
   void _addFeature(OGRLayer* layer, const std::shared_ptr<Feature>& f,
                    const std::shared_ptr<geos::geom::Geometry>& g) const;
   void _addFeatureToLayer(OGRLayer* layer, const std::shared_ptr<Feature>& f, const geos::geom::Geometry* g,

--- a/test-files/cmd/slow/ConvertCmdTest.sh
+++ b/test-files/cmd/slow/ConvertCmdTest.sh
@@ -172,6 +172,7 @@ echo ""
 rm -rf $OUTPUT_DIR/clipped_poly/
 hoot convert $LOG_LEVEL $CONFIG $TRANSLATION_TDS \
   -D bounds="-104.80643134164,39.59123123677,-104.8042456804,39.59369827561" \
+  -D ogr.writer.crop.features.crossing.bounds=true \
   test-files/ToyBuildingsTestA.osm $OUTPUT_DIR/clipped_poly.shp
 hoot convert $LOG_LEVEL $CONFIG $TRANSLATION_TDS \
   $OUTPUT_DIR/clipped_poly/ $OUTPUT_DIR/clipped_poly.osm
@@ -183,6 +184,7 @@ echo ""
 rm -rf $OUTPUT_DIR/clipped_lines/
 hoot convert $LOG_LEVEL $CONFIG $TRANSLATION_TDS \
   -D bounds="-104.90022388323,38.85350714489,-104.8983212846,38.85504576826" \
+  -D ogr.writer.crop.features.crossing.bounds=true \
   test-files/ToyTestA.osm $OUTPUT_DIR/clipped_lines.shp
 hoot convert $LOG_LEVEL $CONFIG $TRANSLATION_TDS \
   $OUTPUT_DIR/clipped_lines/ $OUTPUT_DIR/clipped_lines.osm


### PR DESCRIPTION
Added `ogr.writer.crop.features.crossing.bounds` option (defaults to false) to control the OGR writer's cropping code.

Closes #5552 