### PR TITLE
Translation server sometimes passes empty

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/OsmXmlReaderTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2012, 2013, 2014, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2012-2023 Maxar (http://www.maxar.com/)
  */
 
 // Hoot
@@ -66,6 +66,17 @@ public:
 
     CPPUNIT_ASSERT_EQUAL(36, (int)map->getNodeCount());
     CPPUNIT_ASSERT_EQUAL(4, (int)map->getWayCount());
+  }
+
+  void runEmptyStringTest()
+  {
+    OsmXmlReader uut;
+    OsmMapPtr map = std::make_shared<OsmMap>();
+    uut.readFromString("", map);
+
+    CPPUNIT_ASSERT_EQUAL(0, (int)map->getNodeCount());
+    CPPUNIT_ASSERT_EQUAL(0, (int)map->getWayCount());
+    CPPUNIT_ASSERT_EQUAL(0, (int)map->getRelationCount());
   }
 
   void runUseIdTest()

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
@@ -446,21 +446,25 @@ void OsmXmlReader::readFromString(const QString& xml, const OsmMapPtr& map)
 
     QXmlInputSource xmlInputSource(&buffer);
     if (reader.parse(xmlInputSource) == false)
-      throw HootException(_errorString);
-
-    LOG_DEBUG("Parsed map from xml.");
-
-    LOG_VARD(_bounds.get());
-    if (_bounds.get())
     {
-      IoUtils::cropToBounds(_map, _bounds, _keepImmediatelyConnectedWaysOutsideBounds);
-      LOG_VARD(StringUtils::formatLargeNumber(_map->getElementCount()));
+      LOG_ERROR(_errorString);
     }
+    else
+    {
+      LOG_DEBUG("Parsed map from xml.");
 
-    ReportMissingElementsVisitor visitor;
-    LOG_INFO("\t" << visitor.getInitStatusMessage());
-    _map->visitRw(visitor);
-    LOG_INFO("\t" << visitor.getCompletedStatusMessage());
+      LOG_VARD(_bounds.get());
+      if (_bounds.get())
+      {
+        IoUtils::cropToBounds(_map, _bounds, _keepImmediatelyConnectedWaysOutsideBounds);
+        LOG_VARD(StringUtils::formatLargeNumber(_map->getElementCount()));
+      }
+
+      ReportMissingElementsVisitor visitor;
+      LOG_INFO("\t" << visitor.getInitStatusMessage());
+      _map->visitRw(visitor);
+      LOG_INFO("\t" << visitor.getCompletedStatusMessage());
+    }
   }
   _map.reset();
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 
 #include "OsmXmlReader.h"
@@ -434,32 +434,34 @@ void OsmXmlReader::readFromString(const QString& xml, const OsmMapPtr& map)
 
   LOG_DEBUG("Parsing map from xml...");
 
-  // do xml parsing
-  QXmlSimpleReader reader;
-  reader.setContentHandler(this);
-  reader.setErrorHandler(this);
-
-  QBuffer buffer;
-  buffer.setData(xml.toUtf8());
-
-  QXmlInputSource xmlInputSource(&buffer);
-  if (reader.parse(xmlInputSource) == false)
-    throw HootException(_errorString);
-
-  LOG_DEBUG("Parsed map from xml.");
-
-  LOG_VARD(_bounds.get());
-  if (_bounds.get())
+  if (!xml.isEmpty())
   {
-    IoUtils::cropToBounds(_map, _bounds, _keepImmediatelyConnectedWaysOutsideBounds);
-    LOG_VARD(StringUtils::formatLargeNumber(_map->getElementCount()));
+    // do xml parsing
+    QXmlSimpleReader reader;
+    reader.setContentHandler(this);
+    reader.setErrorHandler(this);
+
+    QBuffer buffer;
+    buffer.setData(xml.toUtf8());
+
+    QXmlInputSource xmlInputSource(&buffer);
+    if (reader.parse(xmlInputSource) == false)
+      throw HootException(_errorString);
+
+    LOG_DEBUG("Parsed map from xml.");
+
+    LOG_VARD(_bounds.get());
+    if (_bounds.get())
+    {
+      IoUtils::cropToBounds(_map, _bounds, _keepImmediatelyConnectedWaysOutsideBounds);
+      LOG_VARD(StringUtils::formatLargeNumber(_map->getElementCount()));
+    }
+
+    ReportMissingElementsVisitor visitor;
+    LOG_INFO("\t" << visitor.getInitStatusMessage());
+    _map->visitRw(visitor);
+    LOG_INFO("\t" << visitor.getCompletedStatusMessage());
   }
-
-  ReportMissingElementsVisitor visitor;
-  LOG_INFO("\t" << visitor.getInitStatusMessage());
-  _map->visitRw(visitor);
-  LOG_INFO("\t" << visitor.getCompletedStatusMessage());
-
   _map.reset();
 }
 

--- a/hoot-test/src/main/cpp/hoot/test/validation/TestOutputValidator.h
+++ b/hoot-test/src/main/cpp/hoot/test/validation/TestOutputValidator.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2021-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef TEST_OUTPUT_VALIDATOR_H
 #define TEST_OUTPUT_VALIDATOR_H
@@ -55,10 +55,9 @@ public:
    * @param printValidationReportDiff if true, for failing tests prints the difference between the
    * baseline validation report and the test validation report output
    */
-  static void validate(
-    const QString& testName, const QString& testOutputPath,
-    const QString& goldValidationReportPath, const bool suppressFailureDetail = false,
-    const bool printValidationReportDiff = false);
+  static void validate(const QString& testName, const QString& testOutputPath,
+                       const QString& goldValidationReportPath, const bool suppressFailureDetail = false,
+                       const bool printValidationReportDiff = false);
 
 private:
 
@@ -69,8 +68,7 @@ private:
    * @param goldValidationReportPath path to the baseline validation report for the test
    * @return true if the baseline report file is valid; false otherwise
    */
-  static bool _validateGoldReport(
-    const QString& testName, const QString& goldValidationReportPath);
+  static bool _validateGoldReport(const QString& testName, const QString& goldValidationReportPath);
 
   /**
    * @brief _printValidationReportDiff Prints the difference between two files
@@ -80,8 +78,7 @@ private:
    * @param timeout how long to wait for the diff command to finish
    * @return difference string
    */
-  static QString _printValidationReportDiff(
-    const QString& testName, const QString& filePath1, const QString& filePath2, const int timeout);
+  static QString _printValidationReportDiff(const QString& testName, const QString& filePath1, const QString& filePath2, const int timeout);
 };
 
 }


### PR DESCRIPTION
Fix `OsmXmlReader` for empty or invalid XML strings and retry errant validators with a shorter timeout.