### PR TITLE
Resolving translation tickets, Adding new test script, Fix idempotency bug

### DIFF
--- a/Makefile.hoot
+++ b/Makefile.hoot
@@ -541,7 +541,7 @@ conf/dictionary/words1.sqlite:
 	echo "Failure downloading words1.sqlite. Build will continue, but conflation accuracy may suffer."
 
 hoot-services/src/main/resources/language-translation/langdetect-183.bin:
-	if [ ! -f $@ ]; then echo "Downloading OpenNLP language detection model..."; wget --quiet -O $@ https://hoot-support.s3.amazonaws.com/langdetect-183.bin; fi
+	if [ ! -f $@ ]; then echo "Downloading OpenNLP language detection model..."; wget --quiet -O $@ https://hoot-support.s3.amazonaws.com/langdetect-183.bin || rm -f $@; fi
 	echo '2ddf585fac2e02a9dcfb9a4a9cc9417562eaac351be2efb506a2eaa87f19e9d4  hoot-services/src/main/resources/language-translation/langdetect-183.bin' | sha256sum -c || echo "OpenNLP language detection not available due to failure downloading model."
 
 bin/HootEnv.sh: scripts/HootEnv.sh

--- a/translations/checkTagPairing.js
+++ b/translations/checkTagPairing.js
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//
+// Quick single tag-pair translation probe.
+//
+// This intentionally calls the translation module directly instead of going
+// through TranslationServer/checkTranslations.js, since those paths can flatten
+// a multi-feature translateToOgr result down to the first feature.
+//
+
+var HOOT_HOME = process.env.HOOT_HOME;
+
+function usage()
+{
+  console.log([
+    'Usage:',
+    '  node translations/checkTagPairing.js <translation> [geometry] <key=value> [key=value ...]',
+    '',
+    'Examples:',
+    '  node translations/checkTagPairing.js TDSv71 highway=primary bridge=yes',
+    '  node translations/checkTagPairing.js TDSv71 Line highway=primary bridge=yes',
+    '  node translations/checkTagPairing.js MGCP highway=primary bridge=yes',
+    '  node translations/checkTagPairing.js TDSv71 natural=water',
+    '',
+    'If geometry is omitted, Point, Line, and Area are tested.',
+    '',
+    'Options:',
+    '  --element=<Node|Way|Relation>       Override inferred element type',
+    '  --thematic=<true|false>             Set writer.thematic.structure',
+    '  --coded-values=<true|false>         Set ogr.coded.values',
+    '  --round-trip                        Show all features from the final OGR pass'
+  ].join('\n'));
+}
+
+function setDefaults(options)
+{
+  hoot.Settings.set({'ogr.add.uuid': 'false'});
+  hoot.Settings.set({'ogr.clean.export': 'false'});
+  hoot.Settings.set({'ogr.compare.output': 'false'});
+  hoot.Settings.set({'ogr.debug.dumptags': 'false'});
+  hoot.Settings.set({'ogr.esri.fcsubtype': 'false'});
+  hoot.Settings.set({'ogr.note.extra': 'attribute'});
+  hoot.Settings.set({'ogr.output.format': 'json'});
+  hoot.Settings.set({'ogr.text.field.number': '4'});
+  hoot.Settings.set({'ogr.throw.error': 'false'});
+  hoot.Settings.set({'reader.drop.defaults': 'true'});
+  hoot.Settings.set({'writer.thematic.structure': options.thematic || 'false'});
+  hoot.Settings.set({'ogr.coded.values': options.codedValues || 'true'});
+}
+
+function loadTranslation(name)
+{
+  var key = name.toLowerCase();
+
+  if (key === 'mgcp')
+  {
+    hoot.require('mgcp');
+    hoot.require('mgcp_schema');
+    hoot.require('mgcp_rules');
+    hoot.require('fcode_common');
+    hoot.require('translate');
+    return {name: 'MGCP', module: mgcp};
+  }
+
+  var tdsVersion = key.match(/^tdsv?([0-9]+)$/);
+  if (tdsVersion)
+  {
+    var base = 'tds' + tdsVersion[1];
+    hoot.require('SchemaTools');
+    hoot.require(base);
+    hoot.require(base + '_schema');
+    hoot.require(base + '_rules');
+    hoot.require('translate');
+    hoot.require('fcode_common');
+    return {name: 'TDSv' + tdsVersion[1], module: global[base] || eval(base)};
+  }
+
+  throw new Error('Unsupported translation for this helper: ' + name);
+}
+
+function parseArgs(argv)
+{
+  var options = {};
+  var positional = [];
+  var defaultGeometries = ['Point', 'Line', 'Area'];
+
+  for (var i = 0; i < argv.length; i++)
+  {
+    var arg = argv[i];
+    if (arg === '--help' || arg === '-h')
+    {
+      usage();
+      process.exit(0);
+    }
+    else if (arg === '--round-trip')
+    {
+      options.roundTrip = true;
+    }
+    else if (arg.indexOf('--element=') === 0)
+    {
+      options.element = arg.substring('--element='.length);
+    }
+    else if (arg.indexOf('--thematic=') === 0)
+    {
+      options.thematic = arg.substring('--thematic='.length);
+    }
+    else if (arg.indexOf('--coded-values=') === 0)
+    {
+      options.codedValues = arg.substring('--coded-values='.length);
+    }
+    else
+    {
+      positional.push(arg);
+    }
+  }
+
+  if (positional.length < 2)
+  {
+    usage();
+    process.exit(1);
+  }
+
+  var geometries = defaultGeometries;
+  var firstTagIndex = 1;
+  var maybeGeometry = positional[1];
+  if (maybeGeometry.indexOf('=') === -1)
+  {
+    geometries = [maybeGeometry];
+    firstTagIndex = 2;
+  }
+
+  if (positional.length <= firstTagIndex)
+  {
+    usage();
+    process.exit(1);
+  }
+
+  var tags = {};
+  for (var j = firstTagIndex; j < positional.length; j++)
+  {
+    var pair = positional[j];
+    var split = pair.indexOf('=');
+    if (split < 1)
+    {
+      throw new Error('Expected key=value, got: ' + pair);
+    }
+    tags[pair.substring(0, split)] = pair.substring(split + 1);
+  }
+
+  return {
+    translation: positional[0],
+    geometries: geometries,
+    tags: tags,
+    options: options
+  };
+}
+
+function inferredElementType(geometry)
+{
+  if (geometry === 'Point' || geometry === 'Vertex') return 'Node';
+  if (geometry === 'Line' || geometry === 'Area') return 'Way';
+  return 'Way';
+}
+
+function clone(value)
+{
+  return JSON.parse(JSON.stringify(value));
+}
+
+function sorted(value)
+{
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value))
+  {
+    return value.map(sorted);
+  }
+
+  var result = {};
+  Object.keys(value).sort().forEach(function(key) {
+    result[key] = sorted(value[key]);
+  });
+  return result;
+}
+
+function stringify(value)
+{
+  return JSON.stringify(sorted(value));
+}
+
+function printJson(label, value)
+{
+  console.log(label + ': ' + stringify(value));
+}
+
+function normalizeFeatures(result)
+{
+  if (!result) return [];
+  return Array.isArray(result) ? result : [result];
+}
+
+function resetDirectionLookups(translator)
+{
+  delete translator.fcodeLookup;
+  delete translator.fcodeLookupOut;
+  delete translator.lookup;
+  delete translator.fuzzy;
+}
+
+function runGeometry(translation, translator, geometry, parsed)
+{
+  var elementType = parsed.options.element || inferredElementType(geometry);
+
+  console.log(translation.name + '  ' + geometry + ':');
+  printJson('Raw', parsed.tags);
+
+  resetDirectionLookups(translator);
+  var features = normalizeFeatures(translator.toOgr(clone(parsed.tags), elementType, geometry));
+
+  if (features.length === 0)
+  {
+    console.log('  ## No Ogr tags ##');
+  }
+
+  for (var i = 0; i < features.length; i++)
+  {
+    var feature = features[i];
+    var ogrLabel = features.length > 1 ? 'Ogr Multi ' + (i + 1) : 'Ogr';
+    if (feature.tableName) ogrLabel += ' (' + feature.tableName + ')';
+    printJson(ogrLabel, feature.attrs);
+
+    // Copy the attrs before translating back because toOsm mutates the object.
+    resetDirectionLookups(translator);
+    var backToOsm = translator.toOsm(clone(feature.attrs), feature.tableName, geometry);
+    var osmLabel = features.length > 1 ? 'OSM Multi ' + (i + 1) : 'OSM';
+    printJson(osmLabel, backToOsm);
+
+    resetDirectionLookups(translator);
+    var roundTripFeatures = normalizeFeatures(translator.toOgr(clone(backToOsm), elementType, geometry));
+    if (parsed.options.roundTrip)
+    {
+      console.log('Round Trip Ogr Count: ' + roundTripFeatures.length);
+      for (var j = 0; j < roundTripFeatures.length; j++)
+      {
+        var roundTripLabel = 'Round Trip Ogr ' + (i + 1) + '.' + (j + 1);
+        if (roundTripFeatures[j].tableName) roundTripLabel += ' (' + roundTripFeatures[j].tableName + ')';
+        printJson(roundTripLabel, roundTripFeatures[j].attrs);
+      }
+    }
+    else if (roundTripFeatures.length > 0)
+    {
+      var secondPassLabel = features.length > 1 ? 'Ogr Multi ' + (i + 1) + ' Again' : 'Ogr';
+      if (roundTripFeatures[0].tableName) secondPassLabel += ' (' + roundTripFeatures[0].tableName + ')';
+      printJson(secondPassLabel, roundTripFeatures[0].attrs);
+    }
+    else
+    {
+      console.log('  ## No second pass Ogr tags ##');
+    }
+  }
+
+  console.log('-----');
+}
+
+function ensureHoot()
+{
+  if (!HOOT_HOME)
+  {
+    throw new Error('HOOT_HOME must be set. Usually: source ./SetupEnv.sh');
+  }
+
+  if (typeof hoot === 'undefined')
+  {
+    hoot = require(HOOT_HOME + '/lib/HootJs');
+  }
+}
+
+function runParsed(parsed)
+{
+  ensureHoot();
+  setDefaults(parsed.options || {});
+
+  var translation = loadTranslation(parsed.translation);
+  var translator = translation.module;
+
+  console.log('---------------');
+  for (var i = 0; i < parsed.geometries.length; i++)
+  {
+    runGeometry(translation, translator, parsed.geometries[i], parsed);
+  }
+}
+
+function runCase(testCase)
+{
+  var geometries = testCase.geometries || testCase.geometry && [testCase.geometry] || ['Point', 'Line', 'Area'];
+  runParsed({
+    translation: testCase.translation,
+    geometries: geometries,
+    tags: testCase.tags || {},
+    options: testCase.options || {}
+  });
+}
+
+if (typeof exports !== 'undefined')
+{
+  exports.runCase = runCase;
+  exports.runParsed = runParsed;
+  exports.parseArgs = parseArgs;
+}
+
+if (require.main === module)
+{
+  try
+  {
+    runParsed(parseArgs(process.argv.slice(2)));
+  }
+  catch (err)
+  {
+    console.error(err.stack || err);
+    process.exit(1);
+  }
+}

