### PR TITLE
Allow longer hoot tags with more complex matching scenarios

### DIFF
--- a/docker/hoot_external_command_nightly/scripts/RunCommandsAcrossContainers.sh
+++ b/docker/hoot_external_command_nightly/scripts/RunCommandsAcrossContainers.sh
@@ -8,7 +8,7 @@
 
 run-conflate()
 {
-    hoot conflate -C UnifyingAlgorithm.conf -C ReferenceConflation.conf -D conflate.match.only=true -D writer.include.conflate.score.tags=true -D match.creators="BuildingMatchCreator;HighwayMatchCreator" -D writer.include.debug.tags=true -D uuid.helper.repeatable=true -D conflate.post.ops-="WayJoinerOp" -D building.match.threshold=$HOOT_MATCH_THRESH -D building.review.threshold=$HOOT_REVIEW_THRESH $HOOT_REF_FILE_NAME $HOOT_TARGET_FILE_NAME $HOOT_MATCH_FILE_NAME
+    hoot conflate -C UnifyingAlgorithm.conf -C ReferenceConflation.conf -D conflate.match.only=true -D writer.include.conflate.score.tags=true -D match.creators="BuildingMatchCreator;HighwayMatchCreator" -D writer.include.debug.tags=true -D uuid.helper.repeatable=true -D conflate.post.ops-="WayJoinerOp" -D conflate.tag.disable.value.truncation=true -D building.match.threshold=$HOOT_MATCH_THRESH -D building.review.threshold=$HOOT_REVIEW_THRESH $HOOT_REF_FILE_NAME $HOOT_TARGET_FILE_NAME $HOOT_MATCH_FILE_NAME
 }
 
 run-task-grid()

--- a/docker/hoot_external_command_nightly/scripts/RunCommandsAcrossContainers.sh
+++ b/docker/hoot_external_command_nightly/scripts/RunCommandsAcrossContainers.sh
@@ -101,4 +101,3 @@ case "$1" in
         OUTPUT_OSM=$7
         run-owt-export-osm ;;
 esac
-


### PR DESCRIPTION
This PR resolves issues Sherlock was having interpreting hoot tags after conflation in complex matching scenarios.