### PR TITLE
Load overpass query file through interface in all cases

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OverpassReaderInterfaceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OverpassReaderInterfaceTest.cpp
@@ -91,14 +91,17 @@ public:
         "relation;\n"
         ");\n"
         "out;\n";
-    QString overpass_query = uut._readOverpassQueryFile("test-files/io/OsmJsonReaderTest/overpass_query.overpassql");
+    QString overpass_query = uut._readOverpassQueryFile("test-files/io/OsmJsonReaderTest/overpass_query.overpassql", false);
     HOOT_STR_EQUALS(overpass_expected, overpass_query);
     //  Check a bad filename, disable warnings beforehand
     DisableLog disable;
     HOOT_STR_EQUALS("", uut._readOverpassQueryFile("/this/file/should/never/exist/right"));
     //  Test out removing comments from the query file
-    QString comment_query = uut._readOverpassQueryFile("test-files/io/OsmJsonReaderTest/overpass_comments_query.overpassql");
+    QString comment_query = uut._readOverpassQueryFile("test-files/io/OsmJsonReaderTest/overpass_comments_query.overpassql", false);
     HOOT_STR_EQUALS(overpass_expected, comment_query);
+    //  Test out stripping comments and new lines
+    comment_query = uut._readOverpassQueryFile("test-files/io/OsmJsonReaderTest/overpass_comments_query.overpassql", true);
+    HOOT_STR_EQUALS(overpass_expected.replace("\n", ""), comment_query);
   }
 
   void parseOverpassErrorTest()

--- a/hoot-core/src/main/cpp/hoot/core/io/OverpassReaderInterface.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OverpassReaderInterface.cpp
@@ -96,7 +96,7 @@ void OverpassReaderInterface::setOverpassUrl(const QString& url)
   _isOverpass = isOverpassUrl(url);
 }
 
-QString OverpassReaderInterface::_readOverpassQueryFile(const QString& path) const
+QString OverpassReaderInterface::_readOverpassQueryFile(const QString& path, bool stripNewLines) const
 {
   //  C-Style comments are valid and should be removed
   static QRegularExpression singleLineComment("\\s*//.*", QRegularExpression::OptimizeOnFirstUsageOption);
@@ -109,6 +109,8 @@ QString OverpassReaderInterface::_readOverpassQueryFile(const QString& path) con
     {
       //  Remove all of the comment lines from the file
       query = FileUtils::readFully(path).replace(singleLineComment, "").replace(multiLineComment, "");
+      if (stripNewLines)
+        query = query.replace("\r", "").replace("\n", "");
     }
   }
   catch (const HootException&)

--- a/hoot-core/src/main/cpp/hoot/core/io/OverpassReaderInterface.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OverpassReaderInterface.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2022-2023 Maxar (http://www.maxar.com/)
  */
 
 #ifndef OVERPASS_READER_INTERFACE_H
@@ -69,7 +69,7 @@ protected:
   /** Overpass */
   QString _queryFilepath;
 
-  QString _readOverpassQueryFile(const QString& path) const;
+  QString _readOverpassQueryFile(const QString& path, bool stripNewLines = true) const;
 
   /**  Allow test class to access protected members for white box testing */
   friend class OverpassReaderInterfaceTest;

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019-2023 Maxar (http://www.maxar.com/)
  */
 
 #include "ParallelBoundedApiReader.h"
@@ -81,7 +81,7 @@ void ParallelBoundedApiReader::beginRead(const QUrl& endpoint, const geos::geom:
   QUrlQuery urlQuery(_sourceUrl);
   if (!urlQuery.hasQueryItem("data") && !_queryFilepath.isEmpty())
   {
-    QString query = FileUtils::readFully(_queryFilepath).replace("\r", "").replace("\n", "");
+    QString query = _readOverpassQueryFile(_queryFilepath);
     //  Should the query be validated here?
     urlQuery.addQueryItem("data", query);
   }


### PR DESCRIPTION
In some cases the overpass query file load function wasn't being called, fix that.