### PR TITLE
Boston Conflate - Circular road error

### DIFF
--- a/hoot-js/src/main/cpp/hoot/js/schema/JsonOsmSchemaLoader.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/JsonOsmSchemaLoader.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #include "JsonOsmSchemaLoader.h"
 
@@ -105,10 +105,8 @@ double JsonOsmSchemaLoader::_asDouble(const QVariant& v) const
   bool ok;
   double result = v.toDouble(&ok);
   if (!ok)
-  {
-    throw IllegalArgumentException(QString("Expected to receive a number, but got: %1 (%2)")
-                                    .arg(toString(v)).arg(v.typeName()));
-  }
+    throw IllegalArgumentException(QString("Expected to receive a number, but got: %1 (%2)").arg(toString(v)).arg(v.typeName()));
+
   return result;
 }
 
@@ -117,8 +115,7 @@ QString JsonOsmSchemaLoader::_asString(const QVariant& v) const
   if (v.type() == QVariant::String)
     return v.toString();
   else
-    throw IllegalArgumentException(QString("Expected to receive a string, but got: %1 (%2)")
-                                    .arg(toString(v)).arg(v.typeName()));
+    throw IllegalArgumentException(QString("Expected to receive a string, but got: %1 (%2)").arg(toString(v)).arg(v.typeName()));
 }
 
 QStringList JsonOsmSchemaLoader::_asStringList(const QVariant& v) const
@@ -134,10 +131,7 @@ QStringList JsonOsmSchemaLoader::_asStringList(const QVariant& v) const
       result.push_back(_asString(var));
   }
   else
-  {
-    throw IllegalArgumentException(QString("Expected to receive a list, but got: %1 (%2)")
-                                    .arg(toString(v)).arg(v.typeName()));
-  }
+    throw IllegalArgumentException(QString("Expected to receive a list, but got: %1 (%2)").arg(toString(v)).arg(v.typeName()));
 
   return result;
 }

--- a/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #include "OsmSchemaJs.h"
 

--- a/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.cpp
@@ -64,53 +64,30 @@ void OsmSchemaJs::Init(Local<Object> exports)
   Local<Object> schema = Object::New(current);
   exports->Set(context, toV8("OsmSchema"), schema);
 
-  schema->Set(context, toV8("getAllTags"),
-              FunctionTemplate::New(current, getAllTags)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("getCategories"),
-              FunctionTemplate::New(current, getCategories)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("getChildTagsAsVertices"),
-              FunctionTemplate::New(current, getChildTagsAsVertices)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("getSimilarTagsAsVertices"),
-              FunctionTemplate::New(current, getSimilarTagsAsVertices)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("getTagVertex"),
-              FunctionTemplate::New(current, getTagVertex)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("isAncestor"),
-              FunctionTemplate::New(current, isAncestor)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("isGeneric"),
-              FunctionTemplate::New(current, isGeneric)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("hasType"),
-              FunctionTemplate::New(current, hasType)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("explicitTypeMismatch"),
-              FunctionTemplate::New(current, explicitTypeMismatch)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("mostSpecificType"),
-              FunctionTemplate::New(current, mostSpecificType)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("score"),
-              FunctionTemplate::New(current, score)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("scoreTypes"),
-              FunctionTemplate::New(current, scoreTypes)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("scoreOneWay"),
-              FunctionTemplate::New(current, scoreOneWay)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("hasName"),
-              FunctionTemplate::New(current, hasName)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("isSpecificallyConflatable"),
-              FunctionTemplate::New(current, isSpecificallyConflatable)->GetFunction(context).ToLocalChecked());
-
-  schema->Set(context, toV8("isPolygon"),
-              FunctionTemplate::New(current, isPolygon)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("isPoint"),
-              FunctionTemplate::New(current, isPoint)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("isLinear"),
-              FunctionTemplate::New(current, isLinear)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("isRiver"),
-              FunctionTemplate::New(current, isRiver)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("isPowerLine"),
-              FunctionTemplate::New(current, isPowerLine)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("isPoi"),
-              FunctionTemplate::New(current, isPoi)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("isRailway"),
-              FunctionTemplate::New(current, isRailway)->GetFunction(context).ToLocalChecked());
-  schema->Set(context, toV8("isNonBuildingArea"),
-              FunctionTemplate::New(current, isNonBuildingArea)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("getAllTags"), FunctionTemplate::New(current, getAllTags)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("getCategories"), FunctionTemplate::New(current, getCategories)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("getChildTagsAsVertices"), FunctionTemplate::New(current, getChildTagsAsVertices)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("getSimilarTagsAsVertices"), FunctionTemplate::New(current, getSimilarTagsAsVertices)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("getTagVertex"),FunctionTemplate::New(current, getTagVertex)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("isAncestor"), FunctionTemplate::New(current, isAncestor)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("isGeneric"), FunctionTemplate::New(current, isGeneric)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("hasType"), FunctionTemplate::New(current, hasType)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("explicitTypeMismatch"), FunctionTemplate::New(current, explicitTypeMismatch)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("mostSpecificType"), FunctionTemplate::New(current, mostSpecificType)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("score"), FunctionTemplate::New(current, score)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("scoreTypes"), FunctionTemplate::New(current, scoreTypes)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("scoreOneWay"), FunctionTemplate::New(current, scoreOneWay)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("hasName"), FunctionTemplate::New(current, hasName)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("isSpecificallyConflatable"), FunctionTemplate::New(current, isSpecificallyConflatable)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("isPolygon"), FunctionTemplate::New(current, isPolygon)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("isPoint"), FunctionTemplate::New(current, isPoint)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("isLinear"), FunctionTemplate::New(current, isLinear)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("isRiver"), FunctionTemplate::New(current, isRiver)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("isPowerLine"), FunctionTemplate::New(current, isPowerLine)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("isPoi"), FunctionTemplate::New(current, isPoi)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("isRailway"), FunctionTemplate::New(current, isRailway)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("isNonBuildingArea"), FunctionTemplate::New(current, isNonBuildingArea)->GetFunction(context).ToLocalChecked());
+  schema->Set(context, toV8("isHighway"), FunctionTemplate::New(current, isHighway)->GetFunction(context).ToLocalChecked());
 }
 
 void OsmSchemaJs::getAllTags(const FunctionCallbackInfo<Value>& args)
