### PR TITLE
Switch to api.openstreetmap.org API host

### DIFF
--- a/conf/core/ConfigOptions.asciidoc
+++ b/conf/core/ConfigOptions.asciidoc
@@ -3294,7 +3294,7 @@ collected (export).
 * Default Value: `https://overpass-api.de/api/interpreter`
 
 URL to an API (OSM or Overpass) to retrieving an missing elements in the initial data.  Can be the OSM API
-`https://www.openstreetmap.org/api/0.6/map` or Overpass API `https://overpass-api.de/api/interpreter`
+`https://api.openstreetmap.org/api/0.6/map` or Overpass API `https://overpass-api.de/api/interpreter`
 or any local OSM or Overpass APIs.
 
 === multilinestring.relation.collapser.types

--- a/hoot-core-test/src/test/cpp/hoot/core/io/ApiElementRetrievalInterfaceTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ApiElementRetrievalInterfaceTest.cpp
@@ -44,7 +44,7 @@ public:
   ApiElementRetrievalInterfaceTest() = default;
 
   const QString overpass_url = "https://overpass-api.de/api/interpreter";
-  const QString osm_api_url = "https://www.openstreetmap.org/api/0.6/map";
+  const QString osm_api_url = "https://api.openstreetmap.org/api/0.6/map";
 
   void checkOsmQueryTest()
   {
@@ -56,8 +56,8 @@ public:
 
     std::vector<QString> osm_queries(
       {
-        "https://www.openstreetmap.org/api/0.6/way/12345/full",
-        "https://www.openstreetmap.org/api/0.6/relation/54321/full"
+        "https://api.openstreetmap.org/api/0.6/way/12345/full",
+        "https://api.openstreetmap.org/api/0.6/relation/54321/full"
       });
 
     int i = 0;

--- a/hoot-core-test/src/test/cpp/hoot/core/ops/MissingElementRetrievalOpTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/ops/MissingElementRetrievalOpTest.cpp
@@ -52,7 +52,7 @@ public:
   }
 
   const QString overpass_url = "https://overpass-api.de/api/interpreter";
-  const QString osm_api_url = "https://www.openstreetmap.org/api/0.6/map";
+  const QString osm_api_url = "https://api.openstreetmap.org/api/0.6/map";
 
   /** NOTE: This test reaches out to the public OSM API to retrieve all nodes and ways for a single relation */
   void runMissingElementOsmApiTest()


### PR DESCRIPTION
Switch from `www.openstreetmap.org/api/*` to `api.openstreetmap.org/api/*` when using OpenstreetMaps API.

Was only found in a couple of unit tests and a comment in the configuration options but was requested by the community.

Closes #5720 