### PR TITLE
Self-intersecting Geometry Issue

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetTaskGridReplacer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetTaskGridReplacer.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
  */
 #include "ChangesetTaskGridReplacer.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetTaskGridReplacer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/changeset/ChangesetTaskGridReplacer.cpp
@@ -81,9 +81,7 @@ OsmMapPtr ChangesetTaskGridReplacer::replace(const QString& toReplace, const QSt
   try
   {
     _replaceEntireTaskGrid(taskGrid);
-    LOG_STATUS(
-      "Task grid cell replacement operation successfully completed in: " <<
-      StringUtils::millisecondsToDhms(_opTimer.elapsed()));
+    LOG_STATUS("Task grid cell replacement operation successfully completed in: " << StringUtils::millisecondsToDhms(_opTimer.elapsed()));
     return _writeUpdatedData(_finalOutput);
   }
   catch (const HootException& e)
@@ -129,7 +127,7 @@ void ChangesetTaskGridReplacer::_initChangesetStats()
 
 void ChangesetTaskGridReplacer::_replaceEntireTaskGrid(const TaskGrid& taskGrid)
 {
-  _changesetCreator =Factory::getInstance().constructObject<ChangesetReplacement>(ConfigOptions().getChangesetReplacementImplementation());
+  _changesetCreator = Factory::getInstance().constructObject<ChangesetReplacement>(ConfigOptions().getChangesetReplacementImplementation());
   _changesetCreator->setChangesetOptions(true, "", _dataToReplaceUrl);
   LOG_VARD(_changesetCreator->toString());
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/ExternalMergeElementSorter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ExternalMergeElementSorter.cpp
@@ -328,6 +328,7 @@ ElementPriorityQueue ExternalMergeElementSorter::_getInitializedPriorityQueue(QL
     if (xmlReader.get())
     {
       xmlReader->setAddChildRefsWhenMissing(true);
+      xmlReader->setCropOnReadIfBounded(false);
     }
 
     reader->setUseDataSourceIds(true);

--- a/hoot-core/src/main/cpp/hoot/core/elements/ExternalMergeElementSorter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ExternalMergeElementSorter.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018, 2019, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
  */
 
 #include "ExternalMergeElementSorter.h"

--- a/hoot-core/src/main/cpp/hoot/core/geometry/ElementToGeometryConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/ElementToGeometryConverter.cpp
@@ -217,15 +217,6 @@ std::shared_ptr<LineString> ElementToGeometryConverter::convertToLineString(cons
 
 std::shared_ptr<Polygon> ElementToGeometryConverter::convertToPolygon(const ConstWayPtr& w) const
 {
-  //  Ignore bad data, unclosed, area=yes, with no other information
-  if (w->getTags().contains("area") &&
-      w->getTags().get("area").compare("yes", Qt::CaseInsensitive) == 0 &&    //  Area (area=yes)
-      w->getNodeIds().at(0) != w->getNodeIds().at(w->getNodeCount() - 1) &&   //  Unclosed way
-      w->getTags().getInformationCount() <= 1)                                //  No-information (aside from area=yes)
-  {
-    LOG_TRACE("Unclosed, area, no information: " << w->getElementId());
-    return nullptr;
-  }
   const std::vector<long>& ids = w->getNodeIds();
   LOG_VART(ids);
   size_t size = ids.size();

--- a/hoot-core/src/main/cpp/hoot/core/geometry/ElementToGeometryConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/ElementToGeometryConverter.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
  */
 
 #include "ElementToGeometryConverter.h"

--- a/hoot-core/src/main/cpp/hoot/core/geometry/RelationToMultiPolygonConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/RelationToMultiPolygonConverter.cpp
@@ -450,7 +450,7 @@ void RelationToMultiPolygonConverter::_createRingsFromPartials(const vector<Cons
     ConstWayPtr wi = partials[i];
     if (!wi)
       continue;
-    for (size_t j = i + 1; j < partials.size(); j++)
+    for (size_t j = i; j < partials.size(); j++)
     {
       ConstWayPtr wj = partials[j];
       if (!wj)

--- a/hoot-core/src/main/cpp/hoot/core/geometry/RelationToMultiPolygonConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/RelationToMultiPolygonConverter.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
  */
 #include "RelationToMultiPolygonConverter.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/geometry/RelationToMultiPolygonConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/RelationToMultiPolygonConverter.cpp
@@ -450,7 +450,7 @@ void RelationToMultiPolygonConverter::_createRingsFromPartials(const vector<Cons
     ConstWayPtr wi = partials[i];
     if (!wi)
       continue;
-    for (size_t j = i; j < partials.size(); j++)
+    for (size_t j = i + 1; j < partials.size(); j++)
     {
       ConstWayPtr wj = partials[j];
       if (!wj)
@@ -476,8 +476,7 @@ void RelationToMultiPolygonConverter::_createSingleRing(const vector<ConstWayPtr
   LOG_TRACE("Creating single ring...");
 
   deque<ConstWayPtr> orderedWays = _orderWaysForRing(partials);
-  CoordinateSequence* cs =
-    GeometryFactory::getDefaultInstance()->getCoordinateSequenceFactory()->create((size_t)0, (size_t)2).release();
+  CoordinateSequence* cs = GeometryFactory::getDefaultInstance()->getCoordinateSequenceFactory()->create((size_t)0, (size_t)2).release();
 
   for (const auto& way : orderedWays)
     _addWayToSequence(way, *cs, false);

--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
  */
 #include "ApiDbReader.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ApiDbReader.cpp
@@ -66,6 +66,8 @@ ApiDbReader::ApiDbReader()
     _numRelationsRead(0),
     _keepImmediatelyConnectedWaysOutsideBounds(ConfigOptions().getBoundsKeepImmediatelyConnectedWaysOutsideBounds())
 {
+  //  API reads always crop bounds
+  _cropOnReadIfBounded = true;
 }
 
 bool ApiDbReader::isSupported(const QString& urlStr) const

--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
  */
 #include "DataConverter.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
@@ -97,6 +97,8 @@ private:
   Progress _progress;
   int _printLengthMax;
 
+  bool _cropReadIfBounded;
+
   void _validateInput(const QStringList& inputs, const QString& output) const;
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
  */
 #ifndef DATACONVERTER_H
 #define DATACONVERTER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/IoUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/IoUtils.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
  */
 
 #include "IoUtils.h"

--- a/hoot-core/src/main/cpp/hoot/core/io/IoUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/IoUtils.cpp
@@ -425,7 +425,7 @@ ElementInputStreamPtr IoUtils::getFilteredInputStream(ElementInputStreamPtr stre
 
 void IoUtils::loadMap(const OsmMapPtr& map, const QString& path, bool useFileId, Status defaultStatus,
                       const QString& translationScript, const int ogrFeatureLimit, const QString& jobSource,
-                      const int numTasks)
+                      const int numTasks, bool cropOnReadIfBounded)
 {
   const QStringList pathLayer = path.split(";");
   const QString justPath = pathLayer[0];
@@ -447,16 +447,16 @@ void IoUtils::loadMap(const OsmMapPtr& map, const QString& path, bool useFileId,
     reader.read(justPath, pathLayer.size() > 1 ? pathLayer[1] : "", map, jobSource, numTasks);
   }
   else  // This handles all non-OGR format reading.
-    OsmMapReaderFactory::read(map, path, useFileId, defaultStatus);
+    OsmMapReaderFactory::read(map, path, useFileId, defaultStatus, cropOnReadIfBounded);
 }
 
 void IoUtils::loadMaps(const OsmMapPtr& map, const QStringList& paths, bool useFileId, Status defaultStatus,
                        const QString& translationScript, const int ogrFeatureLimit, const QString& jobSource,
-                       const int numTasks)
+                       const int numTasks, bool cropOnReadIfBounded)
 {
   // TODO: it would be nice to allow this to take in Progress for updating
   for (const auto& path : paths)
-    loadMap(map, path, useFileId, defaultStatus, translationScript, ogrFeatureLimit, jobSource, numTasks);
+    loadMap(map, path, useFileId, defaultStatus, translationScript, ogrFeatureLimit, jobSource, numTasks, cropOnReadIfBounded);
 }
 
 void IoUtils::cropToBounds(OsmMapPtr& map, const geos::geom::Envelope& bounds, const bool keepConnectedOobWays)

--- a/hoot-core/src/main/cpp/hoot/core/io/IoUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/IoUtils.h
@@ -206,48 +206,44 @@ public:
                                                       const QStringList& ops);
 
   /**
-    Loads an OSM map into an OsmMap object
-
-    @param map the object to load the map into
-    @param path the file path to load the map from
-    @param useFileId if true, uses the element ID's in the map file; otherwise, generates new
-    element ID's
-    @param defaultStatus the hoot status to assign to all elements
-    @param translationScript script used to translate data; required only if the input is an OGR
-    format; ignored otherwise
-    @param ogrFeatureLimit limit of features to read per input; applicable to OGR inputs only;
-    ignored otherwise
-    @param jobSource job name for status reporting; applicable to OGR inputs only; ignored otherwise
-    @param numTasks number of job tasks being performed for status reporting; applicable to OGR
-    inputs only; ignored otherwise
-    */
+   * Loads an OSM map into an OsmMap object
+   *
+   * @param map the object to load the map into
+   * @param path the file path to load the map from
+   * @param useFileId if true, uses the element ID's in the map file; otherwise, generates new element ID's
+   * @param defaultStatus the hoot status to assign to all elements
+   * @param translationScript script used to translate data; required only if the input is an OGR format; ignored otherwise
+   * @param ogrFeatureLimit limit of features to read per input; applicable to OGR inputs only; ignored otherwise
+   * @param jobSource job name for status reporting; applicable to OGR inputs only; ignored otherwise
+   * @param numTasks number of job tasks being performed for status reporting; applicable to OGR inputs only; ignored otherwise
+   * @param cropOnReadIfBounded tell the reader to crop the input if it is bounded; applicable to bounded readers only; ignored otherwise
+   */
   static void loadMap(const OsmMapPtr& map, const QString& path, bool useFileId = true,
                       Status defaultStatus = Status::Invalid, const QString& translationScript = "",
-                      const int ogrFeatureLimit = -1, const QString& jobSource = "", const int numTasks = -1);
+                      const int ogrFeatureLimit = -1, const QString& jobSource = "", const int numTasks = -1,
+                      bool cropOnReadIfBounded = true);
   /**
-    Loads multiple OSM maps into an OsmMap object
-
-    @param map the object to load the map into
-    @param paths the file paths to load the maps from
-    @param useFileId if true, uses the element ID's in the map file; otherwise, generates new
-    element ID's
-    @param defaultStatus the hoot status to assign to all elements
-    @param translationScript script used to translate data; required only if the input is an OGR
-    format; ignored otherwise
-    @param ogrFeatureLimit limit of features to read per input; applicable to OGR inputs only;
-    ignored otherwise
-    @param jobSource job name for status reporting; applicable to OGR inputs only; ignored otherwise
-    @param numTasks number of job tasks being performed for status reporting; applicable to OGR
-    inputs only; ignored otherwise
-    */
+   * Loads multiple OSM maps into an OsmMap object
+   *
+   * @param map the object to load the map into
+   * @param paths the file paths to load the maps from
+   * @param useFileId if true, uses the element ID's in the map file; otherwise, generates new element ID's
+   * @param defaultStatus the hoot status to assign to all elements
+   * @param translationScript script used to translate data; required only if the input is an OGR format; ignored otherwise
+   * @param ogrFeatureLimit limit of features to read per input; applicable to OGR inputs only; ignored otherwise
+   * @param jobSource job name for status reporting; applicable to OGR inputs only; ignored otherwise
+   * @param numTasks number of job tasks being performed for status reporting; applicable to OGR inputs only; ignored otherwise
+   * @param cropOnReadIfBounded tell the reader to crop the input if it is bounded; applicable to bounded readers only; ignored otherwise
+   */
   static void loadMaps(const OsmMapPtr& map, const QStringList& paths, bool useFileId,
                        Status defaultStatus = Status::Invalid, const QString& translationScript = "",
-                       const int ogrFeatureLimit = -1, const QString& jobSource = "", const int numTasks = -1);
+                       const int ogrFeatureLimit = -1, const QString& jobSource = "", const int numTasks = -1,
+                       bool cropOnReadIfBounded = true);
   /**
-    Saves an OSM map to an OsmMap object
-
-    @param map the map object to save
-    @param path the file path to save the map to
+   * Saves an OSM map to an OsmMap object
+   *
+   * @param map the map object to save
+   * @param path the file path to save the map to
    */
   static void saveMap(const OsmMapPtr& map, const QString& path);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/IoUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/IoUtils.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
  */
 
 #ifndef IOUTILS_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -739,8 +739,16 @@ void OgrWriter::_addFeatureToLayer(OGRLayer* layer, const std::shared_ptr<Featur
       if (_cropFeaturesCrossingBounds)
       {
         //  Get the intersection of the geometry with the bounding envelope
-        std::unique_ptr<geos::geom::Geometry> intersection = g->intersection(_bounds.get());
-        wkt = intersection->toString();
+        try
+        {
+          std::unique_ptr<geos::geom::Geometry> intersection = g->intersection(_bounds.get());
+          wkt = intersection->toString();
+        }
+        catch (const geos::util::TopologyException& e)
+        {
+          LOG_WARN(e.what());
+          return;
+        }
       }
       else  //  Geometry doesn't need to be cropped
         wkt = g->toString();

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -252,6 +252,9 @@ void OgrWriter::write(const ConstOsmMapPtr& map)
 void OgrWriter::writeTranslatedFeature(const std::shared_ptr<Geometry>& g,
                                        const vector<ScriptToOgrSchemaTranslator::TranslatedFeature>& tf)
 {
+  //  Cannot write translated feature if there is no geometry
+  if (!g)
+    return;
   // only write the feature if it wasn't filtered by the translation script.
   for (size_t i = 0; i < tf.size(); i++)
   {

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
@@ -199,7 +199,7 @@ void OsmJsonReader::read(const OsmMapPtr& map)
   LOG_VARD(_map->getElementCount());
 
   //  Bounded network queries are already cropped
-  if (_bounds.get() && !_isWeb)
+  if (_bounds.get() && !_isWeb && _cropOnReadIfBounded)
   {
     // See related note in OsmXmlReader::read.
     IoUtils::cropToBounds(_map, _bounds, _keepImmediatelyConnectedWaysOutsideBounds);
@@ -213,7 +213,7 @@ void OsmJsonReader::_readToMap()
   LOG_VARD(_map->getElementCount());
 
   //  Bounded network queries are already cropped
-  if (_bounds.get() && !_isWeb)
+  if (_bounds.get() && !_isWeb && _cropOnReadIfBounded)
   {
     IoUtils::cropToBounds(_map, _bounds, _keepImmediatelyConnectedWaysOutsideBounds);
     LOG_VARD(StringUtils::formatLargeNumber(_map->getElementCount()));

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.cpp
@@ -84,7 +84,7 @@ std::shared_ptr<OsmMapReader> OsmMapReaderFactory::_createReader(const QString& 
   return reader;
 }
 
-std::shared_ptr<OsmMapReader> OsmMapReaderFactory::createReader(const QString& url, bool useDataSourceIds, Status defaultStatus)
+std::shared_ptr<OsmMapReader> OsmMapReaderFactory::createReader(const QString& url, bool useDataSourceIds, Status defaultStatus, bool cropOnReadIfBounded)
 {
   LOG_VART(url);
   LOG_VART(useDataSourceIds);
@@ -93,10 +93,13 @@ std::shared_ptr<OsmMapReader> OsmMapReaderFactory::createReader(const QString& u
   std::shared_ptr<OsmMapReader> reader = _createReader(url);
   reader->setUseDataSourceIds(useDataSourceIds);
   reader->setDefaultStatus(defaultStatus);
+  std::shared_ptr<Boundable> bounded = std::dynamic_pointer_cast<Boundable>(reader);
+  if (bounded)
+    bounded->setCropOnReadIfBounded(cropOnReadIfBounded);
   return reader;
 }
 
-std::shared_ptr<OsmMapReader> OsmMapReaderFactory::createReader(bool useDataSourceIds, bool useFileStatus, const QString& url)
+std::shared_ptr<OsmMapReader> OsmMapReaderFactory::createReader(bool useDataSourceIds, bool useFileStatus, const QString& url, bool cropOnReadIfBounded)
 {
   LOG_VART(url);
   LOG_VART(useDataSourceIds);
@@ -105,6 +108,9 @@ std::shared_ptr<OsmMapReader> OsmMapReaderFactory::createReader(bool useDataSour
   std::shared_ptr<OsmMapReader> reader = _createReader(url);
   reader->setUseDataSourceIds(useDataSourceIds);
   reader->setUseFileStatus(useFileStatus);
+  std::shared_ptr<Boundable> bounded = std::dynamic_pointer_cast<Boundable>(reader);
+  if (bounded)
+    bounded->setCropOnReadIfBounded(cropOnReadIfBounded);
   return reader;
 }
 
@@ -129,18 +135,18 @@ QString OsmMapReaderFactory::getReaderName(const QString& url)
   return "";
 }
 
-void OsmMapReaderFactory::read(const OsmMapPtr& map, const QString& url, bool useDataSourceIds, Status defaultStatus)
+void OsmMapReaderFactory::read(const OsmMapPtr& map, const QString& url, bool useDataSourceIds, Status defaultStatus, bool cropOnReadIfBounded)
 {
   LOG_INFO("Loading map from ..." << FileUtils::toLogFormat(url, 50) << "...");
-  std::shared_ptr<OsmMapReader> reader = createReader(url, useDataSourceIds, defaultStatus);
+  std::shared_ptr<OsmMapReader> reader = createReader(url, useDataSourceIds, defaultStatus, cropOnReadIfBounded);
   _read(map, reader, url);
 }
 
-void OsmMapReaderFactory::read(const OsmMapPtr& map, bool useDataSourceIds, bool useFileStatus, const QString& url)
+void OsmMapReaderFactory::read(const OsmMapPtr& map, bool useDataSourceIds, bool useFileStatus, const QString& url, bool cropOnReadIfBounded)
 {
   LOG_INFO("Loading map from " << FileUtils::toLogFormat(url, 50) << "...");
   LOG_VART(useFileStatus);
-  std::shared_ptr<OsmMapReader> reader = createReader(useDataSourceIds, useFileStatus, url);
+  std::shared_ptr<OsmMapReader> reader = createReader(useDataSourceIds, useFileStatus, url, cropOnReadIfBounded);
   _read(map, reader, url);
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
  */
 #include "OsmMapReaderFactory.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.h
@@ -44,20 +44,20 @@ class OsmMapReaderFactory
 
 public:
 
-  static std::shared_ptr<OsmMapReader> createReader(const QString& url, bool useFileId = true, Status defaultStatus = Status::Invalid);
+  static std::shared_ptr<OsmMapReader> createReader(const QString& url, bool useFileId = true, Status defaultStatus = Status::Invalid, bool cropOnReadIfBounded = true);
   // Note the url as the last param here...was getting runtime overlap between these two where
   // bools were being passed as status ints and vice versa. May need to do some more refactoring
   // here to make things cleaner.
-  static std::shared_ptr<OsmMapReader> createReader(bool useFileId, bool useFileStatus, const QString& url);
+  static std::shared_ptr<OsmMapReader> createReader(bool useFileId, bool useFileStatus, const QString& url, bool cropOnReadIfBounded = true);
 
   /**
    * Returns true if a partial reader is available for the given URL.
    */
   static bool supportsPartialReading(const QString& url);
 
-  static void read(const std::shared_ptr<OsmMap>& map, const QString& url, bool useFileId = true, Status defaultStatus = Status::Invalid);
+  static void read(const std::shared_ptr<OsmMap>& map, const QString& url, bool useFileId = true, Status defaultStatus = Status::Invalid, bool cropOnReadIfBounded = true);
   // See note for createReader.
-  static void read(const std::shared_ptr<OsmMap>& map, bool useFileId, bool useFileStatus, const QString& url);
+  static void read(const std::shared_ptr<OsmMap>& map, bool useFileId, bool useFileStatus, const QString& url, bool cropOnReadIfBounded = true);
 
   static QString getReaderName(const QString& url);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmMapReaderFactory.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
  */
 #ifndef OSMMAPREADERFACTORY_H
 #define OSMMAPREADERFACTORY_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlDiskCache.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlDiskCache.cpp
@@ -65,6 +65,7 @@ OsmXmlDiskCache::OsmXmlDiskCache()
   _reader.setUseDataSourceIds(true);
   _reader.setUseFileStatus(true);
   _reader.setPreserveAllTags(true);
+  _reader.setCropOnReadIfBounded(false);
   _reader.open(_tempFileName);
 
   // Initialize the cache

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
@@ -390,7 +390,7 @@ void OsmXmlReader::read(const OsmMapPtr& map)
   // bounds is already smaller than _bounds, this will have no effect. Also, We don't support
   // cropping during streaming, and there is a check in IoUtils::isStreamableIo to make
   // sure nothing tries to stream with this reader when a bounds has been set.
-  if (_bounds.get())
+  if (_bounds.get() && getCropOnReadIfBounded())
   {
     LOG_VARD(_bounds->toString());
     IoUtils::cropToBounds(_map, _bounds, _keepImmediatelyConnectedWaysOutsideBounds);

--- a/hoot-core/src/main/cpp/hoot/core/io/TranslationInterface.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/TranslationInterface.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2022, 2023 Maxar (http://www.maxar.com/)
  */
 #include "TranslationInterface.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/TranslationInterface.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/TranslationInterface.cpp
@@ -65,8 +65,8 @@ void TranslationInterface::initTranslator()
 }
 
 void TranslationInterface::translateToFeatures(const ElementProviderPtr& provider, const ConstElementPtr& e,
-                                    std::shared_ptr<Geometry> &g, // output
-                                    std::vector<ScriptToOgrSchemaTranslator::TranslatedFeature> &tf) const
+                                               std::shared_ptr<Geometry> &g, // output
+                                               std::vector<ScriptToOgrSchemaTranslator::TranslatedFeature> &tf) const
 {
   if (!_translator)
     throw HootException("You must call open before attempting to write.");
@@ -92,6 +92,12 @@ void TranslationInterface::translateToFeatures(const ElementProviderPtr& provide
       }
       logWarnCount++;
       g = GeometryFactory::getDefaultInstance()->createEmptyGeometry();
+    }
+    //  Validate the geometry before using it
+    if (!g)
+    {
+      LOG_DEBUG("Geometry not created for: " << e->getElementId());
+      return;
     }
     LOG_TRACE("After conversion to geometry, element is now a " << g->getGeometryType());
     //  Copy the tags and remove any empty values from the tags

--- a/hoot-core/src/main/cpp/hoot/core/util/Boundable.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/Boundable.cpp
@@ -33,6 +33,11 @@
 namespace hoot
 {
 
+Boundable::Boundable()
+  : _cropOnReadIfBounded(true)
+{
+}
+
 std::shared_ptr<geos::geom::Geometry> Boundable::loadBounds(const ConfigOptions& options, bool forceEnvelopeBounds)
 {
   //  First try loading the bounds from the `bounds` setting

--- a/hoot-core/src/main/cpp/hoot/core/util/Boundable.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/Boundable.h
@@ -49,7 +49,7 @@ class Boundable
 {
 public:
 
-  Boundable() = default;
+  Boundable();
   virtual ~Boundable() = default;
 
   /**
@@ -130,9 +130,14 @@ public:
     return loadInBoundsCriterionBounds(ConfigOptions(), forceEnvelopeBounds);
   }
 
+  bool getCropOnReadIfBounded() const { return _cropOnReadIfBounded; }
+  void setCropOnReadIfBounded(bool crop) { _cropOnReadIfBounded = crop; }
+
 protected:
   /** Bounding envelope or polygon */
   std::shared_ptr<geos::geom::Geometry> _bounds;
+  /** Flag to indicate if the bounding should happen on read if _bounds is valid */
+  bool _cropOnReadIfBounded;
 
 private:
   /** Convert string to geometry, used by loadBoundsString, loadCropBounds, and loadInBoundsCriterionBounds functions */


### PR DESCRIPTION
Cropping calls to `geos::geom::Geometry::intersection()` can throw a `geos::util::TopologyException` when the geometry is self-intersecting and cannot calculate the intersection.  This needs to be caught and dealt with.  Also when reading with `OsmXmlReader` into an OGR output file with cropping turned on, the reader shouldn't do any cropping, just let the `OgrWriter` do the cropping.

Closes #5561 