### PR TITLE
Add option to auto-config element-cache sizes

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -1581,6 +1581,13 @@ merged together regardless of whether all of their non-name tags match.
 
 The spacing, in meters, used by `EdgeDistanceExtractor`.
 
+=== element.cache.size.auto.threshold
+
+* Data Type: int
+* Default Value: `80`
+
+Percentage of available memory to use when calculating the element cache sizes using cache auto configure
+
 === element.cache.size.node
 
 * Data Type: long

--- a/docs/commands/convert.asciidoc
+++ b/docs/commands/convert.asciidoc
@@ -6,29 +6,33 @@
 The `convert` command converts map data from one format to another. The process may be memory bound 
 depending upon the input or output formats selected.
 
-* `input(s)`          - Input(s); may be any supported input format (e.g. .osm file) or a directory 
-                        if `--recursive` is specified.
-* `output`            - Output; may be any supported output format (e.g. .osm file). If 
-                        `--separate-output` is specified, this should be the format file extension 
-                        (e.g. shp) or base URL of the output to be written and not a full URL 
-                        (e.g. hootapidb://<user name>:<password>@<host name>:<port>/<database name>).
-                        or hootapidb://<user name>:<password>@<host name>:<port>/<database name>).
-* `--recursive`       - Allows for processing the files contained in any directories specified in 
-                        `input(s)` recursively. This parameter has no effect on the processing of 
-                        non-directory inputs. This must be followed by either "*" to denote no 
-                        filtering or one or more wildcard name filters. e.g. "*.osm;*.json" or 
-                        "*myFile*". This parameter is not compatible with the OGR layer input 
-                        syntax.
-* `--separate-output` - The default behavior when processing multiple inputs is to combine them into 
-                        the same single output. With this parameter specified, each input is 
-                        processed and written to a separate output with the format specified in 
-                        `output` and the same file name as the input with the text "-converted" 
-                        appended to it. This parameter cannot be used with OSM API database 
-                        (osmapidb://) or OSM API (http://) inputs. This parameter is not compatible 
-                        with the OGR layer input syntax.
-* `--write-bounds`    - If the `bounds` configuration option is specified, optionally outputs a file 
-                        containing the input bounds. The location of the file is controlled via the 
-                        `bounds.output.file` configuration option.
+* `input(s)`            - Input(s); may be any supported input format (e.g. .osm file) or a directory
+                          if `--recursive` is specified.
+* `output`              - Output; may be any supported output format (e.g. .osm file). If
+                          `--separate-output` is specified, this should be the format file extension
+                          (e.g. shp) or base URL of the output to be written and not a full URL
+                          (e.g. hootapidb://<user name>:<password>@<host name>:<port>/<database name>).
+                          or hootapidb://<user name>:<password>@<host name>:<port>/<database name>).
+* `--recursive`         - Allows for processing the files contained in any directories specified in
+                          `input(s)` recursively. This parameter has no effect on the processing of
+                          non-directory inputs. This must be followed by either "*" to denote no
+                          filtering or one or more wildcard name filters. e.g. "*.osm;*.json" or
+                          "*myFile*". This parameter is not compatible with the OGR layer input
+                          syntax.
+* `--separate-output`   - The default behavior when processing multiple inputs is to combine them into
+                          the same single output. With this parameter specified, each input is
+                          processed and written to a separate output with the format specified in
+                          `output` and the same file name as the input with the text "-converted"
+                          appended to it. This parameter cannot be used with OSM API database
+                          (osmapidb://) or OSM API (http://) inputs. This parameter is not compatible
+                          with the OGR layer input syntax.
+* `--write-bounds`      - If the `bounds` configuration option is specified, optionally outputs a file
+                          containing the input bounds. The location of the file is controlled via the
+                          `bounds.output.file` configuration option.
+* `--autoconfig-cache`  - If the convert operation is a streaming write, this option will automatically
+                          configure the `element.cache.size.*` settings by calculating the amount of free
+                          memory available multiplied by the threshold of 80% (by default) then divided by
+                          the calculated node/way/relation ratio and the actual memory size of the objects.
 
 === Usage
 

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ConvertCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ConvertCmd.cpp
@@ -67,6 +67,12 @@ public:
     LOG_VART(args.size());
     LOG_VART(args);
 
+    if (args.contains("--autoconfig-cache"))
+    {
+      setupAutoConfigCache();
+      args.removeAll("--autoconfig-cache");
+    }
+
     BoundedCommand::runSimple(args);
 
     bool separateOutput = false;
@@ -74,12 +80,6 @@ public:
     {
       separateOutput = true;
       args.removeAt(args.indexOf("--separate-output"));
-    }
-
-    if (args.contains("--auto-cache"))
-    {
-      setupAutoCache();
-      args.removeAll("--auto-cache");
     }
 
     bool recursive = false;
@@ -144,7 +144,7 @@ public:
     return 0;
   }
 
-  void setupAutoCache()
+  void setupAutoConfigCache()
   {
     //  These values were found through testing
     const double node_size = 350.0;
@@ -159,13 +159,14 @@ public:
     const long default_cache_ways = options.getElementCacheSizeWay();
     const long default_cache_relations = options.getElementCacheSizeRelation();
     //  Calculate a number of nodes/ways/relations that will "fit" in that memory
-    //  Use the memory usage checker threshold so that some memory remains
-    const double memory_threshold = static_cast<double>(ConfigOptions().getMemoryUsageCheckerThreshold()) / 100.0;
+    //  Use the element cache memory threshold so that some memory remains
+    const double memory_threshold = static_cast<double>(ConfigOptions().getElementCacheSizeAutoThreshold()) / 100.0;
     //  The current defaults are 10M nodes, 2M ways, and 2M relations since most nodes don't have tags which are the most expensive part
     const double available_for_cache = static_cast<double>(memory_available) * memory_threshold;
     const long cache_nodes = static_cast<long>((available_for_cache * 5.0 / 7.0) / node_size);
     const long cache_ways = static_cast<long>((available_for_cache * 1.0 / 7.0) / way_size);
     const long cache_relations = static_cast<long>((available_for_cache * 1.0 / 7.0) / relation_size);
+    LOG_DEBUG("Available memory for element cache: " << memory_available << " bytes (threshold: " << memory_threshold << ")");
     //  Update the values of the cache size if smaller than the settings
     if (cache_nodes < default_cache_nodes)
     {

--- a/hoot-core/src/main/cpp/hoot/core/cmd/ConvertCmd.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/cmd/ConvertCmd.cpp
@@ -144,7 +144,7 @@ public:
     return 0;
   }
 
-  void setupAutoConfigCache()
+  void setupAutoConfigCache() const
   {
     //  These values were found through testing
     const double node_size = 350.0;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlDiskCache.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlDiskCache.cpp
@@ -59,6 +59,7 @@ OsmXmlDiskCache::OsmXmlDiskCache()
   _writer.setIncludeHootInfo(true);
   _writer.setIncludePid(true);
   _writer.setIncludeDebug(true);
+  _writer.setIgnoreProgress(true);
   _writer.openunbuff(_tempFileName);
 
   // Setup our reader

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.cpp
@@ -75,7 +75,8 @@ OsmXmlReader::OsmXmlReader()
     _addChildRefsWhenMissing(false),
     _logWarningsForMissingElements(true),
     _statusUpdateInterval(1000),
-    _keepImmediatelyConnectedWaysOutsideBounds(false)
+    _keepImmediatelyConnectedWaysOutsideBounds(false),
+    _ignoreProgress(false)
 {
   setConfiguration(conf());
 }
@@ -818,7 +819,7 @@ bool OsmXmlReader::endElement(const QString& /* namespaceURI */,
       _numRead++;
     }
 
-    if (_numRead % _statusUpdateInterval == 0)
+    if (_numRead % _statusUpdateInterval == 0 && !_ignoreProgress)
     {
       PROGRESS_INFO("Read " << StringUtils::formatLargeNumber(_numRead) << " elements from input.");
     }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef OSMXMLREADER_H
 #define OSMXMLREADER_H

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlReader.h
@@ -120,6 +120,7 @@ public:
   void setKeepImmediatelyConnectedWaysOutsideBounds(bool keep)
   { _keepImmediatelyConnectedWaysOutsideBounds = keep; }
   void setLogWarningsForMissingElements(bool log) { _logWarningsForMissingElements = log; }
+  void setIgnoreProgress(const bool ignore) { _ignoreProgress = ignore; }
 
 protected:
 
@@ -180,6 +181,8 @@ protected:
 
   // only valid is _bounds is not null
   bool _keepImmediatelyConnectedWaysOutsideBounds;
+  /** Some usages of the OsmXmlReader don't need progress status written out so it can be ignored */
+  bool _ignoreProgress;
 
   void _createNode(const QXmlAttributes& attributes);
   void _createWay(const QXmlAttributes& attributes);

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.cpp
@@ -64,7 +64,8 @@ OsmXmlWriter::OsmXmlWriter()
     _precision(ConfigOptions().getWriterPrecision()),
     _encodingErrorCount(0),
     _numWritten(0),
-    _statusUpdateInterval(ConfigOptions().getTaskStatusUpdateInterval() * 10)
+    _statusUpdateInterval(ConfigOptions().getTaskStatusUpdateInterval() * 10),
+    _ignoreProgress(false)
 {
 }
 
@@ -396,7 +397,7 @@ void OsmXmlWriter::writePartial(const ConstNodePtr& n)
   _bounds.expandToInclude(n->getX(), n->getY());
 
   _numWritten++;
-  if (_numWritten % _statusUpdateInterval == 0)
+  if (_numWritten % _statusUpdateInterval == 0 && !_ignoreProgress)
   {
     PROGRESS_STATUS("Wrote " << StringUtils::formatLargeNumber(_numWritten) << " elements to output.");
   }
@@ -471,7 +472,7 @@ void OsmXmlWriter::writePartial(const ConstWayPtr& w)
   _writer->writeEndElement();
 
   _numWritten++;
-  if (_numWritten % _statusUpdateInterval == 0)
+  if (_numWritten % _statusUpdateInterval == 0 && !_ignoreProgress)
   {
     PROGRESS_STATUS("Wrote " << StringUtils::formatLargeNumber(_numWritten) << " elements to output.");
   }
@@ -502,7 +503,7 @@ void OsmXmlWriter::writePartial(const ConstRelationPtr& r)
   _writer->writeEndElement();
 
   _numWritten++;
-  if (_numWritten % _statusUpdateInterval == 0)
+  if (_numWritten % _statusUpdateInterval == 0 && !_ignoreProgress)
   {
     PROGRESS_STATUS("Wrote " << StringUtils::formatLargeNumber(_numWritten) << " elements to output.");
   }

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #include "OsmXmlWriter.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.h
@@ -98,6 +98,7 @@ public:
   void setIncludePointsInWays(bool includePoints) { _includePointInWays = includePoints; }
   void setPrecision(int p) { _precision = p; }
   void setFormatXml(const bool format) { _formatXml = format; }
+  void setIgnoreProgress(const bool ignore) { _ignoreProgress = ignore; }
 
 private:
 
@@ -121,6 +122,8 @@ private:
 
   int _numWritten;
   int _statusUpdateInterval;
+  /** Some usages of the OsmXmlWriter don't need progress status written out so it can be ignored */
+  bool _ignoreProgress;
 
   static QString _typeName(ElementType e);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmXmlWriter.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef OSMXMLWRITER_H
 #define OSMXMLWRITER_H

--- a/tgs/src/main/cpp/tgs/DelaunayTriangulation/DelaunayTriangulation.cpp
+++ b/tgs/src/main/cpp/tgs/DelaunayTriangulation/DelaunayTriangulation.cpp
@@ -53,7 +53,8 @@ private:
   Point2d *data;
 public:
   InternalEdge()
-    : next(nullptr),
+    : num(-1),
+      next(nullptr),
       data(nullptr)
   {
   }

--- a/tgs/src/main/cpp/tgs/DelaunayTriangulation/DelaunayTriangulation.cpp
+++ b/tgs/src/main/cpp/tgs/DelaunayTriangulation/DelaunayTriangulation.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 
 #include "DelaunayTriangulation.h"


### PR DESCRIPTION
Added `--autoconfig-cache` to `hoot convert` that finds the amount of available memory and calculates an approximate maximum for nodes/ways/relations (overrides `element.cache.size.*` settings).

Closes #5542 