### PR TITLE
`Remark` tags cause Hoot to parse Overpass JSON incorrectly

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/ParallelBoundedApiReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ParallelBoundedApiReaderTest.cpp
@@ -46,23 +46,23 @@ public:
   {
     QString expected_result = "runtime error: Query ran out of memory in \"query\" at line 1. It would need at least 95 MB of RAM to continue.";
     ParallelBoundedApiReader uut;
-    QString json_result =
+    QString json_error_result =
         "{"
         "\"version\": 0.6,"
         "\"generator\": \"NOME Overpass API 0.7.57 c954ae26\","
         "\"osm3s\": {"
-        "  \"timestamp_osm_base\": \"2021-09-09T17:21:17Z\","
-        "  \"copyright\": \"The data included in this document is from NOME and OpenStreetMap. The data is made available under ODbL. data included in this document falls under NOME Terms of Use https://nome.vgihub.geointservices.io/disclaimer/NOME_Enclave_Disclaimer_V4.pdf\""
+        "\"timestamp_osm_base\": \"2021-09-09T17:21:17Z\","
+        "\"copyright\": \"The data included in this document is from NOME and OpenStreetMap. The data is made available under ODbL. data included in this document falls under NOME Terms of Use https://nome.vgihub.geointservices.io/disclaimer/NOME_Enclave_Disclaimer_V4.pdf\""
         "},"
         "\"elements\": ["
         "],"
         "\"remark\": \"runtime error: Query ran out of memory in \"query\" at line 1. It would need at least 95 MB of RAM to continue.\""
         "}";
     QString error;
-    CPPUNIT_ASSERT(uut._isQueryError(json_result, error));
+    CPPUNIT_ASSERT(uut._isQueryError(json_error_result, error));
     HOOT_STR_EQUALS(expected_result, error);
 
-    QString xml_result =
+    QString xml_error_result =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         "<osm version=\"0.6\" generator=\"NOME Overpass API 0.7.57 c954ae26\">"
         "<note>The data included in this document is from NOME and OpenStreetMap. The data is made available under ODbL. data included in this document falls under NOME Terms of Use https://nome.vgihub.geointservices.io/disclaimer/NOME_Enclave_Disclaimer_V4.pdf</note>"
@@ -70,8 +70,23 @@ public:
         "<remark> runtime error: Query ran out of memory in \"query\" at line 1. It would need at least 95 MB of RAM to continue. </remark>"
         "</osm>";
     error = "";
-    CPPUNIT_ASSERT(uut._isQueryError(xml_result, error));
+    CPPUNIT_ASSERT(uut._isQueryError(xml_error_result, error));
     HOOT_STR_EQUALS(expected_result, error);
+
+    /** This data caused infinite splitting in JOSM because of the 'remark' tag */
+    QString json_success =
+        "{"
+        "\"version\": 0.6,"
+        "\"generator\": \"NOME Overpass API 0.7.57 c954ae26\","
+        "\"osm3s\": {"
+        "\"timestamp_osm_base\": \"2023-01-20T20:40:19Z\","
+        "\"copyright\": \"The data included in this document is from NOME and OpenStreetMap. The data is made available under ODbL. data included in this document falls under NOME Terms of Use https://nome.vgihub.geointservices.io/disclaimer/NOME_Enclave_Disclaimer_V4.pdf\""
+        "},"
+        "\"elements\": ["
+        "\"{\"type\": \"node\",\"id\": 3767576613,\"lat\": 47.8026036,\"lon\": 18.9633523,\"tags\": {\"name\": \"Nagyne Marika\",\"remark\": \"2012-2014\"}}]}}";
+    error = "";
+    CPPUNIT_ASSERT(!uut._isQueryError(json_success, error));
+    HOOT_STR_EQUALS("", error);
   }
 
 };
@@ -79,4 +94,3 @@ public:
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ParallelBoundedApiReaderTest, "quick");
 
 }
-

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of Hootenanny.
  *
  * Hootenanny is free software: you can redistribute it and/or modify

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of Hootenanny.
  *
  * Hootenanny is free software: you can redistribute it and/or modify
