### PR TITLE
GeoJSON writer runs translation twice on data causing some to fail

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.cpp
@@ -32,6 +32,7 @@
 #include <hoot/core/io/ElementCacheLRU.h>
 #include <hoot/core/io/ElementStreamer.h>
 #include <hoot/core/io/ElementTranslatorThread.h>
+#include <hoot/core/io/OsmGeoJsonWriter.h>
 #include <hoot/core/io/IoUtils.h>
 #include <hoot/core/io/OgrWriter.h>
 #include <hoot/core/io/OgrWriterThread.h>
@@ -195,6 +196,8 @@ void DataConverter::_convert(const QStringList& inputs, const QString& output)
     _setToOgrOptions(output);
   else if (IoUtils::anyAreSupportedOgrFormats(inputs, true))
     _setFromOgrOptions(inputs);
+  else if (OsmGeoJsonWriter().isSupported(output))
+    _handleGeoJsonOutputTranslationOpts();
   else if (!_translationScript.trimmed().isEmpty())
     _handleNonOgrOutputTranslationOpts();
 
@@ -508,6 +511,13 @@ void DataConverter::_handleNonOgrOutputTranslationOpts()
     _convertOps.replaceInStrings(SchemaTranslationOp::className(), SchemaTranslationVisitor::className());
   }
   LOG_VARD(_convertOps);
+}
+
+void DataConverter::_handleGeoJsonOutputTranslationOpts()
+{
+  //  For GeoJSON conversions, the translation is done in the writer and not in the reader, so remove the translators
+  _convertOps.removeAll(SchemaTranslationOp::className());
+  _convertOps.removeAll(SchemaTranslationVisitor::className());
 }
 
 void DataConverter::_addMergeNearbyNodesOps()

--- a/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/DataConverter.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef DATACONVERTER_H
 #define DATACONVERTER_H
@@ -130,6 +130,10 @@ private:
    * Sets I/O options for conversions from non-OGR formats
    */
   void _handleNonOgrOutputTranslationOpts();
+  /**
+   * Sets I/O options for conversions to GeoJson format
+   */
+  void _handleGeoJsonOutputTranslationOpts();
 
   /**
    * Add option operations to the options if they aren't already set


### PR DESCRIPTION
Remove one translation for geojson output so it isn't translated twice and fails

Closes #5645 