### PR TITLE
Restore important hoot params when importing from Overpass API

### DIFF
--- a/conf/core/ImportOverpass.conf
+++ b/conf/core/ImportOverpass.conf
@@ -1,4 +1,7 @@
 {
   "#": "Only add entries here that different default values than the options in ConfigOptions.asciidoc",
+  "hootapi.db.writer.overwrite.map": "true",
+  "hootapi.db.writer.remap.ids": "false",
+  "hootapi.db.writer.preserve.version.on.insert": "true",
   "#": "end"
 }


### PR DESCRIPTION
Need to match GrailIngest.conf when grail pull was refactored to be a hoot only command #5593 and no longer uses PushToDbCommand