### PR TITLE
make overpass grail query only traverse down

### DIFF
--- a/conf/services/grailOverpassQuery.overpassql
+++ b/conf/services/grailOverpassQuery.overpassql
@@ -2,9 +2,9 @@
 (node({{bbox}});<;>;)->.all;
 (
    relation({{bbox}})[natural=coastline];>;
-   way({{bbox}})[natural=coastline];>;
+   (way({{bbox}})[natural=coastline];<;);>;
    relation({{bbox}})[boundary=administrative];>;
-   way({{bbox}})[boundary=administrative];>;
+   (way({{bbox}})[boundary=administrative];<;);>;
    node({{bbox}})[boundary=administrative];
 )->.exclude;
 (.all; - .exclude;);

--- a/conf/services/grailOverpassQuery.overpassql
+++ b/conf/services/grailOverpassQuery.overpassql
@@ -2,9 +2,9 @@
 (node({{bbox}});<;>;)->.all;
 (
    relation({{bbox}})[natural=coastline];>;
-   way({{bbox}})[natural=coastline];<;>;
+   way({{bbox}})[natural=coastline];>;
    relation({{bbox}})[boundary=administrative];>;
-   way({{bbox}})[boundary=administrative];<;>;
+   way({{bbox}})[boundary=administrative];>;
    node({{bbox}})[boundary=administrative];
 )->.exclude;
 (.all; - .exclude;);


### PR DESCRIPTION
The traverse up was meant to grab any relations containing the coastline or admin boundary.  These "extensive" features (can be part of very large areas) are not amenable to conflation so are then excluded from the dataset pulled in from Overpass.  However in a recent examination of the data by @maxgrossman it seemed that the untagged nodes of coastline ways were being left in the output.

Not sure why this would be unless traversing up to no parent relation then breaks the traverse down.

Edit:
I find that union'ing with `(   );` after tranversing up fixes this.
```
[out:json];
(node({{bbox}});<;>;)->.all;
(
   relation({{bbox}})[natural=coastline];>;
   (way({{bbox}})[natural=coastline];<;);>;
   relation({{bbox}})[boundary=administrative];>;
   (way({{bbox}})[boundary=administrative];<;);>;
   node({{bbox}})[boundary=administrative];
)->.exclude;
(.all; - .exclude;);
out meta;
```