### PR TITLE
Fix CentOS 7 mirrorlist handling in RPM setup paths

### DIFF
--- a/VagrantProvisionCentOS7.sh
+++ b/VagrantProvisionCentOS7.sh
@@ -23,6 +23,11 @@ echo GROUP: $VMGROUP
 
 export LANG=en_US.UTF-8
 
+echo "### Switch CentOS repos to vault ###"
+sudo sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-*.repo
+sudo sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-*.repo
+sudo sed -i s/^mirrorlist=/#mirrorlist=/g /etc/yum.repos.d/CentOS-*.repo
+
 # Make sure that we are in ~ before trying to wget & install stuff
 cd ~
 source ~/.bash_profile
@@ -59,9 +64,9 @@ fi
 echo "### Add devtoolset repo and postgresql ${POSTGRESQL_VERSION} libraries ###"
 sudo yum install -y \
      centos-release-scl postgresql${POSTGRESQL_VERSION}-libs >> CentOS_upgrade.txt 2>&1
-sudo sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
-sudo sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
-sudo sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+sudo sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-SCLo-*.repo
+sudo sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-SCLo-*.repo
+sudo sed -i s/^mirrorlist=/#mirrorlist=/g /etc/yum.repos.d/CentOS-SCLo-*.repo
 sudo yum-config-manager --enable rhel-server-rhscl-7-rpms
 
 if [ "${YUMUPDATE:-yes}" = "yes" ]; then

--- a/VagrantProvisionCentOS7Rpm.sh
+++ b/VagrantProvisionCentOS7Rpm.sh
@@ -15,6 +15,11 @@ echo HOOT_HOME: $HOOT_HOME
 
 export LANG=en_US.UTF-8
 
+echo "### Switch CentOS repos to vault ###" | tee -a CentOS_install.txt
+sudo sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-*.repo
+sudo sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-*.repo
+sudo sed -i s/^mirrorlist=/#mirrorlist=/g /etc/yum.repos.d/CentOS-*.repo
+
 # Common set of file versions
 source $HOOT_HOME/VagrantProvisionVars.sh
 

--- a/docker/Dockerfile.core-services
+++ b/docker/Dockerfile.core-services
@@ -31,6 +31,9 @@ ENV HOOT_HOME=$hoot_home
 COPY scripts/yum/geoint-repo.sh scripts/yum/hoot-repo.sh scripts/yum/pgdg-repo.sh /tmp/
 
 RUN --mount=type=cache,target=/var/cache/yum \
+    sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-*.repo && \
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-*.repo && \
+    sed -i s/^mirrorlist=/#mirrorlist=/g /etc/yum.repos.d/CentOS-*.repo && \
     /tmp/geoint-repo.sh && \
     /tmp/hoot-repo.sh && \
     /tmp/pgdg-repo.sh $postgresql_version && \
@@ -39,15 +42,11 @@ RUN --mount=type=cache,target=/var/cache/yum \
         --setopt=extras.repo_gpgcheck=1 \
         --setopt=updates.repo_gpgcheck=1 &> /dev/null
 
-RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
-    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
-    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
-
 RUN yum -y --disablerepo=pgdg* install epel-release centos-release-scl
 
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
-    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^mirrorlist=/#mirrorlist=/g /etc/yum.repos.d/*.repo && \
     if [ "$(uname -m)" = "aarch64" ]; then \
         rm -f /etc/yum.repos.d/CentOS-SCLo-*.repo && \
         printf '%s\n' \

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -12,13 +12,17 @@ ENV HOOT_HOME=$hoot_home
 
 COPY scripts/node/nodesource-repo.sh scripts/yum/hoot-repo.sh /tmp/
 
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-*.repo && \
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-*.repo && \
+    sed -i s/^mirrorlist=/#mirrorlist=/g /etc/yum.repos.d/CentOS-*.repo
+
 RUN --mount=type=cache,target=/var/cache/yum \
     /tmp/nodesource-repo.sh $node_version && \
     /tmp/hoot-repo.sh
 
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
-    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^mirrorlist=/#mirrorlist=/g /etc/yum.repos.d/*.repo && \
     yum-config-manager --save \
         --setopt=base.repo_gpgcheck=1 \
         --setopt=extras.repo_gpgcheck=1 \

