### PR TITLE
Bad Allocation Exception in API Reader

### DIFF
--- a/hoot-core-test/src/test/cpp/hoot/core/io/ParallelBoundedApiReaderTest.cpp
+++ b/hoot-core-test/src/test/cpp/hoot/core/io/ParallelBoundedApiReaderTest.cpp
@@ -59,7 +59,7 @@ public:
         "\"remark\": \"runtime error: Query ran out of memory in \"query\" at line 1. It would need at least 95 MB of RAM to continue.\""
         "}";
     QString error;
-    CPPUNIT_ASSERT(uut._isQueryError(json_error_result, error));
+    CPPUNIT_ASSERT(uut._isQueryError(json_error_result.toUtf8(), error));
     HOOT_STR_EQUALS(expected_result, error);
 
     QString xml_error_result =
@@ -70,7 +70,7 @@ public:
         "<remark> runtime error: Query ran out of memory in \"query\" at line 1. It would need at least 95 MB of RAM to continue. </remark>"
         "</osm>";
     error = "";
-    CPPUNIT_ASSERT(uut._isQueryError(xml_error_result, error));
+    CPPUNIT_ASSERT(uut._isQueryError(xml_error_result.toUtf8(), error));
     HOOT_STR_EQUALS(expected_result, error);
 
     /** This data caused infinite splitting in JOSM because of the 'remark' tag */
@@ -85,7 +85,7 @@ public:
         "\"elements\": ["
         "\"{\"type\": \"node\",\"id\": 3767576613,\"lat\": 47.8026036,\"lon\": 18.9633523,\"tags\": {\"name\": \"Nagyne Marika\",\"remark\": \"2012-2014\"}}]}}";
     error = "";
