### PR TITLE
Cached element interface in `OsmApiReader`

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/CachedElementInterface.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/CachedElementInterface.cpp
@@ -24,7 +24,7 @@
  *
  * @copyright Copyright (C) 2023 Maxar (http://www.maxar.com/)
  */
-#include "CachedElementWriterInterface.h"
+#include "CachedElementInterface.h"
 
 // hoot
 #include <hoot/core/elements/Element.h>
@@ -35,20 +35,21 @@
 namespace hoot
 {
 
-CachedElementWriterInterface::CachedElementWriterInterface()
+CachedElementInterface::CachedElementInterface()
   : _elementCache(std::make_shared<ElementCacheLRU>(ConfigOptions().getElementCacheSizeNode(),
                                                     ConfigOptions().getElementCacheSizeWay(),
                                                     ConfigOptions().getElementCacheSizeRelation()))
 {
 }
 
-void CachedElementWriterInterface::_addElementToCache(const ConstElementPtr& element)
+void CachedElementInterface::_addElementToCache(const ConstElementPtr& element)
 {
   ConstElementPtr e(element);
-  _elementCache->addElement(e);
+  if (!_elementCache->containsElement(e->getElementId()))
+    _elementCache->addElement(e);
 }
 
-ElementProviderPtr CachedElementWriterInterface::_getElementProvider() const
+ElementProviderPtr CachedElementInterface::_getElementProvider() const
 {
   return ElementProviderPtr(_elementCache);
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/CachedElementInterface.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/CachedElementInterface.h
@@ -25,8 +25,8 @@
  * @copyright Copyright (C) 2023 Maxar (http://www.maxar.com/)
  */
 
-#ifndef CACHED_ELEMENT_WRITER_INTERFACE_H
-#define CACHED_ELEMENT_WRITER_INTERFACE_H
+#ifndef CACHED_ELEMENT_INTERFACE_H
+#define CACHED_ELEMENT_INTERFACE_H
 
 // hoot
 #include <hoot/core/io/ElementCache.h>
@@ -35,17 +35,16 @@ namespace hoot
 {
 
 /**
- * Interface for writers that must cache nodes, ways, and relations.
+ * Interface for io classes that must cache nodes, ways, and relations.
  */
-class CachedElementWriterInterface
+class CachedElementInterface
 {
 public:
 
-  static QString className() { return "OgrWriter"; }
+  CachedElementInterface();
+  virtual ~CachedElementInterface() = default;
 
-  CachedElementWriterInterface();
-  virtual ~CachedElementWriterInterface() = default;
-
+  ElementCachePtr getCache() const { return _elementCache; }
   void setCache(ElementCachePtr cachePtr) { _elementCache = cachePtr; }
   /** Get max size of the cache for each element type */
   unsigned long getNodeCacheSize() const { return _elementCache->getNodeCacheSize(); }
@@ -70,4 +69,4 @@ protected:
 
 }
 
-#endif // CACHED_ELEMENT_WRITER_INTERFACE_H
+#endif // CACHED_ELEMENT_INTERFACE_H

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.cpp
@@ -27,6 +27,7 @@
 #include "ElementStreamer.h"
 
 // Hoot
+#include <hoot/core/io/CachedElementInterface.h>
 #include <hoot/core/io/ElementInputStream.h>
 #include <hoot/core/io/ElementOutputStream.h>
 #include <hoot/core/io/IoUtils.h>
@@ -82,6 +83,13 @@ void ElementStreamer::stream(const QStringList& inputs, const QString& out, cons
         Status::fromString(ConfigOptions().getReaderSetDefaultStatus()));
     reader->setConfiguration(conf());
     partialReader = std::dynamic_pointer_cast<PartialOsmMapReader>(reader);
+
+    //  Share the cache between reader and writer if they are both cached
+    std::shared_ptr<CachedElementInterface> cachedIn = std::dynamic_pointer_cast<CachedElementInterface>(reader);
+    std::shared_ptr<CachedElementInterface> cachedOut = std::dynamic_pointer_cast<CachedElementInterface>(writer);
+    if (cachedIn && cachedOut)
+      cachedOut->setCache(cachedIn->getCache());
+
     std::shared_ptr<OgrReader> ogrReader = std::dynamic_pointer_cast<OgrReader>(reader);
     std::shared_ptr<OgrWriter> ogrWriter = std::dynamic_pointer_cast<OgrWriter>(writer);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ElementStreamer.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2017-2023 Maxar (http://www.maxar.com/)
  */
 #include "ElementStreamer.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrWriter.h
@@ -29,7 +29,7 @@
 #define OGRWRITER_H
 
 // hoot
-#include <hoot/core/io/CachedElementWriterInterface.h>
+#include <hoot/core/io/CachedElementInterface.h>
 #include <hoot/core/io/PartialOsmMapWriter.h>
 #include <hoot/core/io/TranslationInterface.h>
 #include <hoot/core/util/Boundable.h>
@@ -48,7 +48,7 @@ class Layer;
 /**
  * Writes a file to an OGR data source.
  */
-class OgrWriter : public PartialOsmMapWriter, public Configurable, public TranslationInterface, public Boundable, public CachedElementWriterInterface
+class OgrWriter : public PartialOsmMapWriter, public Configurable, public TranslationInterface, public Boundable, public CachedElementInterface
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
@@ -256,11 +256,6 @@ bool OsmApiReader::hasMoreElements()
     finalizePartial();
     if (!_elementConverter)
       _elementConverter = std::make_shared<ElementToGeometryConverter>(_getElementProvider());
-    //  map needed for assigning new element ids only (not actually putting any of the elements that
-    //  are read into this map, since this is the partial reading logic)
-//    _map = std::make_shared<OsmMap>();
-    //  Update the map in the polygon criterion everytime a new one is created
-//    _polyCriterion->setOsmMap(_map.get());
 
     QString xmlResult;
     //  Get one XML string to parse

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.h
@@ -30,6 +30,7 @@
 // Hoot
 #include <hoot/core/criterion/InBoundsCriterion.h>
 #include <hoot/core/elements/Tags.h>
+#include <hoot/core/io/CachedElementInterface.h>
 #include <hoot/core/io/OsmXmlReader.h>
 #include <hoot/core/io/ParallelBoundedApiReader.h>
 #include <hoot/core/util/Units.h>
@@ -49,7 +50,7 @@ namespace hoot
  * subsequently filter the resulting map on the polygon afterwards
  * https://wiki.openstreetmap.org/wiki/API_v0.6#Retrieving_map_data_by_bounding_box:_GET_.2Fapi.2F0.6.2Fmap
  */
-class OsmApiReader : public OsmXmlReader, public ParallelBoundedApiReader
+class OsmApiReader : public OsmXmlReader, public ParallelBoundedApiReader, public CachedElementInterface
 {
 public:
 
@@ -123,6 +124,9 @@ private:
    * @brief _canUseElement
    */
   bool _canUseElement(const ElementPtr& element) const;
+
+  bool _isInPolyBounds(const ElementPtr& element) const;
+
   /** Bounds information */
   QString _boundsString;
   QString _boundsFilename;
@@ -132,6 +136,7 @@ private:
   std::set<ElementId> _elementSet;
 
   std::shared_ptr<InBoundsCriterion> _polyCriterion;
+  std::shared_ptr<ElementToGeometryConverter> _elementConverter;
 
   /** For testing */
   friend class OsmApiReaderTest;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmGeoJsonWriter.h
@@ -28,7 +28,7 @@
 #define OSM_GEOJSON_WRITER_H
 
 // hoot
-#include <hoot/core/io/CachedElementWriterInterface.h>
+#include <hoot/core/io/CachedElementInterface.h>
 #include <hoot/core/io/OsmJsonWriter.h>
 #include <hoot/core/io/TranslationInterface.h>
 #include <hoot/core/util/Boundable.h>
@@ -42,7 +42,7 @@ namespace hoot
  *
  * https://geojson.org/geojson-spec.html
  */
-class OsmGeoJsonWriter : public OsmJsonWriter, public TranslationInterface, public Boundable, public CachedElementWriterInterface
+class OsmGeoJsonWriter : public OsmJsonWriter, public TranslationInterface, public Boundable, public CachedElementInterface
 {
 public:
   static QString className() { return "OsmGeoJsonWriter"; }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlDiskCache.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlDiskCache.cpp
@@ -88,11 +88,9 @@ OsmXmlDiskCache::~OsmXmlDiskCache()
 void OsmXmlDiskCache::_initCacheDir()
 {
   _tempDir = ConfPath::getHootHome() + "/tmp";
+  // If it exists, and we can't write to it, use system temp
   if (QDir(_tempDir).exists() && !QFileInfo(_tempDir).isWritable())
-  {
-    // If it exists, and we can't write to it, use system temp
     _tempDir = QDir::tempPath();
-  }
   else if (!QDir(_tempDir).exists())
   {
     // Try to make it
@@ -103,9 +101,7 @@ void OsmXmlDiskCache::_initCacheDir()
                                      | QFileDevice::ReadOther | QFileDevice::WriteOther | QFileDevice::ExeOther);
     }
     else
-    {
       _tempDir = QDir::tempPath();
-    }
   }
 
   LOG_DEBUG(QString("OsmXmlDiskCache: using temp dir: %1").arg(_tempDir));
@@ -114,7 +110,7 @@ void OsmXmlDiskCache::_initCacheDir()
 void OsmXmlDiskCache::_initCache()
 {
   // Make a bogus node for the cache, otherwise our reader gets angry
-  uint64_t nodeId(UINT64_MAX);
+  long nodeId(0); //  Zero is the only invalid ID
   double lat(1.123456);
   double lon(1.123456);
   Meters circularError(13.13);
@@ -127,14 +123,11 @@ void OsmXmlDiskCache::addElement(const ConstElementPtr &newElement)
 {
   LOG_TRACE("Adding element: " + newElement->toString() + " to cache...");
 
-  ConstNodePtr newNode;
-  ConstWayPtr newWay;
-  ConstRelationPtr newRelation;
-
   switch (newElement->getElementType().getEnum())
   {
   case ElementType::Node:
-    newNode = std::dynamic_pointer_cast<const Node>(newElement);
+  {
+    ConstNodePtr newNode = std::dynamic_pointer_cast<const Node>(newElement);
     if (newNode != ConstNodePtr())
     {
       uint64_t id = newNode->getId();
@@ -147,8 +140,10 @@ void OsmXmlDiskCache::addElement(const ConstElementPtr &newElement)
       }
     }
     break;
+  }
   case ElementType::Way:
-    newWay = std::dynamic_pointer_cast<const Way>(newElement);
+  {
+    ConstWayPtr newWay = std::dynamic_pointer_cast<const Way>(newElement);
     if (newWay != ConstWayPtr())
     {
       uint64_t id = newWay->getId();
@@ -161,8 +156,10 @@ void OsmXmlDiskCache::addElement(const ConstElementPtr &newElement)
       }
     }
     break;
+  }
   case ElementType::Relation:
-    newRelation = std::dynamic_pointer_cast<const Relation>(newElement);
+  {
+    ConstRelationPtr newRelation = std::dynamic_pointer_cast<const Relation>(newElement);
     if (newRelation != ConstRelationPtr())
     {
       uint64_t id = newRelation->getId();
@@ -175,6 +172,7 @@ void OsmXmlDiskCache::addElement(const ConstElementPtr &newElement)
       }
     }
     break;
+  }
   default:
     throw HootException(QString("Unexpected element type: %1").arg(newElement->getElementType().toString()));
     break;


### PR DESCRIPTION
Renamed `CachedElementWriterInterface` to `CachedElementInterface` for use in readers.  Share the cache if streaming from a reader to a writer that both implement the interface.  `OsmApiReader` needed the interface to check the polygon bounds.