### PR TITLE
Added an "appendFgdb" option to the node export server

### DIFF
--- a/node-export-server/server.js
+++ b/node-export-server/server.js
@@ -472,8 +472,6 @@ function buildCommand(params, style, queryOverrideTags, querybbox, querypoly, is
     }
 
     // Appending to a FGDB is only applicable for FGDB outputs....
-    console.log('Format: ' + params.format + '\n');
-    process.stdout.write('StdFormat: ' + params.format + '\n');
     if (params.appendFgdb === 'true' && params.format === 'File Geodatabase') {
         command += ' -D ogr.append.data=true';
     }

--- a/node-export-server/server.js
+++ b/node-export-server/server.js
@@ -194,6 +194,7 @@ app.get('/export/:datasource/:schema/:format', function(req, res) {
         + req.query.crop
         + req.query.poly
         + req.query.overrideTags
+        + req.query.appendFgdb
         + req.query.style;
     var hash = crypto.createHash('sha1').update(params).digest('hex');
     var input = config.datasources[req.params.datasource].conn;
@@ -468,6 +469,13 @@ function buildCommand(params, style, queryOverrideTags, querybbox, querypoly, is
     var eConf = hootHome + '/' + config.schemas[paramschema].replace('.js','') + 'Export.conf';
     if (fs.existsSync(eConf)) {
         command += ' -C "' + eConf + '"';
+    }
+
+    // Appending to a FGDB is only applicable for FGDB outputs....
+    console.log('Format: ' + params.format + '\n');
+    process.stdout.write('StdFormat: ' + params.format + '\n');
+    if (params.appendFgdb === 'true' && params.format === 'File Geodatabase') {
+        command += ' -D ogr.append.data=true';
     }
 
     command += ' ' + input + ' ' + outFile;


### PR DESCRIPTION
Adds an append option.  This is ignored if the output isn't a FGDB.

It expects to see `appendFgdb=true`