-    CPPUNIT_ASSERT(!uut._isQueryError(json_success, error));
+    CPPUNIT_ASSERT(!uut._isQueryError(json_success.toUtf8(), error));
     HOOT_STR_EQUALS("", error);
   }
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmApiReader.cpp
@@ -129,7 +129,7 @@ void OsmApiReader::read(const OsmMapPtr& map)
   //  Iterate all of the XML results
   while (hasMoreResults())
   {
-    QString xmlResult;
+    QByteArray xmlResult;
     //  Get one XML string at a time
     if (getSingleResult(xmlResult))
     {
@@ -139,7 +139,7 @@ void OsmApiReader::read(const OsmMapPtr& map)
       reader.setErrorHandler(this);
       //  Convert the string to a buffer to parse
       QBuffer buffer;
-      buffer.setData(xmlResult.toUtf8());
+      buffer.setData(xmlResult);
       //  Do the actual parsing
       QXmlInputSource xmlInputSource(&buffer);
       if (reader.parse(xmlInputSource) == false)
@@ -257,7 +257,7 @@ bool OsmApiReader::hasMoreElements()
     if (!_elementConverter)
       _elementConverter = std::make_shared<ElementToGeometryConverter>(_getElementProvider());
 
-    QString xmlResult;
+    QByteArray xmlResult;
     //  Get one XML string to parse
     while (!getSingleResult(xmlResult))
     {
@@ -268,7 +268,7 @@ bool OsmApiReader::hasMoreElements()
 
     if (_xmlBuffer.isOpen())
       _xmlBuffer.close();
-    _xmlBuffer.setData(xmlResult.toUtf8());
+    _xmlBuffer.setData(xmlResult);
     _xmlBuffer.open(QBuffer::ReadOnly);
     _streamReader.setDevice(&_xmlBuffer);
 

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.cpp
@@ -257,6 +257,20 @@ void OsmJsonReader::_loadJSON(const QString& jsonStr)
   _loadJSON(ss);
 }
 
+void OsmJsonReader::_loadJSON(const QByteArray& json)
+{
+  // Clear out anything that might be hanging around
+  _propTree.clear();
+
+  // Convert string to stringstream
+  stringstream ss(json.constData(), ios::in);
+
+  if (!ss.good())
+    throw HootException("Error reading from JSON buffer");
+
+  _loadJSON(ss);
+}
+
 bool OsmJsonReader::isValidJson(const QString& jsonStr)
 {
   try
@@ -876,7 +890,7 @@ void OsmJsonReader::_readFromHttp()
   //  Iterate all of the XML results
   while (hasMoreResults())
   {
-    QString jsonResult;
+    QByteArray jsonResult;
     //  Get one JSON string at a time
     if (getSingleResult(jsonResult))
     {

--- a/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/OsmJsonReader.h
@@ -210,6 +210,8 @@ protected:
    */
   void _loadJSON(const QString& jsonStr);
 
+  void _loadJSON(const QByteArray& json);
+
   /**
    * @brief _loadJSON Loads JSON into a boost property tree
    * @param in_stream Stream to read the JSON from

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
@@ -319,7 +319,7 @@ void ParallelBoundedApiReader::_process()
             _resultsQueue.emplace(request.getResponseContent());
             _totalResults++;
             //  Write out a "debug map" for each result that comes in
-//TODO: FIX ME            _writeDebugMap(result, "bounded-reader-result");
+            _writeDebugMap(request.getResponseContent(), "bounded-reader-result");
             //  Reset the timeout because this thread has successfully received a response
             timeout = 0;
             //  Update the user status
@@ -435,7 +435,7 @@ void ParallelBoundedApiReader::_process()
   }
 }
 
-void ParallelBoundedApiReader::_writeDebugMap(const QString& data, const QString& name)
+void ParallelBoundedApiReader::_writeDebugMap(const QByteArray& data, const QString& name)
 {
   if (ConfigOptions().getDebugMapsWrite())
   {

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.cpp
@@ -143,17 +143,17 @@ bool ParallelBoundedApiReader::isComplete()
   return jobs == results && results > 0;
 }
 
-bool ParallelBoundedApiReader::getSingleResult(QString& result)
+bool ParallelBoundedApiReader::getSingleResult(QByteArray& result)
 {
-  bool success = true;
   std::lock_guard<std::mutex> results_lock(_resultsMutex);
   //  takeFirst() pops the first element and returns it
-  if (!_resultsList.empty())
-    result = _resultsList.takeFirst();
-  else
-    success = false;
-  //  Return the result found
-  return success;
+  if (!_resultsQueue.empty())
+  {
+    result = _resultsQueue.front();
+    _resultsQueue.pop();
+    return true;
+  }
+  return false;
 }
 
 bool ParallelBoundedApiReader::hasMoreResults()
@@ -161,7 +161,7 @@ bool ParallelBoundedApiReader::hasMoreResults()
   bool more = false;
   {
     std::lock_guard<std::mutex> results_lock(_resultsMutex);
-    more = !_resultsList.empty();
+    more = !_resultsQueue.empty();
   }
   bool done = isComplete();
   //  Throw the fatal error here and not in the read threads
@@ -219,7 +219,7 @@ void ParallelBoundedApiReader::_process()
     bool isFull = false;
     {
       std::lock_guard<std::mutex> results_lock(_resultsMutex);
-      isFull = _resultsList.size() >= _threadCount;
+      isFull = _resultsQueue.size() >= static_cast<size_t>(_threadCount);
     }
     if (isFull)
     {
@@ -295,11 +295,9 @@ void ParallelBoundedApiReader::_process()
       case HttpResponseCode::HTTP_OK:
         try
         {
-          //  Store the result and increment the number of results received
-          QString result = QString::fromUtf8(request.getResponseContent().data());
-          //  Check for an error
+         //  Check for an error
           QString error;
-          if (_isQueryError(result, error))
+          if (_isQueryError(request.getResponseContent(), error))
           {
             if (error.contains("Cannot allocate memory"))
             {
@@ -318,10 +316,10 @@ void ParallelBoundedApiReader::_process()
           else
           {
             std::lock_guard<std::mutex> results_lock(_resultsMutex);
-            _resultsList.append(result);
+            _resultsQueue.emplace(request.getResponseContent());
             _totalResults++;
             //  Write out a "debug map" for each result that comes in
-            _writeDebugMap(result, "bounded-reader-result");
+//TODO: FIX ME            _writeDebugMap(result, "bounded-reader-result");
             //  Reset the timeout because this thread has successfully received a response
             timeout = 0;
             //  Update the user status
@@ -469,8 +467,12 @@ void ParallelBoundedApiReader::_logNetworkError(const HootNetworkRequest& reques
   _isError = true;
 }
 
-bool ParallelBoundedApiReader::_isQueryError(const QString& result, QString& error) const
+bool ParallelBoundedApiReader::_isQueryError(const QByteArray& result, QString& error) const
 {
+  //  Run a quick check on the byte array to see if "runtime error" exists, if not then no error occurred.  If that text exists
+  //  further matching and parsing can be done
+  if (result.indexOf("runtime error") == -1)
+    return false;
   //  XML handling regular expression
   // <remark> runtime error: Query ran out of memory in "query" at line 10. It would need at least 0 MB of RAM to continue. </remark>
   static QRegularExpression regexXml("<remark> (.*) </remark>", QRegularExpression::OptimizeOnFirstUsageOption);

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
@@ -181,7 +181,7 @@ private:
    * @param data Response from API to write to file
    * @param name Name of file to write in $HOOT_HOME/tmp/
    */
-  void _writeDebugMap(const QString& data, const QString& name);
+  void _writeDebugMap(const QByteArray& data, const QString& name);
   /**
    * @brief logNetworkError Function to log an unknown network request error
    * @param request Network request object

--- a/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
+++ b/hoot-core/src/main/cpp/hoot/core/io/ParallelBoundedApiReader.h
@@ -92,7 +92,7 @@ public:
    * @param result Single, full query result (output)
    * @return True if there is a result to return, false otherwise
    */
-  bool getSingleResult(QString& result);
+  bool getSingleResult(QByteArray& result);
   /**
    * @brief hasMoreResults
    * @return True if there are more results to process
@@ -161,7 +161,7 @@ protected:
    * @param error
    * @return
    */
-  bool _isQueryError(const QString& result, QString& error) const;
+  bool _isQueryError(const QByteArray& result, QString& error) const;
 
   std::shared_ptr<geos::geom::Geometry> _getBoundingPoly() const { return _boundingPoly; }
   void _setBoundingPoly(const std::shared_ptr<geos::geom::Geometry>& poly);
@@ -193,11 +193,11 @@ private:
    */
   void _splitJob(const ParallelApiJobPtr& job);
 
-  /** List of result strings, one for each HTTP response */
-  QStringList _resultsList;
+  /** Queue of byte arrays, one for each HTTP response */
+  std::queue<QByteArray> _resultsQueue;
   /** Total number of results received, should match _totalEnvelopes at the end to ensure all data has arrived */
   int _totalResults;
-  /** Mutex guarding the results list */
+  /** Mutex guarding the results queue */
   std::mutex _resultsMutex;
   /** Essentially the work queue of bounding boxes that the threads query from */
   std::queue<ParallelApiJobPtr> _workQueue;

--- a/hoot-core/src/main/cpp/hoot/core/util/FileUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/FileUtils.cpp
@@ -156,6 +156,28 @@ void FileUtils::writeFully(const QString& path, const QString& text)
   outFile.close();
 }
 
+void FileUtils::writeFully(const QString& path, const QByteArray& text)
+{
+  QFile outFile(path);
+  QFileInfo fi(outFile);
+  QDir dir = fi.dir();
+  //  Attempt to create the directory if it doesn't exist
+  if (!dir.exists())
+    makeDir(dir.absolutePath());
+  //  Delete the previous file
+  if (outFile.exists() && !outFile.remove())
+    throw HootException("Unable to remove file: " + path);
+  //  Open to write
+  if (!outFile.open(QFile::WriteOnly | QFile::Text))
+    throw HootException("Error opening file: " + path);
+  //  Write a UTF-8 file
+  QTextStream out(&outFile);
+  out.setCodec("UTF-8");
+  out << text;
+  out.flush();
+  outFile.close();
+}
+
 long FileUtils::getNumberOfLinesInFile(const QString& file)
 {
   std::ifstream inFile(file.toStdString().c_str());

--- a/hoot-core/src/main/cpp/hoot/core/util/FileUtils.cpp
+++ b/hoot-core/src/main/cpp/hoot/core/util/FileUtils.cpp
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021, 2022 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 
 #include "FileUtils.h"

--- a/hoot-core/src/main/cpp/hoot/core/util/FileUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/FileUtils.h
@@ -22,7 +22,7 @@
  * This will properly maintain the copyright information. Maxar
  * copyrights will be updated automatically.
  *
- * @copyright Copyright (C) 2015, 2017, 2018, 2019, 2020, 2021 Maxar (http://www.maxar.com/)
+ * @copyright Copyright (C) 2015-2023 Maxar (http://www.maxar.com/)
  */
 
 #ifndef FILEUTILS_H

--- a/hoot-core/src/main/cpp/hoot/core/util/FileUtils.h
+++ b/hoot-core/src/main/cpp/hoot/core/util/FileUtils.h
@@ -103,6 +103,7 @@ public:
    * @param text text to be written
    */
   static void writeFully(const QString& path, const QString& text);
+  static void writeFully(const QString& path, const QByteArray& text);
 
   /**
    * Tokenize a file by line and remove the date from each line

--- a/hoot-test/src/main/cpp/hoot/test/main.cpp
+++ b/hoot-test/src/main/cpp/hoot/test/main.cpp
@@ -602,7 +602,7 @@ void verifyValidationConfig()
   if (ConfigOptions().getTestValidationEnable())
   {
     if (!QFile::exists(testValidationEnabledFile))
-      FileUtils::writeFully(testValidationEnabledFile, "");
+      FileUtils::writeFully(testValidationEnabledFile, QString(""));
   }
   else
   {


### PR DESCRIPTION
Remove `QString` and `QByteArray` conversions that throw 'bad_alloc' exceptions.

Closes #5728