### PR TITLE
Compiler errors for `devtoolset-11`

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/FqTreeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/FqTreeTest.cpp
@@ -46,7 +46,6 @@ class FqDummyData
 public:
 
   FqDummyData() {}
-  FqDummyData(const FqDummyData& dd) : _str(dd._str) {}
   FqDummyData(const char* s) : _str(s) {}
   FqDummyData(const QString& s) : _str(s) {}
 

--- a/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/FqTreeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/FqTreeTest.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2013, 2015, 2016, 2017, 2018, 2019, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2013-2023 Maxar (http://www.maxar.com/)
  */
 
 // Hoot

--- a/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/RFqHybridTreeTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/index/metric-hybrid/RFqHybridTreeTest.cpp
@@ -55,12 +55,6 @@ class RFqHybridDummyData
 public:
 
   RFqHybridDummyData() {}
-  RFqHybridDummyData(const RFqHybridDummyData& dd)
-    : _e(dd._e),
-      _eid(dd._eid),
-      _name(dd._name)
-  {
-  }
 
   RFqHybridDummyData(const QString& name)
     : _name(name)

--- a/hoot-core/src/main/cpp/hoot/core/geometry/PolygonCompare.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/PolygonCompare.cpp
@@ -58,6 +58,21 @@ PolygonCompare::PolygonCompare(const Envelope& e)
 {
 }
 
+PolygonCompare::PolygonCompare(const PolygonCompare& other)
+{
+  _e = other._e;
+  _curve = std::make_shared<HilbertCurve>(*other._curve.get());
+  _size = other._size;
+}
+
+PolygonCompare& PolygonCompare::operator=(PolygonCompare& other)
+{
+  _e = other._e;
+  _curve = std::make_shared<HilbertCurve>(*other._curve.get());
+  _size = other._size;
+  return *this;
+}
+
 bool PolygonCompare::operator()(const std::shared_ptr<geos::geom::Geometry>& p1,
                                 const std::shared_ptr<geos::geom::Geometry>& p2) const
 {

--- a/hoot-core/src/main/cpp/hoot/core/geometry/PolygonCompare.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/PolygonCompare.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020-2023 Maxar (http://www.maxar.com/)
  */
 
 #include "PolygonCompare.h"

--- a/hoot-core/src/main/cpp/hoot/core/geometry/PolygonCompare.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/PolygonCompare.cpp
@@ -65,7 +65,7 @@ PolygonCompare::PolygonCompare(const PolygonCompare& other)
   _size = other._size;
 }
 
-PolygonCompare& PolygonCompare::operator=(PolygonCompare& other)
+PolygonCompare& PolygonCompare::operator=(const PolygonCompare& other)
 {
   _e = other._e;
   _curve = std::make_shared<HilbertCurve>(*other._curve.get());

--- a/hoot-core/src/main/cpp/hoot/core/geometry/PolygonCompare.h
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/PolygonCompare.h
@@ -52,7 +52,7 @@ public:
 private:
 
   PolygonCompare() = default;
-  PolygonCompare& operator=(PolygonCompare& other);
+  PolygonCompare& operator=(const PolygonCompare& other);
 
   geos::geom::Envelope _e;
   std::shared_ptr<Tgs::HilbertCurve> _curve;

--- a/hoot-core/src/main/cpp/hoot/core/geometry/PolygonCompare.h
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/PolygonCompare.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2020-2023 Maxar (http://www.maxar.com/)
  */
 
 #ifndef __POLYGON_COMPARE_H__

--- a/hoot-core/src/main/cpp/hoot/core/geometry/PolygonCompare.h
+++ b/hoot-core/src/main/cpp/hoot/core/geometry/PolygonCompare.h
@@ -43,7 +43,8 @@ class PolygonCompare
 {
 public:
 
-  PolygonCompare(const geos::geom::Envelope& e);
+  explicit PolygonCompare(const geos::geom::Envelope& e);
+  PolygonCompare(const PolygonCompare& other);
 
   bool operator()(const std::shared_ptr<geos::geom::Geometry>& p1,
                   const std::shared_ptr<geos::geom::Geometry>& p2) const;

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmBaseXmlChangesetFileWriter.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmBaseXmlChangesetFileWriter.cpp
@@ -217,7 +217,7 @@ void OsmBaseXmlChangesetFileWriter::write(const QString& path, const QList<Chang
       LOG_TRACE("Writing change end element...");
       writer.writeEndElement();
       last = Change::ChangeType::Unknown;
-      if (!changeElement)
+      if (changeElement)
         _parsedChangeIds.append(changeElement->getElementId());
     }
   }

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
@@ -951,6 +951,15 @@ private:
     }
   }
 
+/**
+ *  Using the boost::graph_traits<>::edge_iterator from boost::edges() and boost::tie can cause compilers
+ *  to assume that the iterator isn't initialized and is maybe being used before initialization.  boost::tie()
+ *  actually does the initialization and therefore the code is correct.  Ignore the warning for these two
+ *  functions only.
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
   void _getAssociatedTags(VertexId from, set<VertexId>& result)
   {
     boost::graph_traits<TagGraph>::edge_iterator ei, eend;
@@ -977,6 +986,9 @@ private:
       }
     }
   }
+
+/** End ignoring maybe-uninitialized warnings */
+#pragma GCC diagnostic pop
 
   VertexId _getParent(VertexId child) const
   {

--- a/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/schema/OsmSchema.cpp
@@ -66,6 +66,14 @@
 #error Bundle support is required.
 #endif
 
+/**
+ *  Using the boost::graph_traits<>::edge_iterator from boost::edges() and boost::tie can cause compilers
+ *  to assume that the iterator isn't initialized and is maybe being used before initialization.  boost::tie()
+ *  actually does the initialization and therefore the code is correct.  Ignore the warning for this file only.
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
 using namespace std;
 
 namespace hoot
@@ -951,15 +959,6 @@ private:
     }
   }
 
-/**
- *  Using the boost::graph_traits<>::edge_iterator from boost::edges() and boost::tie can cause compilers
- *  to assume that the iterator isn't initialized and is maybe being used before initialization.  boost::tie()
- *  actually does the initialization and therefore the code is correct.  Ignore the warning for these two
- *  functions only.
- */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-
   void _getAssociatedTags(VertexId from, set<VertexId>& result)
   {
     boost::graph_traits<TagGraph>::edge_iterator ei, eend;
@@ -986,9 +985,6 @@ private:
       }
     }
   }
-
-/** End ignoring maybe-uninitialized warnings */
-#pragma GCC diagnostic pop
 
   VertexId _getParent(VertexId child) const
   {
@@ -1920,3 +1916,6 @@ QString OsmSchema::getParentKvp(const QString& kvp1, const QString& kvp2) const
 }
 
 }
+
+/** End ignoring maybe-uninitialized warnings */
+#pragma GCC diagnostic pop

--- a/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/visitors/DecomposeBuildingRelationsVisitor.cpp
@@ -43,7 +43,7 @@ HOOT_FACTORY_REGISTER(ElementVisitor, DecomposeBuildingRelationsVisitor)
 
 void DecomposeBuildingRelationsVisitor::visit(const ConstElementPtr& e)
 {
-  if (e == nullptr && e->getElementType() == ElementType::Relation)
+  if (e != nullptr && e->getElementType() == ElementType::Relation)
   {
     const std::shared_ptr<Relation>& r = _map->getRelation(e->getId());
     if (r->getType() == MetadataTags::RelationBuilding())


### PR DESCRIPTION
Newer GCC compilers come with deeper compile time analysis and errors.  Fix those errors in preparation to upgrade the compiler.