@@ -144,8 +121,7 @@ void OsmSchemaJs::getSimilarTagsAsVertices(const FunctionCallbackInfo<Value>& ar
   QString kvp = toCpp<QString>(args[0]);
   double minimumScore = toCpp<double>(args[1]);
 
-  args.GetReturnValue().Set(
-    toV8(OsmSchema::getInstance().getSimilarTagsAsVertices(kvp, minimumScore)));
+  args.GetReturnValue().Set(toV8(OsmSchema::getInstance().getSimilarTagsAsVertices(kvp, minimumScore)));
 }
 
 void OsmSchemaJs::getTagVertex(const FunctionCallbackInfo<Value>& args)
@@ -165,8 +141,7 @@ void OsmSchemaJs::isAncestor(const FunctionCallbackInfo<Value>& args)
   QString childKvp = toCpp<QString>(args[0]);
   QString parentKvp = toCpp<QString>(args[1]);
 
-  args.GetReturnValue().Set(
-    Boolean::New(current, OsmSchema::getInstance().isAncestor(childKvp, parentKvp)));
+  args.GetReturnValue().Set(Boolean::New(current, OsmSchema::getInstance().isAncestor(childKvp, parentKvp)));
 }
 
 void OsmSchemaJs::isGeneric(const FunctionCallbackInfo<Value>& args)
@@ -175,8 +150,7 @@ void OsmSchemaJs::isGeneric(const FunctionCallbackInfo<Value>& args)
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e =
-    ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   const bool isGeneric = OsmSchema::getInstance().isGeneric(e->getTags());
   LOG_VART(isGeneric);
@@ -190,8 +164,7 @@ void OsmSchemaJs::hasType(const FunctionCallbackInfo<Value>& args)
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e =
-    ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   const bool hasType = OsmSchema::getInstance().hasType(e->getTags());
   LOG_VART(hasType);
@@ -205,14 +178,11 @@ void OsmSchemaJs::explicitTypeMismatch(const FunctionCallbackInfo<Value>& args)
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e1 =
-    ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
-  ConstElementPtr e2 =
-    ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
+  ConstElementPtr e1 = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
+  ConstElementPtr e2 = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
   double minimumScore = toCpp<double>(args[2]);
 
-  const bool hasExplicitTypeMismatch =
-    OsmSchema::getInstance().explicitTypeMismatch(e1->getTags(), e2->getTags(), minimumScore);
+  const bool hasExplicitTypeMismatch = OsmSchema::getInstance().explicitTypeMismatch(e1->getTags(), e2->getTags(), minimumScore);
 
   args.GetReturnValue().Set(Boolean::New(current, hasExplicitTypeMismatch));
 }
@@ -224,11 +194,9 @@ void OsmSchemaJs::isPoint(const FunctionCallbackInfo<Value>& args)
   Local<Context> context = current->GetCurrentContext();
 
   OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked());
-  ConstElementPtr e =
-    ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
 
-  args.GetReturnValue().Set(
-    Boolean::New(current, PointCriterion(mapJs->getConstMap()).isSatisfied(e)));
+  args.GetReturnValue().Set(Boolean::New(current, PointCriterion(mapJs->getConstMap()).isSatisfied(e)));
 }
 
 void OsmSchemaJs::isLinear(const FunctionCallbackInfo<Value>& args)
@@ -237,8 +205,7 @@ void OsmSchemaJs::isLinear(const FunctionCallbackInfo<Value>& args)
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e =
-    ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   args.GetReturnValue().Set(Boolean::New(current, LinearCriterion().isSatisfied(e)));
 }
@@ -250,11 +217,9 @@ void OsmSchemaJs::isPolygon(const FunctionCallbackInfo<Value>& args)
   Local<Context> context = current->GetCurrentContext();
 
   OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked());
-  ConstElementPtr e =
-    ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
 
-  args.GetReturnValue().Set(
-    Boolean::New(current, PolygonCriterion(mapJs->getConstMap()).isSatisfied(e)));
+  args.GetReturnValue().Set(Boolean::New(current, PolygonCriterion(mapJs->getConstMap()).isSatisfied(e)));
 }
 
 void OsmSchemaJs::isRiver(const FunctionCallbackInfo<Value>& args)
@@ -263,8 +228,7 @@ void OsmSchemaJs::isRiver(const FunctionCallbackInfo<Value>& args)
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e =
-    ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   args.GetReturnValue().Set(Boolean::New(current, RiverCriterion().isSatisfied(e)));
 }
@@ -275,8 +239,7 @@ void OsmSchemaJs::isPowerLine(const FunctionCallbackInfo<Value>& args)
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e =
-    ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   args.GetReturnValue().Set(Boolean::New(current, PowerLineCriterion().isSatisfied(e)));
 }
@@ -287,8 +250,7 @@ void OsmSchemaJs::isPoi(const FunctionCallbackInfo<Value>& args)
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e =
-    ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   args.GetReturnValue().Set(Boolean::New(current, PoiCriterion().isSatisfied(e)));
 }
@@ -299,8 +261,7 @@ void OsmSchemaJs::isRailway(const FunctionCallbackInfo<Value>& args)
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e =
-    ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   args.GetReturnValue().Set(Boolean::New(current, RailwayCriterion().isSatisfied(e)));
 }
@@ -312,15 +273,24 @@ void OsmSchemaJs::isNonBuildingArea(const FunctionCallbackInfo<Value>& args)
   Local<Context> context = current->GetCurrentContext();
 
   OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked());
-  ConstElementPtr e =
-    ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
 
-  args.GetReturnValue().Set(
-    Boolean::New(current, NonBuildingAreaCriterion(mapJs->getConstMap()).isSatisfied(e)));
+  args.GetReturnValue().Set(Boolean::New(current, NonBuildingAreaCriterion(mapJs->getConstMap()).isSatisfied(e)));
 }
 
