### PR TITLE
Misuse of `ConstOsmMapConsumer`

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 
 #ifndef RDP_WAY_GENERALIZER_H

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.h
@@ -68,7 +68,7 @@ class Way;
  * would have to have been generated for the points kept in the reduction, while deleting the old
  * ones.  That isn't desirable from a runtime performance standpoint.
  */
-class RdpWayGeneralizer : public OsmMapConsumer
+class RdpWayGeneralizer : public OsmMapConsumerImpl
 {
 
 public:
@@ -92,8 +92,6 @@ public:
 
   void setRemoveNodesSharedByWays(bool remove) { _removeNodesSharedByWays = remove; }
 
-  void setOsmMap(OsmMap* map) override { _map = map->shared_from_this(); }
-
 private:
 
   friend class RdpWayGeneralizerTest;
@@ -106,8 +104,6 @@ private:
   // this shouldn't be an option and shared nodes should never be removed, but leaving it optional
   // for now in case there is a use case where they should be removed.
   bool _removeNodesSharedByWays;
-
-  OsmMapPtr _map;
 
   /*
     Generates a set of points that make up a generalized set of the input points

--- a/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.h
+++ b/hoot-core/src/main/cpp/hoot/core/algorithms/RdpWayGeneralizer.h
@@ -68,7 +68,7 @@ class Way;
  * would have to have been generated for the points kept in the reduction, while deleting the old
  * ones.  That isn't desirable from a runtime performance standpoint.
  */
-class RdpWayGeneralizer : public OsmMapConsumerImpl
+class RdpWayGeneralizer : public OsmMapConsumerBase
 {
 
 public:

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/RelationMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/RelationMerger.h
@@ -42,7 +42,7 @@ namespace hoot
  * similar members with different element IDs between reference and secondary layers, the
  * comparisons ignore element IDs and look at the member elements directly.
  */
-class RelationMerger : public OsmMapConsumerImpl
+class RelationMerger : public OsmMapConsumerBase
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/RelationMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/RelationMerger.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef RELATION_MERGER_H
 #define RELATION_MERGER_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/RelationMerger.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/RelationMerger.h
@@ -42,7 +42,7 @@ namespace hoot
  * similar members with different element IDs between reference and secondary layers, the
  * comparisons ignore element IDs and look at the member elements directly.
  */
-class RelationMerger : public OsmMapConsumer
+class RelationMerger : public OsmMapConsumerImpl
 {
 public:
 
@@ -61,17 +61,10 @@ public:
    */
   void merge(const ElementId& elementId1, const ElementId& elementId2);
 
-  /**
-   * @see OsmMapConsumer
-   */
-  void setOsmMap(OsmMap* map) override { _map = map->shared_from_this(); }
-
   void setMergeTags(bool merge) { _mergeTags = merge; }
   void setDeleteRelation2(bool deleteRelation) { _deleteRelation2 = deleteRelation; }
 
 private:
-
-  OsmMapPtr _map;
 
   // determines whether tags of the two relations are merged
   bool _mergeTags;

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/WayNodeCopier.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/WayNodeCopier.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef WAY_NODE_COPIER_H
 #define WAY_NODE_COPIER_H

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/WayNodeCopier.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/WayNodeCopier.h
@@ -39,7 +39,7 @@ namespace hoot
 /**
  * Performs way node copying from one way to another
  */
-class WayNodeCopier : public OsmMapConsumer, public ElementCriterionConsumer, public Configurable
+class WayNodeCopier : public OsmMapConsumerImpl, public ElementCriterionConsumer, public Configurable
 {
 public:
 
@@ -56,11 +56,6 @@ public:
   void copy(const ElementId& toReplaceWayId, const ElementId& replacingWayId) const;
 
   /**
-   * @see OsmMapConsumer
-   */
-  void setOsmMap(OsmMap* map) override { _map = map->shared_from_this(); }
-
-  /**
    * @see ElementCriterionConsumer
    */
   void addCriterion(const ElementCriterionPtr& e) override;
@@ -72,7 +67,6 @@ public:
 
 private:
 
-  OsmMapPtr _map;
   // optional filtering criterion
   ElementCriterionPtr _crit;
   // allows for some leeway in what's considered a duplicate node; passed into WayLocation; 0.0 to

--- a/hoot-core/src/main/cpp/hoot/core/conflate/merging/WayNodeCopier.h
+++ b/hoot-core/src/main/cpp/hoot/core/conflate/merging/WayNodeCopier.h
@@ -39,7 +39,7 @@ namespace hoot
 /**
  * Performs way node copying from one way to another
  */
-class WayNodeCopier : public OsmMapConsumerImpl, public ElementCriterionConsumer, public Configurable
+class WayNodeCopier : public OsmMapConsumerBase, public ElementCriterionConsumer, public Configurable
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/AreaCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/AreaCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016-2023 Maxar (http://www.maxar.com/)
  */
 #include "AreaCriterion.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/AreaCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/AreaCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef AREACRITERION_H
 #define AREACRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/AreaCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/AreaCriterion.h
@@ -38,14 +38,14 @@ namespace hoot
 /**
  * A criterion that identifies areas
  */
-class AreaCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumerImpl
+class AreaCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumerBase
 {
 public:
 
   static QString className() { return "AreaCriterion"; }
 
   AreaCriterion() = default;
-  AreaCriterion(const ConstOsmMapPtr& map) : ConstOsmMapConsumerImpl(map) { }
+  AreaCriterion(const ConstOsmMapPtr& map) : ConstOsmMapConsumerBase(map) { }
   ~AreaCriterion() override = default;
 
   bool isSatisfied(const ConstElementPtr& e) const override;

--- a/hoot-core/src/main/cpp/hoot/core/criterion/AreaCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/AreaCriterion.h
@@ -38,14 +38,14 @@ namespace hoot
 /**
  * A criterion that identifies areas
  */
-class AreaCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumer
+class AreaCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
   static QString className() { return "AreaCriterion"; }
 
   AreaCriterion() = default;
-  AreaCriterion(ConstOsmMapPtr map) : _map(map) { }
+  AreaCriterion(const ConstOsmMapPtr& map) : ConstOsmMapConsumerImpl(map) { }
   ~AreaCriterion() override = default;
 
   bool isSatisfied(const ConstElementPtr& e) const override;
@@ -59,15 +59,12 @@ public:
   QString getClassName() const override { return className(); }
   QString toString() const override { return className(); }
 
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
-
   bool supportsSpecificConflation() const override { return true; }
 
   QStringList getChildCriteria() const override;
 
 private:
 
-  ConstOsmMapPtr _map;
   mutable ElementId _currentElementId;
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/BuildingCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/BuildingCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #include "BuildingCriterion.h"
 
@@ -40,7 +40,7 @@ namespace hoot
 HOOT_FACTORY_REGISTER(ElementCriterion, BuildingCriterion)
 
 BuildingCriterion::BuildingCriterion(ConstOsmMapPtr map)
-  : _map(map)
+  : ConstOsmMapConsumerImpl(map)
 {
 }
 
@@ -79,8 +79,7 @@ bool BuildingCriterion::isSatisfied(const ConstElementPtr& e) const
   LOG_VART(OsmSchema::getInstance().hasCategory(e->getTags(), MetadataTags::Building()));
 
   // if it is a building
-  if ((e->getElementType() != ElementType::Node) &&
-      (OsmSchema::getInstance().hasCategory(e->getTags(), MetadataTags::Building()) == true))
+  if ((e->getElementType() != ElementType::Node) && (OsmSchema::getInstance().hasCategory(e->getTags(), MetadataTags::Building()) == true))
   {
     // If a map was set, then we assume the parent is to be checked as well. This is a little
     // messy but reflects how the logic worked before moving OsmSchema feature type method logic

--- a/hoot-core/src/main/cpp/hoot/core/criterion/BuildingCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/BuildingCriterion.cpp
@@ -40,7 +40,7 @@ namespace hoot
 HOOT_FACTORY_REGISTER(ElementCriterion, BuildingCriterion)
 
 BuildingCriterion::BuildingCriterion(ConstOsmMapPtr map)
-  : ConstOsmMapConsumerImpl(map)
+  : ConstOsmMapConsumerBase(map)
 {
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/BuildingCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/BuildingCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef BUILDINGCRITERION_H
 #define BUILDINGCRITERION_H
@@ -38,7 +38,7 @@ namespace hoot
 /**
  * A criterion to identify buildings
  */
-class BuildingCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumer
+class BuildingCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
@@ -56,8 +56,6 @@ public:
 
   GeometryType getGeometryType() const override { return GeometryType::Polygon; }
 
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
-
   bool supportsSpecificConflation() const override { return true; }
   QStringList getChildCriteria() const override;
 
@@ -66,9 +64,6 @@ public:
   QString getName() const override { return className(); }
   QString toString() const override { return className(); }
 
-private:
-
-  ConstOsmMapPtr _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/BuildingCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/BuildingCriterion.h
@@ -38,7 +38,7 @@ namespace hoot
 /**
  * A criterion to identify buildings
  */
-class BuildingCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumerImpl
+class BuildingCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumerBase
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ChainCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ChainCriterion.cpp
@@ -62,7 +62,7 @@ void ChainCriterion::addCriterion(const ElementCriterionPtr& e)
 
 void ChainCriterion::setOsmMap(const OsmMap* map)
 {
-  ConstOsmMapConsumerImpl::setOsmMap(map);
+  ConstOsmMapConsumerBase::setOsmMap(map);
   for (const auto& crit : _criteria)
   {
     std::shared_ptr<ConstOsmMapConsumer> mapConsumer = std::dynamic_pointer_cast<ConstOsmMapConsumer>(crit);

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ChainCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ChainCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016-2023 Maxar (http://www.maxar.com/)
  */
 #include "ChainCriterion.h"
 
@@ -62,6 +62,7 @@ void ChainCriterion::addCriterion(const ElementCriterionPtr& e)
 
 void ChainCriterion::setOsmMap(const OsmMap* map)
 {
+  ConstOsmMapConsumerImpl::setOsmMap(map);
   for (const auto& crit : _criteria)
   {
     std::shared_ptr<ConstOsmMapConsumer> mapConsumer = std::dynamic_pointer_cast<ConstOsmMapConsumer>(crit);

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ChainCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ChainCriterion.h
@@ -40,7 +40,7 @@ namespace hoot
  * Is satisfied if all of its children criteria are satisfied.
  */
 class ChainCriterion : public ElementCriterion, public ElementCriterionConsumer,
-  public Configurable, public ConstOsmMapConsumer
+  public Configurable, public ConstOsmMapConsumerImpl
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ChainCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ChainCriterion.h
@@ -40,7 +40,7 @@ namespace hoot
  * Is satisfied if all of its children criteria are satisfied.
  */
 class ChainCriterion : public ElementCriterion, public ElementCriterionConsumer,
-  public Configurable, public ConstOsmMapConsumerImpl
+  public Configurable, public ConstOsmMapConsumerBase
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ChainCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ChainCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef CHAINCRITERION_H
 #define CHAINCRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ChildElementCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ChildElementCriterion.h
@@ -38,14 +38,14 @@ namespace hoot
 /**
  * Identifies way nodes and relation members
  */
-class ChildElementCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
+class ChildElementCriterion : public ElementCriterion, public ConstOsmMapConsumerBase
 {
 public:
 
   static QString className() { return "ChildElementCriterion"; }
 
   ChildElementCriterion() = default;
-  ChildElementCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
+  ChildElementCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerBase(map) { }
   ~ChildElementCriterion() override = default;
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ChildElementCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ChildElementCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef CHILD_ELEMENT_CRITERION_H
 #define CHILD_ELEMENT_CRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ChildElementCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ChildElementCriterion.h
@@ -38,14 +38,14 @@ namespace hoot
 /**
  * Identifies way nodes and relation members
  */
-class ChildElementCriterion : public ElementCriterion, public ConstOsmMapConsumer
+class ChildElementCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
   static QString className() { return "ChildElementCriterion"; }
 
   ChildElementCriterion() = default;
-  ChildElementCriterion(ConstOsmMapPtr map) : _map(map) { }
+  ChildElementCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
   ~ChildElementCriterion() override = default;
 
   /**
@@ -59,11 +59,6 @@ public:
   QString getClassName() const override { return className(); }
   QString toString() const override { return className(); }
 
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
-
-private:
-
-  ConstOsmMapPtr _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/DisconnectedWayCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/DisconnectedWayCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020-2023 Maxar (http://www.maxar.com/)
  */
 #include "DisconnectedWayCriterion.h"
 
@@ -34,11 +34,6 @@ namespace hoot
 {
 
 HOOT_FACTORY_REGISTER(ElementCriterion, DisconnectedWayCriterion)
-
-DisconnectedWayCriterion::DisconnectedWayCriterion(ConstOsmMapPtr map)
-  : _map(map)
-{
-}
 
 bool DisconnectedWayCriterion::isSatisfied(const ConstElementPtr& e) const
 {

--- a/hoot-core/src/main/cpp/hoot/core/criterion/DisconnectedWayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/DisconnectedWayCriterion.h
@@ -38,14 +38,14 @@ namespace hoot
 /**
  * @brief The DisconnectedWayCriterion class identifies ways that are disconnected from other ways.
  */
-class DisconnectedWayCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
+class DisconnectedWayCriterion : public ElementCriterion, public ConstOsmMapConsumerBase
 {
 public:
 
   static QString className() { return "DisconnectedWayCriterion"; }
 
   DisconnectedWayCriterion() = default;
-  DisconnectedWayCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
+  DisconnectedWayCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerBase(map) { }
   ~DisconnectedWayCriterion() override = default;
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/criterion/DisconnectedWayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/DisconnectedWayCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef DISCONNECTED_WAY_CRITERION_H
 #define DISCONNECTED_WAY_CRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/DisconnectedWayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/DisconnectedWayCriterion.h
@@ -38,14 +38,14 @@ namespace hoot
 /**
  * @brief The DisconnectedWayCriterion class identifies ways that are disconnected from other ways.
  */
-class DisconnectedWayCriterion : public ElementCriterion, public ConstOsmMapConsumer
+class DisconnectedWayCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
   static QString className() { return "DisconnectedWayCriterion"; }
 
   DisconnectedWayCriterion() = default;
-  DisconnectedWayCriterion(ConstOsmMapPtr map);
+  DisconnectedWayCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
   ~DisconnectedWayCriterion() override = default;
 
   /**
@@ -54,20 +54,12 @@ public:
   bool isSatisfied(const ConstElementPtr& e) const override;
   ElementCriterionPtr clone() override { return std::make_shared<DisconnectedWayCriterion>(_map); }
 
-  /**
-   * @see ConstOsmMapConsumer
-   */
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
-
   QString getDescription() const override
   { return "Identifies ways that are connected to no other ways"; }
   QString getName() const override { return className(); }
   QString getClassName() const override { return className(); }
   QString toString() const override { return className(); }
 
-private:
-
-  ConstOsmMapPtr _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/HighwayCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/HighwayCriterion.cpp
@@ -44,7 +44,7 @@ HighwayCriterion::HighwayCriterion(const bool includeRelations)
 }
 
 HighwayCriterion::HighwayCriterion(ConstOsmMapPtr map, const bool includeRelations)
-  : _map(map),
+  : ConstOsmMapConsumerImpl(map),
     _includeRelations(includeRelations)
 {
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/HighwayCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/HighwayCriterion.cpp
@@ -44,7 +44,7 @@ HighwayCriterion::HighwayCriterion(const bool includeRelations)
 }
 
 HighwayCriterion::HighwayCriterion(ConstOsmMapPtr map, const bool includeRelations)
-  : ConstOsmMapConsumerImpl(map),
+  : ConstOsmMapConsumerBase(map),
     _includeRelations(includeRelations)
 {
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/HighwayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/HighwayCriterion.h
@@ -38,7 +38,7 @@ namespace hoot
 /**
  * A criterion that will either keep or remove road matches.
  */
-class HighwayCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumerImpl
+class HighwayCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumerBase
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/HighwayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/HighwayCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef HIGHWAYCRITERION_H
 #define HIGHWAYCRITERION_H
@@ -38,7 +38,7 @@ namespace hoot
 /**
  * A criterion that will either keep or remove road matches.
  */
-class HighwayCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumer
+class HighwayCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
@@ -51,8 +51,6 @@ public:
   bool isSatisfied(const ConstElementPtr& e) const override;
   ElementCriterionPtr clone() override { return std::make_shared<HighwayCriterion>(_map); }
 
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
-
   GeometryType getGeometryType() const override { return GeometryType::Line; }
   bool supportsSpecificConflation() const override { return true; }
   QStringList getChildCriteria() const override;
@@ -64,7 +62,6 @@ public:
 
 private:
 
-  ConstOsmMapPtr _map;
   // Determines whether we count relations with a highway tag as highways. The main reason we'd want
   // to for conflate is to handle untagged roads in a tagged highway relation. *However*, its still
   // not clear if that situation is valid OSM data. Therefore, have added this switch to allow us

--- a/hoot-core/src/main/cpp/hoot/core/criterion/HighwayIntersectionCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/HighwayIntersectionCriterion.cpp
@@ -40,11 +40,6 @@ namespace hoot
 
 HOOT_FACTORY_REGISTER(ElementCriterion, HighwayIntersectionCriterion)
 
-HighwayIntersectionCriterion::HighwayIntersectionCriterion(ConstOsmMapPtr map)
-{
-  setOsmMap(map.get());
-}
-
 bool HighwayIntersectionCriterion::isSatisfied(const ConstElementPtr& e) const
 {
   if (e->getElementType() != ElementType::Node)
@@ -66,11 +61,6 @@ bool HighwayIntersectionCriterion::isSatisfied(const ConstElementPtr& e) const
 
   // three or more ways meeting at a node is an intersection
   return (hwids.size() >= 3);
-}
-
-void HighwayIntersectionCriterion::setOsmMap(const OsmMap *map)
-{
-  _map = map->shared_from_this();
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/HighwayIntersectionCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/HighwayIntersectionCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016-2023 Maxar (http://www.maxar.com/)
  */
 #include "HighwayIntersectionCriterion.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/HighwayIntersectionCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/HighwayIntersectionCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef HIGHWAYINTERSECTIONCRITERION_H
 #define HIGHWAYINTERSECTIONCRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/HighwayIntersectionCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/HighwayIntersectionCriterion.h
@@ -41,30 +41,25 @@ namespace hoot
  *
  * This class assumes that IntersectionSplitter was applied to the map before being called.
  */
-class HighwayIntersectionCriterion : public ElementCriterion, public ConstOsmMapConsumer
+class HighwayIntersectionCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
   static QString className() { return "HighwayIntersectionCriterion"; }
 
   HighwayIntersectionCriterion() = default;
-  explicit HighwayIntersectionCriterion(ConstOsmMapPtr map);
+  explicit HighwayIntersectionCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
   ~HighwayIntersectionCriterion() override = default;
 
   ElementCriterionPtr clone() override
   { return std::make_shared<HighwayIntersectionCriterion>(_map); }
   bool isSatisfied(const ConstElementPtr& e) const override;
 
-  void setOsmMap(const OsmMap* map) override;
-
   QString getDescription() const override { return "Identifies highway intersections"; }
   QString getName() const override { return className(); }
   QString getClassName() const override { return className(); }
   QString toString() const override { return className(); }
 
-private:
-
-  ConstOsmMapPtr _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/HighwayIntersectionCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/HighwayIntersectionCriterion.h
@@ -41,14 +41,14 @@ namespace hoot
  *
  * This class assumes that IntersectionSplitter was applied to the map before being called.
  */
-class HighwayIntersectionCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
+class HighwayIntersectionCriterion : public ElementCriterion, public ConstOsmMapConsumerBase
 {
 public:
 
   static QString className() { return "HighwayIntersectionCriterion"; }
 
   HighwayIntersectionCriterion() = default;
-  explicit HighwayIntersectionCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
+  explicit HighwayIntersectionCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerBase(map) { }
   ~HighwayIntersectionCriterion() override = default;
 
   ElementCriterionPtr clone() override

--- a/hoot-core/src/main/cpp/hoot/core/criterion/InBoundsCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/InBoundsCriterion.cpp
@@ -72,7 +72,7 @@ void InBoundsCriterion::setConfiguration(const Settings& conf)
 
 void InBoundsCriterion::setOsmMap(const OsmMap* map)
 {
-  ConstOsmMapConsumerImpl::setOsmMap(map);
+  ConstOsmMapConsumerBase::setOsmMap(map);
   _elementConverter = std::make_shared<ElementToGeometryConverter>(_map);
   _wayNodeCrit = std::make_shared<WayNodeCriterion>(_map);
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/InBoundsCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/InBoundsCriterion.cpp
@@ -72,7 +72,7 @@ void InBoundsCriterion::setConfiguration(const Settings& conf)
 
 void InBoundsCriterion::setOsmMap(const OsmMap* map)
 {
-  _map = map->shared_from_this();
+  ConstOsmMapConsumerImpl::setOsmMap(map);
   _elementConverter = std::make_shared<ElementToGeometryConverter>(_map);
   _wayNodeCrit = std::make_shared<WayNodeCriterion>(_map);
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/InBoundsCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/InBoundsCriterion.h
@@ -48,7 +48,7 @@ namespace hoot
  *
  * @todo genericize this to use GeometricRelationShip?
  */
-class InBoundsCriterion : public ElementCriterion, public Boundable, public ConstOsmMapConsumerImpl, public Configurable
+class InBoundsCriterion : public ElementCriterion, public Boundable, public ConstOsmMapConsumerBase, public Configurable
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/InBoundsCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/InBoundsCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019-2023 Maxar (http://www.maxar.com/)
  */
 
 #ifndef IN_BOUNDS_CRITERION_H
@@ -48,8 +48,7 @@ namespace hoot
  *
  * @todo genericize this to use GeometricRelationShip?
  */
-class InBoundsCriterion : public ElementCriterion, public Boundable, public ConstOsmMapConsumer,
-  public Configurable
+class InBoundsCriterion : public ElementCriterion, public Boundable, public ConstOsmMapConsumerImpl, public Configurable
 {
 public:
 
@@ -94,8 +93,6 @@ public:
 
 private:
 
-  // This map must be in the same coord sys as the bounds.
-  ConstOsmMapPtr _map;
   std::shared_ptr<ElementToGeometryConverter> _elementConverter;
   std::shared_ptr<WayNodeCriterion> _wayNodeCrit;
   // If false, the element can cross the bounds and still be considered within bounds.

--- a/hoot-core/src/main/cpp/hoot/core/criterion/IntersectingWayCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/IntersectingWayCriterion.cpp
@@ -37,14 +37,9 @@ const QString IntersectingWayCriterion::EMPTY_SOURCE_IDS_ERROR_MESSAGE = "No way
 
 HOOT_FACTORY_REGISTER(ElementCriterion, IntersectingWayCriterion)
 
-IntersectingWayCriterion::IntersectingWayCriterion(ConstOsmMapPtr map)
-  : _map(map)
-{
-}
-
 IntersectingWayCriterion::IntersectingWayCriterion(const QSet<long>& sourceWayIds, ConstOsmMapPtr map)
-  : _sourceWayIds(sourceWayIds),
-    _map(map)
+  : ConstOsmMapConsumerImpl(map),
+    _sourceWayIds(sourceWayIds)
 {
   if (_sourceWayIds.empty())
     throw IllegalArgumentException(EMPTY_SOURCE_IDS_ERROR_MESSAGE);

--- a/hoot-core/src/main/cpp/hoot/core/criterion/IntersectingWayCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/IntersectingWayCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2021-2023 Maxar (http://www.maxar.com/)
  */
 #include "IntersectingWayCriterion.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/IntersectingWayCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/IntersectingWayCriterion.cpp
@@ -38,7 +38,7 @@ const QString IntersectingWayCriterion::EMPTY_SOURCE_IDS_ERROR_MESSAGE = "No way
 HOOT_FACTORY_REGISTER(ElementCriterion, IntersectingWayCriterion)
 
 IntersectingWayCriterion::IntersectingWayCriterion(const QSet<long>& sourceWayIds, ConstOsmMapPtr map)
-  : ConstOsmMapConsumerImpl(map),
+  : ConstOsmMapConsumerBase(map),
     _sourceWayIds(sourceWayIds)
 {
   if (_sourceWayIds.empty())

--- a/hoot-core/src/main/cpp/hoot/core/criterion/IntersectingWayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/IntersectingWayCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2021-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef INTERSECTING_WAY_CRITERION_H
 #define INTERSECTING_WAY_CRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/IntersectingWayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/IntersectingWayCriterion.h
@@ -44,15 +44,14 @@ namespace hoot
  * time, though, as each intersecting way would have to be checked against the crit. OR maybe we
  * make use of FindIntersectionsOp for that purpose instead...
  */
-class IntersectingWayCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumer,
-  public Configurable
+class IntersectingWayCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerImpl, public Configurable
 {
 public:
 
   static QString className() { return "IntersectingWayCriterion"; }
 
   IntersectingWayCriterion() = default;
-  IntersectingWayCriterion(ConstOsmMapPtr map);
+  IntersectingWayCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
   IntersectingWayCriterion(const QSet<long>& sourceWayIds, ConstOsmMapPtr map);
   ~IntersectingWayCriterion() override = default;
 
@@ -72,11 +71,6 @@ public:
   GeometryType getGeometryType() const override { return GeometryType::Line; }
 
   /**
-   * @see ConstOsmMapConsumer
-   */
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
-
-  /**
    * @see Configurable
    */
   void setConfiguration(const Settings& conf) override;
@@ -91,8 +85,6 @@ private:
 
   // the IDs for the ways to look for other intersecting ways with
   mutable QSet<long> _sourceWayIds;
-
-  ConstOsmMapPtr _map;
 
   static const QString EMPTY_SOURCE_IDS_ERROR_MESSAGE;
 };

--- a/hoot-core/src/main/cpp/hoot/core/criterion/IntersectingWayCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/IntersectingWayCriterion.h
@@ -44,14 +44,14 @@ namespace hoot
  * time, though, as each intersecting way would have to be checked against the crit. OR maybe we
  * make use of FindIntersectionsOp for that purpose instead...
  */
-class IntersectingWayCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerImpl, public Configurable
+class IntersectingWayCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerBase, public Configurable
 {
 public:
 
   static QString className() { return "IntersectingWayCriterion"; }
 
   IntersectingWayCriterion() = default;
-  IntersectingWayCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
+  IntersectingWayCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerBase(map) { }
   IntersectingWayCriterion(const QSet<long>& sourceWayIds, ConstOsmMapPtr map);
   ~IntersectingWayCriterion() override = default;
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NeedsReviewCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NeedsReviewCriterion.cpp
@@ -36,11 +36,6 @@ namespace hoot
 
 HOOT_FACTORY_REGISTER(ElementCriterion, NeedsReviewCriterion)
 
-NeedsReviewCriterion::NeedsReviewCriterion(const ConstOsmMapPtr& map)
-  : _map(map)
-{
-}
-
 bool NeedsReviewCriterion::isSatisfied(const ConstElementPtr& e) const
 {
   return ReviewMarker::isNeedsReview(_map, e);

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NeedsReviewCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NeedsReviewCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #include "NeedsReviewCriterion.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NeedsReviewCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NeedsReviewCriterion.h
@@ -38,29 +38,24 @@ namespace hoot
 /**
  * Determines if a feature requires manual review
  */
-class NeedsReviewCriterion : public ElementCriterion, public ConstOsmMapConsumer
+class NeedsReviewCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
   static QString className() { return "NeedsReviewCriterion"; }
 
   NeedsReviewCriterion() = default;
-  NeedsReviewCriterion(const ConstOsmMapPtr& map);
+  NeedsReviewCriterion(const ConstOsmMapPtr& map) : ConstOsmMapConsumerImpl(map) { }
   ~NeedsReviewCriterion() override = default;
 
   bool isSatisfied(const ConstElementPtr& e) const override;
   ElementCriterionPtr clone() override { return std::make_shared<NeedsReviewCriterion>(_map); }
-
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
 
   QString getDescription() const override { return "Identifies features that need to be reviewed"; }
   QString getName() const override { return className(); }
   QString getClassName() const override { return className(); }
   QString toString() const override { return className(); }
 
-private:
-
-  ConstOsmMapPtr _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NeedsReviewCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NeedsReviewCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef NEEDSREVIEWCRITERION_H
 #define NEEDSREVIEWCRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NeedsReviewCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NeedsReviewCriterion.h
@@ -38,14 +38,14 @@ namespace hoot
 /**
  * Determines if a feature requires manual review
  */
-class NeedsReviewCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
+class NeedsReviewCriterion : public ElementCriterion, public ConstOsmMapConsumerBase
 {
 public:
 
   static QString className() { return "NeedsReviewCriterion"; }
 
   NeedsReviewCriterion() = default;
-  NeedsReviewCriterion(const ConstOsmMapPtr& map) : ConstOsmMapConsumerImpl(map) { }
+  NeedsReviewCriterion(const ConstOsmMapPtr& map) : ConstOsmMapConsumerBase(map) { }
   ~NeedsReviewCriterion() override = default;
 
   bool isSatisfied(const ConstElementPtr& e) const override;

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NetworkTypeCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NetworkTypeCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2021-2023 Maxar (http://www.maxar.com/)
  */
 #include "NetworkTypeCriterion.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NetworkTypeCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NetworkTypeCriterion.cpp
@@ -36,11 +36,6 @@ namespace hoot
 
 HOOT_FACTORY_REGISTER(ElementCriterion, NetworkTypeCriterion)
 
-NetworkTypeCriterion::NetworkTypeCriterion(ConstOsmMapPtr map)
-  : _map(map)
-{
-}
-
 bool NetworkTypeCriterion::isSatisfied(const ConstElementPtr& element) const
 {
   if (element->getElementType() != ElementType::Way)

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NetworkTypeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NetworkTypeCriterion.h
@@ -39,14 +39,14 @@ namespace hoot
  * Identifies features that can be treated as "network" with linear and connectedness attributes.
  * This is primarily used by IntersectionSplitter to determine which features are splittable.
  */
-class NetworkTypeCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumer
+class NetworkTypeCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
   static QString className() { return "NetworkTypeCriterion"; }
 
   NetworkTypeCriterion() = default;
-  NetworkTypeCriterion(ConstOsmMapPtr map);
+  NetworkTypeCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
   ~NetworkTypeCriterion() override = default;
 
   /**
@@ -64,19 +64,11 @@ public:
    */
   GeometryType getGeometryType() const override { return GeometryType::Line; }
 
-  /**
-   * @see ConstOsmMapConsumer
-   */
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
-
   QString getName() const override { return className(); }
   QString getClassName() const override { return className(); }
   QString toString() const override { return className(); }
   QString getDescription() const override { return "Identifies network features"; }
 
-private:
-
-  ConstOsmMapPtr _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NetworkTypeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NetworkTypeCriterion.h
@@ -39,14 +39,14 @@ namespace hoot
  * Identifies features that can be treated as "network" with linear and connectedness attributes.
  * This is primarily used by IntersectionSplitter to determine which features are splittable.
  */
-class NetworkTypeCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerImpl
+class NetworkTypeCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerBase
 {
 public:
 
   static QString className() { return "NetworkTypeCriterion"; }
 
   NetworkTypeCriterion() = default;
-  NetworkTypeCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
+  NetworkTypeCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerBase(map) { }
   ~NetworkTypeCriterion() override = default;
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NetworkTypeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NetworkTypeCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2021-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef NETWORK_TYPE_CRITERION_H
 #define NETWORK_TYPE_CRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NonBuildingAreaCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NonBuildingAreaCriterion.h
@@ -41,14 +41,14 @@ namespace hoot
  * Should be able to accomplish the same thing with a not building and is area chain but
  * couldn't. See comments in train-area/RemoveIrrelevants.js in the regression tests.
  */
-class NonBuildingAreaCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumer
+class NonBuildingAreaCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
   static QString className() { return "NonBuildingAreaCriterion"; }
 
   NonBuildingAreaCriterion() = default;
-  NonBuildingAreaCriterion(ConstOsmMapPtr map) : _map(map) { }
+  NonBuildingAreaCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
   ~NonBuildingAreaCriterion() override = default;
 
   bool isSatisfied(const ConstElementPtr& e) const override;
@@ -56,17 +56,12 @@ public:
 
   GeometryType getGeometryType() const override { return GeometryType::Polygon; }
 
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
-
   QString getName() const override { return className(); }
   QString getClassName() const override { return className(); }
   QString toString() const override { return className(); }
   QString getDescription() const override
   { return "Identifies features that are areas but not buildings"; }
 
-private:
-
-  ConstOsmMapPtr _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NonBuildingAreaCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NonBuildingAreaCriterion.h
@@ -41,14 +41,14 @@ namespace hoot
  * Should be able to accomplish the same thing with a not building and is area chain but
  * couldn't. See comments in train-area/RemoveIrrelevants.js in the regression tests.
  */
-class NonBuildingAreaCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerImpl
+class NonBuildingAreaCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerBase
 {
 public:
 
   static QString className() { return "NonBuildingAreaCriterion"; }
 
   NonBuildingAreaCriterion() = default;
-  NonBuildingAreaCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
+  NonBuildingAreaCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerBase(map) { }
   ~NonBuildingAreaCriterion() override = default;
 
   bool isSatisfied(const ConstElementPtr& e) const override;

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NonBuildingAreaCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NonBuildingAreaCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef NONBUILDINGAREACRITERION_H
 #define NONBUILDINGAREACRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.cpp
@@ -44,7 +44,7 @@ NonConflatableCriterion::NonConflatableCriterion()
 }
 
 NonConflatableCriterion::NonConflatableCriterion(ConstOsmMapPtr map)
-  : _map(map),
+  : ConstOsmMapConsumerImpl(map),
     _ignoreChildren(false),
     _geometryTypeFilter(GeometryTypeCriterion::GeometryType::Unknown),
     _ignoreGenericConflators(false)

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018-2023 Maxar (http://www.maxar.com/)
  */
 #include "NonConflatableCriterion.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.cpp
@@ -44,7 +44,7 @@ NonConflatableCriterion::NonConflatableCriterion()
 }
 
 NonConflatableCriterion::NonConflatableCriterion(ConstOsmMapPtr map)
-  : ConstOsmMapConsumerImpl(map),
+  : ConstOsmMapConsumerBase(map),
     _ignoreChildren(false),
     _geometryTypeFilter(GeometryTypeCriterion::GeometryType::Unknown),
     _ignoreGenericConflators(false)

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.h
@@ -41,7 +41,7 @@ namespace hoot
  * A filter that will remove elements that are not conflatable by Hootenanny. These are elements
  * for which we have no matchers defined.
  */
-class NonConflatableCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl, public Configurable
+class NonConflatableCriterion : public ElementCriterion, public ConstOsmMapConsumerBase, public Configurable
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.h
@@ -41,8 +41,7 @@ namespace hoot
  * A filter that will remove elements that are not conflatable by Hootenanny. These are elements
  * for which we have no matchers defined.
  */
-class NonConflatableCriterion : public ElementCriterion, public ConstOsmMapConsumer,
-  public Configurable
+class NonConflatableCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl, public Configurable
 {
 public:
 
@@ -57,8 +56,6 @@ public:
 
   void setConfiguration(const Settings& conf) override;
 
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
-
   QString getDescription() const override { return "Identifies features that are not conflatable"; }
   QString getName() const override { return className(); }
   QString getClassName() const override { return className(); }
@@ -70,8 +67,6 @@ public:
   void setIgnoreChildren(bool ignore) { _ignoreChildren = ignore; }
 
 private:
-
-  ConstOsmMapPtr _map;
 
   bool _ignoreChildren;
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NonConflatableCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef NONCONFLATABLECRITERION_H
 #define NONCONFLATABLECRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NotCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NotCriterion.cpp
@@ -63,6 +63,7 @@ void NotCriterion::setConfiguration(const Settings& conf)
 
 void NotCriterion::setOsmMap(const OsmMap* map)
 {
+  ConstOsmMapConsumerImpl::setOsmMap(map);
   std::shared_ptr<ConstOsmMapConsumer> mapConsumer = std::dynamic_pointer_cast<ConstOsmMapConsumer>(_child);
   if (mapConsumer)
     mapConsumer->setOsmMap(map);

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NotCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NotCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 
 #include "NotCriterion.h"

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NotCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NotCriterion.cpp
@@ -63,7 +63,7 @@ void NotCriterion::setConfiguration(const Settings& conf)
 
 void NotCriterion::setOsmMap(const OsmMap* map)
 {
-  ConstOsmMapConsumerImpl::setOsmMap(map);
+  ConstOsmMapConsumerBase::setOsmMap(map);
   std::shared_ptr<ConstOsmMapConsumer> mapConsumer = std::dynamic_pointer_cast<ConstOsmMapConsumer>(_child);
   if (mapConsumer)
     mapConsumer->setOsmMap(map);

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NotCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NotCriterion.h
@@ -36,7 +36,7 @@
 namespace hoot
 {
 
-class NotCriterion : public ElementCriterion, public ElementCriterionConsumer, public Configurable, public ConstOsmMapConsumerImpl
+class NotCriterion : public ElementCriterion, public ElementCriterionConsumer, public Configurable, public ConstOsmMapConsumerBase
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NotCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NotCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef NOTCRITERION_H
 #define NOTCRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/NotCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/NotCriterion.h
@@ -36,8 +36,7 @@
 namespace hoot
 {
 
-class NotCriterion : public ElementCriterion, public ElementCriterionConsumer, public Configurable,
-  public ConstOsmMapConsumer
+class NotCriterion : public ElementCriterion, public ElementCriterionConsumer, public Configurable, public ConstOsmMapConsumerImpl
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PointCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PointCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019-2023 Maxar (http://www.maxar.com/)
  */
 
 #include "PointCriterion.h"

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PointCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PointCriterion.cpp
@@ -36,14 +36,14 @@ namespace hoot
 HOOT_FACTORY_REGISTER(ElementCriterion, PointCriterion)
 
 PointCriterion::PointCriterion(ConstOsmMapPtr map)
-  : ConstOsmMapConsumerImpl(map)
+  : ConstOsmMapConsumerBase(map)
 {
   _wayNodeCrit.setOsmMap(map.get());
 }
 
 void PointCriterion::setOsmMap(const OsmMap* map)
 {
-  ConstOsmMapConsumerImpl::setOsmMap(map);
+  ConstOsmMapConsumerBase::setOsmMap(map);
   _wayNodeCrit.setOsmMap(map);
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PointCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PointCriterion.cpp
@@ -36,14 +36,14 @@ namespace hoot
 HOOT_FACTORY_REGISTER(ElementCriterion, PointCriterion)
 
 PointCriterion::PointCriterion(ConstOsmMapPtr map)
-  : _map(map)
+  : ConstOsmMapConsumerImpl(map)
 {
   _wayNodeCrit.setOsmMap(map.get());
 }
 
 void PointCriterion::setOsmMap(const OsmMap* map)
 {
-  _map = map->shared_from_this();
+  ConstOsmMapConsumerImpl::setOsmMap(map);
   _wayNodeCrit.setOsmMap(map);
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PointCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PointCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019-2023 Maxar (http://www.maxar.com/)
  */
 
 #ifndef POINT_CRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PointCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PointCriterion.h
@@ -40,7 +40,7 @@ namespace hoot
 /**
  * Identifies point features
  */
-class PointCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumerImpl
+class PointCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumerBase
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PointCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PointCriterion.h
@@ -40,7 +40,7 @@ namespace hoot
 /**
  * Identifies point features
  */
-class PointCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumer
+class PointCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
@@ -64,8 +64,6 @@ public:
   QString getDescription() const override { return "Identifies point features"; }
 
 private:
-
-  ConstOsmMapPtr _map;
 
   WayNodeCriterion _wayNodeCrit;
 };

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PolygonCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PolygonCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019-2023 Maxar (http://www.maxar.com/)
  */
 
 #include "PolygonCriterion.h"

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PolygonCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PolygonCriterion.cpp
@@ -38,7 +38,7 @@ namespace hoot
 HOOT_FACTORY_REGISTER(ElementCriterion, PolygonCriterion)
 
 PolygonCriterion::PolygonCriterion(ConstOsmMapPtr map)
-  : _map(map)
+  : ConstOsmMapConsumerImpl(map)
 {
   // Set this to allow any on poly child member to satisfy the crit.
   _relationCrit.setAllowMixedChildren(true);
@@ -47,7 +47,7 @@ PolygonCriterion::PolygonCriterion(ConstOsmMapPtr map)
 
 void PolygonCriterion::setOsmMap(const OsmMap* map)
 {
-  _map = map->shared_from_this();
+  ConstOsmMapConsumerImpl::setOsmMap(map);
   _relationCrit.setOsmMap(map);
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PolygonCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PolygonCriterion.cpp
@@ -38,7 +38,7 @@ namespace hoot
 HOOT_FACTORY_REGISTER(ElementCriterion, PolygonCriterion)
 
 PolygonCriterion::PolygonCriterion(ConstOsmMapPtr map)
-  : ConstOsmMapConsumerImpl(map)
+  : ConstOsmMapConsumerBase(map)
 {
   // Set this to allow any on poly child member to satisfy the crit.
   _relationCrit.setAllowMixedChildren(true);
@@ -47,7 +47,7 @@ PolygonCriterion::PolygonCriterion(ConstOsmMapPtr map)
 
 void PolygonCriterion::setOsmMap(const OsmMap* map)
 {
-  ConstOsmMapConsumerImpl::setOsmMap(map);
+  ConstOsmMapConsumerBase::setOsmMap(map);
   _relationCrit.setOsmMap(map);
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PolygonCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PolygonCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019-2023 Maxar (http://www.maxar.com/)
  */
 
 #ifndef POLYGON_CRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PolygonCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PolygonCriterion.h
@@ -39,7 +39,7 @@ namespace hoot
 /**
  * Identifies polygon features
  */
-class PolygonCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumerImpl
+class PolygonCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumerBase
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/PolygonCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/PolygonCriterion.h
@@ -39,7 +39,7 @@ namespace hoot
 /**
  * Identifies polygon features
  */
-class PolygonCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumer
+class PolygonCriterion : public ConflatableElementCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
@@ -67,7 +67,6 @@ public:
 
 private:
 
-  ConstOsmMapPtr _map;
   RelationWithPolygonMembersCriterion _relationCrit;
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationMemberCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationMemberCriterion.cpp
@@ -35,11 +35,6 @@ namespace hoot
 
 HOOT_FACTORY_REGISTER(ElementCriterion, RelationMemberCriterion)
 
-RelationMemberCriterion::RelationMemberCriterion(ConstOsmMapPtr map)
-  : _map(map)
-{
-}
-
 bool RelationMemberCriterion::isSatisfied(const ConstElementPtr& e) const
 {
   if (!_map)

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationMemberCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationMemberCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020-2023 Maxar (http://www.maxar.com/)
  */
 #include "RelationMemberCriterion.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationMemberCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationMemberCriterion.h
@@ -38,14 +38,14 @@ namespace hoot
 /**
  * Identifies relation members
  */
-class RelationMemberCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
+class RelationMemberCriterion : public ElementCriterion, public ConstOsmMapConsumerBase
 {
 public:
 
   static QString className() { return "RelationMemberCriterion"; }
 
   RelationMemberCriterion() = default;
-  RelationMemberCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
+  RelationMemberCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerBase(map) { }
   ~RelationMemberCriterion() override = default;
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationMemberCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationMemberCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef RELATION_MEMBER_CRITERION_H
 #define RELATION_MEMBER_CRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationMemberCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationMemberCriterion.h
@@ -38,14 +38,14 @@ namespace hoot
 /**
  * Identifies relation members
  */
-class RelationMemberCriterion : public ElementCriterion, public ConstOsmMapConsumer
+class RelationMemberCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
   static QString className() { return "RelationMemberCriterion"; }
 
   RelationMemberCriterion() = default;
-  RelationMemberCriterion(ConstOsmMapPtr map);
+  RelationMemberCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
   ~RelationMemberCriterion() override = default;
 
   /**
@@ -59,11 +59,6 @@ public:
   QString getClassName() const override { return className(); }
   QString toString() const override { return className(); }
 
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
-
-private:
-
-  ConstOsmMapPtr _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithMembersOfTypeCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithMembersOfTypeCriterion.cpp
@@ -41,7 +41,7 @@ RelationWithMembersOfTypeCriterion::RelationWithMembersOfTypeCriterion()
 }
 
 RelationWithMembersOfTypeCriterion::RelationWithMembersOfTypeCriterion(ConstOsmMapPtr map)
-  : _map(map),
+  : ConstOsmMapConsumerImpl(map),
     _allowMixedChildren(false)
 {
 }
@@ -55,11 +55,6 @@ void RelationWithMembersOfTypeCriterion::_initCrit() const
     if (consumer.get())
       consumer->setOsmMap(_map.get());
   }
-}
-
-void RelationWithMembersOfTypeCriterion::setOsmMap(const OsmMap* map)
-{
-  _map = map->shared_from_this();
 }
 
 void RelationWithMembersOfTypeCriterion::setConfiguration(const Settings& conf)

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithMembersOfTypeCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithMembersOfTypeCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020-2023 Maxar (http://www.maxar.com/)
  */
 
 #include "RelationWithMembersOfTypeCriterion.h"

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithMembersOfTypeCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithMembersOfTypeCriterion.cpp
@@ -41,7 +41,7 @@ RelationWithMembersOfTypeCriterion::RelationWithMembersOfTypeCriterion()
 }
 
 RelationWithMembersOfTypeCriterion::RelationWithMembersOfTypeCriterion(ConstOsmMapPtr map)
-  : ConstOsmMapConsumerImpl(map),
+  : ConstOsmMapConsumerBase(map),
     _allowMixedChildren(false)
 {
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithMembersOfTypeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithMembersOfTypeCriterion.h
@@ -40,7 +40,7 @@ namespace hoot
 /**
  * Abstract class for identifying relations based on the geometry types of their children
  */
-class RelationWithMembersOfTypeCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerImpl, public Configurable
+class RelationWithMembersOfTypeCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerBase, public Configurable
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithMembersOfTypeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithMembersOfTypeCriterion.h
@@ -40,8 +40,7 @@ namespace hoot
 /**
  * Abstract class for identifying relations based on the geometry types of their children
  */
-class RelationWithMembersOfTypeCriterion : public GeometryTypeCriterion,
-  public ConstOsmMapConsumer, public Configurable
+class RelationWithMembersOfTypeCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerImpl, public Configurable
 {
 public:
 
@@ -55,15 +54,9 @@ public:
 
   virtual QString getCriterion() const = 0;
 
-  void setOsmMap(const OsmMap* map) override;
-
   void setConfiguration(const Settings& conf) override;
 
   void setAllowMixedChildren(bool allow) { _allowMixedChildren = allow; }
-
-protected:
-
-  ConstOsmMapPtr _map;
 
 private:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithMembersOfTypeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/RelationWithMembersOfTypeCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020-2023 Maxar (http://www.maxar.com/)
  */
 
 #ifndef RELATION_WITH_MEMBERS_OF_TYPE_CRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ReversedRoadCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ReversedRoadCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016-2023 Maxar (http://www.maxar.com/)
  */
 #include "ReversedRoadCriterion.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ReversedRoadCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ReversedRoadCriterion.cpp
@@ -35,11 +35,6 @@ namespace hoot
 
 HOOT_FACTORY_REGISTER(ElementCriterion, ReversedRoadCriterion)
 
-ReversedRoadCriterion::ReversedRoadCriterion(ConstOsmMapPtr map)
-  : _map(map)
-{
-}
-
 bool ReversedRoadCriterion::isSatisfied(const ConstElementPtr& e) const
 {
   // The only time reversed road relations have been seen so far is as a result of cropping, but

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ReversedRoadCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ReversedRoadCriterion.h
@@ -38,14 +38,14 @@ namespace hoot
 /**
  * Identifies reversed roads
  */
-class ReversedRoadCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumer
+class ReversedRoadCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
   static QString className() { return "ReversedRoadCriterion"; }
 
   ReversedRoadCriterion() = default;
-  ReversedRoadCriterion(ConstOsmMapPtr map);
+  ReversedRoadCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
   ~ReversedRoadCriterion() override = default;
 
   bool isSatisfied(const ConstElementPtr& e) const override;
@@ -53,16 +53,11 @@ public:
 
   GeometryType getGeometryType() const override { return GeometryType::Line; }
 
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
-
   QString getName() const override { return className(); }
   QString getClassName() const override { return className(); }
   QString toString() const override { return className(); }
   QString getDescription() const override { return "Identifies reversed roads"; }
 
-private:
-
-  ConstOsmMapPtr _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ReversedRoadCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ReversedRoadCriterion.h
@@ -38,14 +38,14 @@ namespace hoot
 /**
  * Identifies reversed roads
  */
-class ReversedRoadCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerImpl
+class ReversedRoadCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerBase
 {
 public:
 
   static QString className() { return "ReversedRoadCriterion"; }
 
   ReversedRoadCriterion() = default;
-  ReversedRoadCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
+  ReversedRoadCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerBase(map) { }
   ~ReversedRoadCriterion() override = default;
 
   bool isSatisfied(const ConstElementPtr& e) const override;

--- a/hoot-core/src/main/cpp/hoot/core/criterion/ReversedRoadCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/ReversedRoadCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef REVERSED_ROAD_CRITERION_H
 #define REVERSED_ROAD_CRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/StandalonePoiCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/StandalonePoiCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2021-2023 Maxar (http://www.maxar.com/)
  */
 #include "StandalonePoiCriterion.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/StandalonePoiCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/StandalonePoiCriterion.cpp
@@ -39,7 +39,7 @@ namespace hoot
 HOOT_FACTORY_REGISTER(ElementCriterion, StandalonePoiCriterion)
 
 StandalonePoiCriterion::StandalonePoiCriterion(ConstOsmMapPtr map)
-  : _map(map)
+  : ConstOsmMapConsumerImpl(map)
 {
   _createCrit();
 }
@@ -56,7 +56,7 @@ void StandalonePoiCriterion::_createCrit()
 
 void StandalonePoiCriterion::setOsmMap(const OsmMap* map)
 {
-  _map = map->shared_from_this();
+  ConstOsmMapConsumerImpl::setOsmMap(map);
   _createCrit();
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/StandalonePoiCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/StandalonePoiCriterion.cpp
@@ -39,7 +39,7 @@ namespace hoot
 HOOT_FACTORY_REGISTER(ElementCriterion, StandalonePoiCriterion)
 
 StandalonePoiCriterion::StandalonePoiCriterion(ConstOsmMapPtr map)
-  : ConstOsmMapConsumerImpl(map)
+  : ConstOsmMapConsumerBase(map)
 {
   _createCrit();
 }
@@ -56,7 +56,7 @@ void StandalonePoiCriterion::_createCrit()
 
 void StandalonePoiCriterion::setOsmMap(const OsmMap* map)
 {
-  ConstOsmMapConsumerImpl::setOsmMap(map);
+  ConstOsmMapConsumerBase::setOsmMap(map);
   _createCrit();
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/StandalonePoiCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/StandalonePoiCriterion.h
@@ -35,7 +35,7 @@
 namespace hoot
 {
 
-class StandalonePoiCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
+class StandalonePoiCriterion : public ElementCriterion, public ConstOsmMapConsumerBase
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/StandalonePoiCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/StandalonePoiCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2021-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef STANDALONE_POI_CRITERION_H
 #define STANDALONE_POI_CRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/StandalonePoiCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/StandalonePoiCriterion.h
@@ -35,7 +35,7 @@
 namespace hoot
 {
 
-class StandalonePoiCriterion : public ElementCriterion, public ConstOsmMapConsumer
+class StandalonePoiCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
@@ -60,7 +60,6 @@ public:
 
 private:
 
-  ConstOsmMapPtr _map;
   ElementCriterionPtr _crit;
 
   void _createCrit();

--- a/hoot-core/src/main/cpp/hoot/core/criterion/UselessElementCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/UselessElementCriterion.h
@@ -42,17 +42,15 @@ namespace hoot
  * For ways: return true if the way has no child nodes or parent relations
  * For relations: return true if the relation has no parent relations or members
  */
-class UselessElementCriterion : public ElementCriterion, public ConstOsmMapConsumer
+class UselessElementCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
   static QString className() { return "UselessElementCriterion"; }
 
   UselessElementCriterion() = default;
-  UselessElementCriterion(ConstOsmMapPtr map) : _map(map) { }
+  UselessElementCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
   ~UselessElementCriterion() override = default;
-
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
 
   bool isSatisfied(const ConstElementPtr& e) const override;
   ElementCriterionPtr clone() override { return std::make_shared<UselessElementCriterion>(); }
@@ -62,9 +60,6 @@ public:
   QString getClassName() const override { return className(); }
   QString toString() const override { return className(); }
 
-private:
-
-  ConstOsmMapPtr _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/UselessElementCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/UselessElementCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2017-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef USELESSELEMENTCRITERION_H
 #define USELESSELEMENTCRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/UselessElementCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/UselessElementCriterion.h
@@ -42,14 +42,14 @@ namespace hoot
  * For ways: return true if the way has no child nodes or parent relations
  * For relations: return true if the relation has no parent relations or members
  */
-class UselessElementCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
+class UselessElementCriterion : public ElementCriterion, public ConstOsmMapConsumerBase
 {
 public:
 
   static QString className() { return "UselessElementCriterion"; }
 
   UselessElementCriterion() = default;
-  UselessElementCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
+  UselessElementCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerBase(map) { }
   ~UselessElementCriterion() override = default;
 
   bool isSatisfied(const ConstElementPtr& e) const override;

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayHeadingVarianceCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayHeadingVarianceCriterion.cpp
@@ -46,7 +46,7 @@ WayHeadingVarianceCriterion::WayHeadingVarianceCriterion()
 WayHeadingVarianceCriterion::WayHeadingVarianceCriterion(const Degrees comparisonVariance,
                                                          const NumericComparisonType& numericComparisonType,
                                                          ConstOsmMapPtr map)
-  : ConstOsmMapConsumerImpl(map),
+  : ConstOsmMapConsumerBase(map),
     _comparisonVariance(comparisonVariance),
     _numericComparisonType(numericComparisonType)
 {

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayHeadingVarianceCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayHeadingVarianceCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2021-2023 Maxar (http://www.maxar.com/)
  */
 #include "WayHeadingVarianceCriterion.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayHeadingVarianceCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayHeadingVarianceCriterion.cpp
@@ -46,9 +46,9 @@ WayHeadingVarianceCriterion::WayHeadingVarianceCriterion()
 WayHeadingVarianceCriterion::WayHeadingVarianceCriterion(const Degrees comparisonVariance,
                                                          const NumericComparisonType& numericComparisonType,
                                                          ConstOsmMapPtr map)
-  : _comparisonVariance(comparisonVariance),
-    _numericComparisonType(numericComparisonType),
-    _map(map)
+  : ConstOsmMapConsumerImpl(map),
+    _comparisonVariance(comparisonVariance),
+    _numericComparisonType(numericComparisonType)
 {
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayHeadingVarianceCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayHeadingVarianceCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2021-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef WAY_HEADING_VARIANCE_CRITERION_H
 #define WAY_HEADING_VARIANCE_CRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayHeadingVarianceCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayHeadingVarianceCriterion.h
@@ -39,7 +39,7 @@
 namespace hoot
 {
 
-class WayHeadingVarianceCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
+class WayHeadingVarianceCriterion : public ElementCriterion, public ConstOsmMapConsumerBase
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayHeadingVarianceCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayHeadingVarianceCriterion.h
@@ -39,7 +39,7 @@
 namespace hoot
 {
 
-class WayHeadingVarianceCriterion : public ElementCriterion, public ConstOsmMapConsumer
+class WayHeadingVarianceCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
@@ -74,8 +74,6 @@ public:
   QString getClassName() const override { return className(); }
   QString toString() const override { return className(); }
 
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
-
   void setNumHistogramBins(const int numBins);
   void setSampleDistance(const Meters distance);
   void setHeadingDelta(const Degrees delta);
@@ -87,7 +85,6 @@ private:
   Degrees _comparisonVariance;
   NumericComparisonType _numericComparisonType;
 
-  ConstOsmMapPtr _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayLengthCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayLengthCriterion.cpp
@@ -44,9 +44,9 @@ WayLengthCriterion::WayLengthCriterion()
 
 WayLengthCriterion::WayLengthCriterion(const double comparisonLength, const NumericComparisonType& numericComparisonType,
                                        ConstOsmMapPtr map)
-  : _comparisonLength(comparisonLength),
-    _numericComparisonType(numericComparisonType),
-    _map(map)
+  : ConstOsmMapConsumerImpl(map),
+    _comparisonLength(comparisonLength),
+    _numericComparisonType(numericComparisonType)
 {
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayLengthCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayLengthCriterion.cpp
@@ -44,7 +44,7 @@ WayLengthCriterion::WayLengthCriterion()
 
 WayLengthCriterion::WayLengthCriterion(const double comparisonLength, const NumericComparisonType& numericComparisonType,
                                        ConstOsmMapPtr map)
-  : ConstOsmMapConsumerImpl(map),
+  : ConstOsmMapConsumerBase(map),
     _comparisonLength(comparisonLength),
     _numericComparisonType(numericComparisonType)
 {

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayLengthCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayLengthCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2021-2023 Maxar (http://www.maxar.com/)
  */
 #include "WayLengthCriterion.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayLengthCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayLengthCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2021-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef WAY_LENGTH_CRITERION_H
 #define WAY_LENGTH_CRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayLengthCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayLengthCriterion.h
@@ -36,7 +36,7 @@
 namespace hoot
 {
 
-class WayLengthCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
+class WayLengthCriterion : public ElementCriterion, public ConstOsmMapConsumerBase
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayLengthCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayLengthCriterion.h
@@ -36,16 +36,14 @@
 namespace hoot
 {
 
-class WayLengthCriterion : public ElementCriterion, public ConstOsmMapConsumer
+class WayLengthCriterion : public ElementCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
   static QString className() { return "WayLengthCriterion"; }
 
   WayLengthCriterion();
-  WayLengthCriterion(
-    const double comparisonLength, const NumericComparisonType& numericComparisonType,
-    ConstOsmMapPtr map);
+  WayLengthCriterion(const double comparisonLength, const NumericComparisonType& numericComparisonType, ConstOsmMapPtr map);
   ~WayLengthCriterion() override = default;
 
   /**
@@ -64,14 +62,11 @@ public:
   QString getClassName() const override { return className(); }
   QString toString() const override { return className(); }
 
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
-
 private:
 
   double _comparisonLength;
   NumericComparisonType _numericComparisonType;
 
-  ConstOsmMapPtr _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayNodeCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayNodeCriterion.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019-2023 Maxar (http://www.maxar.com/)
  */
 #include "WayNodeCriterion.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayNodeCriterion.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayNodeCriterion.cpp
@@ -37,11 +37,6 @@ namespace hoot
 
 HOOT_FACTORY_REGISTER(ElementCriterion, WayNodeCriterion)
 
-WayNodeCriterion::WayNodeCriterion(ConstOsmMapPtr map)
-  : _map(map)
-{
-}
-
 bool WayNodeCriterion::isSatisfied(const ConstElementPtr& e) const
 {
   if (e->getElementType() != ElementType::Node)

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayNodeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayNodeCriterion.h
@@ -35,14 +35,14 @@
 namespace hoot
 {
 
-class WayNodeCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerImpl
+class WayNodeCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerBase
 {
 public:
 
   static QString className() { return "WayNodeCriterion"; }
 
   WayNodeCriterion() = default;
-  WayNodeCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
+  WayNodeCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerBase(map) { }
   ~WayNodeCriterion() override = default;
 
   /**

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayNodeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayNodeCriterion.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef WAY_NODE_CRITERION_H
 #define WAY_NODE_CRITERION_H

--- a/hoot-core/src/main/cpp/hoot/core/criterion/WayNodeCriterion.h
+++ b/hoot-core/src/main/cpp/hoot/core/criterion/WayNodeCriterion.h
@@ -35,14 +35,14 @@
 namespace hoot
 {
 
-class WayNodeCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumer
+class WayNodeCriterion : public GeometryTypeCriterion, public ConstOsmMapConsumerImpl
 {
 public:
 
   static QString className() { return "WayNodeCriterion"; }
 
   WayNodeCriterion() = default;
-  WayNodeCriterion(ConstOsmMapPtr map);
+  WayNodeCriterion(ConstOsmMapPtr map) : ConstOsmMapConsumerImpl(map) { }
   ~WayNodeCriterion() override = default;
 
   /**
@@ -57,8 +57,6 @@ public:
   bool isSatisfied(const ConstElementPtr& e) const override;
   ElementCriterionPtr clone() override { return std::make_shared<WayNodeCriterion>(_map); }
 
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
-
   GeometryType getGeometryType() const override { return GeometryType::Point; }
 
   QString getName() const override { return className(); }
@@ -68,7 +66,6 @@ public:
 
 protected:
 
-  ConstOsmMapPtr _map;
   ElementCriterionPtr _parentCriterion;
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/ConnectedRelationMemberFinder.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ConnectedRelationMemberFinder.h
@@ -38,9 +38,8 @@ namespace hoot
 /**
  * Finds instances where way members across different relations are connected
  */
-class ConnectedRelationMemberFinder : public ConstOsmMapConsumer
+class ConnectedRelationMemberFinder : public ConstOsmMapConsumerImpl
 {
-
 public:
 
   ConnectedRelationMemberFinder() = default;
@@ -55,14 +54,6 @@ public:
    */
   bool haveConnectedWayMembers(const ConstRelationPtr& relation1, const ConstRelationPtr& relation2) const;
 
-  /**
-   * @see ConstOsmMapConsumer
-   */
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
-
-private:
-
-  ConstOsmMapPtr _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/elements/ConnectedRelationMemberFinder.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ConnectedRelationMemberFinder.h
@@ -38,7 +38,7 @@ namespace hoot
 /**
  * Finds instances where way members across different relations are connected
  */
-class ConnectedRelationMemberFinder : public ConstOsmMapConsumerImpl
+class ConnectedRelationMemberFinder : public ConstOsmMapConsumerBase
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/ConnectedRelationMemberFinder.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ConnectedRelationMemberFinder.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020-2023 Maxar (http://www.maxar.com/)
  */
 
 #ifndef CONNECTED_RELATION_MEMBER_FINDER_H

--- a/hoot-core/src/main/cpp/hoot/core/elements/ConstOsmMapConsumer.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ConstOsmMapConsumer.h
@@ -28,12 +28,10 @@
 #define CONSTOSMMAPCONSUMER_H
 
 // Hoot
-#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/elements/OsmMapConsumer.h>
 
 namespace hoot
 {
-class OsmMap;
 
 class ConstOsmMapConsumer : public OsmMapConsumer
 {

--- a/hoot-core/src/main/cpp/hoot/core/elements/ConstOsmMapConsumer.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ConstOsmMapConsumer.h
@@ -57,7 +57,7 @@ public:
   ConstOsmMapConsumerBase(const ConstOsmMapPtr& map) : _map(map) { }
   ~ConstOsmMapConsumerBase() override = default;
 
-  virtual void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
+  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
 
 protected:
   ConstOsmMapPtr _map;

--- a/hoot-core/src/main/cpp/hoot/core/elements/ConstOsmMapConsumer.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ConstOsmMapConsumer.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2018, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef CONSTOSMMAPCONSUMER_H
 #define CONSTOSMMAPCONSUMER_H

--- a/hoot-core/src/main/cpp/hoot/core/elements/ConstOsmMapConsumer.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ConstOsmMapConsumer.h
@@ -28,6 +28,7 @@
 #define CONSTOSMMAPCONSUMER_H
 
 // Hoot
+#include <hoot/core/elements/OsmMap.h>
 #include <hoot/core/elements/OsmMapConsumer.h>
 
 namespace hoot
@@ -47,6 +48,19 @@ public:
   {
     setOsmMap((const OsmMap*)map);
   }
+};
+
+class ConstOsmMapConsumerImpl : public ConstOsmMapConsumer
+{
+public:
+  ConstOsmMapConsumerImpl() = default;
+  ConstOsmMapConsumerImpl(const ConstOsmMapPtr& map) : _map(map) { }
+  ~ConstOsmMapConsumerImpl() override = default;
+
+  virtual void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
+
+protected:
+  ConstOsmMapPtr _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/elements/ConstOsmMapConsumer.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ConstOsmMapConsumer.h
@@ -33,6 +33,7 @@
 namespace hoot
 {
 
+/** Polymorphic base class used for collections and casting */
 class ConstOsmMapConsumer : public OsmMapConsumer
 {
 public:
@@ -48,12 +49,13 @@ public:
   }
 };
 
-class ConstOsmMapConsumerImpl : public ConstOsmMapConsumer
+/** Base class that implements ConstOsmMapConsumer used to derive consumer class implementations */
+class ConstOsmMapConsumerBase : public ConstOsmMapConsumer
 {
 public:
-  ConstOsmMapConsumerImpl() = default;
-  ConstOsmMapConsumerImpl(const ConstOsmMapPtr& map) : _map(map) { }
-  ~ConstOsmMapConsumerImpl() override = default;
+  ConstOsmMapConsumerBase() = default;
+  ConstOsmMapConsumerBase(const ConstOsmMapPtr& map) : _map(map) { }
+  ~ConstOsmMapConsumerBase() override = default;
 
   virtual void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementComparer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementComparer.cpp
@@ -74,7 +74,7 @@ bool ElementComparer::isSame(ElementPtr e1, ElementPtr e2) const
     LOG_TRACE("Compare failed on version: " << e1->getElementId() << ", " << e2->getElementId());
     return false;
   }
-  if (_ignoreElementId && !_map.get())
+  if (_ignoreElementId && !_map)
     throw IllegalArgumentException("If ignoring element IDs in ElementComparer a map must be passed in.");
 
   LOG_VART(e1->getElementId());

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementComparer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementComparer.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016-2023 Maxar (http://www.maxar.com/)
  */
 #include "ElementComparer.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementComparer.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementComparer.h
@@ -44,7 +44,7 @@ namespace hoot
  * The node distance comparison tolerance threshold is controlled via the
  * node.comparison.coordinate.sensitivity configuration option.
  */
-class ElementComparer : public OsmMapConsumerImpl
+class ElementComparer : public OsmMapConsumerBase
 {
 
 public:

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementComparer.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementComparer.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef ELEMENTCOMPARER_H
 #define ELEMENTCOMPARER_H

--- a/hoot-core/src/main/cpp/hoot/core/elements/ElementComparer.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/ElementComparer.h
@@ -44,7 +44,7 @@ namespace hoot
  * The node distance comparison tolerance threshold is controlled via the
  * node.comparison.coordinate.sensitivity configuration option.
  */
-class ElementComparer : public OsmMapConsumer
+class ElementComparer : public OsmMapConsumerImpl
 {
 
 public:
@@ -67,14 +67,6 @@ public:
   bool isSame(ElementPtr e1, ElementPtr e2) const;
 
   /**
-   * @see OsmMapConsumer
-   *
-   * This only needs to be set if _ignoreElementId = true. The reason a const map isn't used here
-   * is for the same reason isSame doesn't take in const elements.
-   */
-  void setOsmMap(OsmMap* map) override { _map = map->shared_from_this(); }
-
-  /**
    * Wrapper around ElementHashVisitor::toHashString
    */
   QString toHashString(const ConstElementPtr& e) const;
@@ -89,8 +81,6 @@ private:
   bool _ignoreElementId;
   // allows for ignoring element versions during comparison
   bool _ignoreVersion;
-  // a map is needed when comparing child elements if ignoring element IDs
-  OsmMapPtr _map;
 
   void _setHash(ElementPtr element) const;
   bool _haveSameHash(ElementPtr re, ElementPtr e) const;

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMapConsumer.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMapConsumer.h
@@ -44,12 +44,12 @@ public:
 };
 
 /** Base class that implements OsmMapConsumer used to derive consumer class implementations */
-class OsmMapConsumerImpl : public OsmMapConsumer
+class OsmMapConsumerBase : public OsmMapConsumer
 {
 public:
 
-  OsmMapConsumerImpl() = default;
-  ~OsmMapConsumerImpl() override = default;
+  OsmMapConsumerBase() = default;
+  ~OsmMapConsumerBase() override = default;
 
   void setOsmMap(OsmMap* map) override { _map = map->shared_from_this(); }
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMapConsumer.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMapConsumer.h
@@ -27,6 +27,8 @@
 #ifndef OSMMAPCONSUMER_H
 #define OSMMAPCONSUMER_H
 
+#include <hoot/core/elements/OsmMap.h>
+
 namespace hoot
 {
 class OsmMap;
@@ -39,6 +41,21 @@ public:
   virtual ~OsmMapConsumer() = default;
 
   virtual void setOsmMap(OsmMap* map) = 0;
+};
+
+class OsmMapConsumerImpl : public OsmMapConsumer
+{
+public:
+
+  OsmMapConsumerImpl() = default;
+  ~OsmMapConsumerImpl() override = default;
+
+  void setOsmMap(OsmMap* map) override { _map = map->shared_from_this(); }
+
+protected:
+
+  OsmMapPtr _map;
+
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMapConsumer.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMapConsumer.h
@@ -31,8 +31,8 @@
 
 namespace hoot
 {
-class OsmMap;
 
+/** Polymorphic base class used for collections and casting */
 class OsmMapConsumer
 {
 public:
@@ -43,6 +43,7 @@ public:
   virtual void setOsmMap(OsmMap* map) = 0;
 };
 
+/** Base class that implements OsmMapConsumer used to derive consumer class implementations */
 class OsmMapConsumerImpl : public OsmMapConsumer
 {
 public:

--- a/hoot-core/src/main/cpp/hoot/core/elements/OsmMapConsumer.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/OsmMapConsumer.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2018, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef OSMMAPCONSUMER_H
 #define OSMMAPCONSUMER_H

--- a/hoot-core/src/main/cpp/hoot/core/elements/RelationMemberNodeCounter.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/RelationMemberNodeCounter.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020-2023 Maxar (http://www.maxar.com/)
  */
 
 #ifndef RELATION_MEMBER_NODE_COUNTER_H

--- a/hoot-core/src/main/cpp/hoot/core/elements/RelationMemberNodeCounter.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/RelationMemberNodeCounter.h
@@ -38,7 +38,7 @@ namespace hoot
 /**
  * Counts total nodes contained by all members in a relation
  */
-class RelationMemberNodeCounter : public ConstOsmMapConsumerImpl
+class RelationMemberNodeCounter : public ConstOsmMapConsumerBase
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/elements/RelationMemberNodeCounter.h
+++ b/hoot-core/src/main/cpp/hoot/core/elements/RelationMemberNodeCounter.h
@@ -38,7 +38,7 @@ namespace hoot
 /**
  * Counts total nodes contained by all members in a relation
  */
-class RelationMemberNodeCounter : public ConstOsmMapConsumer
+class RelationMemberNodeCounter : public ConstOsmMapConsumerImpl
 {
 public:
 
@@ -53,14 +53,6 @@ public:
    */
   int numNodes(const ConstRelationPtr& relation) const;
 
-  /**
-   * @see ConstOsmMapConsumer
-   */
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
-
-private:
-
-  ConstOsmMapPtr _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #include "CopyMapSubsetOp.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.cpp
@@ -116,14 +116,14 @@ CopyMapSubsetOp::CopyMapSubsetOp()
 }
 
 CopyMapSubsetOp::CopyMapSubsetOp(const ConstOsmMapPtr& from, const set<ElementId>& eids)
-  : ConstOsmMapConsumerImpl(from),
+  : ConstOsmMapConsumerBase(from),
     _eids(eids),
     _copyChildren(true)
 {
 }
 
 CopyMapSubsetOp::CopyMapSubsetOp(const ConstOsmMapPtr& from, const vector<long>& wayIds)
-  : ConstOsmMapConsumerImpl(from),
+  : ConstOsmMapConsumerBase(from),
     _copyChildren(true)
 {
   for (auto way_id : wayIds)
@@ -134,14 +134,14 @@ CopyMapSubsetOp::CopyMapSubsetOp(const ConstOsmMapPtr& from, const vector<long>&
 }
 
 CopyMapSubsetOp::CopyMapSubsetOp(const ConstOsmMapPtr& from, ElementId eid)
-  : ConstOsmMapConsumerImpl(from),
+  : ConstOsmMapConsumerBase(from),
     _copyChildren(true)
 {
   _eids.insert(eid);
 }
 
 CopyMapSubsetOp::CopyMapSubsetOp(const ConstOsmMapPtr& from, ElementId eid1, ElementId eid2)
-  : ConstOsmMapConsumerImpl(from),
+  : ConstOsmMapConsumerBase(from),
     _copyChildren(true)
 {
   _eids.insert(eid1);
@@ -149,7 +149,7 @@ CopyMapSubsetOp::CopyMapSubsetOp(const ConstOsmMapPtr& from, ElementId eid1, Ele
 }
 
 CopyMapSubsetOp::CopyMapSubsetOp(const ConstOsmMapPtr& from, const ElementCriterionPtr& crit)
-  : ConstOsmMapConsumerImpl(from),
+  : ConstOsmMapConsumerBase(from),
     _copyChildren(true)
 {
   addCriterion(crit);

--- a/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.h
@@ -41,7 +41,7 @@ namespace hoot
 /**
  * Copies a subset of the map into a new map. The old map is unchanged.
  */
-class CopyMapSubsetOp : public OsmMapOperation, public ConstOsmMapConsumerImpl,
+class CopyMapSubsetOp : public OsmMapOperation, public ConstOsmMapConsumerBase,
   public ElementCriterionConsumer, public Configurable
 {
 public:

--- a/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.h
@@ -41,7 +41,7 @@ namespace hoot
 /**
  * Copies a subset of the map into a new map. The old map is unchanged.
  */
-class CopyMapSubsetOp : public OsmMapOperation, public ConstOsmMapConsumer,
+class CopyMapSubsetOp : public OsmMapOperation, public ConstOsmMapConsumerImpl,
   public ElementCriterionConsumer, public Configurable
 {
 public:
@@ -97,11 +97,6 @@ public:
   void setConfiguration(const Settings& conf) override;
 
   /**
-   * @see ConstOsmMapConsumer
-   */
-  void setOsmMap(const OsmMap* map) override { _from = map->shared_from_this(); }
-
-  /**
    * @see ElementCriterionConsumer
    */
   void addCriterion(const ElementCriterionPtr& crit) override;
@@ -127,7 +122,6 @@ public:
 private:
 
   std::set<ElementId> _eids;
-  ConstOsmMapPtr _from;
   // determines whether child elements are copied (way nodes and relation members)
   bool _copyChildren;
   std::set<ElementId> _eidsCopied;

--- a/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.h
+++ b/hoot-core/src/main/cpp/hoot/core/ops/CopyMapSubsetOp.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef COPYMAPSUBSETOP_H
 #define COPYMAPSUBSETOP_H

--- a/hoot-core/src/main/cpp/hoot/core/schema/AttributeCoOccurrence.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/AttributeCoOccurrence.cpp
@@ -87,7 +87,7 @@ private:
 /**
  * Traverses the OsmMap and build a hashmap of Attribute Co-Occurrence values.
  */
-class CoOccurrenceVisitor : public ConstElementVisitor, public ConstOsmMapConsumerImpl
+class CoOccurrenceVisitor : public ConstElementVisitor, public ConstOsmMapConsumerBase
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/schema/AttributeCoOccurrence.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/AttributeCoOccurrence.cpp
@@ -87,7 +87,7 @@ private:
 /**
  * Traverses the OsmMap and build a hashmap of Attribute Co-Occurrence values.
  */
-class CoOccurrenceVisitor : public ConstElementVisitor, public ConstOsmMapConsumer
+class CoOccurrenceVisitor : public ConstElementVisitor, public ConstOsmMapConsumerImpl
 {
 public:
 
@@ -97,8 +97,6 @@ public:
   {
   }
   ~CoOccurrenceVisitor() override = default;
-
-  void setOsmMap(const OsmMap* map) override { _map = map; }
 
   QString getDescription() const override { return ""; }
   QString getName() const override { return ""; }
@@ -190,7 +188,6 @@ public:
 
 private:
 
-  const OsmMap* _map;
   RefToEidVisitor::RefToEid _refSet;
   AttributeCoOccurrence::CoOccurrenceHash& _coOccurrence;
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ConflatableCriteriaVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ConflatableCriteriaVisitor.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2019-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef CONFLATABLE_CRITERIA_VISITOR_H
 #define CONFLATABLE_CRITERIA_VISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ConflatableCriteriaVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ConflatableCriteriaVisitor.h
@@ -39,7 +39,7 @@ namespace hoot
  * This is primarily useful for debugging when trying to find out whether hoot can conflate or
  * which conflator it will use for a particular feature.
  */
-class ConflatableCriteriaVisitor : public ElementVisitor, public ConstOsmMapConsumer
+class ConflatableCriteriaVisitor : public ElementVisitor, public ConstOsmMapConsumerImpl
 {
 
 public:
@@ -59,11 +59,6 @@ public:
   QString getName() const override { return className(); }
   QString getClassName() const override { return className(); }
 
-  void setOsmMap(const OsmMap* map) override { _map = map->shared_from_this(); }
-
-private:
-
-  ConstOsmMapPtr _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ConflatableCriteriaVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ConflatableCriteriaVisitor.h
@@ -39,7 +39,7 @@ namespace hoot
  * This is primarily useful for debugging when trying to find out whether hoot can conflate or
  * which conflator it will use for a particular feature.
  */
-class ConflatableCriteriaVisitor : public ElementVisitor, public ConstOsmMapConsumerImpl
+class ConflatableCriteriaVisitor : public ElementVisitor, public ConstOsmMapConsumerBase
 {
 
 public:

--- a/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.cpp
@@ -52,7 +52,7 @@ void DecomposeBuildingRelationsVisitor::visit(const ConstElementPtr& e)
   }
 }
 
-void DecomposeBuildingRelationsVisitor::_decomposeBuilding(const std::shared_ptr<Relation>& r)
+void DecomposeBuildingRelationsVisitor::_decomposeBuilding(const std::shared_ptr<Relation>& r) const
 {
   if (r == nullptr)
     return;

--- a/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #include "DecomposeBuildingRelationsVisitor.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.cpp
@@ -108,7 +108,7 @@ void DecomposeBuildingRelationsVisitor::_decomposeBuilding(const std::shared_ptr
   }
 
   // remove the building relation
-  RecursiveElementRemover(r->getElementId()).apply(_map->shared_from_this());
+  RecursiveElementRemover(r->getElementId()).apply(_map);
 }
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.h
@@ -43,7 +43,7 @@ class Relation;
  *
  * http://wiki.openstreetmap.org/wiki/Simple_3D_Buildings
  */
-class DecomposeBuildingRelationsVisitor : public ConstElementVisitor, public OsmMapConsumerImpl
+class DecomposeBuildingRelationsVisitor : public ConstElementVisitor, public OsmMapConsumerBase
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.h
@@ -72,7 +72,7 @@ private:
 
   std::vector<long> _ids;
 
-  void _decomposeBuilding(const std::shared_ptr<Relation>& r);
+  void _decomposeBuilding(const std::shared_ptr<Relation>& r) const;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef DECOMPOSEBUILDINGRELATIONSVISITOR_H
 #define DECOMPOSEBUILDINGRELATIONSVISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.h
@@ -43,7 +43,7 @@ class Relation;
  *
  * http://wiki.openstreetmap.org/wiki/Simple_3D_Buildings
  */
-class DecomposeBuildingRelationsVisitor : public ConstElementVisitor, public OsmMapConsumer
+class DecomposeBuildingRelationsVisitor : public ConstElementVisitor, public OsmMapConsumerImpl
 {
 public:
 
@@ -59,9 +59,6 @@ public:
    */
   void visit(const ConstElementPtr& e) override;
 
-  void setOsmMap(OsmMap* map) override { _map = map; }
-  void setOsmMap(const OsmMap* /*map*/) const { assert(false); }
-
   QString getInitStatusMessage() const override { return "Decomposing complex buildings..."; }
   QString getCompletedStatusMessage() const override
   { return "Decomposed " + QString::number(_numAffected) + " complex buildings"; }
@@ -73,7 +70,6 @@ public:
 
 private:
 
-  OsmMap* _map;
   std::vector<long> _ids;
 
   void _decomposeBuilding(const std::shared_ptr<Relation>& r);

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ElementConstOsmMapVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ElementConstOsmMapVisitor.h
@@ -38,7 +38,7 @@ namespace hoot
 /**
  * Base class to ease ConstOsmMapConsumer usage.
  */
-class ElementConstOsmMapVisitor : public ConstElementVisitor, public ConstOsmMapConsumerImpl
+class ElementConstOsmMapVisitor : public ConstElementVisitor, public ConstOsmMapConsumerBase
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ElementConstOsmMapVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ElementConstOsmMapVisitor.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef ELEMENTCONSTOSMMAPVISITOR_H
 #define ELEMENTCONSTOSMMAPVISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ElementConstOsmMapVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ElementConstOsmMapVisitor.h
@@ -38,20 +38,15 @@ namespace hoot
 /**
  * Base class to ease ConstOsmMapConsumer usage.
  */
-class ElementConstOsmMapVisitor : public ConstElementVisitor, public ConstOsmMapConsumer
+class ElementConstOsmMapVisitor : public ConstElementVisitor, public ConstOsmMapConsumerImpl
 {
 public:
 
   static QString className() { return "ElementConstOsmMapVisitor"; }
 
-  ElementConstOsmMapVisitor() : _map(nullptr) { }
+  ElementConstOsmMapVisitor() = default;
   virtual ~ElementConstOsmMapVisitor() = default;
 
-  void setOsmMap(const OsmMap* map) override { _map = map; }
-
-protected:
-
-  const OsmMap* _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ElementVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ElementVisitor.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef ELEMENTVISITOR_H
 #define ELEMENTVISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ElementVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ElementVisitor.h
@@ -70,8 +70,7 @@ namespace hoot
  * and require them to be implemented in children. If we ever have multiple inheritance issues via
  * inheritance from the OperationStatus, we can change it to be a proper interface.
  */
-class ElementVisitor : public ApiEntityInfo, public FilteredByGeometryTypeCriteria,
-  public OperationStatus
+class ElementVisitor : public ApiEntityInfo, public FilteredByGeometryTypeCriteria, public OperationStatus
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.cpp
@@ -46,24 +46,20 @@ FilteredVisitor::FilteredVisitor()
 
 FilteredVisitor::FilteredVisitor(const ElementCriterion& criterion, ElementVisitor& visitor)
   : _criterion(&criterion),
-    _visitor(&visitor),
-    _map(nullptr)
+    _visitor(&visitor)
 {
 }
 
 FilteredVisitor::FilteredVisitor(ElementCriterionPtr criterion, ElementVisitorPtr visitor)
   : _criterion(criterion.get()),
-    _visitor(visitor.get()),
-    _map(nullptr)
+    _visitor(visitor.get())
 {
 }
 
 void FilteredVisitor::addCriterion(const ElementCriterionPtr& e)
 {
   if (_criterion)
-  {
     throw IllegalArgumentException("FilteredVisitor only takes one criterion.");
-  }
   _criterion = e.get();
 }
 
@@ -74,20 +70,12 @@ void FilteredVisitor::addVisitor(const ElementVisitorPtr& v)
   _visitor = v.get();
 }
 
-void FilteredVisitor::setOsmMap(OsmMap* map)
-{
-  ConstOsmMapConsumer* c = dynamic_cast<ConstOsmMapConsumer*>(_visitor);
-  if (c != nullptr)
-    c->setOsmMap(map);
-  _map = map;
-}
-
 void FilteredVisitor::setOsmMap(const OsmMap* map)
 {
+  ConstOsmMapConsumerImpl::setOsmMap(map);
   ConstOsmMapConsumer* c = dynamic_cast<ConstOsmMapConsumer*>(_visitor);
   if (c != nullptr)
     c->setOsmMap(map);
-  _map = map;
 }
 
 void FilteredVisitor::visit(const ConstElementPtr& e)

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #include "FilteredVisitor.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.cpp
@@ -72,7 +72,7 @@ void FilteredVisitor::addVisitor(const ElementVisitorPtr& v)
 
 void FilteredVisitor::setOsmMap(const OsmMap* map)
 {
-  ConstOsmMapConsumerImpl::setOsmMap(map);
+  ConstOsmMapConsumerBase::setOsmMap(map);
   ConstOsmMapConsumer* c = dynamic_cast<ConstOsmMapConsumer*>(_visitor);
   if (c != nullptr)
     c->setOsmMap(map);

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef FILTEREDVISITOR_H
 #define FILTEREDVISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.h
@@ -37,7 +37,7 @@
 namespace hoot
 {
 
-class FilteredVisitor : public ConstElementVisitor, public ConstOsmMapConsumerImpl, public ElementCriterionConsumer, public ElementVisitorConsumer
+class FilteredVisitor : public ConstElementVisitor, public ConstOsmMapConsumerBase, public ElementCriterionConsumer, public ElementVisitorConsumer
 {
 
 public:

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FilteredVisitor.h
@@ -37,8 +37,7 @@
 namespace hoot
 {
 
-class FilteredVisitor : public ConstElementVisitor, public ConstOsmMapConsumer,
-  public ElementCriterionConsumer, public ElementVisitorConsumer
+class FilteredVisitor : public ConstElementVisitor, public ConstOsmMapConsumerImpl, public ElementCriterionConsumer, public ElementVisitorConsumer
 {
 
 public:
@@ -66,7 +65,6 @@ public:
 
   void addVisitor(const ElementVisitorPtr& v) override;
 
-  void setOsmMap(OsmMap* map) override;
   void setOsmMap(const OsmMap* map) override;
 
   /**
@@ -84,7 +82,6 @@ private:
 
   const ElementCriterion* _criterion;
   ElementVisitor* _visitor;
-  const OsmMap* _map;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FindIntersectionsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FindIntersectionsVisitor.cpp
@@ -50,7 +50,7 @@ void FindIntersectionsVisitor::visit(const ConstElementPtr& e)
   const set<long>& wids = n2w->getWaysByNode(id);
   // create the criterion if needed
   if (!_criterion)
-    _criterion = createCriterion(_map->shared_from_this());
+    _criterion = createCriterion(_map);
   // find all ways that are of the criterion type
   set<long> hwids;
   for (auto way_id : wids)
@@ -70,7 +70,7 @@ void FindIntersectionsVisitor::visit(const ConstElementPtr& e)
 //    _map->getNode(id)->setTag(MetadataTags::HootIntersectionWayCount(), QString::number(hwids.size()));
     _map->getNode(id)->setTag("IntersectionWayCount", QString::number(hwids.size()));
 
-    vector<Radians> angles = NodeMatcher::calculateAngles(_map, id, hwids, 10);
+    vector<Radians> angles = NodeMatcher::calculateAngles(_map.get(), id, hwids, 10);
     vector<double> v;
     for (auto angle : angles)
       v.push_back(toDegrees(angle)+180);

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FindIntersectionsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FindIntersectionsVisitor.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #include "FindIntersectionsVisitor.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FindIntersectionsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FindIntersectionsVisitor.h
@@ -39,7 +39,7 @@ namespace hoot
 /**
  * Finds all intersections (nodes), adds some parameters to them and records their node ids
  */
-class FindIntersectionsVisitor : public ConstElementVisitor, public OsmMapConsumer
+class FindIntersectionsVisitor : public ConstElementVisitor, public OsmMapConsumerImpl
 {
 public:
 
@@ -52,9 +52,6 @@ public:
    * @see ElementVisitor
    */
   void visit(const ConstElementPtr& e) override;
-
-  void setOsmMap(OsmMap* map) override { _map = map; }
-  virtual void setOsmMap(const OsmMap* /*map*/) { assert(false); }
 
   std::vector<long>& getIntersections() { return _ids; }
 
@@ -70,7 +67,6 @@ public:
 
 private:
 
-  OsmMap* _map;
   std::vector<long> _ids;
   ElementCriterionPtr _criterion;
 };

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FindIntersectionsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FindIntersectionsVisitor.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef FINDINTERSECTIONSVISITOR_H
 #define FINDINTERSECTIONSVISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/FindIntersectionsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/FindIntersectionsVisitor.h
@@ -39,7 +39,7 @@ namespace hoot
 /**
  * Finds all intersections (nodes), adds some parameters to them and records their node ids
  */
-class FindIntersectionsVisitor : public ConstElementVisitor, public OsmMapConsumerImpl
+class FindIntersectionsVisitor : public ConstElementVisitor, public OsmMapConsumerBase
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/MultilineStringMergeRelationCollapser.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/MultilineStringMergeRelationCollapser.cpp
@@ -52,7 +52,7 @@ MultilineStringMergeRelationCollapser::MultilineStringMergeRelationCollapser()
 
 void MultilineStringMergeRelationCollapser::setOsmMap(OsmMap* map)
 {
-  OsmMapConsumerImpl::setOsmMap(map);
+  OsmMapConsumerBase::setOsmMap(map);
   _relationMerger.setOsmMap(map);
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/MultilineStringMergeRelationCollapser.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/MultilineStringMergeRelationCollapser.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020-2023 Maxar (http://www.maxar.com/)
  */
 
 #include "MultilineStringMergeRelationCollapser.h"

--- a/hoot-core/src/main/cpp/hoot/core/visitors/MultilineStringMergeRelationCollapser.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/MultilineStringMergeRelationCollapser.cpp
@@ -52,8 +52,8 @@ MultilineStringMergeRelationCollapser::MultilineStringMergeRelationCollapser()
 
 void MultilineStringMergeRelationCollapser::setOsmMap(OsmMap* map)
 {
-  _map = map->shared_from_this();
-  _relationMerger.setOsmMap(_map.get());
+  OsmMapConsumerImpl::setOsmMap(map);
+  _relationMerger.setOsmMap(map);
 }
 
 void MultilineStringMergeRelationCollapser::setTypes(const QStringList& types)

--- a/hoot-core/src/main/cpp/hoot/core/visitors/MultilineStringMergeRelationCollapser.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/MultilineStringMergeRelationCollapser.h
@@ -55,7 +55,7 @@ namespace hoot
  * minimal feature types to be operated on. Alternatively, use of this class could be made automatic
  * and moved to LinearSnapMerger to be called directly from there.
  */
-class MultilineStringMergeRelationCollapser : public MultipleCriterionConsumerVisitor, public OsmMapConsumerImpl, public Configurable
+class MultilineStringMergeRelationCollapser : public MultipleCriterionConsumerVisitor, public OsmMapConsumerBase, public Configurable
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/MultilineStringMergeRelationCollapser.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/MultilineStringMergeRelationCollapser.h
@@ -55,8 +55,7 @@ namespace hoot
  * minimal feature types to be operated on. Alternatively, use of this class could be made automatic
  * and moved to LinearSnapMerger to be called directly from there.
  */
-class MultilineStringMergeRelationCollapser : public MultipleCriterionConsumerVisitor,
-  public OsmMapConsumer, public Configurable
+class MultilineStringMergeRelationCollapser : public MultipleCriterionConsumerVisitor, public OsmMapConsumerImpl, public Configurable
 {
 public:
 
@@ -99,8 +98,6 @@ public:
   void setTypes(const QStringList& types);
 
 private:
-
-  OsmMapPtr _map;
 
   // a list of type keys to be removed from the parent relation and copied to its members
   QStringList _typeKeys;

--- a/hoot-core/src/main/cpp/hoot/core/visitors/MultilineStringMergeRelationCollapser.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/MultilineStringMergeRelationCollapser.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020-2023 Maxar (http://www.maxar.com/)
  */
 
 #ifndef MULTILINESTRING_MERGE_RELATION_COLLAPSER_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveDuplicateWayNodesVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveDuplicateWayNodesVisitor.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2018-2023 Maxar (http://www.maxar.com/)
  */
 
 #ifndef REMOVEDUPLICATEWAYNODESVISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveDuplicateWayNodesVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveDuplicateWayNodesVisitor.h
@@ -45,7 +45,7 @@ namespace hoot
  * nodes appears to be in the conflation routines somewhere and should eventually be found and
  * fixed.
  */
-class RemoveDuplicateWayNodesVisitor : public ElementVisitor, public OsmMapConsumerImpl, public ConflateInfoCacheConsumer
+class RemoveDuplicateWayNodesVisitor : public ElementVisitor, public OsmMapConsumerBase, public ConflateInfoCacheConsumer
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveDuplicateWayNodesVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveDuplicateWayNodesVisitor.h
@@ -45,8 +45,7 @@ namespace hoot
  * nodes appears to be in the conflation routines somewhere and should eventually be found and
  * fixed.
  */
-class RemoveDuplicateWayNodesVisitor : public ElementVisitor, public OsmMapConsumer,
-  public ConflateInfoCacheConsumer
+class RemoveDuplicateWayNodesVisitor : public ElementVisitor, public OsmMapConsumerImpl, public ConflateInfoCacheConsumer
 {
 public:
 
@@ -60,12 +59,7 @@ public:
    */
   void visit(const ElementPtr& e) override;
 
-  /**
-   * @see OsmMapConsumer
-   */
-  void setOsmMap(OsmMap* map) override { _map = map->shared_from_this(); }
-
-  /**
+ /**
    * Removes duplicates nodes from a way
    *
    * @param way the way to remove duplicate nodes from
@@ -89,8 +83,6 @@ public:
   { _conflateInfoCache = cache; }
 
 private:
-
-  OsmMapPtr _map;
 
   // Existence of this cache tells us that elements must be individually checked to see that they
   // are conflatable given the current configuration before modifying them.

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.cpp
@@ -79,7 +79,7 @@ void RemoveElementsVisitor::setConfiguration(const Settings& conf)
 
 void RemoveElementsVisitor::setOsmMap(OsmMap* map)
 {
-  OsmMapConsumerImpl::setOsmMap(map);
+  OsmMapConsumerBase::setOsmMap(map);
   _startElementCount = _map->getElementCount();
 
   for (const auto& crit : _criteria)

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #include "RemoveElementsVisitor.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.cpp
@@ -79,7 +79,7 @@ void RemoveElementsVisitor::setConfiguration(const Settings& conf)
 
 void RemoveElementsVisitor::setOsmMap(OsmMap* map)
 {
-  _map = map;
+  OsmMapConsumerImpl::setOsmMap(map);
   _startElementCount = _map->getElementCount();
 
   for (const auto& crit : _criteria)
@@ -105,8 +105,7 @@ void RemoveElementsVisitor::visit(const ElementPtr& e)
     if (_recursive)
     {
       LOG_TRACE("Removing element: " << e->getElementId() << " recursively...");
-      RecursiveElementRemover(e->getElementId(), _recursiveRemoveRefsFromParents)
-        .apply(_map->shared_from_this());
+      RecursiveElementRemover(e->getElementId(), _recursiveRemoveRefsFromParents).apply(_map);
     }
     else
     {
@@ -115,7 +114,7 @@ void RemoveElementsVisitor::visit(const ElementPtr& e)
       // solved the problem and didn't have any negative impact on the rest of the code...could
       // still be worth looking into, though.
       LOG_TRACE("Removing element: " << e->getElementId() << " non-recursively...");
-      RemoveElementByEid::removeElement(_map->shared_from_this(), e->getElementId());
+      RemoveElementByEid::removeElement(_map, e->getElementId());
     }
     _numAffected++;
   }

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.h
@@ -41,8 +41,7 @@ namespace hoot
  *
  * @todo This class has some redundancy with RecursiveElementRemover.
  */
-class RemoveElementsVisitor : public MultipleCriterionConsumerVisitor, public OsmMapConsumer,
-  public Configurable
+class RemoveElementsVisitor : public MultipleCriterionConsumerVisitor, public OsmMapConsumerImpl, public Configurable
 {
 public:
 
@@ -62,7 +61,6 @@ public:
   void setConfiguration(const Settings& conf) override;
 
   void setOsmMap(OsmMap* map) override;
-  void setOsmMap(const OsmMap* /*map*/) const { assert(false); }
 
   static void removeWays(const std::shared_ptr<OsmMap>& pMap, const ElementCriterionPtr& pCrit);
 
@@ -82,8 +80,6 @@ public:
   void setRecursiveRemoveRefsFromParents(bool remove) { _recursiveRemoveRefsFromParents = remove; }
 
 private:
-
-  OsmMap* _map;
 
   bool _recursive;
   bool _recursiveRemoveRefsFromParents;

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef REMOVEELEMENTSVISITOR_H
 #define REMOVEELEMENTSVISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveElementsVisitor.h
@@ -41,7 +41,7 @@ namespace hoot
  *
  * @todo This class has some redundancy with RecursiveElementRemover.
  */
-class RemoveElementsVisitor : public MultipleCriterionConsumerVisitor, public OsmMapConsumerImpl, public Configurable
+class RemoveElementsVisitor : public MultipleCriterionConsumerVisitor, public OsmMapConsumerBase, public Configurable
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveMissingElementsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveMissingElementsVisitor.cpp
@@ -43,7 +43,7 @@ RemoveMissingElementsVisitor::RemoveMissingElementsVisitor(const Log::WarningLev
 
 void RemoveMissingElementsVisitor::setOsmMap(OsmMap* map)
 {
-  OsmMapConsumerImpl::setOsmMap(map);
+  OsmMapConsumerBase::setOsmMap(map);
   _v->setOsmMap(map);
 }
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveMissingElementsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveMissingElementsVisitor.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016-2023 Maxar (http://www.maxar.com/)
  */
 
 #include "RemoveMissingElementsVisitor.h"

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveMissingElementsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveMissingElementsVisitor.cpp
@@ -41,6 +41,13 @@ RemoveMissingElementsVisitor::RemoveMissingElementsVisitor(const Log::WarningLev
   _v = std::make_shared<ReportMissingElementsVisitor>(true, logLevel, maxReport);
 }
 
+void RemoveMissingElementsVisitor::setOsmMap(OsmMap* map)
+{
+  OsmMapConsumerImpl::setOsmMap(map);
+  _v->setOsmMap(map);
+}
+
+
 void RemoveMissingElementsVisitor::visit(const ConstElementPtr& e)
 {
   _v->visit(e);

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveMissingElementsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveMissingElementsVisitor.h
@@ -38,7 +38,7 @@ namespace hoot
 /**
  * Removes non-existent element references from relations or ways
  */
-class RemoveMissingElementsVisitor : public ConstElementVisitor, public OsmMapConsumer
+class RemoveMissingElementsVisitor : public ConstElementVisitor, public OsmMapConsumerImpl
 {
 public:
 
@@ -48,9 +48,7 @@ public:
                                const int maxReport = Log::getWarnMessageLimit());
   ~RemoveMissingElementsVisitor() override = default;
 
-  void setOsmMap(OsmMap* map) override { _v->setOsmMap(map);}
-  void setOsmMap(const OsmMap* /*map*/) const
-  { throw NotImplementedException("Set Map with const is not supported"); }
+  void setOsmMap(OsmMap* map) override;
 
   /**
    * @see ElementVisitor

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveMissingElementsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveMissingElementsVisitor.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef REMOVEMISSINGELEMENTSVISITOR_H
 #define REMOVEMISSINGELEMENTSVISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveMissingElementsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveMissingElementsVisitor.h
@@ -38,7 +38,7 @@ namespace hoot
 /**
  * Removes non-existent element references from relations or ways
  */
-class RemoveMissingElementsVisitor : public ConstElementVisitor, public OsmMapConsumerImpl
+class RemoveMissingElementsVisitor : public ConstElementVisitor, public OsmMapConsumerBase
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveRef2Visitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveRef2Visitor.cpp
@@ -161,7 +161,7 @@ bool RemoveRef2Visitor::_hasRef2Tag(ElementPtr e) const
 
 void RemoveRef2Visitor::setOsmMap(OsmMap* map)
 {
-  _map = map;
+  OsmMapConsumerImpl::setOsmMap(map);
   // traverse the map and create a REF1 to ElementId map.
   Ref1ToEidVisitor v;
   _map->visitRo(v);

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveRef2Visitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveRef2Visitor.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #include "RemoveRef2Visitor.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveRef2Visitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveRef2Visitor.cpp
@@ -161,7 +161,7 @@ bool RemoveRef2Visitor::_hasRef2Tag(ElementPtr e) const
 
 void RemoveRef2Visitor::setOsmMap(OsmMap* map)
 {
-  OsmMapConsumerImpl::setOsmMap(map);
+  OsmMapConsumerBase::setOsmMap(map);
   // traverse the map and create a REF1 to ElementId map.
   Ref1ToEidVisitor v;
   _map->visitRo(v);

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveRef2Visitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveRef2Visitor.h
@@ -44,7 +44,7 @@ namespace hoot
  *
  * This class is re-entrant, but not thread safe.
  */
-class RemoveRef2Visitor : public ElementVisitor, public OsmMapConsumerImpl, public ElementCriterionConsumer
+class RemoveRef2Visitor : public ElementVisitor, public OsmMapConsumerBase, public ElementCriterionConsumer
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveRef2Visitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveRef2Visitor.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef REMOVEREF2VISITOR_H
 #define REMOVEREF2VISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveRef2Visitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveRef2Visitor.h
@@ -44,9 +44,8 @@ namespace hoot
  *
  * This class is re-entrant, but not thread safe.
  */
-class RemoveRef2Visitor : public ElementVisitor, public OsmMapConsumer, public ElementCriterionConsumer
+class RemoveRef2Visitor : public ElementVisitor, public OsmMapConsumerImpl, public ElementCriterionConsumer
 {
-
 public:
 
   using Ref1ToEid = QMap<QString, ElementId>;
@@ -81,7 +80,6 @@ protected:
 
 private:
 
-  OsmMap* _map;
   Ref1ToEid _ref1ToEid;
   static QStringList _ref2Keys;
   static std::mutex _mutex;

--- a/hoot-core/src/main/cpp/hoot/core/visitors/RemoveRef2Visitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/RemoveRef2Visitor.h
@@ -44,8 +44,7 @@ namespace hoot
  *
  * This class is re-entrant, but not thread safe.
  */
-class RemoveRef2Visitor : public ElementVisitor, public ConstOsmMapConsumer,
-  public ElementCriterionConsumer
+class RemoveRef2Visitor : public ElementVisitor, public OsmMapConsumer, public ElementCriterionConsumer
 {
 
 public:
@@ -62,7 +61,6 @@ public:
   void addCriterion(const ElementCriterionPtr& e) override;
 
   void setOsmMap(OsmMap* map) override;
-  void setOsmMap(const OsmMap* /*map*/) override { assert(false); }
 
   /**
    * @see ElementVisitor

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ReportMissingElementsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ReportMissingElementsVisitor.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #include "ReportMissingElementsVisitor.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ReportMissingElementsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ReportMissingElementsVisitor.cpp
@@ -93,10 +93,10 @@ void ReportMissingElementsVisitor::_updateWay(const WayPtr& way, const QStringLi
 {
   if (!missingChildIds.empty())
   {
-    if (_markWaysForReview && !ReviewMarker::isNeedsReview(_map->shared_from_this(), way))
+    if (_markWaysForReview && !ReviewMarker::isNeedsReview(_map, way))
     {
       _reviewMarker.mark(
-        _map->shared_from_this(), way,
+        _map, way,
         way->getElementId().toString() + ", name: " + way->getTags().getName() +
           "; Missing way node(s): " + missingChildIds.join(","), getName(), 1.0);
       _numWaysMarkedForReview++;
@@ -114,10 +114,10 @@ void ReportMissingElementsVisitor::_updateRelation(const RelationPtr& relation, 
 {
   if (!missingChildIds.empty())
   {
-    if (_markRelationsForReview && !ReviewMarker::isNeedsReview(_map->shared_from_this(), relation))
+    if (_markRelationsForReview && !ReviewMarker::isNeedsReview(_map, relation))
     {
       _reviewMarker.mark(
-        _map->shared_from_this(), relation,
+        _map, relation,
         relation->getElementId().toString() + ", name: " + relation->getTags().getName() +
           ", type: " + relation->getType() +
           ", Missing relation member(s): " + missingChildIds.join(","), getName(), 1.0);

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ReportMissingElementsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ReportMissingElementsVisitor.h
@@ -44,7 +44,7 @@ namespace hoot
  * to either mark elements with missing children as needing review or add a custom tag to the
  * elements.
  */
-class ReportMissingElementsVisitor : public ConstElementVisitor, public OsmMapConsumerImpl, public Configurable
+class ReportMissingElementsVisitor : public ConstElementVisitor, public OsmMapConsumerBase, public Configurable
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ReportMissingElementsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ReportMissingElementsVisitor.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef REPORTMISSINGELEMENTSVISITOR_H
 #define REPORTMISSINGELEMENTSVISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/ReportMissingElementsVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/ReportMissingElementsVisitor.h
@@ -44,8 +44,7 @@ namespace hoot
  * to either mark elements with missing children as needing review or add a custom tag to the
  * elements.
  */
-class ReportMissingElementsVisitor : public ConstElementVisitor, public OsmMapConsumer,
-  public Configurable
+class ReportMissingElementsVisitor : public ConstElementVisitor, public OsmMapConsumerImpl, public Configurable
 {
 public:
 
@@ -59,8 +58,6 @@ public:
    * @see ElementVisitor
    */
   void visit(const ConstElementPtr& e) override;
-
-  void setOsmMap(OsmMap* map) override { _map = map; }
 
   /**
    * @see Configurable
@@ -90,8 +87,6 @@ public:
   void setRelationKvp(QString kvp) { _relationKvp = kvp; }
 
 private:
-
-  OsmMap* _map;
 
   Log::WarningLevel _logLevel;
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/SchemaTranslatedTagCountVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/SchemaTranslatedTagCountVisitor.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #include "SchemaTranslatedTagCountVisitor.h"
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/SchemaTranslatedTagCountVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/SchemaTranslatedTagCountVisitor.cpp
@@ -47,8 +47,7 @@ namespace hoot
 HOOT_FACTORY_REGISTER(ElementVisitor, SchemaTranslatedTagCountVisitor)
 
 SchemaTranslatedTagCountVisitor::SchemaTranslatedTagCountVisitor()
-  : _map(nullptr),
-    _populatedCount(0),
+  : _populatedCount(0),
     _defaultCount(0),
     _nullCount(0),
     _taskStatusUpdateInterval(ConfigOptions().getTaskStatusUpdateInterval())
@@ -56,8 +55,7 @@ SchemaTranslatedTagCountVisitor::SchemaTranslatedTagCountVisitor()
 }
 
 SchemaTranslatedTagCountVisitor::SchemaTranslatedTagCountVisitor(const std::shared_ptr<ScriptSchemaTranslator>& t)
-  : _map(nullptr),
-    _populatedCount(0),
+  : _populatedCount(0),
     _defaultCount(0),
     _nullCount(0),
     _taskStatusUpdateInterval(ConfigOptions().getTaskStatusUpdateInterval())
@@ -101,7 +99,7 @@ void SchemaTranslatedTagCountVisitor::visit(const ConstElementPtr& e)
 {
   if (e->getTags().getInformationCount() > 0)
   {
-    std::shared_ptr<Geometry> g = ElementToGeometryConverter(_map->shared_from_this()).convertToGeometry(e, false);
+    std::shared_ptr<Geometry> g = ElementToGeometryConverter(_map).convertToGeometry(e, false);
     if (!g || g->isEmpty())
       return;
     //  Copy the tags to modify and translate

--- a/hoot-core/src/main/cpp/hoot/core/visitors/SchemaTranslatedTagCountVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/SchemaTranslatedTagCountVisitor.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef SCHEMATRANSLATEDTAGCOUNTVISITOR_H
 #define SCHEMATRANSLATEDTAGCOUNTVISITOR_H

--- a/hoot-core/src/main/cpp/hoot/core/visitors/SchemaTranslatedTagCountVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/SchemaTranslatedTagCountVisitor.h
@@ -45,7 +45,7 @@ class Schema;
  * @brief The SchemaTranslatedTagCountVisitor class counts tags that can be translated with the
  * configured schema.
  */
-class SchemaTranslatedTagCountVisitor : public ConstElementVisitor, public ConstOsmMapConsumerImpl, public SingleStatistic
+class SchemaTranslatedTagCountVisitor : public ConstElementVisitor, public ConstOsmMapConsumerBase, public SingleStatistic
 {
 public:
 

--- a/hoot-core/src/main/cpp/hoot/core/visitors/SchemaTranslatedTagCountVisitor.h
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/SchemaTranslatedTagCountVisitor.h
@@ -45,8 +45,7 @@ class Schema;
  * @brief The SchemaTranslatedTagCountVisitor class counts tags that can be translated with the
  * configured schema.
  */
-class SchemaTranslatedTagCountVisitor : public ConstElementVisitor, public ConstOsmMapConsumer,
-  public SingleStatistic
+class SchemaTranslatedTagCountVisitor : public ConstElementVisitor, public ConstOsmMapConsumerImpl, public SingleStatistic
 {
 public:
 
@@ -57,8 +56,6 @@ public:
   ~SchemaTranslatedTagCountVisitor() override = default;
 
   double getStat() const override { return (double)getPopulatedCount() / (double)getTotalCount(); }
-
-  void setOsmMap(const OsmMap* map) override { _map = map; }
 
   /**
    * @see ElementVisitor
@@ -86,7 +83,6 @@ public:
 
 private:
 
-  const OsmMap* _map;
   std::shared_ptr<const Schema> _schema;
   std::shared_ptr<ScriptToOgrSchemaTranslator> _translator;
   long _populatedCount, _defaultCount, _nullCount;

--- a/hoot-core/src/main/cpp/hoot/core/visitors/SpatialIndexer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/SpatialIndexer.cpp
@@ -59,7 +59,7 @@ SpatialIndexer::SpatialIndexer(std::shared_ptr<HilbertRTree>& index, deque<Eleme
     _index(index),
     _indexToEid(indexToEid)
 {
-  _map = pMap.get();
+  _map = pMap;
 
   std::shared_ptr<ChainCriterion> chainCrit = std::dynamic_pointer_cast<ChainCriterion>(_criterion);
   if (chainCrit)

--- a/hoot-core/src/main/cpp/hoot/core/visitors/SpatialIndexer.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/SpatialIndexer.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016-2023 Maxar (http://www.maxar.com/)
  */
 #include "SpatialIndexer.h"
 

--- a/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #include "JsFunctionVisitor.h"
 

--- a/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.cpp
+++ b/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.cpp
@@ -41,11 +41,6 @@ namespace hoot
 
 HOOT_FACTORY_REGISTER(ElementVisitor, JsFunctionVisitor)
 
-JsFunctionVisitor::JsFunctionVisitor()
-  : _map(nullptr)
-{
-}
-
 void JsFunctionVisitor::visit(const ConstElementPtr& e)
 {
   Isolate* current = v8::Isolate::GetCurrent();

--- a/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.h
+++ b/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.h
@@ -40,19 +40,17 @@ namespace hoot
 /**
  * A criterion that will either keep or remove matches.
  */
-class JsFunctionVisitor : public ConstElementVisitor, public OsmMapConsumer, public JsFunctionConsumer
+class JsFunctionVisitor : public ConstElementVisitor, public OsmMapConsumerImpl, public JsFunctionConsumer
 {
 public:
 
   static QString className() { return "JsFunctionVisitor"; }
 
-  JsFunctionVisitor();
+  JsFunctionVisitor() = default;
   ~JsFunctionVisitor() override = default;
 
   void addFunction(v8::Isolate* isolate, v8::Local<v8::Function>& func) override
   { _func.Reset(isolate, func); }
-
-  void setOsmMap(OsmMap* map) override { _map = map; }
 
   void visit(const ConstElementPtr& e) override;
 
@@ -63,7 +61,7 @@ public:
 private:
 
   v8::Persistent<v8::Function> _func;
-  OsmMap* _map;
+
 };
 
 }

--- a/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.h
+++ b/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.h
@@ -40,7 +40,7 @@ namespace hoot
 /**
  * A criterion that will either keep or remove matches.
  */
-class JsFunctionVisitor : public ConstElementVisitor, public OsmMapConsumerImpl, public JsFunctionConsumer
+class JsFunctionVisitor : public ConstElementVisitor, public OsmMapConsumerBase, public JsFunctionConsumer
 {
 public:
 

--- a/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.h
+++ b/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2016, 2017, 2018, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 #ifndef JSFUNCTIONVISITOR_H
 #define JSFUNCTIONVISITOR_H

--- a/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.h
+++ b/hoot-js/src/main/cpp/hoot/js/visitors/JsFunctionVisitor.h
@@ -28,7 +28,7 @@
 #define JSFUNCTIONVISITOR_H
 
 // hoot
-#include <hoot/core/elements/ConstOsmMapConsumer.h>
+#include <hoot/core/elements/OsmMapConsumer.h>
 #include <hoot/core/visitors/ConstElementVisitor.h>
 
 #include <hoot/js/util/JsFunctionConsumer.h>
@@ -40,8 +40,7 @@ namespace hoot
 /**
  * A criterion that will either keep or remove matches.
  */
-class JsFunctionVisitor : public ConstElementVisitor, public ConstOsmMapConsumer,
-  public JsFunctionConsumer
+class JsFunctionVisitor : public ConstElementVisitor, public OsmMapConsumer, public JsFunctionConsumer
 {
 public:
 
@@ -54,8 +53,6 @@ public:
   { _func.Reset(isolate, func); }
 
   void setOsmMap(OsmMap* map) override { _map = map; }
-
-  void setOsmMap(const OsmMap*) override { }
 
   void visit(const ConstElementPtr& e) override;
 


### PR DESCRIPTION
Create `ConstOsmMapConsumerBase` class that implements `ConstOsmMapConsumer` class to consolidate the `setOsmMap()` function into one class.  All classes that were formerly derived from `ConstOsmMapConsumer` are now derived from the new base class.  `ConstOsmMapConsumer` is now used for polymorphic pointers.

Closes #5659 