### PR TITLE
Sonar: Ignore 'Raw Strings' rule

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -49,7 +49,8 @@ sonar.issue.ignore.multicriteria=cout1,cout3,cout4,cout5,cout6,cout7,cout8, \
                                  ignoreBreaks, \
                                  ignoreNestedBlock, \
                                  ignoreStdLess, \
-                                 ignoreEnumClass
+                                 ignoreEnumClass, \
+                                 ignoreRawStrings
 
 # Remove the "Incremental analysis cache" warning
 sonar.cfamily.cache.enabled=false
@@ -204,5 +205,9 @@ sonar.issue.ignore.multicriteria.ignoreStdLess.resourceKey=**/*
 
 # Ignore the scoped enumeration use
 sonar.issue.ignore.multicriteria.ignoreEnumClass.ruleKey=cpp:S3642
+sonar.issue.ignore.multicriteria.ignoreEnumClass.resourceKey=**/*
+
+# Ignore raw strings rule
+sonar.issue.ignore.multicriteria.ignoreEnumClass.ruleKey=cpp:S3628
 sonar.issue.ignore.multicriteria.ignoreEnumClass.resourceKey=**/*
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -208,6 +208,6 @@ sonar.issue.ignore.multicriteria.ignoreEnumClass.ruleKey=cpp:S3642
 sonar.issue.ignore.multicriteria.ignoreEnumClass.resourceKey=**/*
 
 # Ignore raw strings rule
-sonar.issue.ignore.multicriteria.ignoreEnumClass.ruleKey=cpp:S3628
-sonar.issue.ignore.multicriteria.ignoreEnumClass.resourceKey=**/*
+sonar.issue.ignore.multicriteria.ignoreRawStrings.ruleKey=cpp:S3628
+sonar.issue.ignore.multicriteria.ignoreRawStrings.resourceKey=**/*
 


### PR DESCRIPTION
Ignore `cpp:S3628` "Raw Strings" rule in Sonar.