-void OsmSchemaJs::isSpecificallyConflatable(
-  const FunctionCallbackInfo<Value>& args)
+void OsmSchemaJs::isHighway(const v8::FunctionCallbackInfo<v8::Value>& args)
+{
+  Isolate* current = args.GetIsolate();
+  HandleScope scope(current);
+  Local<Context> context = current->GetCurrentContext();
+
+  OsmMapJs* mapJs = ObjectWrap::Unwrap<OsmMapJs>(args[0]->ToObject(context).ToLocalChecked());
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
+
+  args.GetReturnValue().Set(Boolean::New(current, HighwayCriterion(mapJs->getConstMap()).isSatisfied(e)));
+}
+
+void OsmSchemaJs::isSpecificallyConflatable(const FunctionCallbackInfo<Value>& args)
 {
   bool isSpecificallyConflatable = false;
 
@@ -332,14 +302,11 @@ void OsmSchemaJs::isSpecificallyConflatable(
   NonConflatableCriterion crit(mapJs->getConstMap());
   crit.setIgnoreGenericConflators(true);
 
-  ConstElementPtr e =
-    ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[1]->ToObject(context).ToLocalChecked())->getConstElement();
 
   const QString geometryTypeFilterStr = toCpp<QString>(args[2]).trimmed();
   if (!geometryTypeFilterStr.isEmpty())
-  {
     crit.setGeometryTypeFilter(GeometryTypeCriterion::typeFromString(geometryTypeFilterStr));
-  }
   isSpecificallyConflatable = !crit.isSatisfied(e);
   LOG_VART(e);
   LOG_VART(isSpecificallyConflatable);
@@ -353,8 +320,7 @@ void OsmSchemaJs::hasName(const FunctionCallbackInfo<Value>& args)
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr e =
-    ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
+  ConstElementPtr e = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
 
   args.GetReturnValue().Set(Boolean::New(current, HasNameCriterion().isSatisfied(e)));
 }
@@ -402,8 +368,7 @@ void OsmSchemaJs::mostSpecificType(const FunctionCallbackInfo<Value>& args)
   HandleScope scope(current);
   Local<Context> context = current->GetCurrentContext();
 
-  ConstElementPtr element =
-    ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
+  ConstElementPtr element = ObjectWrap::Unwrap<ElementJs>(args[0]->ToObject(context).ToLocalChecked())->getConstElement();
   const QString kvp = OsmSchema::getInstance().mostSpecificType(element->getTags());
   args.GetReturnValue().Set(String::NewFromUtf8(current, kvp.toUtf8().data()).ToLocalChecked());
 }