--- a/docker/hoot_commandline/Dockerfile
+++ b/docker/hoot_commandline/Dockerfile
@@ -16,6 +16,10 @@ ARG DEV_NAME="dev"
 ARG DEV_UID="1000"
 ARG DEV_GID="1000"
 
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-*.repo && \
+ sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-*.repo && \
+ sed -i s/^mirrorlist=/#mirrorlist=/g /etc/yum.repos.d/CentOS-*.repo
+
 RUN yum install -y wget curl sudo vim yum-utils epel-release && \
  yum-config-manager --add-repo https://hoot-repo.s3.amazonaws.com/el7/pgdg95.repo && \
  yum-config-manager --add-repo https://hoot-repo.s3.amazonaws.com/el7/release/hoot.repo && \
@@ -33,4 +37,3 @@ RUN useradd -mUl -G wheel -u $DEV_UID -s /bin/bash $DEV_NAME \
 
 USER $DEV_NAME
 WORKDIR /home/$DEV_NAME
-

--- a/docker/hoot_commandline_nightly/Dockerfile
+++ b/docker/hoot_commandline_nightly/Dockerfile
@@ -16,6 +16,10 @@ ARG DEV_NAME="dev"
 ARG DEV_UID="1000"
 ARG DEV_GID="1000"
 
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-*.repo && \
+ sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-*.repo && \
+ sed -i s/^mirrorlist=/#mirrorlist=/g /etc/yum.repos.d/CentOS-*.repo
+
 RUN yum install -y wget curl sudo vim yum-utils epel-release && \
  yum-config-manager --add-repo https://hoot-repo.s3.amazonaws.com/el7/master/hoot.repo && \
  yum-config-manager --add-repo https://geoint-deps.s3.amazonaws.com/el7/stable/geoint-deps.repo
@@ -38,4 +42,3 @@ RUN useradd -mUl -G wheel -u $DEV_UID -s /bin/bash $DEV_NAME \
 
 USER $DEV_NAME
 WORKDIR /home/$DEV_NAME
-

--- a/docker/hoot_external_command_nightly/Dockerfile
+++ b/docker/hoot_external_command_nightly/Dockerfile
@@ -11,6 +11,10 @@ ENV container=docker
 ENV LANG=en_US.UTF-8 
 ENV LC_ALL=en_US.UTF-8
 
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-*.repo && \
+ sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-*.repo && \
+ sed -i s/^mirrorlist=/#mirrorlist=/g /etc/yum.repos.d/CentOS-*.repo
+
 RUN yum install -y wget curl sudo vim yum-utils epel-release && \
  yum-config-manager --add-repo https://hoot-repo.s3.amazonaws.com/el7/master/hoot.repo && \
  yum-config-manager --add-repo https://geoint-deps.s3.amazonaws.com/el7/stable/geoint-deps.repo


### PR DESCRIPTION
Fixes #5762.

This updates the CentOS 7 setup flows that still relied on mirrorlist.centos.org and were failing before package install.

- switch CentOS repo definitions to vault before the first yum call in both Vagrant provision scripts
- patch both CentOS-SCLo repo files after `centos-release-scl` is installed
- apply the same repo rewrite early in the CentOS 7 RPM Dockerfiles used for command line and nightly builds

Validation run locally:
- `bash -n VagrantProvisionCentOS7.sh VagrantProvisionCentOS7Rpm.sh`
- `rg -n "mirrorlist\.centos\.org" VagrantProvisionCentOS7*.sh docker || true`
- `rg -n "s/\^mirrorlist=/#mirrorlist=/g" VagrantProvisionCentOS7.sh VagrantProvisionCentOS7Rpm.sh docker/Dockerfile.core-services docker/Dockerfile.frontend docker/hoot_commandline/Dockerfile docker/hoot_commandline_nightly/Dockerfile docker/hoot_external_command_nightly/Dockerfile`