### PR TITLE
Add check for Content-Type header in addition to naive payload check for json starting with curly brace

### DIFF
--- a/translations/TranslationServer.js
+++ b/translations/TranslationServer.js
@@ -192,6 +192,7 @@ function TranslationServer(request, response) {
                     params.method = request.method;
                     params.path = request.path || urlbits.pathname;
                     params.osm = payload;
+                    params.contentType = request.headers['Content-Type'];
                     header['Accept'] = 'text/xml';
                     header['Content-Type'] = 'text/xml';
                     var result = handleInputs(params);
@@ -358,7 +359,7 @@ var postHandler = function(data) {
 
     var map = new hoot.OsmMap();
     // loadMapFrom(JSON)String arguments: map, XML, preserve ID's, hoot:status
-    if (data.osm[0] === "{")
+    if (data.contentType == 'application/json' || data.osm[0] === "{")
         hoot.loadMapFromJSONString(map, data.osm, true);
     else
         hoot.loadMapFromString(map, data.osm, true);


### PR DESCRIPTION
some situations seem to have the osm json payload
escaped like "{\"version\":\"0.6\"...
and it misses the naive test and gets an xml parse error better for clients to set an application/json content-type