### PR TITLE
update TDSv71 for natural=beach to soil surface region

### DIFF
--- a/translations/tds71.js
+++ b/translations/tds71.js
@@ -1895,6 +1895,13 @@ tds71 = {
       }
     }
 
+    // Fix up beach features from OSM
+    if (tags.natural == 'beach')
+    {
+      attrs.TSM = '13';
+      attrs.SRD = '1';
+    }
+
     // Cutlines/Cleared Ways & Highways
     // This might need a cleanup
     if (tags.man_made == 'cutline' && tags.highway)

--- a/translations/tds71_rules.js
+++ b/translations/tds71_rules.js
@@ -64,6 +64,7 @@ tds71.rules = {
   fcodeOne2oneOut : [
     ['F_CODE','DA010','natural','desert'], // EE030 Desert - mapped to DA010 Soil Surface Region
     ['F_CODE','DA010','landuse','brownfield'], // DA010 Soil Surface Region
+    ['F_CODE','DA010','natural','beach'], // Beach
     ['F_CODE','FA091','geophysical_data_track','yes'], // Geophysical Data Track Line
     ['F_CODE','GA005','airspace','yes'], // Airspace
     ['F_CODE','GA035','navaid:aeronautical','yes'], // Aeronautical Navaids


### PR DESCRIPTION
- natural=beach now translates to a Soil Surface Region feature
- appropriate fields are assigned SRD (terrain morphology) = 1, TSM (terrain surface material) = 13 
- https://maxar.atlassian.net/browse/VGI-4893