--- a/translations/checkTagPairingTests.js
+++ b/translations/checkTagPairingTests.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+/*
+ * This file is part of Hootenanny.
+ *
+ * Hootenanny is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//
+// Script to check one-off OSM tag pairing translations.
+//
+// Add short-lived/manual test cases below. Each test runs all geometries by
+// default, matching checkSingleFeature.js behavior.
+//
+
+var tagPairing = require('./checkTagPairing.js');
+
+function testOSM(translation, tags, geometries, options)
+{
+  console.log('\n' + translation + ' ' + JSON.stringify(tags));
+  tagPairing.runCase({
+    translation: translation,
+    tags: tags,
+    geometries: geometries,
+    options: options
+  });
+}
+
+testOSM('TDSv71', {'highway':'road','bridge':'yes'});
+testOSM('TDSv71', {'highway':'road','ford':'yes'});
+testOSM('TDSv71', {'highway':'road','tunnel':'yes'});
+testOSM('TDSv71', {'highway':'track','bridge':'yes'});
+testOSM('TDSv71', {'highway':'track','ford':'yes'});

--- a/translations/tds71.js
+++ b/translations/tds71.js
@@ -450,6 +450,7 @@ tds71 = {
   {
     // Add the first feature to the structure that we return
     var returnData = [{attrs:attrs, tableName:''}];
+    var splitSourceTags = ['highway','railway','bridge','tunnel','embankment','cutting','ford'];
 
     // Quit early if we don't need to check anything. We are only looking at linework
     if (geometryType !== 'Line') return returnData;
@@ -641,7 +642,7 @@ tds71 = {
       // post processing
       tds71.applyToOgrPostProcessing(newFeatures[i]['tags'], newFeatures[i]['attrs'], geometryType, {});
 
-      returnData.push({attrs: newFeatures[i]['attrs'],tableName: ''});
+      returnData.push({attrs: newFeatures[i]['attrs'],tableName: '', dropOsmTags: splitSourceTags});
     }
 
     return returnData;
@@ -3883,16 +3884,26 @@ tds71 = {
           // Validate attrs: remove all that are not supposed to be part of a feature
           tds71.validateAttrs(geometryType,returnData[i]['attrs'], notUsedTags,transMap);
 
+          var osmTags = notUsedTags;
+          if (returnData[i]['dropOsmTags'])
+          {
+            osmTags = JSON.parse(JSON.stringify(notUsedTags));
+            for (var j = 0, dLen = returnData[i]['dropOsmTags'].length; j < dLen; j++)
+            {
+              delete osmTags[returnData[i]['dropOsmTags'][j]];
+            }
+          }
+
           // If we have unused tags, add them to the memo field.
-          if (Object.keys(notUsedTags).length > 0 && tds71.configOut.OgrNoteExtra == 'attribute')
+          if (Object.keys(osmTags).length > 0 && tds71.configOut.OgrNoteExtra == 'attribute')
           {
             // var tStr = '<OSM>' + JSON.stringify(notUsedTags) + '</OSM>';
             // returnData[i]['attrs']['ZI006_MEM'] = translate.appendValue(returnData[i]['attrs']['ZI006_MEM'],tStr,';');
-            var str = JSON.stringify(notUsedTags,Object.keys(notUsedTags).sort());
+            var str = JSON.stringify(osmTags,Object.keys(osmTags).sort());
             if (tds71.configOut.OgrFormat == 'shp')
             {
               // Split the tags into a maximum of 4 fields, each no greater than 225 char long.
-              var tList = translate.packText(notUsedTags,tds71.configOut.OgrTextFieldNumber,250);
+              var tList = translate.packText(osmTags,tds71.configOut.OgrTextFieldNumber,250);
               returnData[i]['attrs']['OSMTAGS'] = tList[1];
               for (var j = 2, tLen = tList.length; j < tLen; j++)
               {


### PR DESCRIPTION
Translation tickets:
https://maxar.atlassian.net/browse/VGI-5599
https://maxar.atlassian.net/browse/VGI-5601
https://maxar.atlassian.net/browse/VGI-5602
https://maxar.atlassian.net/browse/VGI-5603
https://maxar.atlassian.net/browse/VGI-5604

For this round of translation tickets, most of them request the ability for one OSM feature to be split into two TDS features. For example, highway=road, bridge=yes should be separate road and bridge features in TDS. This feature was added [here](https://github.com/ngageoint/hootenanny/pull/5831), so the main translation issues for these tickets were already resolved. However, this PR adds two new things:
1. A new Javascript test script which can be used in the same fashion as checkSingleFeature.js, but it supports displaying results for multiple translation outputs.
2. A bug fix to prevent duplication. Splitting the feature into multiple can cause the split to happen again when re-translating to TDS, back to OSM, then back to TDS, back to OSM etc, leading to duplicate tags. This change removes splitting tags from secondary translation results, so that the split doesn't happen more than once.