### PR TITLE
Cached element writer interface

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/CachedElementWriterInterface.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/CachedElementWriterInterface.cpp
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. Maxar
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2023 Maxar (http://www.maxar.com/)
+ */
+#include "CachedElementWriterInterface.h"
+
+// hoot
+#include <hoot/core/elements/Element.h>
+#include <hoot/core/elements/ElementProvider.h>
+#include <hoot/core/io/ElementCacheLRU.h>
+#include <hoot/core/util/ConfigOptions.h>
+
+namespace hoot
+{
+
+CachedElementWriterInterface::CachedElementWriterInterface()
+  : _elementCache(std::make_shared<ElementCacheLRU>(ConfigOptions().getElementCacheSizeNode(),
+                                                    ConfigOptions().getElementCacheSizeWay(),
+                                                    ConfigOptions().getElementCacheSizeRelation()))
+{
+}
+
+void CachedElementWriterInterface::_addElementToCache(const ConstElementPtr& element)
+{
+  ConstElementPtr e(element);
+  _elementCache->addElement(e);
+}
+
+ElementProviderPtr CachedElementWriterInterface::_getElementProvider() const
+{
+  return ElementProviderPtr(_elementCache);
+}
+
+}

--- a/hoot-core/src/main/cpp/hoot/core/io/CachedElementWriterInterface.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/CachedElementWriterInterface.h
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * --------------------------------------------------------------------
+ *
+ * The following copyright notices are generated automatically. If you
+ * have a new notice to add, please use the format:
+ * " * @copyright Copyright ..."
+ * This will properly maintain the copyright information. Maxar
+ * copyrights will be updated automatically.
+ *
+ * @copyright Copyright (C) 2023 Maxar (http://www.maxar.com/)
+ */
+
+#ifndef CACHED_ELEMENT_WRITER_INTERFACE_H
+#define CACHED_ELEMENT_WRITER_INTERFACE_H
+
+// hoot
+#include <hoot/core/io/ElementCache.h>
+
+namespace hoot
+{
+
+/**
+ * Interface for writers that must cache nodes, ways, and relations.
+ */
+class CachedElementWriterInterface
+{
+public:
+
+  static QString className() { return "OgrWriter"; }
+
+  CachedElementWriterInterface();
+  virtual ~CachedElementWriterInterface() = default;
+
+  void setCache(ElementCachePtr cachePtr) { _elementCache = cachePtr; }
+  /** Get max size of the cache for each element type */
+  unsigned long getNodeCacheSize() const { return _elementCache->getNodeCacheSize(); }
+  unsigned long getWayCacheSize() const { return _elementCache->getWayCacheSize(); }
+  unsigned long getRelationCacheSize() const { return _elementCache->getRelationCacheSize(); }
+  /** Check the cache for a specific element */
+  bool cacheContainsElement(const ElementId& eid) const { return _elementCache->containsElement(eid); }
+  /** Get elements from the cache by ID or ElementId */
+  NodePtr getNode(long id) const { return _elementCache->getNode(id); }
+  WayPtr getWay(long id) const { return _elementCache->getWay(id); }
+  RelationPtr getRelation(long id) const { return _elementCache->getRelation(id); }
+  ConstElementPtr getElement(const ElementId& eid) const { return _elementCache->getElement(eid); }
+
+protected:
+  /** Internal function to add an element to the cache */
+  void _addElementToCache(const ConstElementPtr& element);
+  /** Internal function to convert the element cache into an element provider */
+  ElementProviderPtr _getElementProvider() const;
+  /** Element cache pointer, see ElementCacheLRU */
+  ElementCachePtr _elementCache;
+};
+
+}
+
+#endif // CACHED_ELEMENT_WRITER_INTERFACE_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #include "OgrWriter.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
@@ -29,7 +29,7 @@
 #define OGRWRITER_H
 
 // hoot
-#include <hoot/core/io/ElementCache.h>
+#include <hoot/core/io/CachedElementWriterInterface.h>
 #include <hoot/core/io/PartialOsmMapWriter.h>
 #include <hoot/core/io/TranslationInterface.h>
 #include <hoot/core/util/Boundable.h>
@@ -48,7 +48,7 @@ class Layer;
 /**
  * Writes a file to an OGR data source.
  */
-class OgrWriter : public PartialOsmMapWriter, public Configurable, public TranslationInterface, public Boundable
+class OgrWriter : public PartialOsmMapWriter, public Configurable, public TranslationInterface, public Boundable, public CachedElementWriterInterface
 {
 public:
 
@@ -80,7 +80,6 @@ public:
 
   void setCreateAllLayers(bool createAll) { _createAllLayers = createAll; }
   void setPrependLayerName(const QString& pre) { _prependLayerName = pre; }
-  void setCache(ElementCachePtr cachePtr) { _elementCache = cachePtr; }
 
 protected:
 
@@ -97,7 +96,6 @@ private:
   QHash<QString, OGRLayer*> _layers;
   QHash<QString, std::shared_ptr<OGRSpatialReference>> _projections;
   QString _prependLayerName;
-  ElementCachePtr _elementCache;
   OGRSpatialReference _wgs84;
 
   // contains relations that weren't written on a first pass b/c they contained relations as a

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 
 #ifndef OGRWRITER_H


### PR DESCRIPTION
Move element cache from `OgrWriter` to a shared interface for other writer classes that need it.