### PR TITLE
Remove comments from overpassql queries

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OverpassReaderInterfaceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OverpassReaderInterfaceTest.cpp
@@ -96,6 +96,9 @@ public:
     //  Check a bad filename, disable warnings beforehand
     DisableLog disable;
     HOOT_STR_EQUALS("", uut._readOverpassQueryFile("/this/file/should/never/exist/right"));
+    //  Test out removing comments from the query file
+    QString comment_query = uut._readOverpassQueryFile("test-files/io/OsmJsonReaderTest/overpass_comments_query.overpassql");
+    HOOT_STR_EQUALS(overpass_expected, comment_query);
   }
 
   void parseOverpassErrorTest()

--- a/hoot-core-test/src/test/cpp/hoot/core/io/OverpassReaderInterfaceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OverpassReaderInterfaceTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2022-2023 Maxar (http://www.maxar.com/)
  */
 
 // Hoot

--- a/hoot-core/src/main/cpp/hoot/core/io/OverpassReaderInterface.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OverpassReaderInterface.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2022-2023 Maxar (http://www.maxar.com/)
  */
 
 #include "OverpassReaderInterface.h"

--- a/hoot-core/src/main/cpp/hoot/core/io/OverpassReaderInterface.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OverpassReaderInterface.cpp
@@ -98,12 +98,18 @@ void OverpassReaderInterface::setOverpassUrl(const QString& url)
 
 QString OverpassReaderInterface::_readOverpassQueryFile(const QString& path) const
 {
+  //  C-Style comments are valid and should be removed
+  static QRegularExpression singleLineComment("\\s*//.*", QRegularExpression::OptimizeOnFirstUsageOption);
+  static QRegularExpression multiLineComment("/\\*.*?\\*/", QRegularExpression::OptimizeOnFirstUsageOption | QRegularExpression::DotMatchesEverythingOption);
   QString query;
   try
   {
     //  Load the contents of the overpass query file
     if (!path.isEmpty())
-      query = FileUtils::readFully(path);
+    {
+      //  Remove all of the comment lines from the file
+      query = FileUtils::readFully(path).replace(singleLineComment, "").replace(multiLineComment, "");
+    }
   }
   catch (const HootException&)
   {

--- a/test-files/io/OsmJsonReaderTest/overpass_comments_query.overpassql
+++ b/test-files/io/OsmJsonReaderTest/overpass_comments_query.overpassql
@@ -1,0 +1,10 @@
+[out:json][bbox];/* C-Style comments are removed */
+(
+way;//  This is a comment that should be removed
+relation;
+);/* Multi-
+   * line
+   * comments
+   * are removed
+   * too */
+out;


### PR DESCRIPTION
The slashes in comments mess up the query string in the overpass query, they need to be removed.