### PR TITLE
prevent hard failure on OpenNLP download failure

### DIFF
--- a/Makefile.hoot
+++ b/Makefile.hoot
@@ -541,7 +541,7 @@ conf/dictionary/words1.sqlite:
 	echo "Failure downloading words1.sqlite. Build will continue, but conflation accuracy may suffer."
 
 hoot-services/src/main/resources/language-translation/langdetect-183.bin:
-	if [ ! -f $@ ]; then echo "Downloading OpenNLP language detection model..."; wget --quiet -O $@ https://hoot-support.s3.amazonaws.com/langdetect-183.bin; fi
+	if [ ! -f $@ ]; then echo "Downloading OpenNLP language detection model..."; wget --quiet -O $@ https://hoot-support.s3.amazonaws.com/langdetect-183.bin || rm -f $@; fi
 	echo '2ddf585fac2e02a9dcfb9a4a9cc9417562eaac351be2efb506a2eaa87f19e9d4  hoot-services/src/main/resources/language-translation/langdetect-183.bin' | sha256sum -c || echo "OpenNLP language detection not available due to failure downloading model."
 
 bin/HootEnv.sh: scripts/HootEnv.sh


### PR DESCRIPTION
Small makefile update to prevent RPM builds from failing when one of our modules doesn't download.