### PR TITLE
Changeset derive empty map

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetCreatorTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/algorithms/changeset/ChangesetCreatorTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020-2023 Maxar (http://www.maxar.com/)
  */
 
 // Hoot
@@ -36,6 +36,7 @@ class ChangesetCreatorTest : public HootTestFixture
 {
   CPPUNIT_TEST_SUITE(ChangesetCreatorTest);
   CPPUNIT_TEST(runUpdateVersionTest);
+  CPPUNIT_TEST(runEmptyChangesetTest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -52,6 +53,18 @@ public:
     QString secondary = _inputPath + "ChangesetDeriveUpdateVersion_sec.osm";
     QString output = _outputPath + "ChangsetDeriveUpdateVersion_output.osc";
     QString expected = _inputPath + "ChangesetDeriveUpdateVersion_expected.osc";
+
+    ChangesetCreator(false, "").create(output, reference, secondary);
+
+    HOOT_FILE_EQUALS(output, expected);
+  }
+
+  void runEmptyChangesetTest()
+  {
+    QString reference = _inputPath + "ChangesetDeriveEmpty.osm";
+    QString secondary = "";
+    QString output = _outputPath + "ChangesetDeriveEmpty_output.osc";
+    QString expected = _inputPath + "ChangesetDeriveEmpty_expected.osc";
 
     ChangesetCreator(false, "").create(output, reference, secondary);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmBaseXmlChangesetFileWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmBaseXmlChangesetFileWriter.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2016-2023 Maxar (http://www.maxar.com/)
  */
 #include "OsmBaseXmlChangesetFileWriter.h"
 
@@ -212,12 +212,13 @@ void OsmBaseXmlChangesetFileWriter::write(const QString& path, const QList<Chang
     }
 
     LOG_VART(Change::changeTypeToString(last));
-    if (last != Change::ChangeType::Unknown)
+    if (last != Change::ChangeType::Unknown && last != Change::ChangeType::NoChange)
     {
       LOG_TRACE("Writing change end element...");
       writer.writeEndElement();
       last = Change::ChangeType::Unknown;
-      _parsedChangeIds.append(changeElement->getElementId());
+      if (!changeElement)
+        _parsedChangeIds.append(changeElement->getElementId());
     }
   }
 

--- a/test-files/algorithms/changeset/ChangesetCreatorTest/ChangesetDeriveEmpty.osm
+++ b/test-files/algorithms/changeset/ChangesetCreatorTest/ChangesetDeriveEmpty.osm
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="Hootenanny">
+</osm>

--- a/test-files/algorithms/changeset/ChangesetCreatorTest/ChangesetDeriveEmpty_expected.osc
+++ b/test-files/algorithms/changeset/ChangesetCreatorTest/ChangesetDeriveEmpty_expected.osc
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmChange version="0.6" generator="hootenanny"/>


### PR DESCRIPTION
Empty maps caused `hoot changeset-derive` to fail spectacularly.