@@ -643,7 +643,7 @@ OGRLayer* OgrWriter::_getLayer(const QString& layerName)
 
 void OgrWriter::_addFeature(OGRLayer* layer, const std::shared_ptr<Feature>& f, const std::shared_ptr<Geometry>& g) const
 {
-  OGRFeature* poFeature = OGRFeature::CreateFeature( layer->GetLayerDefn() );
+  OGRFeature* poFeature = OGRFeature::CreateFeature(layer->GetLayerDefn());
 
   // set all the column values.
   const QVariantMap& vm = f->getValues();
@@ -730,19 +730,95 @@ void OgrWriter::_addFeatureToLayer(OGRLayer* layer, const std::shared_ptr<Featur
   if (_bounds && g->intersects(_bounds.get()))
   {
     //  Get the intersection of the geometry with the bounding envelope
-    std::unique_ptr<geos::geom::Geometry> intersection = g->intersection(_bounds.get());
-    wkt = intersection->toString();
+    try
+    {
+      std::unique_ptr<geos::geom::Geometry> intersection = g->intersection(_bounds.get());
+      wkt = intersection->toString();
+    }
+    catch (const geos::util::TopologyException& ex)
+    {
+      LOG_ERROR("Did this fail? - " << ex.what());
+    }
+    catch (...)
+    {
+      LOG_ERROR("Got an error here.");
+    }
+
+/*
+    switch (intersection->getGeometryTypeId())
+    {
+    default:
+    case GEOS_POINT:
+    case GEOS_LINESTRING:
+    case GEOS_LINEARRING:
+    case GEOS_POLYGON:
+    case GEOS_MULTIPOINT:
+    case GEOS_MULTILINESTRING:
+    case GEOS_MULTIPOLYGON:
+    case GEOS_GEOMETRYCOLLECTION:
+      layer->GetGeomType();
+      wkbPoint = 1,
+      wkbLineString = 2,
+      wkbPolygon = 3,
+      wkbMultiPoint = 4,
+      wkbMultiLineString = 5,
+      wkbMultiPolygon = 6,
+      wkbGeometryCollection = 7
+
+      break;
+    }
+    if (intersection->getGeometryTypeId())
+*/
   }
   else
     wkt = g->toString();
   //  Convert the WKT to an OGR geometry for saving
   const char* t = wkt.data();
   OGRGeometry* geom;
-  int errCode = OGRGeometryFactory::createFromWkt(&t, layer->GetSpatialRef(), &geom) ;
+  //Catch here and do something with the self intersecting geometries
+  int errCode;
+  try
+  {
+    errCode = OGRGeometryFactory::createFromWkt(&t, layer->GetSpatialRef(), &geom) ;
+  }
+  catch (...)
+  {
+    LOG_ERROR("createFromWkt() error");
+    //  TODO: Try again with:
+    //    std::shared_ptr<Geometry> cleanedGeom(GeometryUtils::validateGeometry(pGeometry.get()));
+    return;
+  }
   if (errCode != OGRERR_NONE)
     throw HootException(QString("Error parsing WKT (%1).  OGR Error Code: (%2)").arg(QString::fromStdString(wkt), QString::number(errCode)));
+/*
+  OGRwkbGeometryType layerType = layer->GetGeomType();
+  OGRwkbGeometryType geomType = geom->getGeometryType();
 
+  if (geomType == wkbMultiPolygon && layerType == wkbPolygon)
+  {
+    LOG_ERROR("Multipolygon into Polygon layer");
+  }
+  else if (geomType == wkbMultiLineString && layerType == wkbLineString)
+  {
+    LOG_ERROR("Multipolygon into Polygon layer");
+  }
+*/
+//  if (geom->getGeometryType() != layer->GetGeomType())
+//  {
+//    LOG_ERROR("Layer-type mismatch.");
+//    return;
+//  }
+
+  try
+  {
   errCode = poFeature->SetGeometryDirectly(geom);
+  }
+  catch (...)
+  {
+    LOG_ERROR("SetGeometryDirectly() Error");
+    return;
+  }
+
   if (errCode != OGRERR_NONE)
     throw HootException(QString("Error setting geometry - OGR Error Code: (%1)  Geometry: (%2)").arg(QString::number(errCode), QString::fromStdString(g->toString())));
 
@@ -750,7 +826,15 @@ void OgrWriter::_addFeatureToLayer(OGRLayer* layer, const std::shared_ptr<Featur
   // feature object for sequential insertions
   poFeature->SetFID(-1);
 
-  errCode = layer->CreateFeature(poFeature);
+  try
+  {
+    errCode = layer->CreateFeature(poFeature);
+  }
+  catch (...)
+  {
+    LOG_ERROR("CreateFeature() error");
+    return;
+  }
   if (errCode != OGRERR_NONE)
     throw HootException(QString("Error creating feature - OGR Error Code: (%1) \nFeature causing error: (%2)").arg(QString::number(errCode), f->toString()));
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -1,3 +1,29 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. Maxar
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
+ */
 #include "OgrWriter.h"
 
 // geos

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -1,29 +1,3 @@
-/*
- * This file is part of Hootenanny.
- *
- * Hootenanny is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * --------------------------------------------------------------------
- *
- * The following copyright notices are generated automatically. If you
- * have a new notice to add, please use the format:
- * " * @copyright Copyright ..."
- * This will properly maintain the copyright information. Maxar
- * copyrights will be updated automatically.
- *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
- */
 #include "OgrWriter.h"
 
 // geos

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -1,3 +1,29 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. Maxar
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
+ */
 ﻿/*
  * This file is part of Hootenanny.
  *

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -1,29 +1,3 @@
-/*
- * This file is part of Hootenanny.
- *
- * Hootenanny is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * --------------------------------------------------------------------
- *
- * The following copyright notices are generated automatically. If you
- * have a new notice to add, please use the format:
- * " * @copyright Copyright ..."
- * This will properly maintain the copyright information. Maxar
- * copyrights will be updated automatically.
- *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
- */
 ﻿/*
  * This file is part of Hootenanny.
  *

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
@@ -427,7 +427,7 @@ bool ParallelBoundedApiReader::_isQueryError(const QString& result, QString& err
   static QRegularExpression regexXml("<remark> (.*) </remark>", QRegularExpression::OptimizeOnFirstUsageOption);
   //  JSON handling regular expression
   //  "remark": "runtime error: Query ran out of memory in \"query\" at line 10. It would need at least 0 MB of RAM to continue."
-  static QRegularExpression regexJson("[\"|\']remark[\"|\'|>]: *[\"|\']?(.*)[\"|\']", QRegularExpression::OptimizeOnFirstUsageOption);
+  static QRegularExpression regexJson("[\"|\']remark[\"|\'|>]: *[\"|\']?(runtime error.*)[\"|\']", QRegularExpression::OptimizeOnFirstUsageOption);
   static std::vector<QRegularExpression> regexes({regexXml, regexJson});
 
   for (const auto& regex : regexes)


### PR DESCRIPTION
Using a regex instead of parsing the JSON/XML to speed up error detection and the regex didn't take into account a `remark` tag.  This fixes the remark tag issue.

Closes #5554 