### PR TITLE
GeoJSON crop failure with certain translations

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonWriter.cpp
@@ -840,7 +840,7 @@ QString OsmGeoJsonWriter::_getFcodeUnknown(const std::shared_ptr<geos::geom::Geo
 std::shared_ptr<geos::geom::Geometry> OsmGeoJsonWriter::_cropGeometryToBounds(const std::shared_ptr<geos::geom::Geometry>& geometry) const
 {
   //  Treat bounded vs unbounded differently
-  if (_bounds)
+  if (geometry && _bounds)
   {
     if (geometry->intersects(_bounds.get()))
     {


### PR DESCRIPTION
Certain translations will cause the geometry creation to fail, protect against that issue.