### PR TITLE
Add OSM tags for FCODE to translated preset

### DIFF
--- a/translations/TranslationServer.js
+++ b/translations/TranslationServer.js
@@ -809,6 +809,12 @@ var searchSchema = function(options) {
             });
     }
 
+    result.forEach(r => {
+        r.tags = fcodeLookup[translation].toOsm({
+            'FCODE': r.fcode
+        }, '', geomType);
+    })
+
     return result;
 }
 


### PR DESCRIPTION
This fixes an issue when translated presets are switched from one to another, and the code must remove the tags conferred by the old preset.  If there is an equivalent OSM preset for the tags, the old preset gets removed.  But if there is not, then the old translated schema preset remain and the feature now appears like two things (e.g. both sidewalk and trail).