### PR TITLE
Combine FlatGeobuf polygon layers into one layer

### DIFF
--- a/hoot-core/src/main/cpp/hoot/core/io/FlatGeobufWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/FlatGeobufWriter.h
@@ -56,7 +56,7 @@ protected:
   const char* _getDriverName() const override { return "FlatGeobuf"; };
   QString _getFileExtension() const override { return ".fgb"; }
   OgrOptions _getOptions() const override;
-  OGRwkbGeometryType _getPolygonGeometryType() const override { return OGRwkbGeometryType::wkbPolygon; }
+  bool _convertPolygons() const override { return true; }
 
 };
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OgrMultifileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OgrMultifileWriter.h
@@ -87,7 +87,7 @@ protected:
   virtual const char* _getDriverName() const = 0;
   virtual QString _getFileExtension() const = 0;
   virtual OgrOptions _getOptions() const = 0;
-  virtual OGRwkbGeometryType _getPolygonGeometryType() const = 0;
+  virtual bool _convertPolygons() const = 0;
 
   void _writeRelationPolygon(const ConstOsmMapPtr& map, const RelationPtr& relation) const;
   void _writeWayPolygon(const ConstOsmMapPtr& map, const WayPtr& way) const;
@@ -95,6 +95,7 @@ protected:
   void _setupDataset(const ConstOsmMapPtr& map, const QString& path, OGRwkbGeometryType geometry_type, ElementType element_type);
   OGRFeature* _createFeature(const Tags& tags, double circular_error) const;
   void _cleanupDataset();
+  std::shared_ptr<geos::geom::Geometry> _polyToMultipoly(const std::shared_ptr<geos::geom::Geometry>& geometry) const;
 };
 
 }

--- a/hoot-core/src/main/cpp/hoot/core/io/ShapefileWriter.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ShapefileWriter.h
@@ -56,7 +56,7 @@ protected:
   const char* _getDriverName() const override { return "ESRI Shapefile"; };
   QString _getFileExtension() const override { return ".shp"; }
   OgrOptions _getOptions() const override;
-  OGRwkbGeometryType _getPolygonGeometryType() const override { return OGRwkbGeometryType::wkbMultiPolygon; }
+  bool _convertPolygons() const override { return false; }
 
 };
 


### PR DESCRIPTION
Create a multipolygon for all polygons so they can be in one layer together for FlatGeobuf files only.  Shapefiles allow for multi and polys in the same layer already, this creates a multipolygon with only one polygon in it and makes the layer a multipolygon layer.