--- a/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.h
@@ -76,6 +76,7 @@ private:
   static void isPoi(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void isRailway(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void isNonBuildingArea(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void isHighway(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   /**
    * See description in rules/HootLib.js isSpecificallyConflatable method

--- a/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.h
+++ b/hoot-js/src/main/cpp/hoot/js/schema/OsmSchemaJs.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef OSMSCHEMA_JS_H
 #define OSMSCHEMA_JS_H

--- a/rules/Polygon.js
+++ b/rules/Polygon.js
@@ -48,7 +48,9 @@ exports.isMatchCandidate = function(map, e)
   {
     return false;
   }
-  return hoot.OsmSchema.isPolygon(map, e) && !hoot.OsmSchema.isSpecificallyConflatable(map, e, exports.geometryType);
+  return hoot.OsmSchema.isPolygon(map, e) &&
+         !hoot.OsmSchema.isSpecificallyConflatable(map, e, exports.geometryType) &&
+         !hoot.OsmSchema.isHighway(map, e);
 };
 
 /**

--- a/test-files/cases/misc/network/roundabout-connector-conflate-merged-1/Expected.osm
+++ b/test-files/cases/misc/network/roundabout-connector-conflate-merged-1/Expected.osm
@@ -1221,6 +1221,142 @@
         <tag k="hoot:id" v="-490"/>
         <tag k="hoot:status" v="2"/>
     </node>
+    <node visible="true" id="-489" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8896731430811116" lon="-75.4028750295488948">
+        <tag k="hoot:id" v="-489"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-488" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8897192773013671" lon="-75.4028750048370000">
+        <tag k="hoot:id" v="-488"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-487" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8897531688190625" lon="-75.4028666247342727">
+        <tag k="hoot:id" v="-487"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-486" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8897831019781819" lon="-75.4028461121622229">
+        <tag k="hoot:id" v="-486"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-485" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8899664662626350" lon="-75.4026075017016524">
+        <tag k="hoot:id" v="-485"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-484" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8899882008916364" lon="-75.4025734779231556">
+        <tag k="hoot:id" v="-484"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-483" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8900017040779744" lon="-75.4025164056556747">
+        <tag k="hoot:id" v="-483"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-482" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8900014642162901" lon="-75.4024577735240484">
+        <tag k="hoot:id" v="-482"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-481" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8899751414123145" lon="-75.4024011853554015">
+        <tag k="hoot:id" v="-481"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-480" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8899435755133140" lon="-75.4023765742906988">
+        <tag k="hoot:id" v="-480"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-479" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8899065065821432" lon="-75.4023662958700385">
+        <tag k="hoot:id" v="-479"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-478" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8898613069967212" lon="-75.4023774709842201">
+        <tag k="hoot:id" v="-478"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-477" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8898258674108206" lon="-75.4024047101864454">
+        <tag k="hoot:id" v="-477"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-476" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8896672940758634" lon="-75.4026183999721695">
+        <tag k="hoot:id" v="-476"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-475" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8896403903756038" lon="-75.4026782904611679">
+        <tag k="hoot:id" v="-475"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-474" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8896272176176865" lon="-75.4027398568724152">
+        <tag k="hoot:id" v="-474"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-473" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8896223370107990" lon="-75.4028084262165663">
+        <tag k="hoot:id" v="-473"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-472" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8890922913549701" lon="-75.4034774310472073">
+        <tag k="hoot:id" v="-472"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-471" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8890436207898986" lon="-75.4034815616554965">
+        <tag k="hoot:id" v="-471"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-470" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8890032801837080" lon="-75.4034946631373515">
+        <tag k="hoot:id" v="-470"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-469" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8889641333409060" lon="-75.4035303966144284">
+        <tag k="hoot:id" v="-469"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-468" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8887996285861419" lon="-75.4037185394454639">
+        <tag k="hoot:id" v="-468"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-467" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8887759197891114" lon="-75.4037603583585962">
+        <tag k="hoot:id" v="-467"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-466" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8887590107149776" lon="-75.4038091948373363">
+        <tag k="hoot:id" v="-466"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-465" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8887629232601739" lon="-75.4038669899039462">
+        <tag k="hoot:id" v="-465"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-464" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8887819327299695" lon="-75.4039126869476490">
+        <tag k="hoot:id" v="-464"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-463" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8888135498152252" lon="-75.4039424884110332">
+        <tag k="hoot:id" v="-463"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-462" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8888548785322712" lon="-75.4039548915967117">
+        <tag k="hoot:id" v="-462"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-461" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8889074272808983" lon="-75.4039498066115073">
+        <tag k="hoot:id" v="-461"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-460" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8889475643061218" lon="-75.4039254275654542">
+        <tag k="hoot:id" v="-460"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-459" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8891147899892502" lon="-75.4037226128551765">
+        <tag k="hoot:id" v="-459"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-458" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8891388298619134" lon="-75.4036658147224443">
+        <tag k="hoot:id" v="-458"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-457" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8891533923229744" lon="-75.4036023019542085">
+        <tag k="hoot:id" v="-457"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
+    <node visible="true" id="-456" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8891540583057278" lon="-75.4035456859359954">
+        <tag k="hoot:id" v="-456"/>
+        <tag k="hoot:status" v="2"/>
+    </node>
     <node visible="true" id="-452" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8876850566491612" lon="-75.4045800702726439">
         <tag k="hoot:id" v="-452"/>
         <tag k="hoot:status" v="2"/>
@@ -3790,6 +3926,62 @@
         <tag k="hoot:way:node:count" v="17"/>
         <tag k="name" v="Hickory Branch Lane"/>
         <tag k="source:datetime" v="2018-03-18T02:45:44Z"/>
+    </way>
+    <way visible="true" id="-109" timestamp="2020-02-28T16:47:47Z" version="1">
+        <nd ref="4881729181"/>
+        <nd ref="-473"/>
+        <nd ref="-474"/>
+        <nd ref="-475"/>
+        <nd ref="-476"/>
+        <nd ref="-477"/>
+        <nd ref="-478"/>
+        <nd ref="-479"/>
+        <nd ref="-480"/>
+        <nd ref="-481"/>
+        <nd ref="-482"/>
+        <nd ref="-483"/>
+        <nd ref="-484"/>
+        <nd ref="-485"/>
+        <nd ref="-486"/>
+        <nd ref="-487"/>
+        <nd ref="-488"/>
+        <nd ref="-489"/>
+        <nd ref="4881729181"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-109"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:way:node:count" v="19"/>
+        <tag k="name" v="Rock Ledge Court"/>
+        <tag k="source:datetime" v="2018-03-18T02:33:10Z"/>
+    </way>
+    <way visible="true" id="-108" timestamp="2020-02-28T16:47:47Z" version="1">
+        <nd ref="4881727230"/>
+        <nd ref="-456"/>
+        <nd ref="-457"/>
+        <nd ref="-458"/>
+        <nd ref="-459"/>
+        <nd ref="-460"/>
+        <nd ref="-461"/>
+        <nd ref="-462"/>
+        <nd ref="-463"/>
+        <nd ref="-464"/>
+        <nd ref="-465"/>
+        <nd ref="-466"/>
+        <nd ref="-467"/>
+        <nd ref="-468"/>
+        <nd ref="-469"/>
+        <nd ref="-470"/>
+        <nd ref="-471"/>
+        <nd ref="-472"/>
+        <nd ref="4881727230"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-108"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:way:node:count" v="19"/>
+        <tag k="name" v="Rock Ledge Court"/>
+        <tag k="source:datetime" v="2018-03-18T02:33:10Z"/>
     </way>
     <way visible="true" id="-105" timestamp="2020-02-28T16:47:47Z" version="1">
         <nd ref="-437"/>

--- a/test-files/cases/misc/unifying/roundabout-connector-conflate-merged-1/Expected.osm
+++ b/test-files/cases/misc/unifying/roundabout-connector-conflate-merged-1/Expected.osm
@@ -1,68 +1,80 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="hootenanny" srs="+epsg:4326">
     <bounds minlat="38.883" minlon="-75.4059" maxlat="38.8953" maxlon="-75.3899"/>
-    <node visible="true" id="-1126" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8952637827430010" lon="-75.4024734103379330">
-        <tag k="hoot:id" v="-1126"/>
+    <node visible="true" id="-1148" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8952637827430010" lon="-75.4024734103379330">
+        <tag k="hoot:id" v="-1148"/>
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1124" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8887515899763727" lon="-75.4020949936607821">
+    <node visible="true" id="-1146" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8887515899763727" lon="-75.4020949936607821">
+        <tag k="hoot:id" v="-1146"/>
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-1144" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8878891522640515" lon="-75.4042610189708853">
+        <tag k="hoot:id" v="-1144"/>
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-1143" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8877967505348892" lon="-75.4033252655119810">
+        <tag k="hoot:id" v="-1143"/>
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-1140" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8908646300087213" lon="-75.3913158824494900">
+        <tag k="hoot:id" v="-1140"/>
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-1136" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8891415854921263" lon="-75.4034644543114325">
+        <tag k="hoot:id" v="-1136"/>
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-1134" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8952653496500460" lon="-75.4007950493720074">
+        <tag k="hoot:id" v="-1134"/>
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-1132" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8895806118456449" lon="-75.4028140736316033">
+        <tag k="hoot:id" v="-1132"/>
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-1131" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8896449865840736" lon="-75.4029179899515754">
+        <tag k="hoot:id" v="-1131"/>
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-1127" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8863249609576229" lon="-75.3957833653490184">
+        <tag k="hoot:id" v="-1127"/>
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-1125" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8849295297694795" lon="-75.3978990232542827">
+        <tag k="hoot:id" v="-1125"/>
+        <tag k="hoot:status" v="1"/>
+    </node>
+    <node visible="true" id="-1124" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8845216358997590" lon="-75.3984832316498199">
         <tag k="hoot:id" v="-1124"/>
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1122" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8878891522640515" lon="-75.4042610189708853">
-        <tag k="hoot:id" v="-1122"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1121" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8877967505348892" lon="-75.4033252655119810">
+    <node visible="true" id="-1121" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8891947778160301" lon="-75.3999824098793283">
         <tag k="hoot:id" v="-1121"/>
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1118" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8908646300087213" lon="-75.3913158824494900">
+    <node visible="true" id="-1118" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8915669851406633" lon="-75.3946501835812768">
         <tag k="hoot:id" v="-1118"/>
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1116" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8952653496500460" lon="-75.4007950493720074">
-        <tag k="hoot:id" v="-1116"/>
+    <node visible="true" id="-1115" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8845258758324519" lon="-75.4025174271888403">
+        <tag k="hoot:id" v="-1115"/>
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1113" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8863249609576229" lon="-75.3957833653490184">
+    <node visible="true" id="-1113" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8902793921062866" lon="-75.4052461165747303">
         <tag k="hoot:id" v="-1113"/>
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1111" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8849295297694795" lon="-75.3978990232542827">
+    <node visible="true" id="-1111" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904238143514505" lon="-75.4055663828555396">
         <tag k="hoot:id" v="-1111"/>
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1110" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8845216358997590" lon="-75.3984832316498199">
+    <node visible="true" id="-1110" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8898731917197082" lon="-75.4058258800265691">
         <tag k="hoot:id" v="-1110"/>
         <tag k="hoot:status" v="1"/>
     </node>
-    <node visible="true" id="-1107" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8891947778160301" lon="-75.3999824098793283">
+    <node visible="true" id="-1107" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909427859940635" lon="-75.3905696601347444">
         <tag k="hoot:id" v="-1107"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1104" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8915669851406633" lon="-75.3946501835812768">
-        <tag k="hoot:id" v="-1104"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1101" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8845258758324519" lon="-75.4025174271888403">
-        <tag k="hoot:id" v="-1101"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1099" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8902793921062866" lon="-75.4052461165747303">
-        <tag k="hoot:id" v="-1099"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1097" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8904238143514505" lon="-75.4055663828555396">
-        <tag k="hoot:id" v="-1097"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1096" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8898731917197082" lon="-75.4058258800265691">
-        <tag k="hoot:id" v="-1096"/>
-        <tag k="hoot:status" v="1"/>
-    </node>
-    <node visible="true" id="-1093" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8909427859940635" lon="-75.3905696601347444">
-        <tag k="hoot:id" v="-1093"/>
         <tag k="hoot:status" v="1"/>
     </node>
     <node visible="true" id="-787" timestamp="1970-01-01T00:00:00Z" version="1" lat="38.8935614000000029" lon="-75.3918246000000067">
@@ -1245,148 +1257,8 @@
         <tag k="hoot:id" v="-490"/>
         <tag k="hoot:status" v="2"/>
     </node>
-    <node visible="true" id="-489" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8896943000000093" lon="-75.4028681000000063">
-        <tag k="hoot:id" v="-489"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-488" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8897411000000019" lon="-75.4028698000000048">
-        <tag k="hoot:id" v="-488"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-487" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8897754999999989" lon="-75.4028627000000000">
-        <tag k="hoot:id" v="-487"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-486" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8898058999999989" lon="-75.4028433000000007">
-        <tag k="hoot:id" v="-486"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-485" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8899917999999971" lon="-75.4026096999999993">
-        <tag k="hoot:id" v="-485"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-484" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8900138000000055" lon="-75.4025761000000045">
-        <tag k="hoot:id" v="-484"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-483" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8900276000000034" lon="-75.4025194000000027">
-        <tag k="hoot:id" v="-483"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-482" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8900276000000105" lon="-75.4024610000000024">
-        <tag k="hoot:id" v="-482"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-481" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8900014000000027" lon="-75.4024043999999947">
-        <tag k="hoot:id" v="-481"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-480" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8899698000000029" lon="-75.4023796000000033">
-        <tag k="hoot:id" v="-480"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-479" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8899326000000016" lon="-75.4023689999999931">
-        <tag k="hoot:id" v="-479"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-478" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8898871000000028" lon="-75.4023796000000033">
-        <tag k="hoot:id" v="-478"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-477" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8898512999999895" lon="-75.4024062000000015">
-        <tag k="hoot:id" v="-477"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-476" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8896901999999969" lon="-75.4026149999999973">
-        <tag k="hoot:id" v="-476"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-475" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8896626000000012" lon="-75.4026733999999976">
-        <tag k="hoot:id" v="-475"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-474" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8896488000000033" lon="-75.4027336000000048">
-        <tag k="hoot:id" v="-474"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-473" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8896433000000101" lon="-75.4028007999999943">
-        <tag k="hoot:id" v="-473"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-472" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8891130000000018" lon="-75.4034697000000023">
-        <tag k="hoot:id" v="-472"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-471" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8890647999999999" lon="-75.4034750000000003">
-        <tag k="hoot:id" v="-471"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-470" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8890249000000097" lon="-75.4034891999999957">
-        <tag k="hoot:id" v="-470"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-469" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8889862999999991" lon="-75.4035262999999958">
-        <tag k="hoot:id" v="-469"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-468" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8888238000000044" lon="-75.4037191999999976">
-        <tag k="hoot:id" v="-468"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-467" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8888004000000009" lon="-75.4037617000000040">
-        <tag k="hoot:id" v="-467"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-466" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8887837999999988" lon="-75.4038112000000069">
-        <tag k="hoot:id" v="-466"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-465" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8887879999999981" lon="-75.4038695999999931">
-        <tag k="hoot:id" v="-465"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-464" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8888072000000022" lon="-75.4039156999999989">
-        <tag k="hoot:id" v="-464"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-463" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8888389000000032" lon="-75.4039456999999942">
-        <tag k="hoot:id" v="-463"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-462" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8888802000000027" lon="-75.4039580999999970">
-        <tag k="hoot:id" v="-462"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-461" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8889325999999969" lon="-75.4039527999999990">
-        <tag k="hoot:id" v="-461"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-460" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8889725000000013" lon="-75.4039279999999934">
-        <tag k="hoot:id" v="-460"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-459" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8891378000000003" lon="-75.4037210000000044">
-        <tag k="hoot:id" v="-459"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-458" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8891611999999895" lon="-75.4036626000000041">
-        <tag k="hoot:id" v="-458"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-457" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8891749999999945" lon="-75.4035970999999989">
-        <tag k="hoot:id" v="-457"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
     <node visible="true" id="-456" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8891750000000016" lon="-75.4035386999999986">
         <tag k="hoot:id" v="-456"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-455" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8896475000000024" lon="-75.4028574000000020">
-        <tag k="hoot:id" v="-455"/>
-        <tag k="hoot:status" v="2"/>
-    </node>
-    <node visible="true" id="-454" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8891570999999985" lon="-75.4034855999999962">
-        <tag k="hoot:id" v="-454"/>
         <tag k="hoot:status" v="2"/>
     </node>
     <node visible="true" id="-452" timestamp="2020-02-28T16:47:45Z" version="1" lat="38.8877124999999992" lon="-75.4045876999999933">
@@ -3229,7 +3101,19 @@
         <tag k="hoot:id" v="4881737777"/>
         <tag k="hoot:status" v="1"/>
     </node>
-    <way visible="true" id="-1087" timestamp="1970-01-01T00:00:00Z" version="1">
+    <way visible="true" id="-1281" timestamp="2020-02-28T16:47:47Z" version="1">
+        <nd ref="-1136"/>
+        <nd ref="-456"/>
+        <nd ref="4881727230"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-1281"/>
+        <tag k="hoot:status" v="2"/>
+        <tag k="hoot:way:node:count" v="3"/>
+        <tag k="name" v="Rock Ledge Court"/>
+        <tag k="source:datetime" v="2018-03-18T02:33:10Z"/>
+    </way>
+    <way visible="true" id="-1135" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-3"/>
         <nd ref="4881727362"/>
         <nd ref="4881727361"/>
@@ -3242,12 +3126,12 @@
         <nd ref="4881726791"/>
         <nd ref="4881726796"/>
         <nd ref="4881732574"/>
-        <nd ref="-1093"/>
+        <nd ref="-1107"/>
         <nd ref="4881727171"/>
         <tag k="error:circular" v="15"/>
         <tag k="highway" v="secondary"/>
         <tag k="hoot:hash" v="sha1sum:9ad82e2039a4fe2325537f37543641e05ac1ecbb;sha1sum:5f2ded44143b6c54e274afae403d558143c4610d"/>
-        <tag k="hoot:id" v="-1087"/>
+        <tag k="hoot:id" v="-1135"/>
         <tag k="hoot:status" v="3"/>
         <tag k="hoot:way:node:count" v="14"/>
         <tag k="name" v="Cedar Creek Road"/>
@@ -3260,10 +3144,35 @@
         <tag k="tiger:name_type" v="Rd"/>
         <tag k="tiger:reviewed" v="no"/>
     </way>
+    <way visible="true" id="-163" timestamp="2020-02-28T16:48:04Z" version="1">
+        <nd ref="-1131"/>
+        <nd ref="4881730602"/>
+        <nd ref="4881730567"/>
+        <nd ref="4881730830"/>
+        <nd ref="4881727235"/>
+        <nd ref="4881729137"/>
+        <nd ref="4881727219"/>
+        <nd ref="4881729213"/>
+        <nd ref="4881730808"/>
+        <nd ref="4881729193"/>
+        <nd ref="4881730845"/>
+        <nd ref="-1132"/>
+        <nd ref="4881729181"/>
+        <nd ref="-1131"/>
+        <tag k="alt_name" v="Rock Ledge Court"/>
+        <tag k="error:circular" v="15"/>
+        <tag k="highway" v="residential"/>
+        <tag k="hoot:id" v="-163"/>
+        <tag k="hoot:multilinestring" v="yes"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="hoot:way:node:count" v="14"/>
+        <tag k="name" v="Little Birch Lane"/>
+        <tag k="source:datetime" v="2011-04-13T17:05:09.000Z;2018-03-18T02:33:10Z"/>
+    </way>
     <way visible="true" id="-140" timestamp="2020-02-28T16:48:04Z" version="1">
         <nd ref="-786"/>
         <nd ref="4881730846"/>
-        <nd ref="-1107"/>
+        <nd ref="-1121"/>
         <nd ref="4881729188"/>
         <nd ref="4881730462"/>
         <tag k="error:circular" v="15"/>
@@ -3666,7 +3575,7 @@
         <tag k="source:datetime" v="2019-02-09T03:12:21Z"/>
     </way>
     <way visible="true" id="-114" timestamp="2020-02-28T16:47:47Z" version="1">
-        <nd ref="-1113"/>
+        <nd ref="-1127"/>
         <nd ref="-604"/>
         <nd ref="-605"/>
         <nd ref="-606"/>
@@ -3815,74 +3724,6 @@
         <tag k="name" v="Hickory Branch Lane"/>
         <tag k="source:datetime" v="2018-03-18T02:45:44Z"/>
     </way>
-    <way visible="true" id="-109" timestamp="2020-02-28T16:47:47Z" version="1">
-        <nd ref="-455"/>
-        <nd ref="-473"/>
-        <nd ref="-474"/>
-        <nd ref="-475"/>
-        <nd ref="-476"/>
-        <nd ref="-477"/>
-        <nd ref="-478"/>
-        <nd ref="-479"/>
-        <nd ref="-480"/>
-        <nd ref="-481"/>
-        <nd ref="-482"/>
-        <nd ref="-483"/>
-        <nd ref="-484"/>
-        <nd ref="-485"/>
-        <nd ref="-486"/>
-        <nd ref="-487"/>
-        <nd ref="-488"/>
-        <nd ref="-489"/>
-        <nd ref="-455"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:id" v="-109"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="hoot:way:node:count" v="19"/>
-        <tag k="name" v="Rock Ledge Court"/>
-        <tag k="source:datetime" v="2018-03-18T02:33:10Z"/>
-    </way>
-    <way visible="true" id="-108" timestamp="2020-02-28T16:47:47Z" version="1">
-        <nd ref="-454"/>
-        <nd ref="-456"/>
-        <nd ref="-457"/>
-        <nd ref="-458"/>
-        <nd ref="-459"/>
-        <nd ref="-460"/>
-        <nd ref="-461"/>
-        <nd ref="-462"/>
-        <nd ref="-463"/>
-        <nd ref="-464"/>
-        <nd ref="-465"/>
-        <nd ref="-466"/>
-        <nd ref="-467"/>
-        <nd ref="-468"/>
-        <nd ref="-469"/>
-        <nd ref="-470"/>
-        <nd ref="-471"/>
-        <nd ref="-472"/>
-        <nd ref="-454"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:id" v="-108"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="hoot:way:node:count" v="19"/>
-        <tag k="name" v="Rock Ledge Court"/>
-        <tag k="source:datetime" v="2018-03-18T02:33:10Z"/>
-    </way>
-    <way visible="true" id="-107" timestamp="2020-02-28T16:47:47Z" version="1">
-        <nd ref="-454"/>
-        <nd ref="4881727246"/>
-        <nd ref="-455"/>
-        <tag k="error:circular" v="15"/>
-        <tag k="highway" v="residential"/>
-        <tag k="hoot:id" v="-107"/>
-        <tag k="hoot:status" v="2"/>
-        <tag k="hoot:way:node:count" v="3"/>
-        <tag k="name" v="Rock Ledge Court"/>
-        <tag k="source:datetime" v="2018-03-18T02:33:10Z"/>
-    </way>
     <way visible="true" id="-105" timestamp="2020-02-28T16:47:47Z" version="1">
         <nd ref="-437"/>
         <nd ref="-438"/>
@@ -3968,8 +3809,8 @@
         <tag k="source:datetime" v="2018-03-18T02:33:09Z"/>
     </way>
     <way visible="true" id="-98" timestamp="2020-02-28T16:47:47Z" version="1">
-        <nd ref="-1097"/>
-        <nd ref="-1099"/>
+        <nd ref="-1111"/>
+        <nd ref="-1113"/>
         <tag k="error:circular" v="15"/>
         <tag k="highway" v="residential"/>
         <tag k="hoot:id" v="-98"/>
@@ -3978,7 +3819,7 @@
         <tag k="source:datetime" v="2018-03-18T01:51:59Z"/>
     </way>
     <way visible="true" id="-97" timestamp="2020-02-28T16:47:47Z" version="1">
-        <nd ref="-1110"/>
+        <nd ref="-1124"/>
         <nd ref="-400"/>
         <tag k="error:circular" v="15"/>
         <tag k="highway" v="residential"/>
@@ -3996,7 +3837,7 @@
         <nd ref="-395"/>
         <nd ref="-396"/>
         <nd ref="-397"/>
-        <nd ref="-1111"/>
+        <nd ref="-1125"/>
         <tag k="error:circular" v="15"/>
         <tag k="highway" v="residential"/>
         <tag k="hoot:id" v="-96"/>
@@ -4038,7 +3879,7 @@
         <tag k="source:datetime" v="2016-06-08T19:42:43Z"/>
     </way>
     <way visible="true" id="-93" timestamp="2020-02-28T16:47:46Z" version="1">
-        <nd ref="-1107"/>
+        <nd ref="-1121"/>
         <nd ref="-330"/>
         <nd ref="-419"/>
         <nd ref="-329"/>
@@ -4205,7 +4046,7 @@
         <nd ref="-452"/>
         <nd ref="-429"/>
         <nd ref="-290"/>
-        <nd ref="-1122"/>
+        <nd ref="-1144"/>
         <tag k="error:circular" v="15"/>
         <tag k="highway" v="residential"/>
         <tag k="hoot:id" v="-84"/>
@@ -4283,7 +4124,7 @@
     </way>
     <way visible="true" id="-78" timestamp="2020-02-28T16:47:46Z" version="1">
         <nd ref="-219"/>
-        <nd ref="-1121"/>
+        <nd ref="-1143"/>
         <tag k="error:circular" v="15"/>
         <tag k="highway" v="residential"/>
         <tag k="hoot:id" v="-78"/>
@@ -4307,7 +4148,7 @@
         <tag k="source:datetime" v="2018-03-18T02:33:13Z"/>
     </way>
     <way visible="true" id="-76" timestamp="2020-02-28T16:47:46Z" version="1">
-        <nd ref="-1113"/>
+        <nd ref="-1127"/>
         <nd ref="-541"/>
         <nd ref="-273"/>
         <nd ref="-540"/>
@@ -4342,7 +4183,7 @@
         <nd ref="-189"/>
         <nd ref="-415"/>
         <nd ref="-267"/>
-        <nd ref="-1124"/>
+        <nd ref="-1146"/>
         <tag k="error:circular" v="15"/>
         <tag k="highway" v="residential"/>
         <tag k="hoot:id" v="-75"/>
@@ -4619,7 +4460,7 @@
         <nd ref="-334"/>
         <nd ref="-335"/>
         <nd ref="-95"/>
-        <nd ref="-1101"/>
+        <nd ref="-1115"/>
         <tag k="error:circular" v="15"/>
         <tag k="highway" v="service"/>
         <tag k="hoot:id" v="-27"/>
@@ -4657,7 +4498,7 @@
     </way>
     <way visible="true" id="-24" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="4881724671"/>
-        <nd ref="-1116"/>
+        <nd ref="-1134"/>
         <nd ref="-31"/>
         <tag k="error:circular" v="15"/>
         <tag k="highway" v="residential"/>
@@ -4678,7 +4519,7 @@
     </way>
     <way visible="true" id="-23" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="4881726693"/>
-        <nd ref="-1099"/>
+        <nd ref="-1113"/>
         <nd ref="4881737446"/>
         <nd ref="4881736810"/>
         <nd ref="4881736807"/>
@@ -4723,14 +4564,14 @@
         <nd ref="4881737765"/>
         <nd ref="4881737762"/>
         <nd ref="4881737763"/>
-        <nd ref="-1110"/>
+        <nd ref="-1124"/>
         <nd ref="4881737776"/>
         <nd ref="4881737777"/>
         <nd ref="4881728583"/>
-        <nd ref="-1111"/>
+        <nd ref="-1125"/>
         <nd ref="4881728581"/>
         <nd ref="4881737755"/>
-        <nd ref="-1113"/>
+        <nd ref="-1127"/>
         <nd ref="4881737768"/>
         <nd ref="4881737769"/>
         <nd ref="4881729183"/>
@@ -4767,7 +4608,7 @@
     </way>
     <way visible="true" id="-19" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="4881735986"/>
-        <nd ref="-1126"/>
+        <nd ref="-1148"/>
         <nd ref="-26"/>
         <tag k="error:circular" v="15"/>
         <tag k="highway" v="residential"/>
@@ -4823,7 +4664,7 @@
     <way visible="true" id="-16" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-21"/>
         <nd ref="4881732435"/>
-        <nd ref="-1101"/>
+        <nd ref="-1115"/>
         <nd ref="4881728600"/>
         <nd ref="4881728085"/>
         <nd ref="4881728086"/>
@@ -4848,9 +4689,9 @@
     <way visible="true" id="-15" timestamp="1970-01-01T00:00:00Z" version="1">
         <nd ref="-19"/>
         <nd ref="4881726693"/>
-        <nd ref="-1096"/>
+        <nd ref="-1110"/>
         <nd ref="4881726690"/>
-        <nd ref="-1097"/>
+        <nd ref="-1111"/>
         <nd ref="4881726691"/>
         <nd ref="4881726704"/>
         <nd ref="4881726705"/>
@@ -5084,7 +4925,7 @@
         <tag k="source:datetime" v="2015-12-23T16:54:03.000Z;2015-12-23T16:54:03Z"/>
     </way>
     <way visible="true" id="-3" timestamp="1970-01-01T00:00:00Z" version="1">
-        <nd ref="-1093"/>
+        <nd ref="-1107"/>
         <nd ref="4881727171"/>
         <nd ref="4881732586"/>
         <nd ref="-4"/>
@@ -5274,7 +5115,7 @@
         <nd ref="4881726865"/>
         <nd ref="4881726851"/>
         <nd ref="4881725005"/>
-        <nd ref="-1118"/>
+        <nd ref="-1140"/>
         <nd ref="4881725003"/>
         <nd ref="4881725004"/>
         <nd ref="4881724997"/>
@@ -5284,7 +5125,7 @@
         <nd ref="4881724436"/>
         <nd ref="4881724449"/>
         <nd ref="4881724447"/>
-        <nd ref="-1104"/>
+        <nd ref="-1118"/>
         <nd ref="4881725015"/>
         <tag k="error:circular" v="15"/>
         <tag k="highway" v="residential"/>
@@ -5389,6 +5230,7 @@
         <nd ref="4881729207"/>
         <nd ref="4881727246"/>
         <nd ref="4881729187"/>
+        <nd ref="-1136"/>
         <nd ref="4881727230"/>
         <nd ref="4881730426"/>
         <nd ref="4881730877"/>
@@ -5404,22 +5246,22 @@
         <tag k="highway" v="residential"/>
         <tag k="hoot:id" v="496850194"/>
         <tag k="hoot:status" v="3"/>
-        <tag k="hoot:way:node:count" v="14"/>
+        <tag k="hoot:way:node:count" v="15"/>
         <tag k="name" v="Little Birch Lane"/>
         <tag k="source:datetime" v="2011-04-13T17:05:10.000Z;2018-03-18T02:33:10Z"/>
     </way>
     <way visible="true" id="496850195" timestamp="2020-02-28T16:48:04Z" version="1">
         <nd ref="4881729188"/>
-        <nd ref="-1124"/>
+        <nd ref="-1146"/>
         <nd ref="4881730427"/>
-        <nd ref="-1121"/>
+        <nd ref="-1143"/>
         <nd ref="4881730851"/>
         <nd ref="4881729211"/>
         <nd ref="4881727247"/>
         <nd ref="4881729192"/>
         <nd ref="4881729855"/>
         <nd ref="4881727222"/>
-        <nd ref="-1122"/>
+        <nd ref="-1144"/>
         <nd ref="4881730424"/>
         <tag k="error:circular" v="15"/>
         <tag k="highway" v="residential"/>
@@ -5433,24 +5275,15 @@
     <way visible="true" id="496850196" timestamp="2020-02-28T16:48:04Z" version="1">
         <nd ref="4881727246"/>
         <nd ref="4881729181"/>
-        <nd ref="4881730602"/>
-        <nd ref="4881730567"/>
-        <nd ref="4881730830"/>
-        <nd ref="4881727235"/>
-        <nd ref="4881729137"/>
-        <nd ref="4881727219"/>
-        <nd ref="4881729213"/>
-        <nd ref="4881730808"/>
-        <nd ref="4881729193"/>
-        <nd ref="4881730845"/>
-        <nd ref="4881729181"/>
+        <tag k="alt_name" v="Rock Ledge Court"/>
         <tag k="error:circular" v="15"/>
         <tag k="highway" v="residential"/>
+        <tag k="hoot:hash" v="sha1sum:726f14b1eb8b2361b3292d1843fd9c89c2591401;sha1sum:900f8c8ef06e6209abff4e0136a1f06000dbed8f"/>
         <tag k="hoot:id" v="496850196"/>
-        <tag k="hoot:status" v="1"/>
-        <tag k="hoot:way:node:count" v="13"/>
+        <tag k="hoot:status" v="3"/>
+        <tag k="hoot:way:node:count" v="2"/>
         <tag k="name" v="Little Birch Lane"/>
-        <tag k="source:datetime" v="2011-04-13T17:05:09.000Z"/>
+        <tag k="source:datetime" v="2011-04-13T17:05:09.000Z;2018-03-18T02:33:10Z"/>
     </way>
     <way visible="true" id="496850201" timestamp="2020-02-28T16:48:04Z" version="1" changeset="10070">
         <nd ref="4881730876"/>
@@ -5500,19 +5333,18 @@
         <tag k="tiger:name_type" v="Dr"/>
         <tag k="tiger:reviewed" v="no"/>
     </way>
-    <relation visible="true" id="-48" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="way" ref="496850196" role="reviewee"/>
-        <member type="way" ref="-107" role="reviewee"/>
-        <tag k="hoot:id" v="-48"/>
+    <relation visible="true" id="-47" timestamp="1970-01-01T00:00:00Z" version="1">
+        <member type="relation" ref="-6" role="reviewee"/>
+        <tag k="hoot:id" v="-47"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:type" v="Highway"/>
+        <tag k="hoot:review:type" v="Relation"/>
         <tag k="hoot:status" v="3"/>
         <tag k="type" v="review"/>
     </relation>
-    <relation visible="true" id="-46" timestamp="1970-01-01T00:00:00Z" version="1">
+    <relation visible="true" id="-45" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="relation" ref="-6" role="reviewee"/>
-        <tag k="hoot:id" v="-46"/>
+        <tag k="hoot:id" v="-45"/>
         <tag k="hoot:review:members" v="2"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="Relation"/>
@@ -5520,17 +5352,8 @@
         <tag k="type" v="review"/>
     </relation>
     <relation visible="true" id="-44" timestamp="1970-01-01T00:00:00Z" version="1">
-        <member type="relation" ref="-6" role="reviewee"/>
-        <tag k="hoot:id" v="-44"/>
-        <tag k="hoot:review:members" v="2"/>
-        <tag k="hoot:review:needs" v="yes"/>
-        <tag k="hoot:review:type" v="Relation"/>
-        <tag k="hoot:status" v="3"/>
-        <tag k="type" v="review"/>
-    </relation>
-    <relation visible="true" id="-43" timestamp="1970-01-01T00:00:00Z" version="1">
         <member type="node" ref="4881728060" role="reviewee"/>
-        <tag k="hoot:id" v="-43"/>
+        <tag k="hoot:id" v="-44"/>
         <tag k="hoot:review:members" v="1"/>
         <tag k="hoot:review:needs" v="yes"/>
         <tag k="hoot:review:type" v="POI"/>
@@ -5648,7 +5471,7 @@
     </relation>
     <relation visible="true" id="7387471" timestamp="2020-02-28T16:48:04Z" version="1" changeset="10070">
         <member type="way" ref="-3" role=""/>
-        <member type="way" ref="-1087" role=""/>
+        <member type="way" ref="-1135" role=""/>
         <tag k="error:circular" v="15"/>
         <tag k="hoot:id" v="7387471"/>
         <tag k="hoot:status" v="3"/>


### PR DESCRIPTION
For unifying conflation, "circular" roads match for both the `HighwayMatcher` and `Polygon.js` matcher thus causing a conflict and keeping both matches from conflating.  Updated the polygon matcher to not match against highways to remedy this.

Closes #5634 