### PR TITLE
resolve logoutputstream nuance

### DIFF
--- a/hoot-services/src/main/java/hoot/services/command/ExternalCommandRunnerImpl.java
+++ b/hoot-services/src/main/java/hoot/services/command/ExternalCommandRunnerImpl.java
@@ -55,6 +55,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import hoot.services.HootProperties;
+import hoot.services.controllers.conflation.AdvancedConflationOptionsResource;
 import hoot.services.utils.DbUtils;
 
 
@@ -124,6 +125,10 @@ public class ExternalCommandRunnerImpl implements ExternalCommandRunner {
             protected void processLine(String line, int level) {
                 String currentLine = obfuscateConsoleLog(line) + "\n";
 
+                if (caller.equals(AdvancedConflationOptionsResource.class.getName())) {
+                    currentLine = commandResult.getStdout().concat(currentLine);
+                }
+
                 commandResult.setStdout(currentLine);
 
                 if (trackable) {
@@ -132,6 +137,7 @@ public class ExternalCommandRunnerImpl implements ExternalCommandRunner {
                     if (matcher.find()) {
                         commandResult.setPercentProgress(Integer.parseInt(matcher.group(3))); // group 3 is the percent from the pattern regex
                     }
+
 
                     // update command status table stdout
                     DbUtils.upsertCommandStatus(commandResult);


### PR DESCRIPTION
The bug we are seeing 

```
2023-03-14 19:17:53,864 INFO  ExternalCommandRunnerImpl:192 - Command hoot.bin info --tag-mergers --json started at: [2023-03-14T19:17:53.864]
Unexpected token RIGHT BRACE(}) at position 0.
	at org.json.simple.parser.JSONParser.parse(JSONParser.java:257)
	at org.json.simple.parser.JSONParser.parse(JSONParser.java:81)
	at org.json.simple.parser.JSONParser.parse(JSONParser.java:75)
	at hoot.services.controllers.conflation.AdvancedConflationOptionsResource.addGeneralMemberData(AdvancedConflationOptionsResource.java:357)
	at hoot.services.controllers.conflation.AdvancedConflationOptionsResource.cacheTemplates(AdvancedConflationOptionsResource.java:188)
	at hoot.services.HootServletContext.contextInitialized(HootServletContext.java:68)
	at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4762)
	at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5233)
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
	at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:753)
	at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:727)
	at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:695)
	at org.apache.catalina.startup.HostConfig.deployWAR(HostConfig.java:1016)
	at org.apache.catalina.startup.HostConfig$DeployWar.run(HostConfig.java:1903)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
```

Is happening because of #5595 where we now only hold 1 line of standard output at a time.
We probably need to have a deeper think about how to resolve this. this commit can be just way to point us in the right direction.