### PR TITLE
add scenario to fix bug in GeoPackage exports in OSM Schema

### DIFF
--- a/node-export-server/server.js
+++ b/node-export-server/server.js
@@ -390,6 +390,7 @@ function zipOutput(hash,output,outFile,outDir,outZip,isFile,format,cb) {
  */
 function buildCommand(params, style, queryOverrideTags, querybbox, querypoly, isFile, input, outDir, outFile, doCrop, ignoreSourceIds, ignoreConf) {
     var paramschema = params.schema;
+    var paramformat = params.format;
     var command = '', overrideTags = null;
     if (queryOverrideTags) {
         if (queryOverrideTags === 'true') { //if it's true
@@ -434,6 +435,12 @@ function buildCommand(params, style, queryOverrideTags, querybbox, querypoly, is
                 command += ' -D translation.script=' + hootHome  + '/translations/OSM_Ingest.js';
             }
             command += ' -D schema.translation.override=' + overrideTags;
+        }
+        if (paramschema === 'OSM' && paramformat === 'GeoPackage') {
+            convertOpts.push('SchemaTranslationOp')
+            command += ' -D schema.translation.script=' + hootHome + '/' + config.schemas[paramschema];
+            // Set per schema config options
+            if (config.schema_options[paramschema]) command += ' -D ' + config.schema_options[paramschema];
         }
         if (paramschema !== 'OSM' && config.schemas[paramschema] !== '') {
             convertOpts.push('SchemaTranslationOp')


### PR DESCRIPTION
there was a bug in Hoot's node export server that if a user requested an export for a GeoPackage in OSM Schema, the user would get an error about an invalid writer.

I found the bug was caused because the export command wasn't appending the translation script option.  I added a new scenario check that if the schema is OSM and format is GeoPackage to add all necessary params to the command

I have this deployed in testing if you want to test:
https://testing.vgihub.geointservices.io/export#map=17/38.81165/-77.62058