### PR TITLE
Add configurable properties for Overpass maxsize and timeout

### DIFF
--- a/hoot-services/src/main/java/hoot/services/HootProperties.java
+++ b/hoot-services/src/main/java/hoot/services/HootProperties.java
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 package hoot.services;
 
@@ -142,6 +142,9 @@ public final class HootProperties {
 
     public static final String OVERPASS_SYNC_TIMEOUT;
     public static final String OVERPASS_SYNC_INTERVAL;
+
+    public static final String OVERPASS_QUERY_MAXSIZE;
+    public static final String OVERPASS_QUERY_TIMEOUT;
 
     public static final String GRAIL_RAILS_LABEL;
     public static final String GRAIL_OVERPASS_LABEL;
@@ -336,6 +339,10 @@ public final class HootProperties {
         // to propagate to Overpass
         OVERPASS_SYNC_TIMEOUT = getProperty("overpassSyncTimeout");
         OVERPASS_SYNC_INTERVAL = getProperty("overpassSyncInterval");
+
+        // The maxsize (memory) and timeout for overpass queries sent by hoot-services
+        OVERPASS_QUERY_MAXSIZE = getProperty("overpassQueryMaxsize");
+        OVERPASS_QUERY_TIMEOUT = getProperty("overpassQueryTimeout");
 
         DIFFERENTIAL_CHANGESET_TWOSTEP = Boolean.valueOf(getProperty("diffChangesetTwoStep"));
 

--- a/hoot-services/src/main/java/hoot/services/controllers/grail/GrailResource.java
+++ b/hoot-services/src/main/java/hoot/services/controllers/grail/GrailResource.java
@@ -33,6 +33,8 @@ import static hoot.services.HootProperties.GRAIL_OVERPASS_LABEL;
 import static hoot.services.HootProperties.GRAIL_RAILS_LABEL;
 import static hoot.services.HootProperties.HOME_FOLDER;
 import static hoot.services.HootProperties.HOOTAPI_DB_URL;
+import static hoot.services.HootProperties.OVERPASS_QUERY_MAXSIZE;
+import static hoot.services.HootProperties.OVERPASS_QUERY_TIMEOUT;
 import static hoot.services.HootProperties.PRIVATE_OVERPASS_CERT_PATH;
 import static hoot.services.HootProperties.PRIVATE_OVERPASS_URL;
 import static hoot.services.HootProperties.PUBLIC_OVERPASS_URL;
@@ -818,7 +820,10 @@ public class GrailResource {
         }
 
         // first line that lists columns which are counts for each feature type
-        overpassQuery = overpassQuery.replace("[out:json]", "[out:csv(::count, ::\"count:nodes\", ::\"count:ways\", ::\"count:relations\")]");
+        overpassQuery = overpassQuery.replace("[out:json]",
+                String.format("[out:csv(::count, ::\"count:nodes\", ::\"count:ways\", ::\"count:relations\")][maxsize:%s][timeout:%s]",
+                OVERPASS_QUERY_MAXSIZE, OVERPASS_QUERY_TIMEOUT)
+                );
 
         // overpass query can have multiple "out *" lines so need to replace all
         overpassQuery = overpassQuery.replaceAll("out [\\s\\w]+;", "out count;");

--- a/hoot-services/src/main/resources/conf/hoot-services.conf.in
+++ b/hoot-services/src/main/resources/conf/hoot-services.conf.in
@@ -85,20 +85,20 @@ translationServerThreadCount=0
 translationServerScript=/translations/TranslationServer.js
 
 # Ingest size threshold
-ingestSizeThreshold=4000000000
+ingestSizeThreshold=200000000
 
 # Conflate size threshold
-conflateSizeThreshold=4000000000
+conflateSizeThreshold=200000000
 
 # Export size threshold
-exportSizeThreshold=4000000000
+exportSizeThreshold=400000000
 
 # HTTP remote request timeout (10 min)
 httpTimeout=600000
 
 # Label we assign for the rails and overpass pull data
-grailRailsLabel=NOME
-grailOverpassLabel=OSM
+grailRailsLabel=Reference
+grailOverpassLabel=Secondary
 
 # Apply changeset options
 changesetApplyDebug=false

--- a/hoot-services/src/main/resources/conf/hoot-services.conf.in
+++ b/hoot-services/src/main/resources/conf/hoot-services.conf.in
@@ -85,20 +85,20 @@ translationServerThreadCount=0
 translationServerScript=/translations/TranslationServer.js
 
 # Ingest size threshold
-ingestSizeThreshold=200000000
+ingestSizeThreshold=4000000000
 
 # Conflate size threshold
-conflateSizeThreshold=200000000
+conflateSizeThreshold=4000000000
 
 # Export size threshold
-exportSizeThreshold=400000000
+exportSizeThreshold=4000000000
 
 # HTTP remote request timeout (10 min)
 httpTimeout=600000
 
 # Label we assign for the rails and overpass pull data
-grailRailsLabel=Reference
-grailOverpassLabel=Secondary
+grailRailsLabel=NOME
+grailOverpassLabel=OSM
 
 # Apply changeset options
 changesetApplyDebug=false
@@ -113,6 +113,10 @@ grailConnectedWaysQueryPath=conf/services/grailConnectedWaysQuery.overpassql
 # Overpass sync polling interval and timeout
 overpassSyncTimeout=300000
 overpassSyncInterval=30000
+
+# Overpass query maxsize and timeout
+overpassQueryMaxsize=536870912
+overpassQueryTimeout=180
 
 # Differential changeset two-step
 diffChangesetTwoStep=false


### PR DESCRIPTION
these are used by the count query before a grail pull is invoked
